### PR TITLE
Comment out area instance deletion

### DIFF
--- a/SWLOR.Game.Server/Conversation/ApartmentEntrance.cs
+++ b/SWLOR.Game.Server/Conversation/ApartmentEntrance.cs
@@ -141,7 +141,7 @@ namespace SWLOR.Game.Server.Conversation
                     player = (_.GetNextPC());
                 }
 
-                AreaService.DestroyAreaInstance(area);
+                //AreaService.DestroyAreaInstance(area);
             });
 
 

--- a/SWLOR.Game.Server/Scripts/Area/ExitAreaInstance.cs
+++ b/SWLOR.Game.Server/Scripts/Area/ExitAreaInstance.cs
@@ -29,7 +29,7 @@ namespace SWLOR.Game.Server.Scripts.Area
                 int playerCount = NWModule.Get().Players.Count(x => !Equals(x, player) && Equals(x.Area, door.Area));
                 if (playerCount <= 0)
                 {
-                    AreaService.DestroyAreaInstance(door.Area);
+                    //AreaService.DestroyAreaInstance(door.Area);
                 }
             });
 

--- a/SWLOR.Game.Server/Scripts/Placeable/Quests/AbandonedStation/ShuttleExit.cs
+++ b/SWLOR.Game.Server/Scripts/Placeable/Quests/AbandonedStation/ShuttleExit.cs
@@ -41,9 +41,9 @@ namespace SWLOR.Game.Server.Scripts.Placeable.Quests.AbandonedStation
             if (playersInAreas > 0) return;
 
             // Otherwise, everyone has left. Do the cleanup now.
-            AreaService.DestroyAreaInstance(mainLevel);
-            AreaService.DestroyAreaInstance(restrictedLevel);
-            AreaService.DestroyAreaInstance(directorsChambers);
+            //AreaService.DestroyAreaInstance(mainLevel);
+            //AreaService.DestroyAreaInstance(restrictedLevel);
+            //AreaService.DestroyAreaInstance(directorsChambers);
         }
     }
 }

--- a/SWLOR.Game.Server/Service/BaseService.cs
+++ b/SWLOR.Game.Server/Service/BaseService.cs
@@ -1227,7 +1227,7 @@ namespace SWLOR.Game.Server.Service
                     player = (_.GetNextPC());
                 }
 
-                AreaService.DestroyAreaInstance(area);
+                //AreaService.DestroyAreaInstance(area);
             });
         }
 

--- a/SWLOR.Game.Server/Service/DeathService.cs
+++ b/SWLOR.Game.Server/Service/DeathService.cs
@@ -69,18 +69,18 @@ namespace SWLOR.Game.Server.Service
             TeleportPlayerToBindPoint(oPC);
 
             // If player is the last person in an instance, destroy the instance.
-            if (area.IsInstance)
-            {
-                int playersInArea = NWModule.Get().Players.Count(x => x.Area == oPC.Area && x != oPC);
+            //if (area.IsInstance)
+            //{
+            //    int playersInArea = NWModule.Get().Players.Count(x => x.Area == oPC.Area && x != oPC);
 
-                if (playersInArea <= 0)
-                {
-                    _.DelayCommand(12.0f, () =>
-                    {
-                        AreaService.DestroyAreaInstance(area);
-                    }); 
-                }
-            }
+            //    if (playersInArea <= 0)
+            //    {
+            //        _.DelayCommand(12.0f, () =>
+            //        {
+            //            AreaService.DestroyAreaInstance(area);
+            //        }); 
+            //    }
+            //}
         }
         
 


### PR DESCRIPTION
Comment out area instance deletion to work around a potential cause of crashes.

The idea here is to leave the instances in memory and never clear them out (shouldn't be too big of a deal, we have several gigs free)