### PR TITLE
Remove Perk Requirements from Repair kits and remove penalty from stimpacks

### DIFF
--- a/SWLOR.Game.Server/App.config
+++ b/SWLOR.Game.Server/App.config
@@ -2,10 +2,22 @@
 <configuration>
   <configSections>
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
-    
   </configSections>
-  <system.web></system.web>
-  <appSettings></appSettings>
+  <system.web>
+    <membership defaultProvider="ClientAuthenticationMembershipProvider">
+      <providers>
+        <add name="ClientAuthenticationMembershipProvider" type="System.Web.ClientServices.Providers.ClientFormsAuthenticationMembershipProvider, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" serviceUri="" />
+      </providers>
+    </membership>
+    <roleManager defaultProvider="ClientRoleProvider" enabled="true">
+      <providers>
+        <add name="ClientRoleProvider" type="System.Web.ClientServices.Providers.ClientRoleProvider, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" serviceUri="" cacheTimeout="86400" />
+      </providers>
+    </roleManager>
+  </system.web>
+  <appSettings>
+    <add key="ClientSettingsProvider.ServiceUri" value="" />
+  </appSettings>
   <entityFramework>
     <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" />
     <providers>

--- a/SWLOR.Game.Server/Data/Migrations/2018-12-02.1.sql
+++ b/SWLOR.Game.Server/Data/Migrations/2018-12-02.1.sql
@@ -1,45 +1,45 @@
 ﻿UPDATE dbo.Perk
-SET Description = 'Provides a bonus to durability when using Electronic repair kits.'
+SET Description = 'Provides a bonus to repairs when using Electronic repair kits.'
 WHERE ID = 152
 UPDATE dbo.Perk
-SET Description = 'Provides a bonus to durability when using armor repair kits'
+SET Description = 'Provides a bonus to repairs when using armor repair kits'
 WHERE ID = 150
 UPDATE dbo.Perk
-SET Description = 'Provides a bonus to durability when using weapon repair kits'
+SET Description = 'Provides a bonus to repairs when using weapon repair kits'
 WHERE ID = 149
 UPDATE dbo.PerkLevel
-SET Description = 'Gains +2 to the durability of armor when using an armor repair kit'
+SET Description = 'Gains +2 to the repair of armor when using an armor repair kit'
 WHERE ID = 2066
 UPDATE dbo.PerkLevel
-SET Description = 'Gains +4 to the durability of armor when using an armor repair kit'
+SET Description = 'Gains +4 to the repair of armor when using an armor repair kit'
 WHERE ID = 2067
 UPDATE dbo.PerkLevel
-SET Description = 'Gains +6 to the durability of armor when using an armor repair kit'
+SET Description = 'Gains +6 to the repair of armor when using an armor repair kit'
 WHERE ID = 2068
 UPDATE dbo.PerkLevel
-SET Description = 'Gains +8 to the durability of armor when using an armor repair kit'
+SET Description = 'Gains +8 to the repair of armor when using an armor repair kit'
 WHERE ID = 2069
 UPDATE dbo.PerkLevel
-SET Description = 'Gains +2 to the durability of armor when using an weapon repair kit'
+SET Description = 'Gains +2 to the repair of weapon when using an weapon repair kit'
 WHERE ID = 2062
 UPDATE dbo.PerkLevel
-SET Description = 'Gains +4 to the durability of armor when using an weapon repair kit'
+SET Description = 'Gains +4 to the repair of weapon when using an weapon repair kit'
 WHERE ID = 2063
 UPDATE dbo.PerkLevel
-SET Description = 'Gains +6 to the durability of armor when using an weapon repair kit'
+SET Description = 'Gains +6 to the repair of weapon when using an weapon repair kit'
 WHERE ID = 2064
 UPDATE dbo.PerkLevel
-SET Description = 'Gains +8 to the durability of armor when using an weapon repair kit'
+SET Description = 'Gains +8 to the repair of weapon when using an weapon repair kit'
 WHERE ID = 2065
 UPDATE dbo.PerkLevel
-SET Description = 'Gains +2 to the durability of armor when using an electronic repair kit'
+SET Description = 'Gains +2 to the repair of item when using an electronic repair kit'
 WHERE ID = 1957
 UPDATE dbo.PerkLevel
-SET Description = 'Gains +4 to the durability of armor when using an electronic repair kit'
+SET Description = 'Gains +4 to the repair of item when using an electronic repair kit'
 WHERE ID = 1958
 UPDATE dbo.PerkLevel
-SET Description = 'Gains +6 to the durability of armor when using an electronic repair kit'
+SET Description = 'Gains +6 to the repair of item when using an electronic repair kit'
 WHERE ID = 1959
 UPDATE dbo.PerkLevel
-SET Description = 'Gains +8 to the durability of armor when using an electronic repair kit'
+SET Description = 'Gains +8 to the repair of item when using an electronic repair kit'
 WHERE ID = 1960

--- a/SWLOR.Game.Server/Data/Migrations/2018-12-02.1.sql
+++ b/SWLOR.Game.Server/Data/Migrations/2018-12-02.1.sql
@@ -8,38 +8,38 @@ UPDATE dbo.Perk
 SET Description = 'Provides a bonus to repairs when using weapon repair kits'
 WHERE ID = 149
 UPDATE dbo.PerkLevel
-SET Description = 'Gains +2 to the repair of armor when using an armor repair kit'
-WHERE ID = 2066
+SET Description = 'Gain +2 to armor repair when using an armor repair kit.'
+WHERE PerkID = 150 AND Level = 1
 UPDATE dbo.PerkLevel
-SET Description = 'Gains +4 to the repair of armor when using an armor repair kit'
-WHERE ID = 2067
+SET Description = 'Gains +4 to armor repair when using an armor repair kit'
+WHERE PerkID = 150 AND Level = 2
 UPDATE dbo.PerkLevel
-SET Description = 'Gains +6 to the repair of armor when using an armor repair kit'
-WHERE ID = 2068
+SET Description = 'Gains +6 to armor repair when using an armor repair kit'
+WHERE PerkID = 150 AND Level = 3
 UPDATE dbo.PerkLevel
-SET Description = 'Gains +8 to the repair of armor when using an armor repair kit'
-WHERE ID = 2069
+SET Description = 'Gains +8 to armor repair when using an armor repair kit'
+WHERE PerkID = 150 AND Level = 4
 UPDATE dbo.PerkLevel
-SET Description = 'Gains +2 to the repair of weapon when using an weapon repair kit'
-WHERE ID = 2062
+SET Description = 'Gains +2 to weapon repair when using an weapon repair kit'
+WHERE PerkID = 149 AND Level = 1
 UPDATE dbo.PerkLevel
-SET Description = 'Gains +4 to the repair of weapon when using an weapon repair kit'
-WHERE ID = 2063
+SET Description = 'Gains +4 to weapon repair when using an weapon repair kit'
+WHERE PerkID = 149 AND Level = 2
 UPDATE dbo.PerkLevel
-SET Description = 'Gains +6 to the repair of weapon when using an weapon repair kit'
-WHERE ID = 2064
+SET Description = 'Gains +6 to weapon repair when using an weapon repair kit'
+WHERE PerkID = 149 AND Level = 3
 UPDATE dbo.PerkLevel
-SET Description = 'Gains +8 to the repair of weapon when using an weapon repair kit'
-WHERE ID = 2065
+SET Description = 'Gains +8 to weapon repair when using an weapon repair kit'
+WHERE PerkID = 149 AND Level = 4
 UPDATE dbo.PerkLevel
-SET Description = 'Gains +2 to the repair of item when using an electronic repair kit'
-WHERE ID = 1957
+SET Description = 'Gains +2 to electronic repair when using an electronic repair kit'
+WHERE PerkID = 152 AND Level = 1
 UPDATE dbo.PerkLevel
-SET Description = 'Gains +4 to the repair of item when using an electronic repair kit'
-WHERE ID = 1958
+SET Description = 'Gains +4 to electronic repair when using an electronic repair kit'
+WHERE PerkID = 152 AND Level = 2
 UPDATE dbo.PerkLevel
-SET Description = 'Gains +6 to the repair of item when using an electronic repair kit'
-WHERE ID = 1959
+SET Description = 'Gains +6 to electronic repair when using an electronic repair kit'
+WHERE PerkID = 152 AND Level = 3
 UPDATE dbo.PerkLevel
-SET Description = 'Gains +8 to the repair of item when using an electronic repair kit'
-WHERE ID = 1960
+SET Description = 'Gains +8 to electronic repair when using an electronic repair kit'
+WHERE PerkID = 152 AND Level = 1

--- a/SWLOR.Game.Server/Data/Migrations/2018-12-02.1.sql
+++ b/SWLOR.Game.Server/Data/Migrations/2018-12-02.1.sql
@@ -1,0 +1,45 @@
+﻿UPDATE dbo.Perk
+SET Description = 'Provides a bonus to durability when using Electronic repair kits.'
+WHERE ID = 152
+UPDATE dbo.Perk
+SET Description = 'Provides a bonus to durability when using armor repair kits'
+WHERE ID = 150
+UPDATE dbo.Perk
+SET Description = 'Provides a bonus to durability when using weapon repair kits'
+WHERE ID = 149
+UPDATE dbo.PerkLevel
+SET Description = 'Gains +2 to the durability of armor when using an armor repair kit'
+WHERE ID = 2066
+UPDATE dbo.PerkLevel
+SET Description = 'Gains +4 to the durability of armor when using an armor repair kit'
+WHERE ID = 2067
+UPDATE dbo.PerkLevel
+SET Description = 'Gains +6 to the durability of armor when using an armor repair kit'
+WHERE ID = 2068
+UPDATE dbo.PerkLevel
+SET Description = 'Gains +8 to the durability of armor when using an armor repair kit'
+WHERE ID = 2069
+UPDATE dbo.PerkLevel
+SET Description = 'Gains +2 to the durability of armor when using an weapon repair kit'
+WHERE ID = 2062
+UPDATE dbo.PerkLevel
+SET Description = 'Gains +4 to the durability of armor when using an weapon repair kit'
+WHERE ID = 2063
+UPDATE dbo.PerkLevel
+SET Description = 'Gains +6 to the durability of armor when using an weapon repair kit'
+WHERE ID = 2064
+UPDATE dbo.PerkLevel
+SET Description = 'Gains +8 to the durability of armor when using an weapon repair kit'
+WHERE ID = 2065
+UPDATE dbo.PerkLevel
+SET Description = 'Gains +2 to the durability of armor when using an electronic repair kit'
+WHERE ID = 1957
+UPDATE dbo.PerkLevel
+SET Description = 'Gains +4 to the durability of armor when using an electronic repair kit'
+WHERE ID = 1958
+UPDATE dbo.PerkLevel
+SET Description = 'Gains +6 to the durability of armor when using an electronic repair kit'
+WHERE ID = 1959
+UPDATE dbo.PerkLevel
+SET Description = 'Gains +8 to the durability of armor when using an electronic repair kit'
+WHERE ID = 1960

--- a/SWLOR.Game.Server/Data/Migrations/2018-12-02.1.sql
+++ b/SWLOR.Game.Server/Data/Migrations/2018-12-02.1.sql
@@ -42,4 +42,4 @@ SET Description = 'Gains +6 to electronic repair when using an electronic repair
 WHERE PerkID = 152 AND Level = 3
 UPDATE dbo.PerkLevel
 SET Description = 'Gains +8 to electronic repair when using an electronic repair kit'
-WHERE PerkID = 152 AND Level = 1
+WHERE PerkID = 152 AND Level = 4

--- a/SWLOR.Game.Server/Item/Medicine/StimPack.cs
+++ b/SWLOR.Game.Server/Item/Medicine/StimPack.cs
@@ -35,8 +35,6 @@ namespace SWLOR.Game.Server.Item.Medicine
             int amount = item.GetLocalInt("AMOUNT") + item.MedicineBonus;
             int rank = player.IsPlayer ? _skill.GetPCSkillRank(player, SkillType.Medicine) : 0;
             int recommendedLevel = item.RecommendedLevel;
-           // int delta = recommendedLevel - rank;
-           // int penalty = delta / 2; Remove Penalties from being below recommended level(XP penalty should be enough)
             float duration = 30.0f;
             int perkLevel = player.IsPlayer ? _perk.GetPCPerkLevel(player, PerkType.StimFiend) : 0;
             float percentIncrease = perkLevel * 0.25f;

--- a/SWLOR.Game.Server/Item/Medicine/StimPack.cs
+++ b/SWLOR.Game.Server/Item/Medicine/StimPack.cs
@@ -35,17 +35,12 @@ namespace SWLOR.Game.Server.Item.Medicine
             int amount = item.GetLocalInt("AMOUNT") + item.MedicineBonus;
             int rank = player.IsPlayer ? _skill.GetPCSkillRank(player, SkillType.Medicine) : 0;
             int recommendedLevel = item.RecommendedLevel;
-            int delta = recommendedLevel - rank;
-            int penalty = delta / 2;
+           // int delta = recommendedLevel - rank;
+           // int penalty = delta / 2; Remove Penalties from being below recommended level(XP penalty should be enough)
             float duration = 30.0f;
             int perkLevel = player.IsPlayer ? _perk.GetPCPerkLevel(player, PerkType.StimFiend) : 0;
             float percentIncrease = perkLevel * 0.25f;
             duration = duration + (duration * percentIncrease);
-
-            if (penalty > 0)
-                amount -= penalty;
-            if (amount < 1) amount = 1;
-
             Effect effect = _.EffectAbilityIncrease(ability, amount);
             effect = _.TagEffect(effect, "STIM_PACK_EFFECT");
 

--- a/SWLOR.Game.Server/Item/RepairKit.cs
+++ b/SWLOR.Game.Server/Item/RepairKit.cs
@@ -36,12 +36,11 @@ namespace SWLOR.Game.Server.Item
             int repairAmount = tech * 2;
 
             if (skillType == SkillType.Armorsmith)
-                repairAmount += item.CraftBonusArmorsmith;
+                repairAmount += item.CraftBonusArmorsmith + (_perk.GetPcPerkLevel(user.Object,PerkType.ArmorRepair) * 5);
             else if (skillType == SkillType.Weaponsmith)
-                repairAmount += item.CraftBonusWeaponsmith;
+                repairAmount += item.CraftBonusWeaponsmith + (_perk.GetPcPerkLevel(user.Object,PerkType.Weaponsmith) * 5);
             else if (skillType == SkillType.Engineering)
-                repairAmount += item.CraftBonusEngineering;
-
+                repairAmount += item.CraftBonusEngineering + (_perk.GetPcPerkLevel(user.Object,PerkType.Engineering) * 5);
             float minReduction = 0.05f * tech;
             float maxReduction = 0.15f * tech;
             float reductionAmount = _random.RandomFloat(minReduction, maxReduction);
@@ -138,29 +137,6 @@ namespace SWLOR.Game.Server.Item
 
             SkillType skillType = GetSkillType(item);
             int techLevel = item.GetLocalInt("TECH_LEVEL");
-
-            if (skillType == SkillType.Armorsmith)
-            {
-                if (_perk.GetPCPerkLevel(user.Object, PerkType.ArmorRepair) < techLevel)
-                {
-                    return "Your level in the 'Armor Repair' perk is too low to use this repair kit.";
-                }
-            }
-            else if (skillType == SkillType.Weaponsmith)
-            {
-                if (_perk.GetPCPerkLevel(user.Object, PerkType.WeaponRepair) < techLevel)
-                {
-                    return "Your level in the 'Weapon Repair' perk is too low to use this repair kit.";
-                }
-            }
-            else if (skillType == SkillType.Engineering)
-            {
-                if(_perk.GetPCPerkLevel(user.Object, PerkType.ElectronicRepair) < techLevel)
-                {
-                    return "Your level in the 'Electronic Repair' perk is too low to use this repair kit.";
-                }
-            }
-
             return null;
         }
 

--- a/SWLOR.Game.Server/Item/RepairKit.cs
+++ b/SWLOR.Game.Server/Item/RepairKit.cs
@@ -36,11 +36,11 @@ namespace SWLOR.Game.Server.Item
             int repairAmount = tech * 2;
 
             if (skillType == SkillType.Armorsmith)
-                repairAmount += item.CraftBonusArmorsmith + (_perk.GetPCPerkLevel(user.Object,PerkType.ArmorRepair) * 5);
+                repairAmount += item.CraftBonusArmorsmith + (_perk.GetPCPerkLevel(user.Object,PerkType.ArmorRepair) * 2);
             else if (skillType == SkillType.Weaponsmith)
-                repairAmount += item.CraftBonusWeaponsmith + (_perk.GetPCPerkLevel(user.Object,PerkType.WeaponRepair) * 5);
+                repairAmount += item.CraftBonusWeaponsmith + (_perk.GetPCPerkLevel(user.Object,PerkType.WeaponRepair) * 2);
             else if (skillType == SkillType.Engineering)
-                repairAmount += item.CraftBonusEngineering + (_perk.GetPCPerkLevel(user.Object,PerkType.ElectronicRepair) * 5);
+                repairAmount += item.CraftBonusEngineering + (_perk.GetPCPerkLevel(user.Object,PerkType.ElectronicRepair) * 2);
             float minReduction = 0.05f * tech;
             float maxReduction = 0.15f * tech;
             float reductionAmount = _random.RandomFloat(minReduction, maxReduction);

--- a/SWLOR.Game.Server/Item/RepairKit.cs
+++ b/SWLOR.Game.Server/Item/RepairKit.cs
@@ -36,11 +36,11 @@ namespace SWLOR.Game.Server.Item
             int repairAmount = tech * 2;
 
             if (skillType == SkillType.Armorsmith)
-                repairAmount += item.CraftBonusArmorsmith + (_perk.GetPcPerkLevel(user.Object,PerkType.ArmorRepair) * 5);
+                repairAmount += item.CraftBonusArmorsmith + (_perk.GetPCPerkLevel(user.Object,PerkType.ArmorRepair) * 5);
             else if (skillType == SkillType.Weaponsmith)
-                repairAmount += item.CraftBonusWeaponsmith + (_perk.GetPcPerkLevel(user.Object,PerkType.Weaponsmith) * 5);
+                repairAmount += item.CraftBonusWeaponsmith + (_perk.GetPCPerkLevel(user.Object,PerkType.WeaponRepair) * 5);
             else if (skillType == SkillType.Engineering)
-                repairAmount += item.CraftBonusEngineering + (_perk.GetPcPerkLevel(user.Object,PerkType.Engineering) * 5);
+                repairAmount += item.CraftBonusEngineering + (_perk.GetPCPerkLevel(user.Object,PerkType.ElectronicRepair) * 5);
             float minReduction = 0.05f * tech;
             float maxReduction = 0.15f * tech;
             float reductionAmount = _random.RandomFloat(minReduction, maxReduction);

--- a/SWLOR.Game.Server/SWLOR.Game.Server.csproj
+++ b/SWLOR.Game.Server/SWLOR.Game.Server.csproj
@@ -61,6 +61,7 @@
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
     </Reference>
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/SWLOR.Game.Server/SWLOR.Game.Server.csproj
+++ b/SWLOR.Game.Server/SWLOR.Game.Server.csproj
@@ -1562,6 +1562,7 @@
     <EmbeddedResource Include="Data\Migrations\2018-11-30.1.sql" />
     <EmbeddedResource Include="Data\Migrations\2018-12-01.1.sql" />
     <EmbeddedResource Include="Data\Migrations\2018-12-01.2.sql" />
+    <EmbeddedResource Include="Data\Migrations\2018-12-02.1.sql" />
     <Content Include="ServerFiles\Star Wars LOR.mod" />
     <EmbeddedResource Include="Data\Migrations\Initialization.sql" />
     <EmbeddedResource Include="Data\Migrations\2018-11-07.1.sql" />


### PR DESCRIPTION
Repair kits:
Each level of perks is a +5 bonus to the durability of the object
Perk description still needs to be changed but that shouldn't be too hard.
I'll add that in once I know this works!
Stimpacks:
Removed attribute penalty from using stimpacks when below level, the only punishment now is gaining reduced XP in medicine