### PR TITLE
Add chat framework for languages

### DIFF
--- a/SWLOR.Game.Server/App.cs
+++ b/SWLOR.Game.Server/App.cs
@@ -214,7 +214,6 @@ namespace SWLOR.Game.Server
             builder.RegisterType<DeathService>().As<IDeathService>();
             builder.RegisterType<DialogService>().As<IDialogService>();
             builder.RegisterType<DurabilityService>().As<IDurabilityService>();
-            builder.RegisterType<PlayerStatService>().As<IPlayerStatService>();
             builder.RegisterType<EnmityService>().As<IEnmityService>();
             builder.RegisterType<ErrorService>().As<IErrorService>();
             builder.RegisterType<ExaminationService>().As<IExaminationService>();
@@ -223,6 +222,7 @@ namespace SWLOR.Game.Server
             builder.RegisterType<ImpoundService>().As<IImpoundService>();
             builder.RegisterType<ItemService>().As<IItemService>();
             builder.RegisterType<KeyItemService>().As<IKeyItemService>();
+            builder.RegisterType<LanguageService>().As<ILanguageService>();
             builder.RegisterType<LocalVariableService>().As<ILocalVariableService>();
             builder.RegisterType<LootService>().As<ILootService>();
             builder.RegisterType<MapService>().As<IMapService>();
@@ -235,6 +235,7 @@ namespace SWLOR.Game.Server
             builder.RegisterType<PerkService>().As<IPerkService>();
             builder.RegisterType<PlayerDescriptionService>().As<IPlayerDescriptionService>();
             builder.RegisterType<PlayerService>().As<IPlayerService>();
+            builder.RegisterType<PlayerStatService>().As<IPlayerStatService>();
             builder.RegisterType<PVPSanctuaryService>().As<IPVPSanctuaryService>();
             builder.RegisterType<QuestService>().As<IQuestService>();
             builder.RegisterType<RaceService>().As<IRaceService>();

--- a/SWLOR.Game.Server/AppState.cs
+++ b/SWLOR.Game.Server/AppState.cs
@@ -21,6 +21,7 @@ namespace SWLOR.Game.Server
         public Dictionary<NWArea, AreaSpawn> AreaSpawns { get; set; }
         public Dictionary<string, NWObject> VisibilityObjects { get; set; }
         public List<long> PCEffectsForRemoval { get; set; }
+        public List<NWObject> ConnectedDMs { get; set; }
         public AppState()
         {
             PlayerDialogs = new Dictionary<string, PlayerDialog>();
@@ -36,6 +37,7 @@ namespace SWLOR.Game.Server
             AreaSpawns = new Dictionary<NWArea, AreaSpawn>();
             VisibilityObjects = new Dictionary<string, NWObject>();
             PCEffectsForRemoval = new List<long>();
+            ConnectedDMs = new List<NWObject>();
 
             for (int x = 1; x <= Constants.NumberOfDialogs; x++)
             {

--- a/SWLOR.Game.Server/Event/Module/OnModuleChat.cs
+++ b/SWLOR.Game.Server/Event/Module/OnModuleChat.cs
@@ -5,20 +5,16 @@ namespace SWLOR.Game.Server.Event.Module
     internal class OnModuleChat : IRegisteredEvent
     {
         private readonly IPlayerDescriptionService _playerDescription;
-        private readonly IChatTextService _chatText;
 
         public OnModuleChat(
-            IChatTextService chatText,
             IPlayerDescriptionService playerDescription)
         {
-            _chatText = chatText;
             _playerDescription = playerDescription;
         }
 
         public bool Run(params object[] args)
         {
             _playerDescription.OnModuleChat();
-            _chatText.OnModuleChat();
             return true;
 
         }

--- a/SWLOR.Game.Server/Event/Module/OnModuleEnter.cs
+++ b/SWLOR.Game.Server/Event/Module/OnModuleEnter.cs
@@ -43,6 +43,11 @@ namespace SWLOR.Game.Server.Event.Module
         {
             NWPlayer player = GetEnteringPlayer();
 
+            if (player.IsDM)
+            {
+                App.GetAppState().ConnectedDMs.Add(player);
+            }
+
             _.ExecuteScript("x3_mod_def_enter", Object.OBJECT_SELF);
             _player.InitializePlayer(player);
             _skill.OnModuleEnter();

--- a/SWLOR.Game.Server/Event/Module/OnModuleLeave.cs
+++ b/SWLOR.Game.Server/Event/Module/OnModuleLeave.cs
@@ -34,6 +34,11 @@ namespace SWLOR.Game.Server.Event.Module
         {
             NWPlayer pc = (_.GetExitingObject());
 
+            if (pc.IsDM)
+            {
+                App.GetAppState().ConnectedDMs.Remove(pc);
+            }
+
             if (pc.IsPlayer)
             {
                 _.ExportSingleCharacter(pc.Object);

--- a/SWLOR.Game.Server/GameObject/NWArea.cs
+++ b/SWLOR.Game.Server/GameObject/NWArea.cs
@@ -45,6 +45,17 @@ namespace SWLOR.Game.Server.GameObject
             return !(lhs == rhs);
         }
 
+        public override bool Equals(object o)
+        {
+            NWArea other = o as NWArea;
+            return other != null && other == this;
+        }
+
+        public override int GetHashCode()
+        {
+            return Object.GetHashCode();
+        }
+
         public static implicit operator Object(NWArea o)
         {
             return o.Object;

--- a/SWLOR.Game.Server/GameObject/NWArea.cs
+++ b/SWLOR.Game.Server/GameObject/NWArea.cs
@@ -29,6 +29,22 @@ namespace SWLOR.Game.Server.GameObject
             }
         }
 
+        //
+        // -- BELOW THIS POINT IS JUNK TO MAKE THE API FRIENDLIER!
+        //
+
+        public static bool operator ==(NWArea lhs, NWArea rhs)
+        {
+            bool lhsNull = lhs is null;
+            bool rhsNull = rhs is null;
+            return (lhsNull && rhsNull) || (!lhsNull && !rhsNull && lhs.Object == rhs.Object);
+        }
+
+        public static bool operator !=(NWArea lhs, NWArea rhs)
+        {
+            return !(lhs == rhs);
+        }
+
         public static implicit operator Object(NWArea o)
         {
             return o.Object;

--- a/SWLOR.Game.Server/GameObject/NWArea.cs
+++ b/SWLOR.Game.Server/GameObject/NWArea.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using NWN;
+﻿using System.Collections.Generic;
 using static NWN.NWScript;
 using Object = NWN.Object;
 
@@ -18,7 +17,18 @@ namespace SWLOR.Game.Server.GameObject
         public int Height => _.GetAreaSize(AREA_HEIGHT, Object);
 
         public bool IsInstance => _.GetLocalInt(Object, "IS_AREA_INSTANCE") == TRUE;
-        
+
+        public IEnumerable<NWObject> Objects
+        {
+            get
+            {
+                for (NWObject obj = _.GetFirstObjectInArea(Object); obj.IsValid; obj = _.GetNextObjectInArea(Object))
+                {
+                    yield return obj;
+                }
+            }
+        }
+
         public static implicit operator Object(NWArea o)
         {
             return o.Object;

--- a/SWLOR.Game.Server/GameObject/NWCreature.cs
+++ b/SWLOR.Game.Server/GameObject/NWCreature.cs
@@ -164,6 +164,17 @@ namespace SWLOR.Game.Server.GameObject
             return !(lhs == rhs);
         }
 
+        public override bool Equals(object o)
+        {
+            NWCreature other = o as NWCreature;
+            return other != null && other == this;
+        }
+
+        public override int GetHashCode()
+        {
+            return Object.GetHashCode();
+        }
+
         public static implicit operator Object(NWCreature o)
         {
             return o.Object;

--- a/SWLOR.Game.Server/GameObject/NWCreature.cs
+++ b/SWLOR.Game.Server/GameObject/NWCreature.cs
@@ -148,7 +148,21 @@ namespace SWLOR.Game.Server.GameObject
             }
         }
 
+        //
+        // -- BELOW THIS POINT IS JUNK TO MAKE THE API FRIENDLIER!
+        //
 
+        public static bool operator ==(NWCreature lhs, NWCreature rhs)
+        {
+            bool lhsNull = lhs is null;
+            bool rhsNull = rhs is null;
+            return (lhsNull && rhsNull) || (!lhsNull && !rhsNull && lhs.Object == rhs.Object);
+        }
+
+        public static bool operator !=(NWCreature lhs, NWCreature rhs)
+        {
+            return !(lhs == rhs);
+        }
 
         public static implicit operator Object(NWCreature o)
         {

--- a/SWLOR.Game.Server/GameObject/NWItem.cs
+++ b/SWLOR.Game.Server/GameObject/NWItem.cs
@@ -645,6 +645,17 @@ namespace SWLOR.Game.Server.GameObject
             return !(lhs == rhs);
         }
 
+        public override bool Equals(object o)
+        {
+            NWItem other = o as NWItem;
+            return other != null && other == this;
+        }
+
+        public override int GetHashCode()
+        {
+            return Object.GetHashCode();
+        }
+
         public static implicit operator Object(NWItem o)
         {
             return o.Object;

--- a/SWLOR.Game.Server/GameObject/NWItem.cs
+++ b/SWLOR.Game.Server/GameObject/NWItem.cs
@@ -629,6 +629,21 @@ namespace SWLOR.Game.Server.GameObject
             return -1;
         }
 
+        //
+        // -- BELOW THIS POINT IS JUNK TO MAKE THE API FRIENDLIER!
+        //
+
+        public static bool operator ==(NWItem lhs, NWItem rhs)
+        {
+            bool lhsNull = lhs is null;
+            bool rhsNull = rhs is null;
+            return (lhsNull && rhsNull) || (!lhsNull && !rhsNull && lhs.Object == rhs.Object);
+        }
+
+        public static bool operator !=(NWItem lhs, NWItem rhs)
+        {
+            return !(lhs == rhs);
+        }
 
         public static implicit operator Object(NWItem o)
         {

--- a/SWLOR.Game.Server/GameObject/NWModule.cs
+++ b/SWLOR.Game.Server/GameObject/NWModule.cs
@@ -58,6 +58,17 @@ namespace SWLOR.Game.Server.GameObject
             return !(lhs == rhs);
         }
 
+        public override bool Equals(object o)
+        {
+            NWModule other = o as NWModule;
+            return other != null && other == this;
+        }
+
+        public override int GetHashCode()
+        {
+            return Object.GetHashCode();
+        }
+
         public static implicit operator Object(NWModule o)
         {
             return o.Object;

--- a/SWLOR.Game.Server/GameObject/NWModule.cs
+++ b/SWLOR.Game.Server/GameObject/NWModule.cs
@@ -42,6 +42,21 @@ namespace SWLOR.Game.Server.GameObject
             }
         }
 
+        //
+        // -- BELOW THIS POINT IS JUNK TO MAKE THE API FRIENDLIER!
+        //
+
+        public static bool operator ==(NWModule lhs, NWModule rhs)
+        {
+            bool lhsNull = lhs is null;
+            bool rhsNull = rhs is null;
+            return (lhsNull && rhsNull) || (!lhsNull && !rhsNull && lhs.Object == rhs.Object);
+        }
+
+        public static bool operator !=(NWModule lhs, NWModule rhs)
+        {
+            return !(lhs == rhs);
+        }
 
         public static implicit operator Object(NWModule o)
         {

--- a/SWLOR.Game.Server/GameObject/NWObject.cs
+++ b/SWLOR.Game.Server/GameObject/NWObject.cs
@@ -22,11 +22,6 @@ namespace SWLOR.Game.Server.GameObject
             _state = App.GetAppState();
         }
 
-        public static implicit operator NWObject(uint objId)
-        {
-            return new NWObject(objId);
-        }
-
         public virtual bool IsInitializedAsPlayer
         {
             get

--- a/SWLOR.Game.Server/GameObject/NWObject.cs
+++ b/SWLOR.Game.Server/GameObject/NWObject.cs
@@ -21,7 +21,12 @@ namespace SWLOR.Game.Server.GameObject
             _ = App.GetNWScript();
             _state = App.GetAppState();
         }
-        
+
+        public static implicit operator NWObject(uint objId)
+        {
+            return new NWObject(objId);
+        }
+
         public virtual bool IsInitializedAsPlayer
         {
             get

--- a/SWLOR.Game.Server/GameObject/NWObject.cs
+++ b/SWLOR.Game.Server/GameObject/NWObject.cs
@@ -333,11 +333,26 @@ namespace SWLOR.Game.Server.GameObject
             }
         }
 
-        public override bool Equals(object obj)
-        {
-            if (!(obj is NWObject item)) return false;
+        //
+        // -- BELOW THIS POINT IS JUNK TO MAKE THE API FRIENDLIER!
+        //
 
-            return item.Object == Object;
+        public static bool operator ==(NWObject lhs, NWObject rhs)
+        {
+            bool lhsNull = lhs is null;
+            bool rhsNull = rhs is null;
+            return (lhsNull && rhsNull) || (!lhsNull && !rhsNull && lhs.Object == rhs.Object);
+        }
+
+        public static bool operator !=(NWObject lhs, NWObject rhs)
+        {
+            return !(lhs == rhs);
+        }
+
+        public override bool Equals(object o)
+        {
+            NWObject other = o as NWObject;
+            return other != null && other == this;
         }
 
         public override int GetHashCode()
@@ -353,10 +368,6 @@ namespace SWLOR.Game.Server.GameObject
         public static implicit operator NWObject(Object o)
         {
             return new NWObject(o);
-        }
-
-        public void Dispose()
-        {
         }
     }
 }

--- a/SWLOR.Game.Server/GameObject/NWPlaceable.cs
+++ b/SWLOR.Game.Server/GameObject/NWPlaceable.cs
@@ -37,6 +37,17 @@ namespace SWLOR.Game.Server.GameObject
             return !(lhs == rhs);
         }
 
+        public override bool Equals(object o)
+        {
+            NWPlaceable other = o as NWPlaceable;
+            return other != null && other == this;
+        }
+
+        public override int GetHashCode()
+        {
+            return Object.GetHashCode();
+        }
+
         public static implicit operator Object(NWPlaceable o)
         {
             return o.Object;

--- a/SWLOR.Game.Server/GameObject/NWPlaceable.cs
+++ b/SWLOR.Game.Server/GameObject/NWPlaceable.cs
@@ -21,14 +21,30 @@ namespace SWLOR.Game.Server.GameObject
             set => _.SetLocked(Object, value ? 1 : 0);
         }
 
+        //
+        // -- BELOW THIS POINT IS JUNK TO MAKE THE API FRIENDLIER!
+        //
+
+        public static bool operator ==(NWPlaceable lhs, NWPlaceable rhs)
+        {
+            bool lhsNull = lhs is null;
+            bool rhsNull = rhs is null;
+            return (lhsNull && rhsNull) || (!lhsNull && !rhsNull && lhs.Object == rhs.Object);
+        }
+
+        public static bool operator !=(NWPlaceable lhs, NWPlaceable rhs)
+        {
+            return !(lhs == rhs);
+        }
+
         public static implicit operator Object(NWPlaceable o)
         {
             return o.Object;
         }
+
         public static implicit operator NWPlaceable(Object o)
         {
             return new NWPlaceable(o);
         }
-
     }
 }

--- a/SWLOR.Game.Server/GameObject/NWPlayer.cs
+++ b/SWLOR.Game.Server/GameObject/NWPlayer.cs
@@ -44,6 +44,17 @@ namespace SWLOR.Game.Server.GameObject
             return !(lhs == rhs);
         }
 
+        public override bool Equals(object o)
+        {
+            NWPlayer other = o as NWPlayer;
+            return other != null && other == this;
+        }
+
+        public override int GetHashCode()
+        {
+            return Object.GetHashCode();
+        }
+
         public static implicit operator Object(NWPlayer o)
         {
             return o.Object;

--- a/SWLOR.Game.Server/GameObject/NWPlayer.cs
+++ b/SWLOR.Game.Server/GameObject/NWPlayer.cs
@@ -27,7 +27,22 @@ namespace SWLOR.Game.Server.GameObject
                 }
             }
         }
-        
+
+        //
+        // -- BELOW THIS POINT IS JUNK TO MAKE THE API FRIENDLIER!
+        //
+
+        public static bool operator ==(NWPlayer lhs, NWPlayer rhs)
+        {
+            bool lhsNull = lhs is null;
+            bool rhsNull = rhs is null;
+            return (lhsNull && rhsNull) || (!lhsNull && !rhsNull && lhs.Object == rhs.Object);
+        }
+
+        public static bool operator !=(NWPlayer lhs, NWPlayer rhs)
+        {
+            return !(lhs == rhs);
+        }
 
         public static implicit operator Object(NWPlayer o)
         {

--- a/SWLOR.Game.Server/Language/ITranslator.cs
+++ b/SWLOR.Game.Server/Language/ITranslator.cs
@@ -1,0 +1,7 @@
+﻿namespace SWLOR.Game.Server.Language
+{
+    public interface ITranslator
+    {
+        string Translate(string message);
+    }
+}

--- a/SWLOR.Game.Server/Language/TranslatorBothese.cs
+++ b/SWLOR.Game.Server/Language/TranslatorBothese.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace SWLOR.Game.Server.Language
+{
+    public class TranslatorBothese : ITranslator
+    {
+        public string Translate(string message)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/SWLOR.Game.Server/Language/TranslatorCatharese.cs
+++ b/SWLOR.Game.Server/Language/TranslatorCatharese.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace SWLOR.Game.Server.Language
+{
+    public class TranslatorCatharese : ITranslator
+    {
+        public string Translate(string message)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/SWLOR.Game.Server/Language/TranslatorCheunh.cs
+++ b/SWLOR.Game.Server/Language/TranslatorCheunh.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace SWLOR.Game.Server.Language
+{
+    public class TranslatorCheunh : ITranslator
+    {
+        public string Translate(string message)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/SWLOR.Game.Server/Language/TranslatorDosh.cs
+++ b/SWLOR.Game.Server/Language/TranslatorDosh.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace SWLOR.Game.Server.Language
+{
+    public class TranslatorDosh : ITranslator
+    {
+        public string Translate(string message)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/SWLOR.Game.Server/Language/TranslatorDroidspeak.cs
+++ b/SWLOR.Game.Server/Language/TranslatorDroidspeak.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace SWLOR.Game.Server.Language
+{
+    public class TranslatorDroidspeak : ITranslator
+    {
+        public string Translate(string message)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/SWLOR.Game.Server/Language/TranslatorGeneric.cs
+++ b/SWLOR.Game.Server/Language/TranslatorGeneric.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace SWLOR.Game.Server.Language
+{
+    public class TranslatorGeneric : ITranslator
+    {
+        public string Translate(string message)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/SWLOR.Game.Server/Language/TranslatorHuttese.cs
+++ b/SWLOR.Game.Server/Language/TranslatorHuttese.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace SWLOR.Game.Server.Language
+{
+    public class TranslatorHuttese : ITranslator
+    {
+        public string Translate(string message)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/SWLOR.Game.Server/Language/TranslatorMandoa.cs
+++ b/SWLOR.Game.Server/Language/TranslatorMandoa.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace SWLOR.Game.Server.Language
+{
+    public class TranslatorMandoa : ITranslator
+    {
+        public string Translate(string message)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/SWLOR.Game.Server/Language/TranslatorShyriiwook.cs
+++ b/SWLOR.Game.Server/Language/TranslatorShyriiwook.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace SWLOR.Game.Server.Language
+{
+    public class TranslatorShyriiwook : ITranslator
+    {
+        public string Translate(string message)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/SWLOR.Game.Server/Language/TranslatorTwileki.cs
+++ b/SWLOR.Game.Server/Language/TranslatorTwileki.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Text;
+
+namespace SWLOR.Game.Server.Language
+{
+    public class TranslatorTwileki : ITranslator
+    {
+        public string Translate(string message)
+        {
+            StringBuilder sb = new StringBuilder();
+
+            foreach (char ch in message)
+            {
+                switch (ch)
+                {
+                    case 'a': sb.Append("ca"); break;
+                    case 'A': sb.Append("C"); break;
+
+                    case 'b': sb.Append("z"); break;
+                    case 'B': sb.Append("Z"); break;
+
+                    case 'c': sb.Append("h"); break;
+                    case 'C': sb.Append("H"); break;
+
+                    case 'd': sb.Append("'"); break;
+                    case 'D': sb.Append("Q"); break;
+
+                    case 'e': sb.Append("a"); break;
+                    case 'E': sb.Append("A"); break;
+
+                    case 'f': sb.Append("f"); break;
+                    case 'F': sb.Append("F"); break;
+
+                    case 'g': sb.Append("zn"); break;
+                    case 'G': sb.Append("Z"); break;
+
+                    case 'h': sb.Append("g"); break;
+                    case 'H': sb.Append("G"); break;
+
+                    case 'i': sb.Append("e"); break;
+                    case 'I': sb.Append("E"); break;
+
+                    case 'j': sb.Append("n"); break;
+                    case 'J': sb.Append("N"); break;
+
+                    case 'k': sb.Append("ka"); break;
+                    case 'K': sb.Append("K"); break;
+
+                    case 'l': sb.Append("ca"); break;
+                    case 'L': sb.Append("C"); break;
+
+                    case 'm': sb.Append("x"); break;
+                    case 'M': sb.Append("X"); break;
+
+                    case 'n': sb.Append("k"); break;
+                    case 'N': sb.Append("K"); break;
+
+                    case 'o': sb.Append("p"); break;
+                    case 'O': sb.Append("P"); break;
+
+                    case 'p': sb.Append("l"); break;
+                    case 'P': sb.Append("L"); break;
+
+                    case 'q': sb.Append("r"); break;
+                    case 'Q': sb.Append("R"); break;
+
+                    case 'r': sb.Append("j"); break;
+                    case 'R': sb.Append("J"); break;
+
+                    case 's': sb.Append("h"); break;
+                    case 'S': sb.Append("H"); break;
+
+                    case 't': sb.Append("u"); break;
+                    case 'T': sb.Append("U"); break;
+
+                    case 'u': sb.Append("t"); break;
+                    case 'U': sb.Append("T"); break;
+
+                    case 'v': sb.Append("s"); break;
+                    case 'V': sb.Append("S"); break;
+
+                    case 'w': sb.Append("m"); break;
+                    case 'W': sb.Append("M"); break;
+
+                    case 'x': sb.Append("sk"); break;
+                    case 'X': sb.Append("S"); break;
+
+                    case 'y': sb.Append("b"); break;
+                    case 'Y': sb.Append("B"); break;
+
+                    case 'z': sb.Append("vz"); break;
+                    case 'Z': sb.Append("V"); break;
+
+                    default: sb.Append(ch); break;
+                }
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/SWLOR.Game.Server/Language/TranslatorZabraki.cs
+++ b/SWLOR.Game.Server/Language/TranslatorZabraki.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace SWLOR.Game.Server.Language
+{
+    public class TranslatorZabraki : ITranslator
+    {
+        public string Translate(string message)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/SWLOR.Game.Server/NWN/NWScript/INTERNAL_Internal.cs
+++ b/SWLOR.Game.Server/NWN/NWScript/INTERNAL_Internal.cs
@@ -7,9 +7,7 @@ namespace NWN
 {
     public class Internal
     {
-        public const uint OBJECT_INVALID = 0x7F000000;
-
-        public static Object OBJECT_SELF { get; private set; } = OBJECT_INVALID;
+        public static Object OBJECT_SELF { get; private set; } = Object.OBJECT_INVALID;
 
         private static Stack<Object> s_ScriptContexts = new Stack<Object>();
 
@@ -22,7 +20,7 @@ namespace NWN
         private static void PopScriptContext()
         {
             s_ScriptContexts.Pop();
-            OBJECT_SELF = s_ScriptContexts.Count == 0 ? OBJECT_INVALID : s_ScriptContexts.Peek();
+            OBJECT_SELF = s_ScriptContexts.Count == 0 ? Object.OBJECT_INVALID : s_ScriptContexts.Peek();
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
@@ -44,7 +42,7 @@ namespace NWN
         {
             if (value == null)
             {
-                value = defAsObjSelf ? OBJECT_SELF : OBJECT_INVALID;
+                value = defAsObjSelf ? OBJECT_SELF : Object.OBJECT_INVALID;
             }
 
             StackPushObject_Native(value.m_ObjId);

--- a/SWLOR.Game.Server/NWN/NWScript/INTERNAL_Types.cs
+++ b/SWLOR.Game.Server/NWN/NWScript/INTERNAL_Types.cs
@@ -5,9 +5,10 @@ namespace NWN
 {
     public partial class Object
     {
+        public const uint OBJECT_INVALID = 0x7F000000;
         public static Object OBJECT_SELF { get { return Internal.OBJECT_SELF; } }
 
-        public uint m_ObjId = Internal.OBJECT_INVALID;
+        public uint m_ObjId = OBJECT_INVALID;
 
         public static implicit operator Object(uint objId)
         {

--- a/SWLOR.Game.Server/SWLOR.Game.Server.csproj
+++ b/SWLOR.Game.Server/SWLOR.Game.Server.csproj
@@ -626,6 +626,18 @@
     <Compile Include="Item\ResourceHarvester.cs" />
     <Compile Include="Item\ResourceScanner.cs" />
     <Compile Include="Item\StructureItem.cs" />
+    <Compile Include="Language\TranslatorCatharese.cs" />
+    <Compile Include="Language\TranslatorCheunh.cs" />
+    <Compile Include="Language\TranslatorBothese.cs" />
+    <Compile Include="Language\ITranslator.cs" />
+    <Compile Include="Language\TranslatorDosh.cs" />
+    <Compile Include="Language\TranslatorDroidspeak.cs" />
+    <Compile Include="Language\TranslatorGeneric.cs" />
+    <Compile Include="Language\TranslatorHuttese.cs" />
+    <Compile Include="Language\TranslatorMandoa.cs" />
+    <Compile Include="Language\TranslatorShyriiwook.cs" />
+    <Compile Include="Language\TranslatorTwileki.cs" />
+    <Compile Include="Language\TranslatorZabraki.cs" />
     <Compile Include="Mod\FabricationMod.cs" />
     <Compile Include="Mod\RestMod.cs" />
     <Compile Include="NWNX\DamageData.cs" />
@@ -1251,6 +1263,7 @@
     <Compile Include="Service\BehaviourService.cs" />
     <Compile Include="Service\ChatCommandService.cs" />
     <Compile Include="Service\ChatTextService.cs" />
+    <Compile Include="Service\LanguageService.cs" />
     <Compile Include="Service\ColorTokenService.cs" />
     <Compile Include="Service\ComponentBonusService.cs" />
     <Compile Include="Service\Contracts\IAbilityService.cs" />
@@ -1316,6 +1329,7 @@
     <Compile Include="Service\Contracts\IHelmetToggleService.cs" />
     <Compile Include="Service\Contracts\IItemService.cs" />
     <Compile Include="Service\Contracts\IKeyItemService.cs" />
+    <Compile Include="Service\Contracts\ILanguageService.cs" />
     <Compile Include="Service\Contracts\ILocalVariableService.cs" />
     <Compile Include="Service\Contracts\ILootService.cs" />
     <Compile Include="Service\Contracts\IMapPinService.cs" />

--- a/SWLOR.Game.Server/Service/BaseService.cs
+++ b/SWLOR.Game.Server/Service/BaseService.cs
@@ -710,13 +710,23 @@ namespace SWLOR.Game.Server.Service
             });
         }
 
+        public static bool CanHandleChat(NWObject sender, string message)
+        {
+            bool validTarget = sender.IsPlayer || sender.IsDM;
+            return validTarget && sender.GetLocalInt("LISTENING_FOR_NEW_CONTAINER_NAME") == TRUE;
+        }
+
         public void OnModuleNWNXChat(NWPlayer sender)
         {
-            if (sender.GetLocalInt("LISTENING_FOR_NEW_CONTAINER_NAME") != 1) return;
-            if (!sender.IsPlayer && !sender.IsDM) return;
+            string text = _nwnxChat.GetMessage().Trim();
+
+            if (!CanHandleChat(sender, text))
+            {
+                return;
+            }
 
             _nwnxChat.SkipMessage();
-            string text = _nwnxChat.GetMessage().Trim();
+
             if (text.Length > 32)
             {
                 sender.FloatingText("Container names must be 32 characters or less.");

--- a/SWLOR.Game.Server/Service/ChatCommandService.cs
+++ b/SWLOR.Game.Server/Service/ChatCommandService.cs
@@ -36,19 +36,18 @@ namespace SWLOR.Game.Server.Service
             _ = script;
         }
 
+        public static bool CanHandleChat(NWObject sender, string message)
+        {
+            bool validTarget = sender.IsPlayer || sender.IsDM;
+            bool validMessage = message.Length >= 2 && message[0] == '/' && message[1] != '/';
+            return validTarget && validMessage;
+        }
+
         public void OnModuleNWNXChat(NWPlayer sender)
         {
-            if (!sender.IsPlayer && !sender.IsDM) return;
-
             string originalMessage = _nwnxChat.GetMessage().Trim();
 
-            if (originalMessage.Length <= 1)
-                return;
-
-            // If it is double slash (//) treat it as a normal message (this is used by role-players to denote OOC speech)
-            if (originalMessage.Substring(0, 2) == "//") return;
-
-            if (originalMessage.Substring(0, 1) != "/")
+            if (!CanHandleChat(sender, originalMessage))
             {
                 return;
             }

--- a/SWLOR.Game.Server/Service/ChatTextService.cs
+++ b/SWLOR.Game.Server/Service/ChatTextService.cs
@@ -14,9 +14,26 @@ using SWLOR.Game.Server.GameObject;
 using SWLOR.Game.Server.NWNX.Contracts;
 using SWLOR.Game.Server.Service.Contracts;
 using static NWN.NWScript;
+using System.Text;
 
 namespace SWLOR.Game.Server.Service
 {
+    public struct ChatComponent
+    {
+        public string m_Text;
+        public bool m_Translatable;
+        public bool m_CustomColour;
+        public byte m_ColourRed;
+        public byte m_ColourGreen;
+        public byte m_ColourBlue;
+    };
+
+    public enum EmoteMode
+    {
+        Regular,
+        Novel
+    };
+
     public class ChatTextService : IChatTextService
     {
         private readonly INWScript _;
@@ -39,55 +56,196 @@ namespace SWLOR.Game.Server.Service
             _httpClient = httpClient;
         }
 
-        public void OnModuleChat()
-        {
-            int mode = _.GetPCChatVolume();
-
-            if (mode != TALKVOLUME_SHOUT)
-            {
-                HandleChat();
-            }
-        }
-
         public void OnNWNXChat()
         {
-            if (_nwnxChat.GetChannel() != (int)ChatChannelType.PlayerShout) return;
-            NWPlayer sender = _nwnxChat.GetSender().Object;
-            bool displayHolonet = sender.GetLocalInt("DISPLAY_HOLONET") == TRUE;
-            string message = _nwnxChat.GetMessage();
+            ChatChannelType channel = (ChatChannelType)_nwnxChat.GetChannel();
 
-            // Ignore chat command messages, but include OOC speech.
-            if (message.Substring(0, 2) != "//" && message.Substring(0, 1) == "/")
+            // So we're going to play with a couple of channels here.
+
+            // - PlayerTalk, PlayerWhisper, PlayerParty, and PlayerShout are all IC channels. These channels
+            //   are subject to emote colouring and language translation. (see below for more info).
+            // - PlayerParty is an IC channel with special behaviour. Those outside of the party but within
+            //   range may listen in to the party chat. (see below for more information).
+            // - PlayerShout sends a holocom message server-wide through the DMTell channel.
+            // - PlayerDM echoes back the message received to the sender.
+
+            bool inCharacterChat =
+                channel == ChatChannelType.PlayerTalk ||
+                channel == ChatChannelType.PlayerWhisper ||
+                channel == ChatChannelType.PlayerParty ||
+                channel == ChatChannelType.PlayerShout;
+
+            bool messageToDm = channel == ChatChannelType.PlayerDM;
+
+            if (!inCharacterChat && !messageToDm)
             {
+                // We don't much care about traffic on the other channels.
                 return;
             }
-            
-            message = _color.Custom("[Holonet] " + sender.Name + ": " + message, 0, 180, 255);
+
+            NWPlayer sender = _nwnxChat.GetSender().Object;
+            string message = _nwnxChat.GetMessage();
+
+            if (channel == ChatChannelType.PlayerDM)
+            {
+                // Simply echo the message back to the player.
+                _nwnxChat.SendMessage((int)ChatChannelType.ServerMessage, "(Sent to DM) " + message, sender, sender);
+                return;
+            }
+
+            // At this point, every channel left is one we want to manually handle.
             _nwnxChat.SkipMessage();
 
-            if (!displayHolonet)
+            // If this is a party message, and the holonet is disabled, we disallow it.
+            if (sender.GetLocalInt("DISPLAY_HOLONET") == FALSE)
             {
                 sender.SendMessage("You have disabled the holonet and cannot send this message.");
                 return;
             }
-            
-            NWCreature holonetCreature = _.GetObjectByTag("Holonet");
-            if (!holonetCreature.IsValid) return;
-            
-            _.SetPortraitId(holonetCreature, _.GetPortraitId(sender));
-            
-            _.DelayCommand(0.1f, () =>
-            {
-                foreach (var player in NWModule.Get().Players)
-                {
-                    displayHolonet = player.GetLocalInt("DISPLAY_HOLONET") == TRUE;
 
-                    if (displayHolonet)
-                    {
-                        _nwnxChat.SendMessage((int)ChatChannelType.PlayerTell, message, holonetCreature, player);
-                    }
+            // TODO: If chat command, skip.
+
+            // TODO: If crafting command, skip.
+
+            // TODO - Assume emote mode is regular.
+            List<ChatComponent> chatComponents;
+            EmoteMode emoteMode = EmoteMode.Regular;
+
+            // Quick early out - if we start with "//" or "((", this is an OOC message.
+            if (message.Substring(0, 2) == "//" || message.Substring(0, 2) == "((")
+            {
+                ChatComponent component = new ChatComponent
+                {
+                    m_Text = message,
+                    m_CustomColour = true,
+                    m_ColourRed = 64,
+                    m_ColourGreen = 64,
+                    m_ColourBlue = 64,
+                    m_Translatable = false
+                };
+
+                chatComponents = new List<ChatComponent>();
+                chatComponents.Add(component);
+            }
+            else
+            {
+                if (emoteMode == EmoteMode.Regular)
+                {
+                    chatComponents = SplitMessageIntoComponents_Regular(message);
                 }
-            });
+                else
+                {
+                    chatComponents = SplitMessageIntoComponents_Novel(message);
+                }
+            }
+
+            // Now, depending on the chat channel, we need to build a list of recipients.
+            bool needsAreaCheck = false;
+            float distanceCheck = 0.0f;
+
+            List<NWObject> recipients = new List<NWObject>();
+
+            // The sender always wants to see their own message.
+            recipients.Add(sender);
+
+            // This is a server-wide holonet message (that receivers can toggle on or off).
+            if (channel == ChatChannelType.PlayerShout)
+            {
+                recipients.AddRange(NWModule.Get().Players.Where(player => player.GetLocalInt("DISPLAY_HOLONET") == FALSE));
+            }
+            // This is the normal party chat, plus everyone within 20 units of the sender.
+            else if (channel == ChatChannelType.PlayerParty)
+            {
+                recipients.AddRange(sender.PartyMembers.Where(pm => !pm.Equals(sender)).Cast<NWObject>());
+                needsAreaCheck = true;
+                distanceCheck = 20.0f;
+            }
+            // Normal talk - 20 units.
+            else if (channel == ChatChannelType.PlayerTalk)
+            {
+                needsAreaCheck = true;
+                distanceCheck = 20.0f;
+            }
+            // Whisper - 4 units.
+            else if (channel == ChatChannelType.PlayerWhisper)
+            {
+                needsAreaCheck = true;
+                distanceCheck = 4.0f;
+            }
+
+            if (needsAreaCheck)
+            {
+                recipients.AddRange(sender.Area.Objects.Where(obj => !obj.Equals(sender) && obj.IsPlayer && _.GetDistanceBetween(sender, obj) <= distanceCheck));
+                // TODO: Need to add DMs too, Area.Objects doesn't return them. We need to cache them on entry.
+            }
+
+            // Now we have a list of who is going to actually receive a message, we need to modify
+            // the message for each recipient then dispatch them.
+
+            foreach (NWObject obj in recipients)
+            {
+                // Generate the final message as perceived by obj.
+
+                StringBuilder finalMessage = new StringBuilder();
+
+                if (channel == ChatChannelType.PlayerShout)
+                {
+                    finalMessage.Append("[Holonet] ");
+                }
+                else if (channel == ChatChannelType.PlayerParty)
+                {
+                    finalMessage.Append("[Comms] ");
+                }
+
+                // TODO - append language name if not basic.
+
+                foreach (ChatComponent component in chatComponents)
+                {
+                    string text = component.m_Text;
+
+                    if (component.m_Translatable)
+                    {
+                        // TODO - Translate from translation service.
+                    }
+
+                    if (component.m_CustomColour)
+                    {
+                        text = _color.Custom(text, component.m_ColourRed, component.m_ColourGreen, component.m_ColourBlue);
+                    }
+
+                    finalMessage.Append(text);
+                }
+
+                // Dispatch the final message - method depends on the original chat channel.
+                // - Shout is sent as talk.
+                // - Party is sent as talk.
+                // - Talk is sent as talk.
+                // - Whisper is sent as whisper.
+
+                ChatChannelType finalChannel = channel;
+
+                if (channel == ChatChannelType.PlayerShout || channel == ChatChannelType.PlayerParty)
+                {
+                    finalChannel = ChatChannelType.PlayerTalk;
+                }
+
+                // There are a couple of colour overrides we want to use here.
+                // - One for holonet (shout).
+                // - One for comms (party chat).
+
+                string finalMessageColoured = finalMessage.ToString();
+
+                if (channel == ChatChannelType.PlayerShout)
+                {
+                    finalMessageColoured = _color.Custom(finalMessageColoured, 0, 180, 255);
+                }
+                else if (channel == ChatChannelType.PlayerParty)
+                {
+                    finalMessageColoured = _color.Yellow(finalMessageColoured);
+                }
+            
+                _nwnxChat.SendMessage((int)finalChannel, finalMessageColoured, sender, obj);
+            }
         }
 
         public void OnModuleEnter()
@@ -116,6 +274,42 @@ namespace SWLOR.Game.Server.Service
             }
 
             _db.SaveChanges();
+        }
+
+        private List<ChatComponent> SplitMessageIntoComponents_Regular(string message)
+        {
+            // TODO
+
+            List<ChatComponent> components = new List<ChatComponent>();
+
+            ChatComponent component = new ChatComponent
+            {
+                m_Text = message,
+                m_CustomColour = false,
+                m_Translatable = false
+            };
+
+            components.Add(component);
+
+            return components;
+        }
+
+        private List<ChatComponent> SplitMessageIntoComponents_Novel(string message)
+        {
+            // TODO
+        
+            List<ChatComponent> components = new List<ChatComponent>();
+
+            ChatComponent component = new ChatComponent
+            {
+                m_Text = message,
+                m_CustomColour = false,
+                m_Translatable = false
+            };
+
+            components.Add(component);
+
+            return components;
         }
 
         private async void PostAsync(int queueID, string characterName, string message, string accountName)
@@ -172,48 +366,6 @@ namespace SWLOR.Game.Server.Service
                     db.SaveChanges();
                 });
             }
-        }
-
-        private void HandleChat()
-        {
-            string message = _.GetPCChatMessage();
-
-            bool foundEmote = false;
-            string finalText = string.Empty;
-            string coloringText = string.Empty;
-            foreach (var @char in message)
-            {
-                if (foundEmote)
-                {
-                    coloringText += @char;
-
-                    if (@char == '*')
-                    {
-                        finalText += _color.Custom(coloringText, 200, 172, 150);
-                        coloringText = string.Empty;
-                        foundEmote = false;
-                    }
-                }
-                else
-                {
-                    if (@char == '*')
-                    {
-                        coloringText += @char;
-                        foundEmote = true;
-                    }
-                    else
-                    {
-                        finalText += @char;
-                    }
-                }
-            }
-
-            if (coloringText.Length > 0)
-            {
-                finalText += coloringText;
-            }
-
-            _.SetPCChatMessage(finalText);
         }
     }
 }

--- a/SWLOR.Game.Server/Service/ChatTextService.cs
+++ b/SWLOR.Game.Server/Service/ChatTextService.cs
@@ -151,7 +151,7 @@ namespace SWLOR.Game.Server.Service
             // This is a server-wide holonet message (that receivers can toggle on or off).
             if (channel == ChatChannelType.PlayerShout)
             {
-                recipients.AddRange(NWModule.Get().Players.Where(player => player.GetLocalInt("DISPLAY_HOLONET") == FALSE));
+                recipients.AddRange(NWModule.Get().Players.Where(player => player.GetLocalInt("DISPLAY_HOLONET") == TRUE));
             }
             // This is the normal party chat, plus everyone within 20 units of the sender.
             else if (channel == ChatChannelType.PlayerParty)

--- a/SWLOR.Game.Server/Service/ChatTextService.cs
+++ b/SWLOR.Game.Server/Service/ChatTextService.cs
@@ -86,12 +86,22 @@ namespace SWLOR.Game.Server.Service
             NWPlayer sender = _nwnxChat.GetSender().Object;
             string message = _nwnxChat.GetMessage();
 
+            if (ChatCommandService.CanHandleChat(sender, message) ||
+                BaseService.CanHandleChat(sender, message) ||
+                CraftService.CanHandleChat(sender, message))
+            {
+                // This will be handled by other services, so just bail.
+                return;
+            }
+
+
             if (channel == ChatChannelType.PlayerDM)
             {
                 // Simply echo the message back to the player.
                 _nwnxChat.SendMessage((int)ChatChannelType.ServerMessage, "(Sent to DM) " + message, sender, sender);
                 return;
             }
+
 
             // At this point, every channel left is one we want to manually handle.
             _nwnxChat.SkipMessage();
@@ -103,9 +113,7 @@ namespace SWLOR.Game.Server.Service
                 return;
             }
 
-            // TODO: If chat command, skip.
 
-            // TODO: If crafting command, skip.
 
             // TODO - Assume emote mode is regular.
             List<ChatComponent> chatComponents;

--- a/SWLOR.Game.Server/Service/Contracts/IChatTextService.cs
+++ b/SWLOR.Game.Server/Service/Contracts/IChatTextService.cs
@@ -4,7 +4,6 @@ namespace SWLOR.Game.Server.Service.Contracts
 {
     public interface IChatTextService
     {
-        void OnModuleChat();
         void OnNWNXChat();
         void OnModuleEnter();
         void OnModuleHeartbeat();

--- a/SWLOR.Game.Server/Service/Contracts/ILanguageService.cs
+++ b/SWLOR.Game.Server/Service/Contracts/ILanguageService.cs
@@ -1,0 +1,12 @@
+﻿using SWLOR.Game.Server.Enumeration;
+using SWLOR.Game.Server.GameObject;
+
+namespace SWLOR.Game.Server.Service.Contracts
+{
+    public interface ILanguageService
+    {
+        string TranslateSnippetForListener(NWPlayer player, SkillType language, string snippet);
+        int GetColour(SkillType language);
+        string GetName(SkillType language);
+    }
+}

--- a/SWLOR.Game.Server/Service/CraftService.cs
+++ b/SWLOR.Game.Server/Service/CraftService.cs
@@ -469,16 +469,23 @@ namespace SWLOR.Game.Server.Service
 
         }
 
+        public static bool CanHandleChat(NWObject sender, string message)
+        {
+            return sender.GetLocalInt("CRAFT_RENAMING_ITEM") == TRUE;
+        }
+
         public void OnNWNXChat()
         {
             NWPlayer pc = _nwnxChat.GetSender().Object;
-            bool isRenamingCraftedItem = pc.GetLocalInt("CRAFT_RENAMING_ITEM") == TRUE;
+            string newName = _nwnxChat.GetMessage();
 
-            if (!isRenamingCraftedItem) return;
-            
+            if (!CanHandleChat(pc, newName))
+            {
+                return;
+            }
+
             _nwnxChat.SkipMessage();
             NWItem renameItem = pc.GetLocalObject("CRAFT_RENAMING_ITEM_OBJECT");
-            string newName = _nwnxChat.GetMessage();
 
             pc.DeleteLocalInt("CRAFT_RENAMING_ITEM");
             pc.DeleteLocalObject("CRAFT_RENAMING_ITEM_OBJECT");

--- a/SWLOR.Game.Server/Service/LanguageService.cs
+++ b/SWLOR.Game.Server/Service/LanguageService.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using SWLOR.Game.Server.Data;
+using SWLOR.Game.Server.Enumeration;
+using SWLOR.Game.Server.GameObject;
+using SWLOR.Game.Server.Language;
+using SWLOR.Game.Server.Service.Contracts;
+
+namespace SWLOR.Game.Server.Service
+{
+    public class LanguageService : ILanguageService
+    {
+        private readonly ISkillService _skillService;
+        private readonly IRandomService _randomService;
+
+        public LanguageService(
+            ISkillService skillService,
+            IRandomService randomService)
+        {
+            _skillService = skillService;
+            _randomService = randomService;
+        }
+
+        public string TranslateSnippetForListener(NWPlayer player, SkillType language, string snippet)
+        {
+            Dictionary<SkillType, System.Type> map = new Dictionary<SkillType, Type>
+            {
+                { SkillType.Bothese, typeof(TranslatorBothese) },
+                { SkillType.Catharese, typeof(TranslatorCatharese) },
+                { SkillType.Cheunh, typeof(TranslatorCheunh) },
+                { SkillType.Dosh, typeof(TranslatorDosh) },
+                //{ SkillType.Droidspeak, typeof(TranslatorDroidspeak) },
+                //{ SkillType.Huttesse, typeof(TranslatorHuttese) },
+                //{ SkillType.Mandoa, typeof(TranslatorMandoa) },
+                //{ SkillType.Shyriiwook, typeof(TranslatorShyriiwook) }
+                { SkillType.Twileki, typeof(TranslatorTwileki) },
+                { SkillType.Zabraki, typeof(TranslatorZabraki) }
+            };
+
+            System.Type type = typeof(TranslatorGeneric);
+            map.TryGetValue(language, out type);
+            ITranslator translator = Activator.CreateInstance(type) as ITranslator;
+
+            // This gives us the thing written in Bothese.
+            string textAsForeignLanguage = translator.Translate(snippet);
+
+            // Now we know what the English text is and we know what the Bothese text is.
+            // Let's grab the max rank for our skill, and then we roll for a successful translate based on that.
+
+            PCSkill skill = _skillService.GetPCSkill(player, language);
+            int rank = skill.Rank;
+            int maxRank = skill.Skill.MaxRank;
+
+            if (rank == maxRank)
+            {
+                // Guaranteed success - return original.
+                return snippet;
+            }
+            else if (rank == 0)
+            {
+                // Guaranteed failure - return translated.
+                return textAsForeignLanguage;
+            }
+
+            int englishChance = (int)(((float)rank / (float)maxRank) * 100);
+
+            string[] originalSplit = snippet.Split(' ');
+            string[] foreignSplit = textAsForeignLanguage.Split(' ');
+
+            StringBuilder endResult = new StringBuilder();
+
+            // WARNING: We're making the assumption that originalSplit.Length == foreignSplit.Length.
+            // If this assumption changes, the below logic needs to change too.
+            for (int i = 0; i < originalSplit.Length; ++i)
+            {
+                if (_randomService.Random(100) <= englishChance)
+                {
+                    endResult.Append(originalSplit[i]);
+                }
+                else
+                {
+                    endResult.Append(foreignSplit[i]);
+                }
+
+                endResult.Append(" ");
+            }
+
+            // TODO: Skill increase
+            return endResult.ToString();
+        }
+
+        public int GetColour(SkillType language)
+        {
+            byte r;
+            byte g;
+            byte b;
+
+            // TODO - Database
+            r = 100;
+            g = 149;
+            b = 237;
+
+            return r << 24 | g << 16 | b << 8;
+        }
+
+        public string GetName(SkillType language)
+        {
+            // TODO - Database???
+
+            switch (language)
+            {
+                case SkillType.Bothese: return "Bothese";
+                case SkillType.Catharese: return "Catharese";
+                case SkillType.Cheunh: return "Cheunh";
+                case SkillType.Dosh: return "Dosh";
+                // case SkillType.Droidspeak: return "Droidspeak";
+                // case SkillType.Huttesse: return "Huttese";
+                // case SkillType.Mandoa: return "Mandoa";
+                // case SkillType.Shyriiwook: return "Shyriiwook";
+                case SkillType.Twileki: return "Twi'leki";
+                case SkillType.Zabraki: return "Zabraki";
+            }
+
+            return "Basic";
+        }
+    }
+}


### PR DESCRIPTION
This has a lot of backend changes, but only a few visible client changes:

- Emotes are now coloured (we can change the colour later) with multiple styles. Need to write player documentation on how it works. **, :: ::, [], and "" style emotes work, with a single bracket surround causing that text to come out untranslated (useful for names, e.g. [John]).
- Server chat messages are sent manually.
- Party chat is called comms, and players speaking in it can be overheard by those close to them.