### PR TITLE
Allowing Medical Kits to be used on NPCs

### DIFF
--- a/SWLOR.Game.Server/GameObject/NWObject.cs
+++ b/SWLOR.Game.Server/GameObject/NWObject.cs
@@ -277,7 +277,9 @@ namespace SWLOR.Game.Server.GameObject
 
         public virtual bool IsDM =>  _.GetIsDM(Object) == 1 || _.GetIsDMPossessed(Object) == 1;
 
-        public virtual bool IsNPC => !IsPlayer && !IsDM;
+        public virtual bool IsNPC => !IsPlayer && !IsDM && IsCreature;
+        
+        public virtual bool IsCreature => _.GetObjectType(Object) == 1;
 
         public virtual IEnumerable<NWItem> InventoryItems
         {

--- a/SWLOR.Game.Server/Item/Medicine/Bandages.cs
+++ b/SWLOR.Game.Server/Item/Medicine/Bandages.cs
@@ -55,9 +55,10 @@ namespace SWLOR.Game.Server.Item.Medicine
             {
                 _.ApplyEffectToObject(DURATION_TYPE_INSTANT, _.EffectHeal(healAmount), target);
             }
-
-            int xp = (int)_skill.CalculateRegisteredSkillLevelAdjustedXP(100, item.RecommendedLevel, rank);
-            _skill.GiveSkillXP(player, SkillType.Medicine, xp);
+            if(target.IsPlayer){
+                int xp = (int)_skill.CalculateRegisteredSkillLevelAdjustedXP(100, item.RecommendedLevel, rank);
+                _skill.GiveSkillXP(player, SkillType.Medicine, xp);
+            }
         }
 
         public float Seconds(NWCreature user, NWItem item, NWObject target, Location targetLocation, CustomData customData)
@@ -95,9 +96,9 @@ namespace SWLOR.Game.Server.Item.Medicine
 
         public string IsValidTarget(NWCreature user, NWItem item, NWObject target, Location targetLocation)
         {
-            if (!user.IsPlayer)
+            if (target.IsCreature && !target.IsDM)
             {
-                return "Only players may be targeted with this item.";
+                return "Only creatures may be targeted with this item.";
             }
 
             if (!_customEffect.DoesPCHaveCustomEffect(target.Object, CustomEffectType.Bleeding))

--- a/SWLOR.Game.Server/Item/Medicine/HealingKit.cs
+++ b/SWLOR.Game.Server/Item/Medicine/HealingKit.cs
@@ -79,8 +79,10 @@ namespace SWLOR.Game.Server.Item.Medicine
             _.ApplyEffectToObject(DURATION_TYPE_TEMPORARY, regeneration, target.Object, duration);
             player.SendMessage("You successfully treat " + target.Name + "'s wounds.");
 
-            int xp = (int)_skill.CalculateRegisteredSkillLevelAdjustedXP(300, item.RecommendedLevel, rank);
-            _skill.GiveSkillXP(player, SkillType.Medicine, xp);
+            if(target.IsPlayer){
+                int xp = (int)_skill.CalculateRegisteredSkillLevelAdjustedXP(300, item.RecommendedLevel, rank);
+                _skill.GiveSkillXP(player, SkillType.Medicine, xp);
+            }
         }
 
         public float Seconds(NWCreature user, NWItem item, NWObject target, Location targetLocation, CustomData customData)
@@ -125,9 +127,9 @@ namespace SWLOR.Game.Server.Item.Medicine
 
         public string IsValidTarget(NWCreature user, NWItem item, NWObject target, Location targetLocation)
         {
-            if (_.GetIsPC(target.Object) == FALSE || _.GetIsDM(target.Object) == TRUE)
+            if (target.IsCreature && !target.IsDM)
             {
-                return "Only players may be targeted with this item.";
+                return "Only creatures may be targeted with this item.";
             }
 
             if (target.CurrentHP >= target.MaxHP)

--- a/SWLOR.Game.Server/Item/Medicine/ResuscitationKit.cs
+++ b/SWLOR.Game.Server/Item/Medicine/ResuscitationKit.cs
@@ -92,8 +92,11 @@ namespace SWLOR.Game.Server.Item.Medicine
             dbPlayer.CurrentFP = fpRecover;
             _data.SubmitDataChange(dbPlayer, DatabaseActionType.Update);
             player.SendMessage("You successfully resuscitate " + target.Name + "!");
-            int xp = (int)_skill.CalculateRegisteredSkillLevelAdjustedXP(600, item.RecommendedLevel, skillRank);
-            _skill.GiveSkillXP(player, SkillType.Medicine, xp);
+            
+            if(target.IsPlayer){
+                int xp = (int)_skill.CalculateRegisteredSkillLevelAdjustedXP(600, item.RecommendedLevel, skillRank);
+                _skill.GiveSkillXP(player, SkillType.Medicine, xp);
+            }
         }
 
         public float Seconds(NWCreature user, NWItem item, NWObject target, Location targetLocation, CustomData customData)
@@ -130,9 +133,9 @@ namespace SWLOR.Game.Server.Item.Medicine
 
         public string IsValidTarget(NWCreature user, NWItem item, NWObject target, Location targetLocation)
         {
-            if (_.GetIsPC(target.Object) == FALSE || _.GetIsDM(target.Object) == TRUE)
+             if (target.IsCreature && !target.IsDM)
             {
-                return "Only players may be targeted with this item.";
+                return "Only creatures may be targeted with this item.";
             }
 
             if (target.CurrentHP > -11)

--- a/SWLOR.Game.Server/Item/Medicine/TreatmentKit.cs
+++ b/SWLOR.Game.Server/Item/Medicine/TreatmentKit.cs
@@ -58,8 +58,11 @@ namespace SWLOR.Game.Server.Item.Medicine
             user.SendMessage("You successfully treat " + target.Name + "'s infection.");
 
             int rank = _skill.GetPCSkillRank((NWPlayer)user, SkillType.Medicine);
-            int xp = (int)_skill.CalculateRegisteredSkillLevelAdjustedXP(300, item.RecommendedLevel, rank);
-            _skill.GiveSkillXP((NWPlayer)user, SkillType.Medicine, xp);
+            
+            if(target.IsPlayer){
+                int xp = (int)_skill.CalculateRegisteredSkillLevelAdjustedXP(300, item.RecommendedLevel, rank);
+                _skill.GiveSkillXP((NWPlayer)user, SkillType.Medicine, xp);
+            }
         }
 
         public float Seconds(NWCreature user, NWItem item, NWObject target, Location targetLocation, CustomData customData)
@@ -99,9 +102,9 @@ namespace SWLOR.Game.Server.Item.Medicine
 
         public string IsValidTarget(NWCreature user, NWItem item, NWObject target, Location targetLocation)
         {
-            if (!target.IsPlayer)
+             if (target.IsCreature && !target.IsDM)
             {
-                return "Only players may be targeted with this item.";
+                return "Only creatures may be targeted with this item.";
             }
 
             bool hasEffect = false;


### PR DESCRIPTION
- Allowing Bandages, Resuscitation Kits, Treatment Kits and Healing Kits to be used on NPCs rather than just players
- Adding IsCreature to NWObject
- Updating IsNPC of NWObject to use IsCreature to prevent returning a false positive if the NWObject is a placeable