### PR TITLE
Fix an issue where structure level inventory access permissions in...

### DIFF
--- a/SWLOR.Game.Server/Service/BasePermissionService.cs
+++ b/SWLOR.Game.Server/Service/BasePermissionService.cs
@@ -80,6 +80,12 @@ namespace SWLOR.Game.Server.Service
 
             var dbStructure = _data.GetAll<PCBaseStructure>().Single(x => x.ID == pcBaseStructureID);
 
+            // Check whether this is an item of furniture in a building.  If so, check the building's permissions.
+            if (!String.IsNullOrWhiteSpace(dbStructure.ParentPCBaseStructureID.ToString()))
+            {
+                return HasStructurePermission(player, (Guid)dbStructure.ParentPCBaseStructureID, permission);
+            }
+
             // Public base permissions take priority over all other permissions. Check those first.
             var publicBasePermission = _data.SingleOrDefault<PCBasePermission>(x => x.PCBaseID == dbStructure.PCBaseID &&
                                                                                 x.IsPublicPermission);


### PR DESCRIPTION
…buildings and starships don't work.  This is because we look up permissions using the
furniture item structure ID rather than the building structure ID.