### PR TITLE
Trigger weapon skill perks only when we hit an enemy, not when an enemy

### DIFF
--- a/SWLOR.Game.Server/Service/AbilityService.cs
+++ b/SWLOR.Game.Server/Service/AbilityService.cs
@@ -416,6 +416,10 @@ namespace SWLOR.Game.Server.Service
         public void OnHitCastSpell(NWPlayer oPC)
         {
             NWObject oTarget = _.GetSpellTargetObject();
+            NWItem oItem = _.GetSpellCastItem();
+
+            // If this method was triggered by our own armor (from getting hit), return. 
+            if (oItem.BaseItemType == BASE_ITEM_ARMOR) return;
 
             // Flag this attack as physical so that the damage scripts treat it properly.
             _error.Trace(TraceComponent.LastAttack, "Setting attack type from " + oPC.GlobalID + " against " + _.GetName(oTarget) + " to physical (" + ATTACK_PHYSICAL.ToString() + ")");


### PR DESCRIPTION
hits us.  Should fix #687.