### PR TITLE
fix: envvars in compose 2 need to be in strings if they have spaces

### DIFF
--- a/SWLOR.Game.Server/ServerFiles/Docker/swlor.env
+++ b/SWLOR.Game.Server/ServerFiles/Docker/swlor.env
@@ -2,8 +2,8 @@
 # Star Wars: Legends of the Old Republic
 
 # NWN Environment Variables
-NWN_SERVERNAME=SWLOR Development
-NWN_MODULE=Star Wars LOR
+NWN_SERVERNAME="SWLOR Development"
+NWN_MODULE="Star Wars LOR"
 NWN_PUBLICSERVER=1 
 NWN_MAXCLIENTS=96 
 NWN_MINLEVEL=1 


### PR DESCRIPTION
see: https://stackoverflow.com/questions/69512549/key-cannot-contain-a-space-error-while-running-docker-compose

Fix for issue: #1160 