### PR TITLE
Helmets use "Associated Skill: X Armor" rather than "Custom Item Type…

### DIFF
--- a/SWLOR.Game.Server/Service/ItemService.cs
+++ b/SWLOR.Game.Server/Service/ItemService.cs
@@ -775,6 +775,9 @@ namespace SWLOR.Game.Server.Service
             {
                 int type = item.BaseItemType;
 
+                // Check for explicit override.
+                if (item.AssociatedSkillType > 0) return (SkillType)item.AssociatedSkillType;
+
                 // Armor has to specifically be set on the item in order to count.
                 // Look for an item type property first.
                 if (item.CustomItemType == CustomItemType.LightArmor) return SkillType.LightArmor;


### PR DESCRIPTION
…: X Armor".  Add the code to GetSkillTypeForItem to respect this.