### PR TITLE
Allow buildings with structure permissions to be deleted from the

### DIFF
--- a/SWLOR.Game.Server/Conversation/BaseManagementTool.cs
+++ b/SWLOR.Game.Server/Conversation/BaseManagementTool.cs
@@ -733,12 +733,20 @@ namespace SWLOR.Game.Server.Conversation
                     impoundedCount++;
                 }
                 
+                // Remove any primary owner permissions.
                 var primaryOwner = _data.SingleOrDefault<Player>(x => x.PrimaryResidencePCBaseStructureID == structure.ID);
                 if (primaryOwner != null)
                 {
                     primaryOwner.PrimaryResidencePCBaseStructureID = null;
                     _data.SubmitDataChange(primaryOwner, DatabaseActionType.Update);
                 }
+
+                // Remove any access permissions.
+                foreach (var buildingPermission in _data.Where<PCBaseStructurePermission>(x => x.PCBaseStructureID == structure.ID))
+                {
+                    _data.SubmitDataChange(buildingPermission, DatabaseActionType.Delete);
+                }
+
             }
             else if (structureType == BaseStructureType.StarshipProduction && data.ManipulatingStructure.Structure.GetLocalInt("DOCKED_STARSHIP") == 1)
             {


### PR DESCRIPTION
database when picked up.

Current exception that this code should fix:
Exception type: System.Data.SqlClient.SqlException
Message       : The DELETE statement conflicted with the REFERENCE constraint "FK_PCBaseStructurePermissions_PCBaseStructureID". The conflict occurred in database "swlor", table "dbo.PCBaseStructurePermission", column 'PCBaseStructureID'.
The statement has been terminated.
The DELETE statement conflicted with the REFERENCE constraint "FK_PCBaseStructurePermissions_PCBaseStructureID". The conflict occurred in database "swlor", table "dbo.PCBaseStructurePermission", column 'PCBaseStructureID'.
The statement has been terminated.