### PR TITLE
Fix the cloning bug, use data.Get instead of data.Single

### DIFF
--- a/SWLOR.Game.Server/Conversation/BaseManagementTool.cs
+++ b/SWLOR.Game.Server/Conversation/BaseManagementTool.cs
@@ -65,8 +65,8 @@ namespace SWLOR.Game.Server.Conversation
                 "75 degrees",
                 "90 degrees",
                 "180 degrees");
-            DialogPage renamePage = new DialogPage("Type a name into the chat box. Once you are done select confirm.",
-                "Confirm");
+            DialogPage renamePage = new DialogPage("Type a name into the chat box. Once you are done select next.",
+                "Next");
             DialogPage confirmRenamePage = new DialogPage(
     "<SET LATER>",
     "Confirm Name Change"
@@ -262,6 +262,7 @@ namespace SWLOR.Game.Server.Conversation
                     RotateResponses(responseID);
                     break;
                 case "RenamePage":
+                    GetPC().SetLocalInt("LISTENING_FOR_DESCRIPTION", 1);
                     RenameResponses(responseID);
                     break;
                 case "ConfirmRenamePage":
@@ -271,7 +272,6 @@ namespace SWLOR.Game.Server.Conversation
         }
         private void RenameResponses(int responseID)
         {
-            GetPC().SetLocalInt("LISTENING_FOR_DESCRIPTION", 1);
             switch(responseID)
             {
                 case 1:
@@ -316,10 +316,10 @@ namespace SWLOR.Game.Server.Conversation
                     else if (buildingType == Enumeration.BuildingType.Interior)
                     {
                         Guid pcBaseStructureID = new Guid(data.TargetArea.GetLocalString("PC_BASE_STRUCTURE_ID"));
-                        var structure = _data.Single<PCBaseStructure>(x => x.ID == pcBaseStructureID);
+                        var structure = _data.Get<PCBaseStructure>(pcBaseStructureID);
                         structure.CustomName = GetPC().GetLocalString("NEW_DESCRIPTION_TO_SET");
                         _data.SubmitDataChange(structure, DatabaseActionType.Update);
-                        sender.SendMessage("Name is now set to" + structure.CustomName);
+                        sender.SendMessage("Name is now set to " + structure.CustomName);
                     }
                     EndConversation();
                     break;


### PR DESCRIPTION
start listening on rename page and change back to back confirm responses