### PR TITLE
AOO - Auto miss if busy

### DIFF
--- a/SWLOR.Game.Server/Native/ResolveAttackRoll.cs
+++ b/SWLOR.Game.Server/Native/ResolveAttackRoll.cs
@@ -72,6 +72,8 @@ namespace SWLOR.Game.Server.Native
             {
                 pAttackData.m_nAttackResult = 4; // Automatic miss while busy.
                 pAttackData.m_nMissedBy = 1;
+                pAttackData.m_nToHitRoll = 1;
+                pAttackData.m_nToHitMod = 0;
                 return;
             }
 

--- a/SWLOR.Game.Server/Native/ResolveAttackRoll.cs
+++ b/SWLOR.Game.Server/Native/ResolveAttackRoll.cs
@@ -65,6 +65,16 @@ namespace SWLOR.Game.Server.Native
             Log.Write(LogGroup.Attack, "Attacker: " + attacker.GetFirstName().GetSimple(0) + ", defender " + targetObject.GetFirstName().GetSimple(0));
 
             var pAttackData = pCombatRound.GetAttack(pCombatRound.m_nCurrentAttack);
+
+            // Attacks of opportunity - If player is busy with another action, cancel the attack.
+            if (pAttackData.m_nAttackType == 65002 &&
+                attacker.m_ScriptVars.GetInt(new CExoString("IS_BUSY")) == 1)
+            {
+                pAttackData.m_nAttackResult = 4; // Automatic miss while busy.
+                pAttackData.m_nMissedBy = 1;
+                return;
+            }
+
             var isOffhandAttack = (int)pAttackData.m_nWeaponAttackType == 2;
 
             if (targetObject.m_nObjectType != (int)ObjectType.Creature)


### PR DESCRIPTION
Add section to attack roll to automatically miss if player has an attack of opportunity while busy with another action.

@Mithreas - I wasn't super confident this will address your bug report about using a med kit and getting an AOO. We have a busy flag assigned to the player when they perform an action (refer to Activity service for more info). If the player has this flag and they're performing an AOO, I've set it to automatically miss.

Let me know your thoughts on that as well as the implementation.