### PR TITLE
Adding feedback to ForceHeal, DarkHeal, ForceBreach, Healing Kits and Force Packs

### DIFF
--- a/SWLOR.Game.Server/Item/Medicine/ForcePack.cs
+++ b/SWLOR.Game.Server/Item/Medicine/ForcePack.cs
@@ -90,7 +90,9 @@ namespace SWLOR.Game.Server.Item.Medicine
             string data = (int)interval + ", " + restoreAmount;
             _customEffect.ApplyCustomEffect(user, target.Object, CustomEffectType.ForcePack, (int)duration, restoreAmount, data);
 
-            player.SendMessage("You successfully apply a force pack to " + target.Name + ".");
+            player.SendMessage("You successfully apply a force pack to " + target.Name + ". The force pack will expire in " + duration + " seconds.");
+
+            _.DelayCommand(duration + 0.5f, () => { player.SendMessage("The force pack that you applied to " + target.Name + " has expired."); });
 
             int xp = (int)_skill.CalculateRegisteredSkillLevelAdjustedXP(300, item.RecommendedLevel, rank);
             _skill.GiveSkillXP(player, SkillType.Medicine, xp);

--- a/SWLOR.Game.Server/Item/Medicine/HealingKit.cs
+++ b/SWLOR.Game.Server/Item/Medicine/HealingKit.cs
@@ -77,7 +77,9 @@ namespace SWLOR.Game.Server.Item.Medicine
 
             Effect regeneration = _.EffectRegenerate(restoreAmount, interval);
             _.ApplyEffectToObject(DURATION_TYPE_TEMPORARY, regeneration, target.Object, duration);
-            player.SendMessage("You successfully treat " + target.Name + "'s wounds.");
+            player.SendMessage("You successfully treat " + target.Name + "'s wounds. The healing kit will expire in " + duration + " seconds.");
+            
+            _.DelayCommand(duration + 0.5f, () => { player.SendMessage("The healing kit that you applied to " + target.Name + " has expired."); });
 
             if(target.IsPlayer){
                 int xp = (int)_skill.CalculateRegisteredSkillLevelAdjustedXP(300, item.RecommendedLevel, rank);

--- a/SWLOR.Game.Server/Item/Medicine/StimPack.cs
+++ b/SWLOR.Game.Server/Item/Medicine/StimPack.cs
@@ -51,7 +51,9 @@ namespace SWLOR.Game.Server.Item.Medicine
 
             _.ApplyEffectToObject(NWScript.DURATION_TYPE_TEMPORARY, effect, target, duration);
 
-            user.SendMessage("You inject " + target.Name + " with a stim pack.");
+            user.SendMessage("You inject " + target.Name + " with a stim pack. The stim pack will expire in " + duration + " seconds.");
+
+            _.DelayCommand(duration + 0.5f, () => { player.SendMessage("The stim pack that you applied to " + target.Name + " has expired."); });
 
             if (!Equals(user, target))
             {

--- a/SWLOR.Game.Server/Perk/DarkSide/DarkHeal.cs
+++ b/SWLOR.Game.Server/Perk/DarkSide/DarkHeal.cs
@@ -186,17 +186,20 @@ namespace SWLOR.Game.Server.Perk.DarkSide
                 oPC.SendMessage("Lucky heal!");
             }
 
-            Effect heal = _.EffectHeal(amount);
-            _.ApplyEffectToObject(DURATION_TYPE_INSTANT, heal, oTarget.Object);
-
-            if (length > 0.0f && regenAmount > 0)
+            oPC.AssignCommand(() =>
             {
-                Effect regen = _.EffectRegenerate(regenAmount, 1.0f);
-                _.ApplyEffectToObject(DURATION_TYPE_TEMPORARY, regen, oTarget.Object, length + 0.1f);
-            }
+                Effect heal = _.EffectHeal(amount);
+                _.ApplyEffectToObject(DURATION_TYPE_INSTANT, heal, oTarget);
 
-            Effect vfx = _.EffectVisualEffect(VFX_IMP_HEALING_M);
-            _.ApplyEffectToObject(DURATION_TYPE_INSTANT, vfx, oTarget.Object);
+                if (length > 0.0f && regenAmount > 0)
+                {
+                    Effect regen = _.EffectRegenerate(regenAmount, 1.0f);
+                    _.ApplyEffectToObject(DURATION_TYPE_TEMPORARY, regen, oTarget, length + 0.1f);
+                }
+
+                Effect vfx = _.EffectVisualEffect(VFX_IMP_HEALING_M);
+                _.ApplyEffectToObject(DURATION_TYPE_INSTANT, vfx, oTarget.Object);
+            });            
         }
 
         public void OnPurchased(NWPlayer oPC, int newLevel)

--- a/SWLOR.Game.Server/Perk/LightSide/ForceBreach.cs
+++ b/SWLOR.Game.Server/Perk/LightSide/ForceBreach.cs
@@ -139,8 +139,11 @@ namespace SWLOR.Game.Server.Perk.LightSide
                 player.SendMessage("Lucky force breach!");
             }
 
-            Effect damage = _.EffectDamage(amount);
-            _.ApplyEffectToObject(DURATION_TYPE_INSTANT, damage, target.Object);
+            player.AssignCommand(() =>
+            {
+                Effect damage = _.EffectDamage(amount);
+                _.ApplyEffectToObject(DURATION_TYPE_INSTANT, damage, target);
+            });
             
             if (length > 0.0f && dotAmount > 0)
             {
@@ -149,8 +152,12 @@ namespace SWLOR.Game.Server.Perk.LightSide
 
             _skill.RegisterPCToAllCombatTargetsForSkill(player, SkillType.LightSideAbilities, target.Object);
 
-            Effect vfx = _.EffectVisualEffect(VFX_IMP_DOMINATE_S);
-            _.ApplyEffectToObject(DURATION_TYPE_INSTANT, vfx, target.Object);
+            player.AssignCommand(() =>
+            {
+                Effect vfx = _.EffectVisualEffect(VFX_IMP_DOMINATE_S);
+                _.ApplyEffectToObject(DURATION_TYPE_INSTANT, vfx, target);
+            });
+            
         }
 
         public void OnPurchased(NWPlayer oPC, int newLevel)

--- a/SWLOR.Game.Server/Perk/LightSide/ForceHeal.cs
+++ b/SWLOR.Game.Server/Perk/LightSide/ForceHeal.cs
@@ -185,18 +185,21 @@ namespace SWLOR.Game.Server.Perk.LightSide
                 length = length * 2;
                 oPC.SendMessage("Lucky heal!");
             }
-
-            Effect heal = _.EffectHeal(amount);
-            _.ApplyEffectToObject(DURATION_TYPE_INSTANT, heal, oTarget.Object);
-
-            if (length > 0.0f && regenAmount > 0)
+            
+            oPC.AssignCommand(() =>
             {
-                Effect regen = _.EffectRegenerate(regenAmount, 1.0f);
-                _.ApplyEffectToObject(DURATION_TYPE_TEMPORARY, regen, oTarget.Object, length + 0.1f);
-            }
+                Effect heal = _.EffectHeal(amount);
+                _.ApplyEffectToObject(DURATION_TYPE_INSTANT, heal, oTarget);
 
-            Effect vfx = _.EffectVisualEffect(VFX_IMP_HEALING_M);
-            _.ApplyEffectToObject(DURATION_TYPE_INSTANT, vfx, oTarget.Object);
+                if (length > 0.0f && regenAmount > 0)
+                {
+                    Effect regen = _.EffectRegenerate(regenAmount, 1.0f);
+                    _.ApplyEffectToObject(DURATION_TYPE_TEMPORARY, regen, oTarget, length + 0.1f);
+                }
+
+                Effect vfx = _.EffectVisualEffect(VFX_IMP_HEALING_M);
+                _.ApplyEffectToObject(DURATION_TYPE_INSTANT, vfx, oTarget.Object);
+            });            
         }
 
         public void OnPurchased(NWPlayer oPC, int newLevel)


### PR DESCRIPTION
Adding feedback messages to ForceHeal, DarkHeal, ForceBreach, Healing Kits and Force Packs to allow player to know when the effect wears off.

Fix for https://github.com/zunath/SWLOR_NWN/issues/573