### PR TITLE
Performance tweaks

### DIFF
--- a/SWLOR.Game.Server/App.cs
+++ b/SWLOR.Game.Server/App.cs
@@ -18,6 +18,8 @@ using SWLOR.Game.Server.Mod.Contracts;
 using NWN;
 using SWLOR.Game.Server.AreaInstance.Contracts;
 using SWLOR.Game.Server.DoorRule.Contracts;
+using SWLOR.Game.Server.Messaging;
+using SWLOR.Game.Server.Messaging.Contracts;
 using SWLOR.Game.Server.NWNX;
 using SWLOR.Game.Server.NWNX.Contracts;
 using SWLOR.Game.Server.Perk;
@@ -253,7 +255,8 @@ namespace SWLOR.Game.Server
             builder.RegisterType<BackgroundThreadManager>()
                 .As<IBackgroundThreadManager>()
                 .SingleInstance();
-            
+            builder.RegisterInstance(MessageHub.Instance).As<IMessageHub>().SingleInstance();
+
             // Game Objects
             builder.RegisterType<NWObject>();
             builder.RegisterType<NWCreature>();

--- a/SWLOR.Game.Server/AppCache.cs
+++ b/SWLOR.Game.Server/AppCache.cs
@@ -24,6 +24,7 @@ namespace SWLOR.Game.Server
         public Dictionary<string, NWObject> VisibilityObjects { get; set; }
         public List<Guid> PCEffectsForRemoval { get; set; }
         public List<NWObject> ConnectedDMs { get; set; }
+        public Dictionary<Guid, Dictionary<int, int>> PlayerEffectivePerkLevels { get; set; }
 
         public AppCache()
         {
@@ -41,7 +42,7 @@ namespace SWLOR.Game.Server
             VisibilityObjects = new Dictionary<string, NWObject>();
             PCEffectsForRemoval = new List<Guid>();
             ConnectedDMs = new List<NWObject>();
-            
+            PlayerEffectivePerkLevels = new Dictionary<Guid, Dictionary<int, int>>();
 
             for (int x = 1; x <= DialogService.NumberOfDialogs; x++)
             {

--- a/SWLOR.Game.Server/Conversation/PerkRefund.cs
+++ b/SWLOR.Game.Server/Conversation/PerkRefund.cs
@@ -6,6 +6,8 @@ using SWLOR.Game.Server.Data;
 using SWLOR.Game.Server.Data.Entity;
 using SWLOR.Game.Server.Enumeration;
 using SWLOR.Game.Server.GameObject;
+using SWLOR.Game.Server.Messaging.Contracts;
+using SWLOR.Game.Server.Messaging.Messages;
 using SWLOR.Game.Server.NWNX.Contracts;
 using SWLOR.Game.Server.Perk;
 using SWLOR.Game.Server.Service.Contracts;
@@ -30,6 +32,7 @@ namespace SWLOR.Game.Server.Conversation
         private readonly IPlayerStatService _stat;
         private readonly ITimeService _time;
         private readonly IBackgroundService _background;
+        private readonly IMessageHub _messageHub;
 
         public PerkRefund(
             INWScript script, 
@@ -40,7 +43,8 @@ namespace SWLOR.Game.Server.Conversation
             ICustomEffectService customEffect,
             IPlayerStatService stat,
             ITimeService time, 
-            IBackgroundService background)
+            IBackgroundService background,
+            IMessageHub messageHub)
             : base(script, dialog)
         {
             _data = data;
@@ -50,6 +54,7 @@ namespace SWLOR.Game.Server.Conversation
             _stat = stat;
             _time = time;
             _background = background;
+            _messageHub = messageHub;
         }
 
         public override PlayerDialog SetUp(NWPlayer player)
@@ -251,6 +256,8 @@ namespace SWLOR.Game.Server.Conversation
             {
                 perkAction?.OnRemoved(player);
             });
+
+            _messageHub.Publish(new PerkRefundedMessage(player, pcPerk.PerkID));
         }
 
         private bool IsGrantedByBackground(PerkType perkType)

--- a/SWLOR.Game.Server/Event/Legacy/LegacyJVMEvent.cs
+++ b/SWLOR.Game.Server/Event/Legacy/LegacyJVMEvent.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Reflection;
 using SWLOR.Game.Server.GameObject;
+using SWLOR.Game.Server.ValueObject;
 using Object = NWN.Object;
 
 namespace SWLOR.Game.Server.Event.Legacy
@@ -12,15 +13,19 @@ namespace SWLOR.Game.Server.Event.Legacy
             NWObject self = (Object.OBJECT_SELF);
             string script = self.GetLocalString((string) args[0]);
 
-            Type type = Type.GetType(Assembly.GetExecutingAssembly().GetName().Name + "." + script);
-
-            if (type == null)
+            using (new Profiler("LegacyJVMEvent::" + script))
             {
-                Console.WriteLine("Unable to locate type for LegacyJVMEvent: " + script);
-                return false;
+                Type type = Type.GetType(Assembly.GetExecutingAssembly().GetName().Name + "." + script);
+
+                if (type == null)
+                {
+                    Console.WriteLine("Unable to locate type for LegacyJVMEvent: " + script);
+                    return false;
+                }
+
+                App.RunEvent(type);
             }
 
-            App.RunEvent(type);
 
             return true;
         }

--- a/SWLOR.Game.Server/Event/Module/OnModuleEnter.cs
+++ b/SWLOR.Game.Server/Event/Module/OnModuleEnter.cs
@@ -23,6 +23,7 @@ namespace SWLOR.Game.Server.Event.Module
         private readonly IRaceService _race;
         private readonly IPlayerMigrationService _migration;
         private readonly IMarketService _market;
+        private readonly IPerkService _perk;
 
         public OnModuleEnter(
             INWScript script,
@@ -38,7 +39,8 @@ namespace SWLOR.Game.Server.Event.Module
             IDataService data,
             IRaceService race,
             IPlayerMigrationService migration,
-            IMarketService market)
+            IMarketService market,
+            IPerkService perk)
         {
             _ = script;
             _player = player;
@@ -54,6 +56,7 @@ namespace SWLOR.Game.Server.Event.Module
             _race = race;
             _migration = migration;
             _market = market;
+            _perk = perk;
         }
 
         public bool Run(params object[] args)
@@ -71,6 +74,7 @@ namespace SWLOR.Game.Server.Event.Module
             _player.InitializePlayer(player);
             _data.CachePlayerData(player);
             _skill.OnModuleEnter();
+            _perk.OnModuleEnter();
             _player.LoadCharacter(player);
             _migration.OnModuleEnter();
             _player.ShowMOTD(player);

--- a/SWLOR.Game.Server/Messaging/Contracts/IMessageHub.cs
+++ b/SWLOR.Game.Server/Messaging/Contracts/IMessageHub.cs
@@ -1,0 +1,68 @@
+﻿using System;
+
+namespace SWLOR.Game.Server.Messaging.Contracts
+{
+    /// <summary>
+    /// An implementation of the <c>Event Aggregator</c> pattern.
+    /// </summary>
+    public interface IMessageHub : IDisposable
+    {
+        /// <summary>
+        /// Registers a callback which is invoked on every message published by the <see cref="IMessageHub"/>.
+        /// <remarks>Invoking this method with a new <paramref name="onMessage"/>overwrites the previous one.</remarks>
+        /// </summary>
+        /// <param name="onMessage">
+        /// The callback to invoke on every message
+        /// <remarks>The callback receives the type of the message and the message as arguments</remarks>
+        /// </param>
+        void RegisterGlobalHandler(Action<Type, object> onMessage);
+
+        /// <summary>
+        /// Invoked if an error occurs when publishing a message to a subscriber.
+        /// <remarks>Invoking this method with a new <paramref name="onError"/>overwrites the previous one.</remarks>
+        /// </summary>
+        void RegisterGlobalErrorHandler(Action<Guid, Exception> onError);
+
+        /// <summary>
+        /// Publishes the <paramref name="message"/> on the <see cref="IMessageHub"/>.
+        /// </summary>
+        /// <param name="message">The message to published</param>
+        void Publish<T>(T message);
+
+        /// <summary>
+        /// Subscribes a callback against the <see cref="IMessageHub"/> for a specific type of message.
+        /// </summary>
+        /// <typeparam name="T">The type of message to subscribe to</typeparam>
+        /// <param name="action">The callback to be invoked once the message is published on the <see cref="IMessageHub"/></param>
+        /// <returns>The token representing the subscription</returns>
+        Guid Subscribe<T>(Action<T> action);
+
+        /// <summary>
+        /// Subscribes a callback against the <see cref="MessageHub"/> for a specific type of message.
+        /// </summary>
+        /// <typeparam name="T">The type of message to subscribe to</typeparam>
+        /// <param name="action">The callback to be invoked once the message is published on the <see cref="MessageHub"/></param>
+        /// <param name="throttleBy">The <see cref="TimeSpan"/> specifying the rate at which subscription is throttled</param>
+        /// <returns>The token representing the subscription</returns>
+        Guid Subscribe<T>(Action<T> action, TimeSpan throttleBy);
+
+        /// <summary>
+        /// Unsubscribes a subscription from the <see cref="IMessageHub"/>.
+        /// </summary>
+        /// <param name="token">The token representing the subscription</param>
+        void Unsubscribe(Guid token);
+
+        /// <summary>
+        /// Checks if a specific subscription is active on the <see cref="IMessageHub"/>.
+        /// </summary>
+        /// <param name="token">The token representing the subscription</param>
+        /// <returns><c>True</c> if the subscription is active otherwise <c>False</c></returns>
+        bool IsSubscribed(Guid token);
+
+        /// <summary>
+        /// Clears all the subscriptions from the <see cref="MessageHub"/>.
+        /// <remarks>The global handler and the global error handler are not affected</remarks>
+        /// </summary>
+        void ClearSubscriptions();
+    }
+}

--- a/SWLOR.Game.Server/Messaging/MessageHub.cs
+++ b/SWLOR.Game.Server/Messaging/MessageHub.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using System.Diagnostics;
+using SWLOR.Game.Server.Messaging.Contracts;
+
+namespace SWLOR.Game.Server.Messaging
+{
+#if NET_STANDARD
+    using System.Reflection;
+#endif   
+
+    /// <summary>
+    /// An implementation of the <c>Event Aggregator</c> pattern.
+    /// </summary>
+    public sealed class MessageHub : IMessageHub
+    {
+        private readonly Subscriptions _subscriptions;
+        private Action<Type, object> _globalHandler;
+        private Action<Guid, Exception> _globalErrorHandler;
+
+        private MessageHub() => _subscriptions = new Subscriptions();
+
+        /// <summary>
+        /// Returns a single instance of the <see cref="MessageHub"/>
+        /// </summary>
+        public static MessageHub Instance { get; } = new MessageHub();
+
+        /// <summary>
+        /// Registers a callback which is invoked on every message published by the <see cref="MessageHub"/>.
+        /// <remarks>Invoking this method with a new <paramref name="onMessage"/>overwrites the previous one.</remarks>
+        /// </summary>
+        /// <param name="onMessage">
+        /// The callback to invoke on every message
+        /// <remarks>The callback receives the type of the message and the message as arguments</remarks>
+        /// </param>
+        public void RegisterGlobalHandler(Action<Type, object> onMessage)
+        {
+            EnsureNotNull(onMessage);
+            _globalHandler = onMessage;
+        }
+
+        /// <summary>
+        /// Invoked if an error occurs when publishing a message to a subscriber.
+        /// <remarks>Invoking this method with a new <paramref name="onError"/>overwrites the previous one.</remarks>
+        /// </summary>
+        public void RegisterGlobalErrorHandler(Action<Guid, Exception> onError)
+        {
+            EnsureNotNull(onError);
+            _globalErrorHandler = onError;
+        }
+
+        /// <summary>
+        /// Publishes the <paramref name="message"/> on the <see cref="MessageHub"/>.
+        /// </summary>
+        /// <param name="message">The message to published</param>
+        public void Publish<T>(T message)
+        {
+            var localSubscriptions = _subscriptions.GetTheLatestSubscriptions();
+
+            var msgType = typeof(T);
+
+#if NET_STANDARD
+            var msgTypeInfo = msgType.GetTypeInfo();
+#endif
+            _globalHandler?.Invoke(msgType, message);
+
+            // ReSharper disable once ForCanBeConvertedToForeach | Performance Critical
+            for (var idx = 0; idx < localSubscriptions.Count; idx++)
+            {
+                var subscription = localSubscriptions[idx];
+
+#if NET_STANDARD
+                if (!subscription.Type.GetTypeInfo().IsAssignableFrom(msgTypeInfo)) { continue; }
+#else
+                if (!subscription.Type.IsAssignableFrom(msgType)) { continue; }
+#endif
+                try
+                {
+                    subscription.Handle(message);
+                }
+                catch (Exception e)
+                {
+                    _globalErrorHandler?.Invoke(subscription.Token, e);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Subscribes a callback against the <see cref="MessageHub"/> for a specific type of message.
+        /// </summary>
+        /// <typeparam name="T">The type of message to subscribe to</typeparam>
+        /// <param name="action">The callback to be invoked once the message is published on the <see cref="MessageHub"/></param>
+        /// <returns>The token representing the subscription</returns>
+        public Guid Subscribe<T>(Action<T> action) => Subscribe(action, TimeSpan.Zero);
+
+        /// <summary>
+        /// Subscribes a callback against the <see cref="MessageHub"/> for a specific type of message.
+        /// </summary>
+        /// <typeparam name="T">The type of message to subscribe to</typeparam>
+        /// <param name="action">The callback to be invoked once the message is published on the <see cref="MessageHub"/></param>
+        /// <param name="throttleBy">The <see cref="TimeSpan"/> specifying the rate at which subscription is throttled</param>
+        /// <returns>The token representing the subscription</returns>
+        public Guid Subscribe<T>(Action<T> action, TimeSpan throttleBy)
+        {
+            EnsureNotNull(action);
+            return _subscriptions.Register(throttleBy, action);
+        }
+
+        /// <summary>
+        /// Unsubscribes a subscription from the <see cref="MessageHub"/>.
+        /// </summary>
+        /// <param name="token">The token representing the subscription</param>
+        public void Unsubscribe(Guid token) => _subscriptions.UnRegister(token);
+
+        /// <summary>
+        /// Checks if a specific subscription is active on the <see cref="MessageHub"/>.
+        /// </summary>
+        /// <param name="token">The token representing the subscription</param>
+        /// <returns><c>True</c> if the subscription is active otherwise <c>False</c></returns>
+        public bool IsSubscribed(Guid token) => _subscriptions.IsRegistered(token);
+
+        /// <summary>
+        /// Clears all the subscriptions from the <see cref="MessageHub"/>.
+        /// <remarks>The global handler and the global error handler are not affected</remarks>
+        /// </summary>
+        public void ClearSubscriptions() => _subscriptions.Clear(false);
+
+        /// <summary>
+        /// Disposes the <see cref="MessageHub"/>.
+        /// </summary>
+        public void Dispose()
+        {
+            _globalHandler = null;
+            _subscriptions.Clear(true);
+        }
+
+        [DebuggerStepThrough]
+        private void EnsureNotNull(object obj)
+        {
+            if (obj == null) { throw new NullReferenceException(nameof(obj)); }
+        }
+    }
+}

--- a/SWLOR.Game.Server/Messaging/Messages/PerkRefundedMessage.cs
+++ b/SWLOR.Game.Server/Messaging/Messages/PerkRefundedMessage.cs
@@ -1,0 +1,16 @@
+﻿using SWLOR.Game.Server.GameObject;
+
+namespace SWLOR.Game.Server.Messaging.Messages
+{
+    public class PerkRefundedMessage
+    {
+        public NWPlayer Player { get; set; }
+        public int PerkID { get; set; }
+
+        public PerkRefundedMessage(NWPlayer player, int perkID)
+        {
+            Player = player;
+            PerkID = perkID;
+        }
+    }
+}

--- a/SWLOR.Game.Server/Messaging/Messages/PerkUpgradedMessage.cs
+++ b/SWLOR.Game.Server/Messaging/Messages/PerkUpgradedMessage.cs
@@ -1,0 +1,16 @@
+﻿using SWLOR.Game.Server.GameObject;
+
+namespace SWLOR.Game.Server.Messaging.Messages
+{
+    public class PerkUpgradedMessage
+    {
+        public NWPlayer Player { get; set; }
+        public int PerkID { get; set; }
+
+        public PerkUpgradedMessage(NWPlayer player, int perkID)
+        {
+            Player = player;
+            PerkID = perkID;
+        }
+    }
+}

--- a/SWLOR.Game.Server/Messaging/Messages/QuestCompletedMessage.cs
+++ b/SWLOR.Game.Server/Messaging/Messages/QuestCompletedMessage.cs
@@ -1,0 +1,16 @@
+﻿using SWLOR.Game.Server.GameObject;
+
+namespace SWLOR.Game.Server.Messaging.Messages
+{
+    public class QuestCompletedMessage
+    {
+        public NWPlayer Player { get; set; }
+        public int QuestID { get; set; }
+
+        public QuestCompletedMessage(NWPlayer player, int questID)
+        {
+            Player = player;
+            QuestID = questID;
+        }
+    }
+}

--- a/SWLOR.Game.Server/Messaging/Messages/SkillDecayedMessage.cs
+++ b/SWLOR.Game.Server/Messaging/Messages/SkillDecayedMessage.cs
@@ -1,0 +1,21 @@
+﻿
+using SWLOR.Game.Server.GameObject;
+
+namespace SWLOR.Game.Server.Messaging.Messages
+{
+    public class SkillDecayedMessage
+    {
+        public NWPlayer Player { get; set; }
+        public int SkillID { get; set; }
+        public int OldLevel { get; set; }
+        public int NewLevel { get; set; }
+
+        public SkillDecayedMessage(NWPlayer player, int skillID, int oldLevel, int newLevel)
+        {
+            Player = player;
+            SkillID = skillID;
+            OldLevel = oldLevel;
+            NewLevel = newLevel;
+        }
+    }
+}

--- a/SWLOR.Game.Server/Messaging/Messages/SkillGainedMessage.cs
+++ b/SWLOR.Game.Server/Messaging/Messages/SkillGainedMessage.cs
@@ -1,0 +1,16 @@
+﻿using SWLOR.Game.Server.GameObject;
+
+namespace SWLOR.Game.Server.Messaging.Messages
+{
+    public class SkillGainedMessage
+    {
+        public NWPlayer Player { get; set; }
+        public int SkillID { get; set; }
+
+        public SkillGainedMessage(NWPlayer player, int skillID)
+        {
+            Player = player;
+            SkillID = skillID;
+        }
+    }
+}

--- a/SWLOR.Game.Server/Messaging/Subscription.cs
+++ b/SWLOR.Game.Server/Messaging/Subscription.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace SWLOR.Game.Server.Messaging
+{
+    internal sealed class Subscription
+    {
+        private const long TicksMultiplier = 1000 * TimeSpan.TicksPerMillisecond;
+        private readonly long _throttleByTicks;
+        private double? _lastHandleTimestamp;
+
+        internal Subscription(Type type, Guid token, TimeSpan throttleBy, object handler)
+        {
+            Type = type;
+            Token = token;
+            Handler = handler;
+            _throttleByTicks = throttleBy.Ticks;
+        }
+
+        internal void Handle<T>(T message)
+        {
+            if (!CanHandle()) { return; }
+
+            ((Action<T>)Handler)(message);
+        }
+
+        private bool CanHandle()
+        {
+            if (_throttleByTicks == 0) { return true; }
+
+            if (_lastHandleTimestamp == null)
+            {
+                _lastHandleTimestamp = Stopwatch.GetTimestamp();
+                return true;
+            }
+
+            var now = Stopwatch.GetTimestamp();
+            var durationInTicks = (now - _lastHandleTimestamp) / Stopwatch.Frequency * TicksMultiplier;
+
+            if (durationInTicks >= _throttleByTicks)
+            {
+                _lastHandleTimestamp = now;
+                return true;
+            }
+
+            return false;
+        }
+
+        internal Guid Token { get; }
+        internal Type Type { get; }
+        private object Handler { get; }
+    }
+}

--- a/SWLOR.Game.Server/Messaging/Subscriptions.cs
+++ b/SWLOR.Game.Server/Messaging/Subscriptions.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading;
+
+namespace SWLOR.Game.Server.Messaging
+{
+    [SuppressMessage("ReSharper", "ForCanBeConvertedToForeach")]
+    internal class Subscriptions
+    {
+        private readonly List<Subscription> AllSubscriptions = new List<Subscription>();
+        private int _subscriptionsChangeCounter;
+
+        private readonly ThreadLocal<int> _localSubscriptionRevision =
+            new ThreadLocal<int>(() => 0, true);
+
+        private readonly ThreadLocal<List<Subscription>> _localSubscriptions =
+            new ThreadLocal<List<Subscription>>(() => new List<Subscription>(), true);
+
+        private bool _disposed;
+
+        internal Guid Register<T>(TimeSpan throttleBy, Action<T> action)
+        {
+            var type = typeof(T);
+            var key = Guid.NewGuid();
+            var subscription = new Subscription(type, key, throttleBy, action);
+
+            lock (AllSubscriptions)
+            {
+                AllSubscriptions.Add(subscription);
+                _subscriptionsChangeCounter++;
+            }
+
+            return key;
+        }
+
+        internal void UnRegister(Guid token)
+        {
+            lock (AllSubscriptions)
+            {
+                var idx = AllSubscriptions.FindIndex(s => s.Token == token);
+
+                if (idx < 0) { return; }
+
+                var subscription = AllSubscriptions[idx];
+
+                AllSubscriptions.RemoveAt(idx);
+
+                for (var i = 0; i < _localSubscriptions.Values.Count; i++)
+                {
+                    var threadLocal = _localSubscriptions.Values[i];
+                    var localIdx = threadLocal.IndexOf(subscription);
+                    if (localIdx < 0) { continue; }
+
+                    threadLocal.RemoveAt(localIdx);
+                }
+
+                _subscriptionsChangeCounter++;
+            }
+        }
+
+        internal void Clear(bool dispose)
+        {
+            lock (AllSubscriptions)
+            {
+                if (_disposed) { return; }
+
+                AllSubscriptions.Clear();
+
+                for (var i = 0; i < _localSubscriptions.Values.Count; i++)
+                {
+                    _localSubscriptions.Values[i].Clear();
+                }
+
+                if (dispose)
+                {
+                    _localSubscriptionRevision.Dispose();
+                    _localSubscriptions.Dispose();
+                    _disposed = true;
+                }
+                else
+                {
+                    _subscriptionsChangeCounter++;
+                }
+            }
+        }
+
+        internal bool IsRegistered(Guid token)
+        {
+            lock (AllSubscriptions) { return AllSubscriptions.Any(s => s.Token == token); }
+        }
+
+        internal List<Subscription> GetTheLatestSubscriptions()
+        {
+            var changeCounterLatestCopy = Interlocked.CompareExchange(
+                ref _subscriptionsChangeCounter, 0, 0);
+
+            if (_localSubscriptionRevision.Value == changeCounterLatestCopy)
+            {
+                return _localSubscriptions.Value;
+            }
+
+            List<Subscription> latestSubscriptions;
+            lock (AllSubscriptions)
+            {
+                latestSubscriptions = AllSubscriptions.ToList();
+            }
+
+            _localSubscriptionRevision.Value = changeCounterLatestCopy;
+            _localSubscriptions.Value = latestSubscriptions;
+            return _localSubscriptions.Value;
+        }
+    }
+}

--- a/SWLOR.Game.Server/SWLOR.Game.Server.csproj
+++ b/SWLOR.Game.Server/SWLOR.Game.Server.csproj
@@ -420,6 +420,15 @@
     <Compile Include="Extension\StringExtensions.cs" />
     <Compile Include="Language\TranslatorMirialan.cs" />
     <Compile Include="Language\TranslatorMonCalamarian.cs" />
+    <Compile Include="Messaging\Contracts\IMessageHub.cs" />
+    <Compile Include="Messaging\MessageHub.cs" />
+    <Compile Include="Messaging\Messages\PerkUpgradedMessage.cs" />
+    <Compile Include="Messaging\Messages\PerkRefundedMessage.cs" />
+    <Compile Include="Messaging\Messages\QuestCompletedMessage.cs" />
+    <Compile Include="Messaging\Messages\SkillDecayedMessage.cs" />
+    <Compile Include="Messaging\Messages\SkillGainedMessage.cs" />
+    <Compile Include="Messaging\Subscription.cs" />
+    <Compile Include="Messaging\Subscriptions.cs" />
     <Compile Include="NWNX\ClericDomain.cs" />
     <Compile Include="Enumeration\CommandPermissionType.cs" />
     <Compile Include="Enumeration\ComponentBonusType.cs" />

--- a/SWLOR.Game.Server/Service/Contracts/IPerkService.cs
+++ b/SWLOR.Game.Server/Service/Contracts/IPerkService.cs
@@ -10,6 +10,7 @@ namespace SWLOR.Game.Server.Service.Contracts
 {
     public interface IPerkService
     {
+        void OnModuleEnter();
         void OnModuleItemEquipped();
         void OnModuleItemUnequipped();
         int GetPCPerkLevel(NWPlayer player, PerkType perkType);
@@ -23,5 +24,6 @@ namespace SWLOR.Game.Server.Service.Contracts
         void DoPerkUpgrade(NWPlayer player, int perkID, bool freeUpgrade = false);
         void DoPerkUpgrade(NWPlayer player, PerkType perkType, bool freeUpgrade = false);
         void OnHitCastSpell(NWPlayer oPC);
+        void CacheEffectivePerkLevel(NWPlayer player, int perkID);
     }
 }

--- a/SWLOR.Game.Server/Service/QuestService.cs
+++ b/SWLOR.Game.Server/Service/QuestService.cs
@@ -11,6 +11,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using SWLOR.Game.Server.Data.Entity;
+using SWLOR.Game.Server.Messaging.Contracts;
+using SWLOR.Game.Server.Messaging.Messages;
 using static NWN.NWScript;
 using Quest = SWLOR.Game.Server.Data.Entity.Quest;
 using QuestType = SWLOR.Game.Server.Enumeration.QuestType;
@@ -28,6 +30,7 @@ namespace SWLOR.Game.Server.Service
         private readonly IDialogService _dialog;
         private readonly IColorTokenService _color;
         private readonly IObjectVisibilityService _ovs;
+        private readonly IMessageHub _messageHub;
 
         public QuestService(INWScript script,
             IDataService data,
@@ -35,7 +38,8 @@ namespace SWLOR.Game.Server.Service
             IMapPinService mapPin,
             IDialogService dialog,
             IColorTokenService color,
-            IObjectVisibilityService ovs)
+            IObjectVisibilityService ovs,
+            IMessageHub messageHub)
         {
             _ = script;
             _data = data;
@@ -44,6 +48,7 @@ namespace SWLOR.Game.Server.Service
             _dialog = dialog;
             _color = color;
             _ovs = ovs;
+            _messageHub = messageHub;
         }
 
         public Quest GetQuestByID(int questID)
@@ -154,6 +159,7 @@ namespace SWLOR.Game.Server.Service
                 });
             }
 
+            _messageHub.Publish(new QuestCompletedMessage(player, questID));
         }
 
         public void OnModuleItemAcquired()


### PR DESCRIPTION
Sets up a messaging process for notifying the rest of the app about events. We leverage this to help with caching player effective levels so they're quicker to get.

Also wraps event calls into the profiler so we get more detailed information on the Grafana website.