### PR TITLE
Allow toolset creation of Key-like behavior against tagged doors

### DIFF
--- a/SWLOR.Game.Server/SWLOR.Game.Server.csproj
+++ b/SWLOR.Game.Server/SWLOR.Game.Server.csproj
@@ -47,6 +47,10 @@
     <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Event\Door\" />
+  </ItemGroup>
+
   <Target Name="NWN" AfterTargets="Build">
     <ItemGroup>
       <AllOutputs Include="$(OutputPath)$(MSBuildProjectName).dll" />

--- a/SWLOR.Game.Server/Scripts/Door/OnOpenKeyCheck.cs
+++ b/SWLOR.Game.Server/Scripts/Door/OnOpenKeyCheck.cs
@@ -1,0 +1,57 @@
+﻿using SWLOR.Game.Server.GameObject;
+using SWLOR.Game.Server.NWN.Enum;
+using SWLOR.Game.Server.NWN.Enum.Item;
+using SWLOR.Game.Server.Service;
+using System.Linq;
+using static SWLOR.Game.Server.NWN._;
+
+namespace SWLOR.Game.Server.Scripts.Door
+{
+    public class OnOpenKeyCheck : IScript
+    {
+        public void SubscribeEvents()
+        {
+        }
+
+        public void UnsubscribeEvents()
+        {
+        }
+
+        public void Main()
+        {
+            NWPlayer player = GetLastOpenedBy();
+            var door = OBJECT_SELF;
+            var keyTag = GetLocalString(door, "REQ_KEY_TAG");
+            int highestMatchingKeyTier = 0;
+
+            if (!string.IsNullOrEmpty(keyTag))
+            {
+                var key = player.InventoryItems.ToList().Find(i => i.Tag == keyTag);
+                if (key != null)
+                {
+                    highestMatchingKeyTier = key.ItemProperties.ToList().Aggregate(0, (currentHighest, iprop) => 
+                    {
+                        var propTypeID = GetItemPropertyType(iprop);
+                        if (propTypeID == ItemPropertyType.ACBonus)
+                        {
+                            var keyTier = GetItemPropertyCostTableValue(iprop);
+                            return keyTier > currentHighest ? keyTier : currentHighest;
+                        }
+
+                        return currentHighest;
+                    });    
+                }
+            }
+
+            var expectedKeyTier = GetLocalInt(door, "REQ_KEY_TIER");
+
+            // if user not allowed, close the door and optionally send a message
+            if (highestMatchingKeyTier < expectedKeyTier)
+            {
+                ActionCloseDoor(door);
+                var msg = GetLocalString(door, "REQ_KEY_FAIL_MSG");
+                if (!string.IsNullOrEmpty(msg)) SpeakString(msg);
+            }
+        }
+    }
+}

--- a/SWLOR.Game.Server/Scripts/Door/OnOpenKeyCheck.cs
+++ b/SWLOR.Game.Server/Scripts/Door/OnOpenKeyCheck.cs
@@ -26,19 +26,13 @@ namespace SWLOR.Game.Server.Scripts.Door
 
             if (!string.IsNullOrEmpty(keyTag))
             {
-                var key = player.InventoryItems.ToList().Find(i => i.Tag == keyTag);
-                if (key != null)
+                var keys = player.InventoryItems.ToList().FindAll(i => i.Tag == keyTag);
+                if (keys.Count > 0)
                 {
-                    highestMatchingKeyTier = key.ItemProperties.ToList().Aggregate(0, (currentHighest, iprop) => 
+                    highestMatchingKeyTier = keys.Aggregate(0, (currentHighest, key) => 
                     {
-                        var propTypeID = GetItemPropertyType(iprop);
-                        if (propTypeID == ItemPropertyType.ACBonus)
-                        {
-                            var keyTier = GetItemPropertyCostTableValue(iprop);
-                            return keyTier > currentHighest ? keyTier : currentHighest;
-                        }
-
-                        return currentHighest;
+                        var tier = GetLocalInt(key, "TIER");
+                        return tier > currentHighest ? tier : currentHighest;
                     });    
                 }
             }


### PR DESCRIPTION
### Door

| Variable | Type | Required | Purpose |
| -------- | ----  | --------- | -------- |
| REQ_KEY_TAG | string | x | Sets the item key to check in opening player's inventory |
| REQ_KEY_TIER | int | x | Sets the tier the item key must match or exceed to open |
| REQ_KEY_FAIL_MSG | string |  | Optionally emits a message if the opening player is denied access |


### Key Item

Should have a Tag that matches the REQ_KEY_TAG of any door that it should open.

EG for the Jedi Temple, this may be called `JEDI_KEY` in both the Door Variable and Key Tag

Also has a variable:

| Variable | Type | Required | Purpose |
| -------- | ----  | --------- | -------- |
| TIER | int| x | The value the OnOpen event checks when verifying whether the user can open a door |

If the TAG matches, the door will then check against the TIER.  If the TIER >= the REQ_KEY_TIER, then the door will open.


### Relationship
| Door | Key (an NWN Item) |
| ----- | -------------------- |
| var: REQ_KEY_TAG | tag |
| var: REQ_KEY_TIER | var: TIER |

