### PR TITLE
Grenades - Attempt to fix: System.InvalidCastException

### DIFF
--- a/SWLOR.Game.Server/Conversation/PlaceStructure.cs
+++ b/SWLOR.Game.Server/Conversation/PlaceStructure.cs
@@ -530,7 +530,7 @@ namespace SWLOR.Game.Server.Conversation
             {
                 if (placementGrid.Key.StartsWith("PLACEMENT_GRID_"))
                 {                    
-                    _.DestroyObject(placementGrid.Value);
+                    _.DelayCommand(10.0f, () => { _.DestroyObject(placementGrid.Value); });
                 }
             }
                 

--- a/SWLOR.Game.Server/Item/Grenade.cs
+++ b/SWLOR.Game.Server/Item/Grenade.cs
@@ -344,6 +344,7 @@ namespace SWLOR.Game.Server.Item
 
         public static void grenadeAoe(NWObject oTarget, string grenadeType)
         {
+            if (oTarget.ObjectType !== ObjectType.Creature) return;
             NWCreature user = GetAreaOfEffectCreator(_.OBJECT_SELF);
             int perkLevel = PerkService.GetCreaturePerkLevel(user, PerkType.GrenadeProficiency);
             int duration = 1;

--- a/SWLOR.Game.Server/Item/Grenade.cs
+++ b/SWLOR.Game.Server/Item/Grenade.cs
@@ -344,7 +344,7 @@ namespace SWLOR.Game.Server.Item
 
         public static void grenadeAoe(NWObject oTarget, string grenadeType)
         {
-            if (oTarget.ObjectType !== ObjectType.Creature) return;
+            if (oTarget.ObjectType != ObjectType.Creature) return;
             NWCreature user = GetAreaOfEffectCreator(_.OBJECT_SELF);
             int perkLevel = PerkService.GetCreaturePerkLevel(user, PerkType.GrenadeProficiency);
             int duration = 1;


### PR DESCRIPTION
Exception type: System.InvalidCastException
Message       : Unable to cast object of type 'SWLOR.Game.Server.GameObject.NWObject' to type 'SWLOR.Game.Server.GameObject.NWCreature'.
Stacktrace:
   at SWLOR.Game.Server.Item.Grenade.grenadeAoe(NWObject oTarget, String grenadeType) in C:\Projects\SWLOR_NWN\SWLOR.Game.Server\Item\Grenade.cs:line 368
   at NWN.Scripts.grenade_incen_hb.Main() in C:\Projects\SWLOR_NWN\SWLOR.Game.Server\Event\Grenade\grenade_incen_hb.cs:line 19