### PR TITLE
Creature updates

### DIFF
--- a/Module/utc/byysk_warrior.utc.json
+++ b/Module/utc/byysk_warrior.utc.json
@@ -14,7 +14,7 @@
   },
   "ChallengeRating": {
     "type": "float",
-    "value": 12.0
+    "value": 11.0
   },
   "ClassList": {
     "type": "list",
@@ -38,7 +38,7 @@
   },
   "Con": {
     "type": "byte",
-    "value": 18
+    "value": 20
   },
   "Conversation": {
     "type": "resref",
@@ -63,12 +63,12 @@
   "Description": {
     "type": "cexolocstring",
     "value": {
-      "0": ""
+      "0": "Fiercely territorial, the Byysk tribal peoples tend to keep to themselves... but react poorly to intruders."
     }
   },
   "Dex": {
     "type": "byte",
-    "value": 40
+    "value": 18
   },
   "Disarmable": {
     "type": "byte",
@@ -92,17 +92,10 @@
         }
       },
       {
-        "__struct_id": 16384,
-        "EquippedRes": {
-          "type": "resref",
-          "value": "nw_it_crewpsp015"
-        }
-      },
-      {
         "__struct_id": 131072,
         "EquippedRes": {
           "type": "resref",
-          "value": "mc_amphihy_hide"
+          "value": "hu_byysk_hide"
         }
       }
     ]
@@ -146,7 +139,35 @@
         "__struct_id": 1,
         "Feat": {
           "type": "word",
+          "value": 1151
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1152
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1153
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
           "value": 41
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1140
         }
       },
       {
@@ -226,11 +247,11 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 161
+    "value": 170
   },
   "NaturalAC": {
     "type": "byte",
-    "value": 8
+    "value": 0
   },
   "NoPermDeath": {
     "type": "byte",
@@ -607,7 +628,7 @@
   },
   "Str": {
     "type": "byte",
-    "value": 34
+    "value": 26
   },
   "Subrace": {
     "type": "cexostring",
@@ -678,6 +699,6 @@
   },
   "Wis": {
     "type": "byte",
-    "value": 18
+    "value": 16
   }
 }

--- a/Module/utc/byysk_warrior2.utc.json
+++ b/Module/utc/byysk_warrior2.utc.json
@@ -14,7 +14,7 @@
   },
   "ChallengeRating": {
     "type": "float",
-    "value": 11.0
+    "value": 10.0
   },
   "ClassList": {
     "type": "list",
@@ -38,7 +38,7 @@
   },
   "Con": {
     "type": "byte",
-    "value": 22
+    "value": 20
   },
   "Conversation": {
     "type": "resref",
@@ -63,12 +63,12 @@
   "Description": {
     "type": "cexolocstring",
     "value": {
-      "0": ""
+      "0": "Fiercely territorial, the Byysk tribal peoples tend to keep to themselves... but react poorly to intruders."
     }
   },
   "Dex": {
     "type": "byte",
-    "value": 20
+    "value": 26
   },
   "Disarmable": {
     "type": "byte",
@@ -78,17 +78,17 @@
     "type": "list",
     "value": [
       {
-        "__struct_id": 16384,
+        "__struct_id": 16,
         "EquippedRes": {
           "type": "resref",
-          "value": "nw_it_crewpsp015"
+          "value": "proto_pistol"
         }
       },
       {
         "__struct_id": 131072,
         "EquippedRes": {
           "type": "resref",
-          "value": "mc_amphihy_hide"
+          "value": "hu_byysk_hide"
         }
       }
     ]
@@ -111,21 +111,70 @@
         "__struct_id": 1,
         "Feat": {
           "type": "word",
-          "value": 72
+          "value": 1296
         }
       },
       {
         "__struct_id": 1,
         "Feat": {
           "type": "word",
-          "value": 954
+          "value": 1297
         }
       },
       {
         "__struct_id": 1,
         "Feat": {
           "type": "word",
-          "value": 73
+          "value": 1284
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1290
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1285
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1286
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1287
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1288
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1293
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1294
         }
       },
       {
@@ -139,7 +188,7 @@
         "__struct_id": 1,
         "Feat": {
           "type": "word",
-          "value": 103
+          "value": 1282
         }
       },
       {
@@ -212,11 +261,11 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 176
+    "value": 167
   },
   "NaturalAC": {
     "type": "byte",
-    "value": 10
+    "value": 0
   },
   "NoPermDeath": {
     "type": "byte",
@@ -593,7 +642,7 @@
   },
   "Str": {
     "type": "byte",
-    "value": 30
+    "value": 16
   },
   "Subrace": {
     "type": "cexostring",
@@ -664,6 +713,6 @@
   },
   "Wis": {
     "type": "byte",
-    "value": 11
+    "value": 18
   }
 }

--- a/Module/utc/crycrazewarocas.utc.json
+++ b/Module/utc/crycrazewarocas.utc.json
@@ -102,6 +102,13 @@
         "__struct_id": 1,
         "Feat": {
           "type": "word",
+          "value": 1751
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
           "value": 289
         }
       }

--- a/Module/utc/crystalspider.utc.json
+++ b/Module/utc/crystalspider.utc.json
@@ -63,7 +63,7 @@
   "Description": {
     "type": "cexolocstring",
     "value": {
-      "0": "\nCrystal spiders are arachnids that inhabit the abandoned ore mines of Viscara. They live in complete darkness inside the mine's caves spinning webs around the crystals, made of glitterstim. The spiders shoot webbing from their mouths to capture prey, impale them and then quickly suck the life energy from them. "
+      "0": "\nCrystal spiders are arachnids that inhabit the abandoned ore mines of Viscara. They live in complete darkness inside the mine's caves spinning webs around the crystals, made of glitterstim. The spiders shoot webbing from their mouths to capture prey, impale them and then quickly suck the life energy from them."
     }
   },
   "Dex": {
@@ -105,6 +105,20 @@
         "Feat": {
           "type": "word",
           "value": 332
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1350
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1364
         }
       },
       {
@@ -182,7 +196,7 @@
   },
   "PaletteID": {
     "type": "byte",
-    "value": 11
+    "value": 151
   },
   "PerceptionRange": {
     "type": "byte",
@@ -467,23 +481,7 @@
   },
   "SpecAbilityList": {
     "type": "list",
-    "value": [
-      {
-        "__struct_id": 4,
-        "Spell": {
-          "type": "word",
-          "value": 192
-        },
-        "SpellCasterLevel": {
-          "type": "byte",
-          "value": 14
-        },
-        "SpellFlags": {
-          "type": "byte",
-          "value": 1
-        }
-      }
-    ]
+    "value": []
   },
   "StartingPackage": {
     "type": "byte",
@@ -491,7 +489,7 @@
   },
   "Str": {
     "type": "byte",
-    "value": 20
+    "value": 18
   },
   "Subrace": {
     "type": "cexostring",

--- a/Module/utc/ecoterr_1.utc.json
+++ b/Module/utc/ecoterr_1.utc.json
@@ -86,7 +86,7 @@
   },
   "Cha": {
     "type": "byte",
-    "value": 20
+    "value": 16
   },
   "ChallengeRating": {
     "type": "float",
@@ -130,7 +130,7 @@
   },
   "Con": {
     "type": "byte",
-    "value": 26
+    "value": 20
   },
   "Conversation": {
     "type": "resref",
@@ -160,7 +160,7 @@
   },
   "Dex": {
     "type": "byte",
-    "value": 32
+    "value": 22
   },
   "Disarmable": {
     "type": "byte",
@@ -174,6 +174,20 @@
         "EquippedRes": {
           "type": "resref",
           "value": "npc_ecot_3"
+        }
+      },
+      {
+        "__struct_id": 16,
+        "EquippedRes": {
+          "type": "resref",
+          "value": "del_rifle"
+        }
+      },
+      {
+        "__struct_id": 131072,
+        "EquippedRes": {
+          "type": "resref",
+          "value": "ecoter_hide"
         }
       }
     ]
@@ -217,6 +231,20 @@
         "__struct_id": 1,
         "Feat": {
           "type": "word",
+          "value": 1347
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1348
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
           "value": 332
         }
       },
@@ -231,34 +259,6 @@
         "__struct_id": 1,
         "Feat": {
           "type": "word",
-          "value": 543
-        }
-      },
-      {
-        "__struct_id": 1,
-        "Feat": {
-          "type": "word",
-          "value": 563
-        }
-      },
-      {
-        "__struct_id": 1,
-        "Feat": {
-          "type": "word",
-          "value": 553
-        }
-      },
-      {
-        "__struct_id": 1,
-        "Feat": {
-          "type": "word",
-          "value": 573
-        }
-      },
-      {
-        "__struct_id": 1,
-        "Feat": {
-          "type": "word",
           "value": 26
         }
       },
@@ -266,7 +266,28 @@
         "__struct_id": 1,
         "Feat": {
           "type": "word",
-          "value": 345
+          "value": 1341
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1336
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1337
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1338
         }
       },
       {
@@ -339,11 +360,11 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 136
+    "value": 106
   },
   "NaturalAC": {
     "type": "byte",
-    "value": 1
+    "value": 0
   },
   "NoPermDeath": {
     "type": "byte",
@@ -715,6 +736,6 @@
   },
   "Wis": {
     "type": "byte",
-    "value": 20
+    "value": 18
   }
 }

--- a/Module/utc/ecoterr_2.utc.json
+++ b/Module/utc/ecoterr_2.utc.json
@@ -639,7 +639,7 @@
   },
   "SoundSetFile": {
     "type": "word",
-    "value": 367
+    "value": 435
   },
   "SpecAbilityList": {
     "type": "list",

--- a/Module/utc/ecoterr_ldr.utc.json
+++ b/Module/utc/ecoterr_ldr.utc.json
@@ -86,11 +86,11 @@
   },
   "Cha": {
     "type": "byte",
-    "value": 40
+    "value": 20
   },
   "ChallengeRating": {
     "type": "float",
-    "value": 10.0
+    "value": 9.0
   },
   "ClassList": {
     "type": "list",
@@ -130,7 +130,7 @@
   },
   "Con": {
     "type": "byte",
-    "value": 26
+    "value": 22
   },
   "Conversation": {
     "type": "resref",
@@ -160,7 +160,7 @@
   },
   "Dex": {
     "type": "byte",
-    "value": 46
+    "value": 24
   },
   "Disarmable": {
     "type": "byte",
@@ -174,6 +174,13 @@
         "EquippedRes": {
           "type": "resref",
           "value": "npc_ecot_2"
+        }
+      },
+      {
+        "__struct_id": 16,
+        "EquippedRes": {
+          "type": "resref",
+          "value": "del_shuriken"
         }
       }
     ]
@@ -231,28 +238,14 @@
         "__struct_id": 1,
         "Feat": {
           "type": "word",
-          "value": 543
+          "value": 1310
         }
       },
       {
         "__struct_id": 1,
         "Feat": {
           "type": "word",
-          "value": 563
-        }
-      },
-      {
-        "__struct_id": 1,
-        "Feat": {
-          "type": "word",
-          "value": 553
-        }
-      },
-      {
-        "__struct_id": 1,
-        "Feat": {
-          "type": "word",
-          "value": 573
+          "value": 1311
         }
       },
       {
@@ -280,7 +273,28 @@
         "__struct_id": 1,
         "Feat": {
           "type": "word",
-          "value": 345
+          "value": 1307
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1302
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1303
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1304
         }
       },
       {
@@ -302,7 +316,7 @@
   "FirstName": {
     "type": "cexolocstring",
     "value": {
-      "0": "Eco Terrorist"
+      "0": "Eco Terrorist Leader"
     }
   },
   "fortbonus": {
@@ -323,7 +337,7 @@
   },
   "Int": {
     "type": "byte",
-    "value": 40
+    "value": 20
   },
   "Interruptable": {
     "type": "byte",
@@ -336,6 +350,41 @@
   "IsPC": {
     "type": "byte",
     "value": 0
+  },
+  "ItemList": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "InventoryRes": {
+          "type": "resref",
+          "value": "grenade_frag004"
+        },
+        "Repos_PosX": {
+          "type": "word",
+          "value": 0
+        },
+        "Repos_Posy": {
+          "type": "word",
+          "value": 0
+        }
+      },
+      {
+        "__struct_id": 1,
+        "InventoryRes": {
+          "type": "resref",
+          "value": "grenade_frag004"
+        },
+        "Repos_PosX": {
+          "type": "word",
+          "value": 1
+        },
+        "Repos_Posy": {
+          "type": "word",
+          "value": 0
+        }
+      }
+    ]
   },
   "LastName": {
     "type": "cexolocstring",
@@ -353,7 +402,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 170
+    "value": 146
   },
   "NaturalAC": {
     "type": "byte",
@@ -658,7 +707,7 @@
   },
   "Str": {
     "type": "byte",
-    "value": 17
+    "value": 18
   },
   "Subrace": {
     "type": "cexostring",
@@ -729,6 +778,6 @@
   },
   "Wis": {
     "type": "byte",
-    "value": 40
+    "value": 20
   }
 }

--- a/Module/utc/ext_tusken_tr003.utc.json
+++ b/Module/utc/ext_tusken_tr003.utc.json
@@ -90,7 +90,7 @@
   },
   "ChallengeRating": {
     "type": "float",
-    "value": 15.0
+    "value": 14.0
   },
   "ClassList": {
     "type": "list",
@@ -141,7 +141,7 @@
   },
   "Con": {
     "type": "byte",
-    "value": 14
+    "value": 17
   },
   "Conversation": {
     "type": "resref",
@@ -169,7 +169,7 @@
   },
   "Dex": {
     "type": "byte",
-    "value": 60
+    "value": 29
   },
   "Disarmable": {
     "type": "byte",
@@ -197,6 +197,13 @@
         "EquippedRes": {
           "type": "resref",
           "value": "tuskenblasterrif"
+        }
+      },
+      {
+        "__struct_id": 131072,
+        "EquippedRes": {
+          "type": "resref",
+          "value": "tusken_skin"
         }
       }
     ]
@@ -227,6 +234,13 @@
         "Feat": {
           "type": "word",
           "value": 4
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1155
         }
       },
       {
@@ -276,13 +290,6 @@
         "Feat": {
           "type": "word",
           "value": 721
-        }
-      },
-      {
-        "__struct_id": 1,
-        "Feat": {
-          "type": "word",
-          "value": 1155
         }
       },
       {
@@ -433,7 +440,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 372
+    "value": 394
   },
   "NaturalAC": {
     "type": "byte",
@@ -445,7 +452,7 @@
   },
   "PaletteID": {
     "type": "byte",
-    "value": 4
+    "value": 154
   },
   "PerceptionRange": {
     "type": "byte",
@@ -513,7 +520,7 @@
   },
   "ScriptSpawn": {
     "type": "resref",
-    "value": "dt_tusken_spawn"
+    "value": "x2_def_spawn"
   },
   "ScriptSpellAt": {
     "type": "resref",
@@ -738,7 +745,7 @@
   },
   "Str": {
     "type": "byte",
-    "value": 13
+    "value": 14
   },
   "Subrace": {
     "type": "cexostring",

--- a/Module/utc/forest_king.utc.json
+++ b/Module/utc/forest_king.utc.json
@@ -14,7 +14,7 @@
   },
   "ChallengeRating": {
     "type": "float",
-    "value": 0.125
+    "value": 50.0
   },
   "ClassList": {
     "type": "list",
@@ -27,7 +27,7 @@
         },
         "ClassLevel": {
           "type": "short",
-          "value": 11
+          "value": 15
         }
       }
     ]
@@ -38,7 +38,7 @@
   },
   "Con": {
     "type": "byte",
-    "value": 15
+    "value": 30
   },
   "Conversation": {
     "type": "resref",
@@ -46,7 +46,7 @@
   },
   "CRAdjust": {
     "type": "int",
-    "value": -72
+    "value": -19
   },
   "CurrentHitPoints": {
     "type": "short",
@@ -62,7 +62,9 @@
   },
   "Description": {
     "type": "cexolocstring",
-    "value": {}
+    "value": {
+      "0": "Run.  Run now."
+    }
   },
   "Dex": {
     "type": "byte",
@@ -80,6 +82,13 @@
         "EquippedRes": {
           "type": "resref",
           "value": "vellenking_0001"
+        }
+      },
+      {
+        "__struct_id": 131072,
+        "EquippedRes": {
+          "type": "resref",
+          "value": "v_kraptor_skin"
         }
       }
     ]
@@ -138,7 +147,7 @@
   "FirstName": {
     "type": "cexolocstring",
     "value": {
-      "0": "Vellen King"
+      "0": "Vellen King Raptor"
     }
   },
   "fortbonus": {
@@ -189,11 +198,11 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1522
+    "value": 1650
   },
   "NaturalAC": {
     "type": "byte",
-    "value": 14
+    "value": 0
   },
   "NoPermDeath": {
     "type": "byte",
@@ -795,7 +804,7 @@
   },
   "Str": {
     "type": "byte",
-    "value": 50
+    "value": 30
   },
   "Subrace": {
     "type": "cexostring",
@@ -831,6 +840,6 @@
   },
   "Wis": {
     "type": "byte",
-    "value": 10
+    "value": 20
   }
 }

--- a/Module/utc/looter_1.utc.json
+++ b/Module/utc/looter_1.utc.json
@@ -90,7 +90,7 @@
   },
   "ChallengeRating": {
     "type": "float",
-    "value": 3.0
+    "value": 2.0
   },
   "ClassList": {
     "type": "list",
@@ -130,7 +130,7 @@
   },
   "Con": {
     "type": "byte",
-    "value": 12
+    "value": 11
   },
   "Conversation": {
     "type": "resref",
@@ -142,7 +142,7 @@
   },
   "CurrentHitPoints": {
     "type": "short",
-    "value": 44
+    "value": 36
   },
   "DecayTime": {
     "type": "dword",
@@ -160,7 +160,7 @@
   },
   "Dex": {
     "type": "byte",
-    "value": 20
+    "value": 17
   },
   "Disarmable": {
     "type": "byte",
@@ -180,7 +180,14 @@
         "__struct_id": 16,
         "EquippedRes": {
           "type": "resref",
-          "value": "rifle_npc"
+          "value": "b_rifle"
+        }
+      },
+      {
+        "__struct_id": 131072,
+        "EquippedRes": {
+          "type": "resref",
+          "value": "ww_outlaw_skin"
         }
       }
     ]
@@ -291,7 +298,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 44
+    "value": 36
   },
   "Int": {
     "type": "byte",
@@ -325,7 +332,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 48
+    "value": 40
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/looter_2.utc.json
+++ b/Module/utc/looter_2.utc.json
@@ -130,7 +130,7 @@
   },
   "Con": {
     "type": "byte",
-    "value": 12
+    "value": 13
   },
   "Conversation": {
     "type": "resref",
@@ -160,7 +160,7 @@
   },
   "Dex": {
     "type": "byte",
-    "value": 20
+    "value": 17
   },
   "Disarmable": {
     "type": "byte",
@@ -180,7 +180,14 @@
         "__struct_id": 16,
         "EquippedRes": {
           "type": "resref",
-          "value": "rifle_npc"
+          "value": "b_pistol"
+        }
+      },
+      {
+        "__struct_id": 131072,
+        "EquippedRes": {
+          "type": "resref",
+          "value": "ww_outlaw_skin"
         }
       }
     ]
@@ -325,7 +332,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 47
+    "value": 51
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/malsecdroid.utc.json
+++ b/Module/utc/malsecdroid.utc.json
@@ -50,7 +50,7 @@
   },
   "CurrentHitPoints": {
     "type": "short",
-    "value": 16
+    "value": 20
   },
   "DecayTime": {
     "type": "dword",
@@ -134,7 +134,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 16
+    "value": 20
   },
   "Int": {
     "type": "byte",
@@ -168,7 +168,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 20
+    "value": 24
   },
   "NaturalAC": {
     "type": "byte",
@@ -473,7 +473,7 @@
   },
   "Str": {
     "type": "byte",
-    "value": 12
+    "value": 10
   },
   "Subrace": {
     "type": "cexostring",
@@ -544,6 +544,6 @@
   },
   "Wis": {
     "type": "byte",
-    "value": 11
+    "value": 10
   }
 }

--- a/Module/utc/malspiderdroid.utc.json
+++ b/Module/utc/malspiderdroid.utc.json
@@ -473,7 +473,7 @@
   },
   "Str": {
     "type": "byte",
-    "value": 12
+    "value": 10
   },
   "Subrace": {
     "type": "cexostring",

--- a/Module/utc/man_leader.utc.json
+++ b/Module/utc/man_leader.utc.json
@@ -130,7 +130,7 @@
   },
   "Con": {
     "type": "byte",
-    "value": 16
+    "value": 22
   },
   "Conversation": {
     "type": "resref",
@@ -155,12 +155,12 @@
   "Description": {
     "type": "cexolocstring",
     "value": {
-      "0": "This man has been chosen out of a large clan of rogue Mandalorians to lead them as their own de-facto Mandalore.. He is well armed, confident, and incredible lethal with his blade."
+      "0": "This man has been chosen out of a large clan of rogue Mandalorians to lead them as their own de-facto Mandalore.. He is well armed, confident, and incredibly lethal with his twin blades."
     }
   },
   "Dex": {
     "type": "byte",
-    "value": 12
+    "value": 13
   },
   "Disarmable": {
     "type": "byte",
@@ -181,6 +181,20 @@
         "EquippedRes": {
           "type": "resref",
           "value": "man_larmor_npc"
+        }
+      },
+      {
+        "__struct_id": 16,
+        "EquippedRes": {
+          "type": "resref",
+          "value": "tit_twinblade"
+        }
+      },
+      {
+        "__struct_id": 131072,
+        "EquippedRes": {
+          "type": "resref",
+          "value": "mando_hero_skin"
         }
       }
     ]
@@ -217,7 +231,21 @@
         "__struct_id": 1,
         "Feat": {
           "type": "word",
+          "value": 1222
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
           "value": 10
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1219
         }
       },
       {
@@ -252,7 +280,35 @@
         "__struct_id": 1,
         "Feat": {
           "type": "word",
-          "value": 106
+          "value": 1216
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1211
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1212
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1208
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 44
         }
       },
       {
@@ -267,6 +323,13 @@
         "Feat": {
           "type": "word",
           "value": 46
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1209
         }
       }
     ]
@@ -325,11 +388,11 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 300
+    "value": 303
   },
   "NaturalAC": {
     "type": "byte",
-    "value": 7
+    "value": 1
   },
   "NoPermDeath": {
     "type": "byte",
@@ -706,7 +769,7 @@
   },
   "Str": {
     "type": "byte",
-    "value": 30
+    "value": 22
   },
   "Subrace": {
     "type": "cexostring",
@@ -792,6 +855,6 @@
   },
   "Wis": {
     "type": "byte",
-    "value": 10
+    "value": 12
   }
 }

--- a/Module/utc/man_ranger_1.utc.json
+++ b/Module/utc/man_ranger_1.utc.json
@@ -130,7 +130,7 @@
   },
   "Con": {
     "type": "byte",
-    "value": 18
+    "value": 17
   },
   "Conversation": {
     "type": "resref",
@@ -160,7 +160,7 @@
   },
   "Dex": {
     "type": "byte",
-    "value": 22
+    "value": 21
   },
   "Disarmable": {
     "type": "byte",
@@ -187,7 +187,14 @@
         "__struct_id": 16,
         "EquippedRes": {
           "type": "resref",
-          "value": "npc_man_rifle"
+          "value": "tit_rifle"
+        }
+      },
+      {
+        "__struct_id": 131072,
+        "EquippedRes": {
+          "type": "resref",
+          "value": "mando_rgr_skin"
         }
       }
     ]
@@ -224,6 +231,13 @@
         "__struct_id": 1,
         "Feat": {
           "type": "word",
+          "value": 1347
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
           "value": 10
         }
       },
@@ -246,6 +260,20 @@
         "Feat": {
           "type": "word",
           "value": 258
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1336
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1337
         }
       },
       {

--- a/Module/utc/man_ranger_2.utc.json
+++ b/Module/utc/man_ranger_2.utc.json
@@ -187,7 +187,14 @@
         "__struct_id": 16,
         "EquippedRes": {
           "type": "resref",
-          "value": "npc_man_rifle"
+          "value": "tit_rifle"
+        }
+      },
+      {
+        "__struct_id": 131072,
+        "EquippedRes": {
+          "type": "resref",
+          "value": "mando_rgr_skin"
         }
       }
     ]
@@ -224,6 +231,13 @@
         "__struct_id": 1,
         "Feat": {
           "type": "word",
+          "value": 1347
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
           "value": 10
         }
       },
@@ -246,6 +260,20 @@
         "Feat": {
           "type": "word",
           "value": 258
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1336
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1337
         }
       },
       {

--- a/Module/utc/man_warrior_1.utc.json
+++ b/Module/utc/man_warrior_1.utc.json
@@ -130,7 +130,7 @@
   },
   "Con": {
     "type": "byte",
-    "value": 24
+    "value": 19
   },
   "Conversation": {
     "type": "resref",
@@ -160,7 +160,7 @@
   },
   "Dex": {
     "type": "byte",
-    "value": 20
+    "value": 17
   },
   "Disarmable": {
     "type": "byte",
@@ -181,6 +181,20 @@
         "EquippedRes": {
           "type": "resref",
           "value": "man_armor_npc"
+        }
+      },
+      {
+        "__struct_id": 16,
+        "EquippedRes": {
+          "type": "resref",
+          "value": "tit_longsword"
+        }
+      },
+      {
+        "__struct_id": 131072,
+        "EquippedRes": {
+          "type": "resref",
+          "value": "mando_war_skin"
         }
       }
     ]
@@ -224,6 +238,13 @@
         "__struct_id": 1,
         "Feat": {
           "type": "word",
+          "value": 1134
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
           "value": 1089
         }
       },
@@ -246,6 +267,20 @@
         "Feat": {
           "type": "word",
           "value": 32
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1126
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1127
         }
       },
       {
@@ -325,7 +360,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 135
+    "value": 125
   },
   "NaturalAC": {
     "type": "byte",
@@ -646,7 +681,7 @@
   },
   "Str": {
     "type": "byte",
-    "value": 22
+    "value": 18
   },
   "Subrace": {
     "type": "cexostring",

--- a/Module/utc/man_warrior_2.utc.json
+++ b/Module/utc/man_warrior_2.utc.json
@@ -90,7 +90,7 @@
   },
   "ChallengeRating": {
     "type": "float",
-    "value": 4.0
+    "value": 5.0
   },
   "ClassList": {
     "type": "list",
@@ -130,7 +130,7 @@
   },
   "Con": {
     "type": "byte",
-    "value": 24
+    "value": 19
   },
   "Conversation": {
     "type": "resref",
@@ -142,7 +142,7 @@
   },
   "CurrentHitPoints": {
     "type": "short",
-    "value": 100
+    "value": 120
   },
   "DecayTime": {
     "type": "dword",
@@ -160,7 +160,7 @@
   },
   "Dex": {
     "type": "byte",
-    "value": 18
+    "value": 15
   },
   "Disarmable": {
     "type": "byte",
@@ -181,6 +181,20 @@
         "EquippedRes": {
           "type": "resref",
           "value": "man_armor_npc"
+        }
+      },
+      {
+        "__struct_id": 16,
+        "EquippedRes": {
+          "type": "resref",
+          "value": "tit_longsword"
+        }
+      },
+      {
+        "__struct_id": 131072,
+        "EquippedRes": {
+          "type": "resref",
+          "value": "mando_war_skin"
         }
       }
     ]
@@ -245,7 +259,28 @@
         "__struct_id": 1,
         "Feat": {
           "type": "word",
+          "value": 1137
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
           "value": 32
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1126
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1127
         }
       },
       {
@@ -291,7 +326,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 100
+    "value": 120
   },
   "Int": {
     "type": "byte",
@@ -325,7 +360,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 107
+    "value": 125
   },
   "NaturalAC": {
     "type": "byte",
@@ -646,7 +681,7 @@
   },
   "Str": {
     "type": "byte",
-    "value": 22
+    "value": 20
   },
   "Subrace": {
     "type": "cexostring",

--- a/Module/utc/mc_amphihydrus.utc.json
+++ b/Module/utc/mc_amphihydrus.utc.json
@@ -14,7 +14,7 @@
   },
   "ChallengeRating": {
     "type": "float",
-    "value": 8.0
+    "value": 9.0
   },
   "ClassList": {
     "type": "list",
@@ -68,7 +68,7 @@
   },
   "Dex": {
     "type": "byte",
-    "value": 20
+    "value": 18
   },
   "Disarmable": {
     "type": "byte",
@@ -81,7 +81,7 @@
         "__struct_id": 16384,
         "EquippedRes": {
           "type": "resref",
-          "value": "nw_it_crewpsp015"
+          "value": "amphih_claw"
         }
       },
       {
@@ -111,7 +111,7 @@
         "__struct_id": 1,
         "Feat": {
           "type": "word",
-          "value": 1203
+          "value": 1730
         }
       },
       {
@@ -181,7 +181,7 @@
   },
   "NaturalAC": {
     "type": "byte",
-    "value": 0
+    "value": 3
   },
   "NoPermDeath": {
     "type": "byte",
@@ -629,6 +629,6 @@
   },
   "Wis": {
     "type": "byte",
-    "value": 20
+    "value": 24
   }
 }

--- a/Module/utc/mc_aradile.utc.json
+++ b/Module/utc/mc_aradile.utc.json
@@ -14,7 +14,7 @@
   },
   "ChallengeRating": {
     "type": "float",
-    "value": 9.0
+    "value": 7.0
   },
   "ClassList": {
     "type": "list",
@@ -38,7 +38,7 @@
   },
   "Con": {
     "type": "byte",
-    "value": 20
+    "value": 26
   },
   "Conversation": {
     "type": "resref",
@@ -50,7 +50,7 @@
   },
   "CurrentHitPoints": {
     "type": "short",
-    "value": 220
+    "value": 150
   },
   "DecayTime": {
     "type": "dword",
@@ -68,7 +68,7 @@
   },
   "Dex": {
     "type": "byte",
-    "value": 20
+    "value": 10
   },
   "Disarmable": {
     "type": "byte",
@@ -81,7 +81,14 @@
         "__struct_id": 16384,
         "EquippedRes": {
           "type": "resref",
-          "value": "nw_it_crewps016"
+          "value": "aradile_bite"
+        }
+      },
+      {
+        "__struct_id": 131072,
+        "EquippedRes": {
+          "type": "resref",
+          "value": "aradile_skin"
         }
       }
     ]
@@ -93,6 +100,13 @@
   "FeatList": {
     "type": "list",
     "value": [
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1745
+        }
+      },
       {
         "__struct_id": 1,
         "Feat": {
@@ -122,7 +136,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 220
+    "value": 150
   },
   "Int": {
     "type": "byte",
@@ -156,7 +170,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 250
+    "value": 198
   },
   "NaturalAC": {
     "type": "byte",
@@ -461,7 +475,7 @@
   },
   "Str": {
     "type": "byte",
-    "value": 30
+    "value": 24
   },
   "Subrace": {
     "type": "cexostring",
@@ -532,6 +546,6 @@
   },
   "Wis": {
     "type": "byte",
-    "value": 10
+    "value": 16
   }
 }

--- a/Module/utc/qion_slug.utc.json
+++ b/Module/utc/qion_slug.utc.json
@@ -14,7 +14,7 @@
   },
   "ChallengeRating": {
     "type": "float",
-    "value": 11.0
+    "value": 10.0
   },
   "ClassList": {
     "type": "list",
@@ -38,7 +38,7 @@
   },
   "Con": {
     "type": "byte",
-    "value": 18
+    "value": 30
   },
   "Conversation": {
     "type": "resref",
@@ -63,12 +63,12 @@
   "Description": {
     "type": "cexolocstring",
     "value": {
-      "0": ""
+      "0": "Giant slugs roam this landscape.  Their usual mode of attack is to try to engulf nearby creatures in heavy layers of slime until they lose the will to keep fighting."
     }
   },
   "Dex": {
     "type": "byte",
-    "value": 32
+    "value": 10
   },
   "Disarmable": {
     "type": "byte",
@@ -104,35 +104,7 @@
         "__struct_id": 1,
         "Feat": {
           "type": "word",
-          "value": 1
-        }
-      },
-      {
-        "__struct_id": 1,
-        "Feat": {
-          "type": "word",
-          "value": 656
-        }
-      },
-      {
-        "__struct_id": 1,
-        "Feat": {
-          "type": "word",
-          "value": 41
-        }
-      },
-      {
-        "__struct_id": 1,
-        "Feat": {
-          "type": "word",
-          "value": 42
-        }
-      },
-      {
-        "__struct_id": 1,
-        "Feat": {
-          "type": "word",
-          "value": 103
+          "value": 291
         }
       },
       {
@@ -205,11 +177,11 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 190
+    "value": 244
   },
   "NaturalAC": {
     "type": "byte",
-    "value": 9
+    "value": 0
   },
   "NoPermDeath": {
     "type": "byte",
@@ -586,7 +558,7 @@
   },
   "Str": {
     "type": "byte",
-    "value": 20
+    "value": 18
   },
   "Subrace": {
     "type": "cexostring",
@@ -657,6 +629,6 @@
   },
   "Wis": {
     "type": "byte",
-    "value": 24
+    "value": 20
   }
 }

--- a/Module/utc/qion_tiger.utc.json
+++ b/Module/utc/qion_tiger.utc.json
@@ -14,7 +14,7 @@
   },
   "ChallengeRating": {
     "type": "float",
-    "value": 12.0
+    "value": 9.0
   },
   "ClassList": {
     "type": "list",
@@ -78,6 +78,13 @@
     "type": "list",
     "value": [
       {
+        "__struct_id": 65536,
+        "EquippedRes": {
+          "type": "resref",
+          "value": "hu_qutig_bite"
+        }
+      },
+      {
         "__struct_id": 131072,
         "EquippedRes": {
           "type": "resref",
@@ -97,14 +104,14 @@
         "__struct_id": 1,
         "Feat": {
           "type": "word",
-          "value": 41
+          "value": 1745
         }
       },
       {
         "__struct_id": 1,
         "Feat": {
           "type": "word",
-          "value": 103
+          "value": 291
         }
       },
       {
@@ -181,7 +188,7 @@
   },
   "NaturalAC": {
     "type": "byte",
-    "value": 16
+    "value": 1
   },
   "NoPermDeath": {
     "type": "byte",
@@ -558,7 +565,7 @@
   },
   "Str": {
     "type": "byte",
-    "value": 60
+    "value": 22
   },
   "Subrace": {
     "type": "cexostring",
@@ -629,6 +636,6 @@
   },
   "Wis": {
     "type": "byte",
-    "value": 20
+    "value": 14
   }
 }

--- a/Module/utc/sandbeetle.utc.json
+++ b/Module/utc/sandbeetle.utc.json
@@ -14,7 +14,7 @@
   },
   "ChallengeRating": {
     "type": "float",
-    "value": 16.0
+    "value": 12.0
   },
   "ClassList": {
     "type": "list",
@@ -38,7 +38,7 @@
   },
   "Con": {
     "type": "byte",
-    "value": 11
+    "value": 20
   },
   "Conversation": {
     "type": "resref",
@@ -82,6 +82,13 @@
         "EquippedRes": {
           "type": "resref",
           "value": "sandbeetlebite"
+        }
+      },
+      {
+        "__struct_id": 131072,
+        "EquippedRes": {
+          "type": "resref",
+          "value": "sandbtl_skin"
         }
       }
     ]
@@ -226,11 +233,11 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 520
+    "value": 595
   },
   "NaturalAC": {
     "type": "byte",
-    "value": 25
+    "value": 0
   },
   "NoPermDeath": {
     "type": "byte",
@@ -238,7 +245,7 @@
   },
   "PaletteID": {
     "type": "byte",
-    "value": 10
+    "value": 154
   },
   "PerceptionRange": {
     "type": "byte",
@@ -547,7 +554,7 @@
   },
   "Str": {
     "type": "byte",
-    "value": 70
+    "value": 30
   },
   "Subrace": {
     "type": "cexostring",

--- a/Module/utc/sanddemon.utc.json
+++ b/Module/utc/sanddemon.utc.json
@@ -14,7 +14,7 @@
   },
   "ChallengeRating": {
     "type": "float",
-    "value": 16.0
+    "value": 13.0
   },
   "ClassList": {
     "type": "list",
@@ -38,7 +38,7 @@
   },
   "Con": {
     "type": "byte",
-    "value": 15
+    "value": 34
   },
   "Conversation": {
     "type": "resref",
@@ -68,7 +68,7 @@
   },
   "Dex": {
     "type": "byte",
-    "value": 10
+    "value": 20
   },
   "Disarmable": {
     "type": "byte",
@@ -296,11 +296,11 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 820
+    "value": 920
   },
   "NaturalAC": {
     "type": "byte",
-    "value": 30
+    "value": 0
   },
   "NoPermDeath": {
     "type": "byte",
@@ -308,7 +308,7 @@
   },
   "PaletteID": {
     "type": "byte",
-    "value": 4
+    "value": 154
   },
   "PerceptionRange": {
     "type": "byte",
@@ -601,7 +601,7 @@
   },
   "Str": {
     "type": "byte",
-    "value": 80
+    "value": 34
   },
   "Subrace": {
     "type": "cexostring",
@@ -672,6 +672,6 @@
   },
   "Wis": {
     "type": "byte",
-    "value": 35
+    "value": 26
   }
 }

--- a/Module/utc/sandswimmer.utc.json
+++ b/Module/utc/sandswimmer.utc.json
@@ -14,7 +14,7 @@
   },
   "ChallengeRating": {
     "type": "float",
-    "value": 16.0
+    "value": 2.0
   },
   "ClassList": {
     "type": "list",
@@ -50,7 +50,7 @@
   },
   "CurrentHitPoints": {
     "type": "short",
-    "value": 450
+    "value": 300
   },
   "DecayTime": {
     "type": "dword",
@@ -63,12 +63,12 @@
   "Description": {
     "type": "cexolocstring",
     "value": {
-      "0": "Sandswimmers were spider-like creatures that dwelled on Tatooine. They were among the planet's most deadly predators, as they would \"swim\" underneath the arid sands of the desert before moving up to the surface to drain all fluids from their prey. The Sandswimmer exoskeleton provided a natural resistance to Tatooine's harsh conditions"
+      "0": "Sandswimmers were spider-like creatures that dwelled on Tatooine. They were among the planet's most deadly predators, as they would \"swim\" underneath the arid sands of the desert before moving up to the surface to drain all fluids from their prey, using a sonic shriek to try and paralyse the foe so it didn't resist. The Sandswimmer exoskeleton provided a natural resistance to Tatooine's harsh conditions"
     }
   },
   "Dex": {
     "type": "byte",
-    "value": 35
+    "value": 20
   },
   "Disarmable": {
     "type": "byte",
@@ -88,7 +88,7 @@
         "__struct_id": 131072,
         "EquippedRes": {
           "type": "resref",
-          "value": "nw_it_creitem005"
+          "value": "sandswimmer_hide"
         }
       }
     ]
@@ -164,7 +164,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 450
+    "value": 300
   },
   "Int": {
     "type": "byte",
@@ -198,11 +198,11 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 585
+    "value": 435
   },
   "NaturalAC": {
     "type": "byte",
-    "value": 25
+    "value": 1
   },
   "NoPermDeath": {
     "type": "byte",
@@ -210,7 +210,7 @@
   },
   "PaletteID": {
     "type": "byte",
-    "value": 48
+    "value": 154
   },
   "PerceptionRange": {
     "type": "byte",
@@ -500,11 +500,11 @@
         "__struct_id": 4,
         "Spell": {
           "type": "word",
-          "value": 90
+          "value": 799
         },
         "SpellCasterLevel": {
           "type": "byte",
-          "value": 10
+          "value": 0
         },
         "SpellFlags": {
           "type": "byte",
@@ -515,11 +515,11 @@
         "__struct_id": 4,
         "Spell": {
           "type": "word",
-          "value": 799
+          "value": 90
         },
         "SpellCasterLevel": {
           "type": "byte",
-          "value": 0
+          "value": 10
         },
         "SpellFlags": {
           "type": "byte",
@@ -534,7 +534,7 @@
   },
   "Str": {
     "type": "byte",
-    "value": 55
+    "value": 20
   },
   "Subrace": {
     "type": "cexostring",
@@ -605,6 +605,6 @@
   },
   "Wis": {
     "type": "byte",
-    "value": 20
+    "value": 28
   }
 }

--- a/Module/utc/swampvines.utc.json
+++ b/Module/utc/swampvines.utc.json
@@ -14,7 +14,7 @@
   },
   "ChallengeRating": {
     "type": "float",
-    "value": 13.0
+    "value": 0.125
   },
   "ClassList": {
     "type": "list",
@@ -27,7 +27,7 @@
         },
         "ClassLevel": {
           "type": "short",
-          "value": 15
+          "value": 5
         }
       }
     ]
@@ -80,6 +80,13 @@
         "EquippedRes": {
           "type": "resref",
           "value": "swampvinethorns"
+        }
+      },
+      {
+        "__struct_id": 131072,
+        "EquippedRes": {
+          "type": "resref",
+          "value": "v_cairnmoga_prop"
         }
       }
     ]
@@ -210,7 +217,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 575
+    "value": 535
   },
   "NaturalAC": {
     "type": "byte",
@@ -539,7 +546,7 @@
   },
   "WalkRate": {
     "type": "int",
-    "value": 3
+    "value": 1
   },
   "willbonus": {
     "type": "short",

--- a/Module/utc/tusken_melee.utc.json
+++ b/Module/utc/tusken_melee.utc.json
@@ -90,7 +90,7 @@
   },
   "ChallengeRating": {
     "type": "float",
-    "value": 15.0
+    "value": 17.0
   },
   "ClassList": {
     "type": "list",
@@ -141,7 +141,7 @@
   },
   "Con": {
     "type": "byte",
-    "value": 18
+    "value": 17
   },
   "Conversation": {
     "type": "resref",
@@ -153,7 +153,7 @@
   },
   "CurrentHitPoints": {
     "type": "short",
-    "value": 216
+    "value": 320
   },
   "DecayTime": {
     "type": "dword",
@@ -171,7 +171,7 @@
   },
   "Dex": {
     "type": "byte",
-    "value": 60
+    "value": 15
   },
   "Disarmable": {
     "type": "byte",
@@ -199,6 +199,13 @@
         "EquippedRes": {
           "type": "resref",
           "value": "tusken_gaffi"
+        }
+      },
+      {
+        "__struct_id": 131072,
+        "EquippedRes": {
+          "type": "resref",
+          "value": "tusken_skin"
         }
       }
     ]
@@ -229,6 +236,13 @@
         "Feat": {
           "type": "word",
           "value": 4
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1155
         }
       },
       {
@@ -285,13 +299,6 @@
         "Feat": {
           "type": "word",
           "value": 716
-        }
-      },
-      {
-        "__struct_id": 1,
-        "Feat": {
-          "type": "word",
-          "value": 1155
         }
       },
       {
@@ -422,7 +429,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 216
+    "value": 320
   },
   "Int": {
     "type": "byte",
@@ -456,7 +463,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 300
+    "value": 404
   },
   "NaturalAC": {
     "type": "byte",
@@ -468,7 +475,7 @@
   },
   "PaletteID": {
     "type": "byte",
-    "value": 4
+    "value": 154
   },
   "PerceptionRange": {
     "type": "byte",
@@ -536,7 +543,7 @@
   },
   "ScriptSpawn": {
     "type": "resref",
-    "value": "dt_tusken_spawn"
+    "value": "x2_def_spawn"
   },
   "ScriptSpellAt": {
     "type": "resref",
@@ -761,7 +768,7 @@
   },
   "Str": {
     "type": "byte",
-    "value": 40
+    "value": 28
   },
   "Subrace": {
     "type": "cexostring",

--- a/Module/utc/v_flesheater.utc.json
+++ b/Module/utc/v_flesheater.utc.json
@@ -38,7 +38,7 @@
   },
   "Con": {
     "type": "byte",
-    "value": 12
+    "value": 16
   },
   "Conversation": {
     "type": "resref",
@@ -68,7 +68,7 @@
   },
   "Dex": {
     "type": "byte",
-    "value": 16
+    "value": 10
   },
   "Disarmable": {
     "type": "byte",
@@ -82,6 +82,13 @@
         "EquippedRes": {
           "type": "resref",
           "value": "vellen_claw"
+        }
+      },
+      {
+        "__struct_id": 131072,
+        "EquippedRes": {
+          "type": "resref",
+          "value": "flesheater_skin"
         }
       }
     ]
@@ -163,7 +170,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 206
+    "value": 222
   },
   "NaturalAC": {
     "type": "byte",
@@ -499,7 +506,7 @@
   },
   "Str": {
     "type": "byte",
-    "value": 28
+    "value": 18
   },
   "Subrace": {
     "type": "cexostring",
@@ -570,6 +577,6 @@
   },
   "Wis": {
     "type": "byte",
-    "value": 3
+    "value": 18
   }
 }

--- a/Module/utc/v_flesheater2.utc.json
+++ b/Module/utc/v_flesheater2.utc.json
@@ -2,7 +2,7 @@
   "__data_type": "UTC ",
   "Appearance_Type": {
     "type": "word",
-    "value": 101
+    "value": 1850
   },
   "BodyBag": {
     "type": "byte",
@@ -38,7 +38,7 @@
   },
   "Con": {
     "type": "byte",
-    "value": 12
+    "value": 16
   },
   "Conversation": {
     "type": "resref",
@@ -50,7 +50,7 @@
   },
   "CurrentHitPoints": {
     "type": "short",
-    "value": 204
+    "value": 198
   },
   "DecayTime": {
     "type": "dword",
@@ -68,7 +68,7 @@
   },
   "Dex": {
     "type": "byte",
-    "value": 16
+    "value": 10
   },
   "Disarmable": {
     "type": "byte",
@@ -82,6 +82,13 @@
         "EquippedRes": {
           "type": "resref",
           "value": "vellen_claw"
+        }
+      },
+      {
+        "__struct_id": 131072,
+        "EquippedRes": {
+          "type": "resref",
+          "value": "flesheater_skin"
         }
       }
     ]
@@ -129,11 +136,11 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 204
+    "value": 198
   },
   "Int": {
     "type": "byte",
-    "value": 8
+    "value": 9
   },
   "Interruptable": {
     "type": "byte",
@@ -163,7 +170,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 212
+    "value": 222
   },
   "NaturalAC": {
     "type": "byte",
@@ -191,7 +198,7 @@
   },
   "PortraitId": {
     "type": "word",
-    "value": 188
+    "value": 3350
   },
   "Race": {
     "type": "byte",
@@ -514,7 +521,7 @@
   },
   "Str": {
     "type": "byte",
-    "value": 30
+    "value": 18
   },
   "Subrace": {
     "type": "cexostring",
@@ -585,6 +592,6 @@
   },
   "Wis": {
     "type": "byte",
-    "value": 3
+    "value": 18
   }
 }

--- a/Module/utc/v_fleshleader.utc.json
+++ b/Module/utc/v_fleshleader.utc.json
@@ -14,7 +14,7 @@
   },
   "ChallengeRating": {
     "type": "float",
-    "value": 8.0
+    "value": 9.0
   },
   "ClassList": {
     "type": "list",
@@ -87,7 +87,15 @@
   },
   "Equip_ItemList": {
     "type": "list",
-    "value": []
+    "value": [
+      {
+        "__struct_id": 16,
+        "EquippedRes": {
+          "type": "resref",
+          "value": "fleshleader_ls"
+        }
+      }
+    ]
   },
   "FactionID": {
     "type": "word",
@@ -121,7 +129,35 @@
         "__struct_id": 1,
         "Feat": {
           "type": "word",
-          "value": 23
+          "value": 1165
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1160
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1161
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1171
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1172
         }
       },
       {
@@ -552,7 +588,7 @@
   },
   "Str": {
     "type": "byte",
-    "value": 30
+    "value": 24
   },
   "Subrace": {
     "type": "cexostring",
@@ -638,6 +674,6 @@
   },
   "Wis": {
     "type": "byte",
-    "value": 3
+    "value": 20
   }
 }

--- a/Module/utc/v_raivor.utc.json
+++ b/Module/utc/v_raivor.utc.json
@@ -14,7 +14,7 @@
   },
   "ChallengeRating": {
     "type": "float",
-    "value": 6.0
+    "value": 7.0
   },
   "ClassList": {
     "type": "list",
@@ -50,7 +50,7 @@
   },
   "CurrentHitPoints": {
     "type": "short",
-    "value": 100
+    "value": 145
   },
   "DecayTime": {
     "type": "dword",
@@ -136,7 +136,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 100
+    "value": 145
   },
   "Int": {
     "type": "byte",
@@ -170,11 +170,11 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 105
+    "value": 150
   },
   "NaturalAC": {
     "type": "byte",
-    "value": 8
+    "value": 3
   },
   "NoPermDeath": {
     "type": "byte",
@@ -546,6 +546,6 @@
   },
   "Wis": {
     "type": "byte",
-    "value": 3
+    "value": 6
   }
 }

--- a/Module/utc/v_raivor2.utc.json
+++ b/Module/utc/v_raivor2.utc.json
@@ -14,7 +14,7 @@
   },
   "ChallengeRating": {
     "type": "float",
-    "value": 6.0
+    "value": 8.0
   },
   "ClassList": {
     "type": "list",
@@ -27,7 +27,7 @@
         },
         "ClassLevel": {
           "type": "short",
-          "value": 2
+          "value": 5
         }
       }
     ]
@@ -50,7 +50,7 @@
   },
   "CurrentHitPoints": {
     "type": "short",
-    "value": 100
+    "value": 145
   },
   "DecayTime": {
     "type": "dword",
@@ -68,7 +68,7 @@
   },
   "Dex": {
     "type": "byte",
-    "value": 24
+    "value": 14
   },
   "Disarmable": {
     "type": "byte",
@@ -136,7 +136,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 100
+    "value": 145
   },
   "Int": {
     "type": "byte",
@@ -170,11 +170,11 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 102
+    "value": 150
   },
   "NaturalAC": {
     "type": "byte",
-    "value": 5
+    "value": 3
   },
   "NoPermDeath": {
     "type": "byte",
@@ -506,7 +506,7 @@
   },
   "Str": {
     "type": "byte",
-    "value": 20
+    "value": 18
   },
   "Subrace": {
     "type": "cexostring",
@@ -577,6 +577,6 @@
   },
   "Wis": {
     "type": "byte",
-    "value": 3
+    "value": 6
   }
 }

--- a/Module/utc/vall_nashtah.utc.json
+++ b/Module/utc/vall_nashtah.utc.json
@@ -68,7 +68,7 @@
   },
   "Dex": {
     "type": "byte",
-    "value": 16
+    "value": 18
   },
   "Disarmable": {
     "type": "byte",
@@ -174,7 +174,7 @@
   },
   "NaturalAC": {
     "type": "byte",
-    "value": 3
+    "value": 1
   },
   "NoPermDeath": {
     "type": "byte",
@@ -491,7 +491,7 @@
   },
   "Str": {
     "type": "byte",
-    "value": 20
+    "value": 14
   },
   "Subrace": {
     "type": "cexostring",

--- a/Module/utc/valley_cairnmog.utc.json
+++ b/Module/utc/valley_cairnmog.utc.json
@@ -14,7 +14,7 @@
   },
   "ChallengeRating": {
     "type": "float",
-    "value": 6.0
+    "value": 5.0
   },
   "ClassList": {
     "type": "list",
@@ -38,7 +38,7 @@
   },
   "Con": {
     "type": "byte",
-    "value": 12
+    "value": 16
   },
   "Conversation": {
     "type": "resref",
@@ -50,7 +50,7 @@
   },
   "CurrentHitPoints": {
     "type": "short",
-    "value": 138
+    "value": 114
   },
   "DecayTime": {
     "type": "dword",
@@ -68,7 +68,7 @@
   },
   "Dex": {
     "type": "byte",
-    "value": 14
+    "value": 12
   },
   "Disarmable": {
     "type": "byte",
@@ -100,6 +100,13 @@
   "FeatList": {
     "type": "list",
     "value": [
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1745
+        }
+      },
       {
         "__struct_id": 1,
         "Feat": {
@@ -136,7 +143,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 138
+    "value": 114
   },
   "Int": {
     "type": "byte",
@@ -170,7 +177,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 144
+    "value": 132
   },
   "NaturalAC": {
     "type": "byte",
@@ -475,7 +482,7 @@
   },
   "Str": {
     "type": "byte",
-    "value": 20
+    "value": 16
   },
   "Subrace": {
     "type": "cexostring",

--- a/Module/utc/valley_cairnmog2.utc.json
+++ b/Module/utc/valley_cairnmog2.utc.json
@@ -38,7 +38,7 @@
   },
   "Con": {
     "type": "byte",
-    "value": 12
+    "value": 18
   },
   "Conversation": {
     "type": "resref",
@@ -68,7 +68,7 @@
   },
   "Dex": {
     "type": "byte",
-    "value": 16
+    "value": 12
   },
   "Disarmable": {
     "type": "byte",
@@ -88,7 +88,7 @@
         "__struct_id": 131072,
         "EquippedRes": {
           "type": "resref",
-          "value": "v_cairnmog_prop"
+          "value": "v_cairnmoga_prop"
         }
       }
     ]
@@ -100,6 +100,13 @@
   "FeatList": {
     "type": "list",
     "value": [
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1745
+        }
+      },
       {
         "__struct_id": 1,
         "Feat": {
@@ -170,7 +177,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 185
+    "value": 200
   },
   "NaturalAC": {
     "type": "byte",
@@ -506,7 +513,7 @@
   },
   "Str": {
     "type": "byte",
-    "value": 24
+    "value": 18
   },
   "Subrace": {
     "type": "cexostring",
@@ -577,6 +584,6 @@
   },
   "Wis": {
     "type": "byte",
-    "value": 9
+    "value": 10
   }
 }

--- a/Module/utc/vellen_raptor.utc.json
+++ b/Module/utc/vellen_raptor.utc.json
@@ -38,7 +38,7 @@
   },
   "Con": {
     "type": "byte",
-    "value": 13
+    "value": 14
   },
   "Conversation": {
     "type": "resref",
@@ -66,7 +66,7 @@
   },
   "Dex": {
     "type": "byte",
-    "value": 10
+    "value": 14
   },
   "Disarmable": {
     "type": "byte",
@@ -80,6 +80,13 @@
         "EquippedRes": {
           "type": "resref",
           "value": "raptorbite"
+        }
+      },
+      {
+        "__struct_id": 131072,
+        "EquippedRes": {
+          "type": "resref",
+          "value": "v_raptor_skin"
         }
       }
     ]
@@ -95,6 +102,13 @@
         "__struct_id": 1,
         "Feat": {
           "type": "word",
+          "value": 1745
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
           "value": 196
         }
       },
@@ -103,13 +117,6 @@
         "Feat": {
           "type": "word",
           "value": 332
-        }
-      },
-      {
-        "__struct_id": 1,
-        "Feat": {
-          "type": "word",
-          "value": 347
         }
       },
       {
@@ -189,7 +196,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 310
+    "value": 320
   },
   "NaturalAC": {
     "type": "byte",
@@ -494,7 +501,7 @@
   },
   "Str": {
     "type": "byte",
-    "value": 50
+    "value": 24
   },
   "Subrace": {
     "type": "cexostring",
@@ -530,6 +537,6 @@
   },
   "Wis": {
     "type": "byte",
-    "value": 11
+    "value": 14
   }
 }

--- a/Module/utc/viper.utc.json
+++ b/Module/utc/viper.utc.json
@@ -14,7 +14,7 @@
   },
   "ChallengeRating": {
     "type": "float",
-    "value": 8.0
+    "value": 7.0
   },
   "ClassList": {
     "type": "list",
@@ -86,7 +86,7 @@
         "__struct_id": 131072,
         "EquippedRes": {
           "type": "resref",
-          "value": "nw_it_creitem005"
+          "value": "mc_amphihy_hi001"
         }
       }
     ]
@@ -103,6 +103,13 @@
         "Feat": {
           "type": "word",
           "value": 195
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1750
         }
       },
       {
@@ -179,7 +186,7 @@
   },
   "NaturalAC": {
     "type": "byte",
-    "value": 6
+    "value": 3
   },
   "NoPermDeath": {
     "type": "byte",
@@ -480,7 +487,7 @@
   },
   "Str": {
     "type": "byte",
-    "value": 16
+    "value": 14
   },
   "Subrace": {
     "type": "cexostring",
@@ -551,6 +558,6 @@
   },
   "Wis": {
     "type": "byte",
-    "value": 12
+    "value": 10
   }
 }

--- a/Module/utc/womprat.utc.json
+++ b/Module/utc/womprat.utc.json
@@ -68,7 +68,7 @@
   },
   "Dex": {
     "type": "byte",
-    "value": 40
+    "value": 26
   },
   "Disarmable": {
     "type": "byte",
@@ -88,7 +88,7 @@
         "__struct_id": 131072,
         "EquippedRes": {
           "type": "resref",
-          "value": "nw_it_creitem005"
+          "value": "womprat_skin"
         }
       }
     ]
@@ -167,7 +167,7 @@
   },
   "NaturalAC": {
     "type": "byte",
-    "value": 1
+    "value": 2
   },
   "NoPermDeath": {
     "type": "byte",
@@ -468,7 +468,7 @@
   },
   "Str": {
     "type": "byte",
-    "value": 35
+    "value": 20
   },
   "Subrace": {
     "type": "cexostring",
@@ -539,6 +539,6 @@
   },
   "Wis": {
     "type": "byte",
-    "value": 10
+    "value": 18
   }
 }

--- a/Module/utc/ww_gimpassa.utc.json
+++ b/Module/utc/ww_gimpassa.utc.json
@@ -10,11 +10,11 @@
   },
   "Cha": {
     "type": "byte",
-    "value": 40
+    "value": 8
   },
   "ChallengeRating": {
     "type": "float",
-    "value": 5.0
+    "value": 4.0
   },
   "ClassList": {
     "type": "list",
@@ -83,6 +83,13 @@
           "type": "resref",
           "value": "gimp_bite"
         }
+      },
+      {
+        "__struct_id": 131072,
+        "EquippedRes": {
+          "type": "resref",
+          "value": "ww_gimp_hide"
+        }
       }
     ]
   },
@@ -140,7 +147,7 @@
   },
   "Int": {
     "type": "byte",
-    "value": 40
+    "value": 18
   },
   "Interruptable": {
     "type": "byte",
@@ -577,6 +584,6 @@
   },
   "Wis": {
     "type": "byte",
-    "value": 40
+    "value": 18
   }
 }

--- a/Module/utc/ww_kinrath.utc.json
+++ b/Module/utc/ww_kinrath.utc.json
@@ -14,7 +14,7 @@
   },
   "ChallengeRating": {
     "type": "float",
-    "value": 3.0
+    "value": 2.0
   },
   "ClassList": {
     "type": "list",
@@ -63,12 +63,12 @@
   "Description": {
     "type": "cexolocstring",
     "value": {
-      "0": "The average Kinrath. Of a light yellow-brownish color, but other varieties show different markings and come in colors as diverse as orange and green. Kinrath seem to be hive creatures, and a single female kinrath matriarch is the leader of a hive. Kinrath have four legs and a leg-like, poisonous appendage coming out of their faces that they used to attack prey or other perceived enemies. All kinrath are blind but can sense heat which allows them to navigate their way around and identify potential threats. They identify members of their own hive using a specialized sweat gland in the abdomen which excreted a specific scent."
+      "0": "The average Kinrath. Of a light yellow-brownish color, but other varieties show different markings and come in colors as diverse as orange and green. Kinrath seem to be hive creatures, and a single female kinrath matriarch is the leader of a hive. Kinrath have four legs and a leg-like, poisonous appendage coming out of their faces that they used to attack prey or other perceived enemies. All kinrath are blind but can sense heat which allows them to navigate their way around and identify potential threats, and makes them effective ambush hunters. They identify members of their own hive using a specialized sweat gland in the abdomen which excreted a specific scent."
     }
   },
   "Dex": {
     "type": "byte",
-    "value": 20
+    "value": 16
   },
   "Disarmable": {
     "type": "byte",
@@ -167,7 +167,7 @@
   },
   "NaturalAC": {
     "type": "byte",
-    "value": 6
+    "value": 1
   },
   "NoPermDeath": {
     "type": "byte",
@@ -175,7 +175,7 @@
   },
   "PaletteID": {
     "type": "byte",
-    "value": 11
+    "value": 151
   },
   "PerceptionRange": {
     "type": "byte",
@@ -499,7 +499,7 @@
   },
   "Str": {
     "type": "byte",
-    "value": 20
+    "value": 12
   },
   "Subrace": {
     "type": "cexostring",
@@ -570,6 +570,6 @@
   },
   "Wis": {
     "type": "byte",
-    "value": 8
+    "value": 10
   }
 }

--- a/Module/uti/TaserPistol.uti.json
+++ b/Module/uti/TaserPistol.uti.json
@@ -1,0 +1,183 @@
+{
+  "__data_type": "UTI ",
+  "AddCost": {
+    "type": "dword",
+    "value": 15
+  },
+  "BaseItem": {
+    "type": "int",
+    "value": 11
+  },
+  "Charges": {
+    "type": "byte",
+    "value": 0
+  },
+  "Comment": {
+    "type": "cexostring",
+    "value": ""
+  },
+  "Cost": {
+    "type": "dword",
+    "value": 75
+  },
+  "Cursed": {
+    "type": "byte",
+    "value": 0
+  },
+  "DescIdentified": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "Tasers can be used to incapacitate living creatures, or fuse the circuits of droids.  "
+    }
+  },
+  "Description": {
+    "type": "cexolocstring",
+    "value": {
+      "0": ""
+    }
+  },
+  "Identified": {
+    "type": "byte",
+    "value": 0
+  },
+  "LocalizedName": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "Taser Pistol"
+    }
+  },
+  "ModelPart1": {
+    "type": "byte",
+    "value": 11
+  },
+  "ModelPart2": {
+    "type": "byte",
+    "value": 221
+  },
+  "ModelPart3": {
+    "type": "byte",
+    "value": 11
+  },
+  "PaletteID": {
+    "type": "byte",
+    "value": 45
+  },
+  "Plot": {
+    "type": "byte",
+    "value": 0
+  },
+  "PropertiesList": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 34
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 1
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 93
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 5
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 0
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 0
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 103
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 4
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 14
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 1
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 61
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      }
+    ]
+  },
+  "StackSize": {
+    "type": "word",
+    "value": 1
+  },
+  "Stolen": {
+    "type": "byte",
+    "value": 0
+  },
+  "Tag": {
+    "type": "cexostring",
+    "value": "TaserPistol"
+  },
+  "TemplateResRef": {
+    "type": "resref",
+    "value": "taserpistol"
+  }
+}

--- a/Module/uti/amphih_claw.uti.json
+++ b/Module/uti/amphih_claw.uti.json
@@ -1,0 +1,143 @@
+{
+  "__data_type": "UTI ",
+  "AddCost": {
+    "type": "dword",
+    "value": 0
+  },
+  "BaseItem": {
+    "type": "int",
+    "value": 72
+  },
+  "Charges": {
+    "type": "byte",
+    "value": 0
+  },
+  "Comment": {
+    "type": "cexostring",
+    "value": ""
+  },
+  "Cost": {
+    "type": "dword",
+    "value": 0
+  },
+  "Cursed": {
+    "type": "byte",
+    "value": 0
+  },
+  "DescIdentified": {
+    "type": "cexolocstring",
+    "value": {}
+  },
+  "Description": {
+    "type": "cexolocstring",
+    "value": {
+      "0": ""
+    }
+  },
+  "Identified": {
+    "type": "byte",
+    "value": 0
+  },
+  "LocalizedName": {
+    "id": 13274,
+    "type": "cexolocstring",
+    "value": {
+      "0": "Amphi-Hydrus Claw"
+    }
+  },
+  "ModelPart1": {
+    "type": "byte",
+    "value": 1
+  },
+  "PaletteID": {
+    "type": "byte",
+    "value": 13
+  },
+  "Plot": {
+    "type": "byte",
+    "value": 0
+  },
+  "PropertiesList": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 34
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 3
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 93
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 5
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 0
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 0
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 103
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 4
+        }
+      }
+    ]
+  },
+  "StackSize": {
+    "type": "word",
+    "value": 1
+  },
+  "Stolen": {
+    "type": "byte",
+    "value": 0
+  },
+  "Tag": {
+    "type": "cexostring",
+    "value": "amphih_claw"
+  },
+  "TemplateResRef": {
+    "type": "resref",
+    "value": "amphih_claw"
+  }
+}

--- a/Module/uti/aradile_bite.uti.json
+++ b/Module/uti/aradile_bite.uti.json
@@ -1,0 +1,112 @@
+{
+  "__data_type": "UTI ",
+  "AddCost": {
+    "type": "dword",
+    "value": 0
+  },
+  "BaseItem": {
+    "type": "int",
+    "value": 69
+  },
+  "Charges": {
+    "type": "byte",
+    "value": 0
+  },
+  "Comment": {
+    "type": "cexostring",
+    "value": ""
+  },
+  "Cost": {
+    "type": "dword",
+    "value": 0
+  },
+  "Cursed": {
+    "type": "byte",
+    "value": 0
+  },
+  "DescIdentified": {
+    "type": "cexolocstring",
+    "value": {}
+  },
+  "Description": {
+    "type": "cexolocstring",
+    "value": {
+      "0": ""
+    }
+  },
+  "Identified": {
+    "type": "byte",
+    "value": 0
+  },
+  "LocalizedName": {
+    "id": 13248,
+    "type": "cexolocstring",
+    "value": {
+      "0": "Aradile Bite"
+    }
+  },
+  "ModelPart1": {
+    "type": "byte",
+    "value": 1
+  },
+  "PaletteID": {
+    "type": "byte",
+    "value": 55
+  },
+  "Plot": {
+    "type": "byte",
+    "value": 0
+  },
+  "PropertiesList": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 34
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 15
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 93
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 1
+        }
+      }
+    ]
+  },
+  "StackSize": {
+    "type": "word",
+    "value": 1
+  },
+  "Stolen": {
+    "type": "byte",
+    "value": 0
+  },
+  "Tag": {
+    "type": "cexostring",
+    "value": "aradile_bite"
+  },
+  "TemplateResRef": {
+    "type": "resref",
+    "value": "aradile_bite"
+  }
+}

--- a/Module/uti/aradile_skin.uti.json
+++ b/Module/uti/aradile_skin.uti.json
@@ -1,0 +1,204 @@
+{
+  "__data_type": "UTI ",
+  "AddCost": {
+    "type": "dword",
+    "value": 0
+  },
+  "BaseItem": {
+    "type": "int",
+    "value": 73
+  },
+  "Charges": {
+    "type": "byte",
+    "value": 0
+  },
+  "Comment": {
+    "type": "cexostring",
+    "value": ""
+  },
+  "Cost": {
+    "type": "dword",
+    "value": 0
+  },
+  "Cursed": {
+    "type": "byte",
+    "value": 0
+  },
+  "DescIdentified": {
+    "type": "cexolocstring",
+    "value": {}
+  },
+  "Description": {
+    "type": "cexolocstring",
+    "value": {
+      "0": ""
+    }
+  },
+  "Identified": {
+    "type": "byte",
+    "value": 1
+  },
+  "LocalizedName": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "Aradile Skin"
+    }
+  },
+  "ModelPart1": {
+    "type": "byte",
+    "value": 1
+  },
+  "PaletteID": {
+    "type": "byte",
+    "value": 14
+  },
+  "Plot": {
+    "type": "byte",
+    "value": 0
+  },
+  "PropertiesList": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 15
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 2
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 50
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 1
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 43
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 25
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 99
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 41
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 50
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 98
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      }
+    ]
+  },
+  "StackSize": {
+    "type": "word",
+    "value": 1
+  },
+  "Stolen": {
+    "type": "byte",
+    "value": 0
+  },
+  "Tag": {
+    "type": "cexostring",
+    "value": "aradile_skin"
+  },
+  "TemplateResRef": {
+    "type": "resref",
+    "value": "aradile_skin"
+  }
+}

--- a/Module/uti/byyskwarriorswor.uti.json
+++ b/Module/uti/byyskwarriorswor.uti.json
@@ -73,11 +73,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 2
+          "value": 34
         },
         "CostValue": {
           "type": "word",
-          "value": 10
+          "value": 16
         },
         "Param1": {
           "type": "byte",
@@ -89,11 +89,11 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 56
+          "value": 93
         },
         "Subtype": {
           "type": "word",
-          "value": 0
+          "value": 1
         }
       },
       {

--- a/Module/uti/colicoid_claw.uti.json
+++ b/Module/uti/colicoid_claw.uti.json
@@ -36,12 +36,12 @@
   },
   "Identified": {
     "type": "byte",
-    "value": 1
+    "value": 0
   },
   "LocalizedName": {
     "type": "cexolocstring",
     "value": {
-      "0": "Colidcoid Claw"
+      "0": "Colicoid Claw"
     }
   },
   "ModelPart1": {
@@ -87,7 +87,7 @@
         },
         "Subtype": {
           "type": "word",
-          "value": 0
+          "value": 1
         }
       }
     ]

--- a/Module/uti/crazedwarocasbk.uti.json
+++ b/Module/uti/crazedwarocasbk.uti.json
@@ -34,7 +34,7 @@
   },
   "Identified": {
     "type": "byte",
-    "value": 1
+    "value": 0
   },
   "LocalizedName": {
     "type": "cexolocstring",
@@ -69,7 +69,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 14
+          "value": 10
         },
         "Param1": {
           "type": "byte",
@@ -96,38 +96,7 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 4
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 13
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 16
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 15
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
-          "value": 4
+          "value": 34
         },
         "CostValue": {
           "type": "word",
@@ -143,7 +112,7 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 16
+          "value": 93
         },
         "Subtype": {
           "type": "word",

--- a/Module/uti/crazedwarocassk.uti.json
+++ b/Module/uti/crazedwarocassk.uti.json
@@ -65,11 +65,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 22
+          "value": 35
         },
         "CostValue": {
           "type": "word",
-          "value": 4
+          "value": 35
         },
         "Param1": {
           "type": "byte",
@@ -81,42 +81,11 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 24
+          "value": 94
         },
         "Subtype": {
-          "type": "word",
-          "value": 0
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
-          "value": 22
-        },
-        "CostValue": {
           "type": "word",
           "value": 2
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 24
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 10
         }
       },
       {
@@ -127,11 +96,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 5
+          "value": 35
         },
         "CostValue": {
           "type": "word",
-          "value": 130
+          "value": 35
         },
         "Param1": {
           "type": "byte",
@@ -143,135 +112,11 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 20
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 9
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
-          "value": 5
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 130
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 20
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 5
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
-          "value": 5
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 70
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 20
+          "value": 94
         },
         "Subtype": {
           "type": "word",
           "value": 1
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
-          "value": 5
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 70
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 20
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 2
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
-          "value": 5
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 130
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 20
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 13
         }
       },
       {
@@ -303,6 +148,37 @@
         "Subtype": {
           "type": "word",
           "value": 6
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 43
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 25
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 99
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
         }
       }
     ]

--- a/Module/uti/cryspider_bite.uti.json
+++ b/Module/uti/cryspider_bite.uti.json
@@ -36,7 +36,7 @@
   },
   "Identified": {
     "type": "byte",
-    "value": 1
+    "value": 0
   },
   "LocalizedName": {
     "type": "cexolocstring",
@@ -67,58 +67,27 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 2
+          "value": 34
         },
         "CostValue": {
+          "type": "word",
+          "value": 4
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 93
+        },
+        "Subtype": {
           "type": "word",
           "value": 1
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 56
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 0
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
-          "value": 19
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 2
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 77
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 0
         }
       }
     ]

--- a/Module/uti/ecoter_hide.uti.json
+++ b/Module/uti/ecoter_hide.uti.json
@@ -1,0 +1,204 @@
+{
+  "__data_type": "UTI ",
+  "AddCost": {
+    "type": "dword",
+    "value": 0
+  },
+  "BaseItem": {
+    "type": "int",
+    "value": 73
+  },
+  "Charges": {
+    "type": "byte",
+    "value": 0
+  },
+  "Comment": {
+    "type": "cexostring",
+    "value": ""
+  },
+  "Cost": {
+    "type": "dword",
+    "value": 0
+  },
+  "Cursed": {
+    "type": "byte",
+    "value": 0
+  },
+  "DescIdentified": {
+    "type": "cexolocstring",
+    "value": {}
+  },
+  "Description": {
+    "type": "cexolocstring",
+    "value": {
+      "0": ""
+    }
+  },
+  "Identified": {
+    "type": "byte",
+    "value": 1
+  },
+  "LocalizedName": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "Eco-Terrorist Hide"
+    }
+  },
+  "ModelPart1": {
+    "type": "byte",
+    "value": 1
+  },
+  "PaletteID": {
+    "type": "byte",
+    "value": 14
+  },
+  "Plot": {
+    "type": "byte",
+    "value": 0
+  },
+  "PropertiesList": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 50
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 2
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 50
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 1
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 43
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 27
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 99
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 41
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 50
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 98
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      }
+    ]
+  },
+  "StackSize": {
+    "type": "word",
+    "value": 1
+  },
+  "Stolen": {
+    "type": "byte",
+    "value": 0
+  },
+  "Tag": {
+    "type": "cexostring",
+    "value": "ecoter_hide"
+  },
+  "TemplateResRef": {
+    "type": "resref",
+    "value": "ecoter_hide"
+  }
+}

--- a/Module/uti/ecoterldr_hide.uti.json
+++ b/Module/uti/ecoterldr_hide.uti.json
@@ -1,0 +1,204 @@
+{
+  "__data_type": "UTI ",
+  "AddCost": {
+    "type": "dword",
+    "value": 0
+  },
+  "BaseItem": {
+    "type": "int",
+    "value": 73
+  },
+  "Charges": {
+    "type": "byte",
+    "value": 0
+  },
+  "Comment": {
+    "type": "cexostring",
+    "value": ""
+  },
+  "Cost": {
+    "type": "dword",
+    "value": 0
+  },
+  "Cursed": {
+    "type": "byte",
+    "value": 0
+  },
+  "DescIdentified": {
+    "type": "cexolocstring",
+    "value": {}
+  },
+  "Description": {
+    "type": "cexolocstring",
+    "value": {
+      "0": ""
+    }
+  },
+  "Identified": {
+    "type": "byte",
+    "value": 1
+  },
+  "LocalizedName": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "Eco-Terrorist Leader Hide"
+    }
+  },
+  "ModelPart1": {
+    "type": "byte",
+    "value": 1
+  },
+  "PaletteID": {
+    "type": "byte",
+    "value": 14
+  },
+  "Plot": {
+    "type": "byte",
+    "value": 0
+  },
+  "PropertiesList": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 60
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 2
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 60
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 1
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 43
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 30
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 99
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 41
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 50
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 98
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      }
+    ]
+  },
+  "StackSize": {
+    "type": "word",
+    "value": 1
+  },
+  "Stolen": {
+    "type": "byte",
+    "value": 0
+  },
+  "Tag": {
+    "type": "cexostring",
+    "value": "ecoterldr_hide"
+  },
+  "TemplateResRef": {
+    "type": "resref",
+    "value": "ecoterldr_hide"
+  }
+}

--- a/Module/uti/flesheater_skin.uti.json
+++ b/Module/uti/flesheater_skin.uti.json
@@ -1,0 +1,204 @@
+{
+  "__data_type": "UTI ",
+  "AddCost": {
+    "type": "dword",
+    "value": 0
+  },
+  "BaseItem": {
+    "type": "int",
+    "value": 73
+  },
+  "Charges": {
+    "type": "byte",
+    "value": 0
+  },
+  "Comment": {
+    "type": "cexostring",
+    "value": ""
+  },
+  "Cost": {
+    "type": "dword",
+    "value": 0
+  },
+  "Cursed": {
+    "type": "byte",
+    "value": 0
+  },
+  "DescIdentified": {
+    "type": "cexolocstring",
+    "value": {}
+  },
+  "Description": {
+    "type": "cexolocstring",
+    "value": {
+      "0": ""
+    }
+  },
+  "Identified": {
+    "type": "byte",
+    "value": 1
+  },
+  "LocalizedName": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "Vellen Flesheater Skin"
+    }
+  },
+  "ModelPart1": {
+    "type": "byte",
+    "value": 1
+  },
+  "PaletteID": {
+    "type": "byte",
+    "value": 14
+  },
+  "Plot": {
+    "type": "byte",
+    "value": 0
+  },
+  "PropertiesList": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 24
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 2
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 14
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 1
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 43
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 13
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 99
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 41
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 50
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 98
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      }
+    ]
+  },
+  "StackSize": {
+    "type": "word",
+    "value": 1
+  },
+  "Stolen": {
+    "type": "byte",
+    "value": 0
+  },
+  "Tag": {
+    "type": "cexostring",
+    "value": "flesheater_skin"
+  },
+  "TemplateResRef": {
+    "type": "resref",
+    "value": "flesheater_skin"
+  }
+}

--- a/Module/uti/fleshleader_ls.uti.json
+++ b/Module/uti/fleshleader_ls.uti.json
@@ -1,0 +1,181 @@
+{
+  "__data_type": "UTI ",
+  "AddCost": {
+    "type": "dword",
+    "value": 0
+  },
+  "BaseItem": {
+    "type": "int",
+    "value": 512
+  },
+  "Charges": {
+    "type": "byte",
+    "value": 0
+  },
+  "Comment": {
+    "type": "cexostring",
+    "value": ""
+  },
+  "Cost": {
+    "type": "dword",
+    "value": 3
+  },
+  "Cursed": {
+    "type": "byte",
+    "value": 0
+  },
+  "DescIdentified": {
+    "type": "cexolocstring",
+    "value": {}
+  },
+  "Description": {
+    "type": "cexolocstring",
+    "value": {
+      "0": ""
+    }
+  },
+  "Identified": {
+    "type": "byte",
+    "value": 1
+  },
+  "LocalizedName": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "Vellen Fleshleader Lightsaber"
+    }
+  },
+  "ModelPart1": {
+    "type": "byte",
+    "value": 21
+  },
+  "ModelPart2": {
+    "type": "byte",
+    "value": 11
+  },
+  "ModelPart3": {
+    "type": "byte",
+    "value": 14
+  },
+  "PaletteID": {
+    "type": "byte",
+    "value": 36
+  },
+  "Plot": {
+    "type": "byte",
+    "value": 1
+  },
+  "PropertiesList": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 34
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 13
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 93
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 26
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 39
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 82
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 125
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 33
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 1
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 100
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 18
+        }
+      }
+    ]
+  },
+  "StackSize": {
+    "type": "word",
+    "value": 1
+  },
+  "Stolen": {
+    "type": "byte",
+    "value": 0
+  },
+  "Tag": {
+    "type": "cexostring",
+    "value": "fleshleader_ls"
+  },
+  "TemplateResRef": {
+    "type": "resref",
+    "value": "fleshleader_ls"
+  }
+}

--- a/Module/uti/fleshleader_skin.uti.json
+++ b/Module/uti/fleshleader_skin.uti.json
@@ -1,0 +1,204 @@
+{
+  "__data_type": "UTI ",
+  "AddCost": {
+    "type": "dword",
+    "value": 0
+  },
+  "BaseItem": {
+    "type": "int",
+    "value": 73
+  },
+  "Charges": {
+    "type": "byte",
+    "value": 0
+  },
+  "Comment": {
+    "type": "cexostring",
+    "value": ""
+  },
+  "Cost": {
+    "type": "dword",
+    "value": 0
+  },
+  "Cursed": {
+    "type": "byte",
+    "value": 0
+  },
+  "DescIdentified": {
+    "type": "cexolocstring",
+    "value": {}
+  },
+  "Description": {
+    "type": "cexolocstring",
+    "value": {
+      "0": ""
+    }
+  },
+  "Identified": {
+    "type": "byte",
+    "value": 1
+  },
+  "LocalizedName": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "Vellen Fleshleader Skin"
+    }
+  },
+  "ModelPart1": {
+    "type": "byte",
+    "value": 1
+  },
+  "PaletteID": {
+    "type": "byte",
+    "value": 14
+  },
+  "Plot": {
+    "type": "byte",
+    "value": 0
+  },
+  "PropertiesList": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 30
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 2
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 24
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 1
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 43
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 20
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 99
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 41
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 50
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 98
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      }
+    ]
+  },
+  "StackSize": {
+    "type": "word",
+    "value": 1
+  },
+  "Stolen": {
+    "type": "byte",
+    "value": 0
+  },
+  "Tag": {
+    "type": "cexostring",
+    "value": "fleshleader_skin"
+  },
+  "TemplateResRef": {
+    "type": "resref",
+    "value": "fleshleader_skin"
+  }
+}

--- a/Module/uti/gimp_bite.uti.json
+++ b/Module/uti/gimp_bite.uti.json
@@ -36,7 +36,7 @@
   },
   "Identified": {
     "type": "byte",
-    "value": 1
+    "value": 0
   },
   "LocalizedName": {
     "type": "cexolocstring",
@@ -67,11 +67,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 19
+          "value": 34
         },
         "CostValue": {
           "type": "word",
-          "value": 5
+          "value": 3
         },
         "Param1": {
           "type": "byte",
@@ -83,11 +83,11 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 77
+          "value": 93
         },
         "Subtype": {
           "type": "word",
-          "value": 0
+          "value": 1
         }
       }
     ]

--- a/Module/uti/hu_byysk_hide.uti.json
+++ b/Module/uti/hu_byysk_hide.uti.json
@@ -1,0 +1,202 @@
+{
+  "__data_type": "UTI ",
+  "AddCost": {
+    "type": "dword",
+    "value": 0
+  },
+  "BaseItem": {
+    "type": "int",
+    "value": 73
+  },
+  "Charges": {
+    "type": "byte",
+    "value": 0
+  },
+  "Comment": {
+    "type": "cexostring",
+    "value": ""
+  },
+  "Cost": {
+    "type": "dword",
+    "value": 0
+  },
+  "Cursed": {
+    "type": "byte",
+    "value": 0
+  },
+  "DescIdentified": {
+    "type": "cexolocstring",
+    "value": {}
+  },
+  "Description": {
+    "type": "cexolocstring",
+    "value": {}
+  },
+  "Identified": {
+    "type": "byte",
+    "value": 0
+  },
+  "LocalizedName": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "Byysk Warrior Hide"
+    }
+  },
+  "ModelPart1": {
+    "type": "byte",
+    "value": 1
+  },
+  "PaletteID": {
+    "type": "byte",
+    "value": 14
+  },
+  "Plot": {
+    "type": "byte",
+    "value": 0
+  },
+  "PropertiesList": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 30
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 2
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 70
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 1
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 43
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 34
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 99
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 41
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 50
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 98
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      }
+    ]
+  },
+  "StackSize": {
+    "type": "word",
+    "value": 1
+  },
+  "Stolen": {
+    "type": "byte",
+    "value": 0
+  },
+  "Tag": {
+    "type": "cexostring",
+    "value": "hu_byysk_hide"
+  },
+  "TemplateResRef": {
+    "type": "resref",
+    "value": "hu_byysk_hide"
+  }
+}

--- a/Module/uti/hu_qutig_bite.uti.json
+++ b/Module/uti/hu_qutig_bite.uti.json
@@ -1,0 +1,143 @@
+{
+  "__data_type": "UTI ",
+  "AddCost": {
+    "type": "dword",
+    "value": 0
+  },
+  "BaseItem": {
+    "type": "int",
+    "value": 69
+  },
+  "Charges": {
+    "type": "byte",
+    "value": 0
+  },
+  "Comment": {
+    "type": "cexostring",
+    "value": ""
+  },
+  "Cost": {
+    "type": "dword",
+    "value": 0
+  },
+  "Cursed": {
+    "type": "byte",
+    "value": 0
+  },
+  "DescIdentified": {
+    "type": "cexolocstring",
+    "value": {}
+  },
+  "Description": {
+    "type": "cexolocstring",
+    "value": {
+      "0": ""
+    }
+  },
+  "Identified": {
+    "type": "byte",
+    "value": 0
+  },
+  "LocalizedName": {
+    "id": 13248,
+    "type": "cexolocstring",
+    "value": {
+      "0": "Qion Tiger Bite"
+    }
+  },
+  "ModelPart1": {
+    "type": "byte",
+    "value": 1
+  },
+  "PaletteID": {
+    "type": "byte",
+    "value": 55
+  },
+  "Plot": {
+    "type": "byte",
+    "value": 0
+  },
+  "PropertiesList": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 2
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 3
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 56
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 34
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 17
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 93
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 1
+        }
+      }
+    ]
+  },
+  "StackSize": {
+    "type": "word",
+    "value": 1
+  },
+  "Stolen": {
+    "type": "byte",
+    "value": 0
+  },
+  "Tag": {
+    "type": "cexostring",
+    "value": "hu_qutig_bite"
+  },
+  "TemplateResRef": {
+    "type": "resref",
+    "value": "hu_qutig_bite"
+  }
+}

--- a/Module/uti/k_hound_bite.uti.json
+++ b/Module/uti/k_hound_bite.uti.json
@@ -36,7 +36,7 @@
   },
   "Identified": {
     "type": "byte",
-    "value": 1
+    "value": 0
   },
   "LocalizedName": {
     "type": "cexolocstring",
@@ -87,7 +87,7 @@
         },
         "Subtype": {
           "type": "word",
-          "value": 0
+          "value": 1
         }
       }
     ]

--- a/Module/uti/kinrath_bite.uti.json
+++ b/Module/uti/kinrath_bite.uti.json
@@ -36,7 +36,7 @@
   },
   "Identified": {
     "type": "byte",
-    "value": 1
+    "value": 0
   },
   "LocalizedName": {
     "type": "cexolocstring",
@@ -67,11 +67,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 19
+          "value": 34
         },
         "CostValue": {
           "type": "word",
-          "value": 8
+          "value": 2
         },
         "Param1": {
           "type": "byte",
@@ -83,11 +83,42 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 77
+          "value": 93
         },
         "Subtype": {
           "type": "word",
+          "value": 4
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
           "value": 0
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 0
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 103
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 1
         }
       }
     ]

--- a/Module/uti/lightsaber.uti.json
+++ b/Module/uti/lightsaber.uti.json
@@ -137,6 +137,37 @@
         },
         "CostTable": {
           "type": "byte",
+          "value": 26
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 39
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 82
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 125
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
           "value": 33
         },
         "CostValue": {

--- a/Module/uti/mando_hero_skin.uti.json
+++ b/Module/uti/mando_hero_skin.uti.json
@@ -1,0 +1,204 @@
+{
+  "__data_type": "UTI ",
+  "AddCost": {
+    "type": "dword",
+    "value": 0
+  },
+  "BaseItem": {
+    "type": "int",
+    "value": 73
+  },
+  "Charges": {
+    "type": "byte",
+    "value": 0
+  },
+  "Comment": {
+    "type": "cexostring",
+    "value": ""
+  },
+  "Cost": {
+    "type": "dword",
+    "value": 0
+  },
+  "Cursed": {
+    "type": "byte",
+    "value": 0
+  },
+  "DescIdentified": {
+    "type": "cexolocstring",
+    "value": {}
+  },
+  "Description": {
+    "type": "cexolocstring",
+    "value": {
+      "0": ""
+    }
+  },
+  "Identified": {
+    "type": "byte",
+    "value": 1
+  },
+  "LocalizedName": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "Mandalorian War Hero Skin"
+    }
+  },
+  "ModelPart1": {
+    "type": "byte",
+    "value": 1
+  },
+  "PaletteID": {
+    "type": "byte",
+    "value": 14
+  },
+  "Plot": {
+    "type": "byte",
+    "value": 0
+  },
+  "PropertiesList": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 10
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 2
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 25
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 1
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 43
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 15
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 99
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 41
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 50
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 98
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      }
+    ]
+  },
+  "StackSize": {
+    "type": "word",
+    "value": 1
+  },
+  "Stolen": {
+    "type": "byte",
+    "value": 0
+  },
+  "Tag": {
+    "type": "cexostring",
+    "value": "mando_hero_skin"
+  },
+  "TemplateResRef": {
+    "type": "resref",
+    "value": "mando_hero_skin"
+  }
+}

--- a/Module/uti/mando_war_skin.uti.json
+++ b/Module/uti/mando_war_skin.uti.json
@@ -1,0 +1,204 @@
+{
+  "__data_type": "UTI ",
+  "AddCost": {
+    "type": "dword",
+    "value": 0
+  },
+  "BaseItem": {
+    "type": "int",
+    "value": 73
+  },
+  "Charges": {
+    "type": "byte",
+    "value": 0
+  },
+  "Comment": {
+    "type": "cexostring",
+    "value": ""
+  },
+  "Cost": {
+    "type": "dword",
+    "value": 0
+  },
+  "Cursed": {
+    "type": "byte",
+    "value": 0
+  },
+  "DescIdentified": {
+    "type": "cexolocstring",
+    "value": {}
+  },
+  "Description": {
+    "type": "cexolocstring",
+    "value": {
+      "0": ""
+    }
+  },
+  "Identified": {
+    "type": "byte",
+    "value": 1
+  },
+  "LocalizedName": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "Mandalorian Warrior Skin"
+    }
+  },
+  "ModelPart1": {
+    "type": "byte",
+    "value": 1
+  },
+  "PaletteID": {
+    "type": "byte",
+    "value": 14
+  },
+  "Plot": {
+    "type": "byte",
+    "value": 0
+  },
+  "PropertiesList": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 5
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 2
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 20
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 1
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 43
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 11
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 99
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 41
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 50
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 98
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      }
+    ]
+  },
+  "StackSize": {
+    "type": "word",
+    "value": 1
+  },
+  "Stolen": {
+    "type": "byte",
+    "value": 0
+  },
+  "Tag": {
+    "type": "cexostring",
+    "value": "mando_war_skin"
+  },
+  "TemplateResRef": {
+    "type": "resref",
+    "value": "mando_war_skin"
+  }
+}

--- a/Module/uti/mc_amphihy_hi001.uti.json
+++ b/Module/uti/mc_amphihy_hi001.uti.json
@@ -1,0 +1,202 @@
+{
+  "__data_type": "UTI ",
+  "AddCost": {
+    "type": "dword",
+    "value": 0
+  },
+  "BaseItem": {
+    "type": "int",
+    "value": 73
+  },
+  "Charges": {
+    "type": "byte",
+    "value": 0
+  },
+  "Comment": {
+    "type": "cexostring",
+    "value": ""
+  },
+  "Cost": {
+    "type": "dword",
+    "value": 0
+  },
+  "Cursed": {
+    "type": "byte",
+    "value": 0
+  },
+  "DescIdentified": {
+    "type": "cexolocstring",
+    "value": {}
+  },
+  "Description": {
+    "type": "cexolocstring",
+    "value": {}
+  },
+  "Identified": {
+    "type": "byte",
+    "value": 0
+  },
+  "LocalizedName": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "Viper Hide"
+    }
+  },
+  "ModelPart1": {
+    "type": "byte",
+    "value": 1
+  },
+  "PaletteID": {
+    "type": "byte",
+    "value": 14
+  },
+  "Plot": {
+    "type": "byte",
+    "value": 0
+  },
+  "PropertiesList": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 40
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 2
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 40
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 1
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 43
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 25
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 99
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 41
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 15
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 98
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      }
+    ]
+  },
+  "StackSize": {
+    "type": "word",
+    "value": 1
+  },
+  "Stolen": {
+    "type": "byte",
+    "value": 0
+  },
+  "Tag": {
+    "type": "cexostring",
+    "value": "mc_viper_hide"
+  },
+  "TemplateResRef": {
+    "type": "resref",
+    "value": "mc_amphihy_hi001"
+  }
+}

--- a/Module/uti/mc_amphihy_hide.uti.json
+++ b/Module/uti/mc_amphihy_hide.uti.json
@@ -65,11 +65,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 22
+          "value": 35
         },
         "CostValue": {
           "type": "word",
-          "value": 4
+          "value": 70
         },
         "Param1": {
           "type": "byte",
@@ -81,11 +81,11 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 24
+          "value": 94
         },
         "Subtype": {
           "type": "word",
-          "value": 13
+          "value": 2
         }
       },
       {
@@ -96,11 +96,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 5
+          "value": 35
         },
         "CostValue": {
           "type": "word",
-          "value": 4
+          "value": 32
         },
         "Param1": {
           "type": "byte",
@@ -112,38 +112,7 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 20
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 0
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
-          "value": 5
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 4
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 20
+          "value": 94
         },
         "Subtype": {
           "type": "word",
@@ -158,11 +127,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 5
+          "value": 40
         },
         "CostValue": {
           "type": "word",
-          "value": 4
+          "value": 100
         },
         "Param1": {
           "type": "byte",
@@ -174,11 +143,42 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 20
+          "value": 97
         },
         "Subtype": {
           "type": "word",
-          "value": 2
+          "value": 0
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 43
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 25
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 99
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
         }
       }
     ]

--- a/Module/uti/mynock_claw.uti.json
+++ b/Module/uti/mynock_claw.uti.json
@@ -87,7 +87,7 @@
         },
         "Subtype": {
           "type": "word",
-          "value": 0
+          "value": 1
         }
       }
     ]

--- a/Module/uti/qionslugattack.uti.json
+++ b/Module/uti/qionslugattack.uti.json
@@ -65,11 +65,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 2
+          "value": 34
         },
         "CostValue": {
           "type": "word",
-          "value": 12
+          "value": 17
         },
         "Param1": {
           "type": "byte",
@@ -81,11 +81,11 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 56
+          "value": 93
         },
         "Subtype": {
           "type": "word",
-          "value": 0
+          "value": 1
         }
       },
       {
@@ -117,6 +117,37 @@
         "Subtype": {
           "type": "word",
           "value": 25
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 0
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 0
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 103
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 4
         }
       },
       {

--- a/Module/uti/quion_slug_hide.uti.json
+++ b/Module/uti/quion_slug_hide.uti.json
@@ -65,11 +65,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 7
+          "value": 35
         },
         "CostValue": {
           "type": "word",
-          "value": 2
+          "value": 15
         },
         "Param1": {
           "type": "byte",
@@ -81,7 +81,7 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 23
+          "value": 94
         },
         "Subtype": {
           "type": "word",
@@ -96,11 +96,197 @@
         },
         "CostTable": {
           "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 10
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 3
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 50
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 2
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 50
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 6
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 70
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 1
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 30
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 4
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 43
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 31
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 99
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
           "value": 2
         },
         "CostValue": {
           "type": "word",
-          "value": 5
+          "value": 8
         },
         "Param1": {
           "type": "byte",

--- a/Module/uti/raivor_skin.uti.json
+++ b/Module/uti/raivor_skin.uti.json
@@ -67,11 +67,104 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 43
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 100
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 3
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
         },
         "CostValue": {
           "type": "word",
           "value": 7
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 2
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 9
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 1
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 43
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 14
         },
         "Param1": {
           "type": "byte",

--- a/Module/uti/raptorbite.uti.json
+++ b/Module/uti/raptorbite.uti.json
@@ -65,11 +65,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 4
+          "value": 34
         },
         "CostValue": {
           "type": "word",
-          "value": 13
+          "value": 15
         },
         "Param1": {
           "type": "byte",
@@ -81,42 +81,11 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 16
+          "value": 93
         },
         "Subtype": {
           "type": "word",
           "value": 1
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
-          "value": 0
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 0
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 35
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 0
         }
       }
     ]

--- a/Module/uti/raptorbite001.uti.json
+++ b/Module/uti/raptorbite001.uti.json
@@ -18,7 +18,7 @@
   },
   "Cost": {
     "type": "dword",
-    "value": 450000
+    "value": 40500
   },
   "Cursed": {
     "type": "byte",
@@ -65,11 +65,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 2
+          "value": 34
         },
         "CostValue": {
           "type": "word",
-          "value": 20
+          "value": 13
         },
         "Param1": {
           "type": "byte",
@@ -81,11 +81,11 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 56
+          "value": 93
         },
         "Subtype": {
           "type": "word",
-          "value": 0
+          "value": 1
         }
       },
       {
@@ -100,7 +100,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 6
+          "value": 1
         },
         "Param1": {
           "type": "byte",
@@ -131,7 +131,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 6
+          "value": 1
         },
         "Param1": {
           "type": "byte",
@@ -148,6 +148,37 @@
         "Subtype": {
           "type": "word",
           "value": 9
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 0
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 0
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 103
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 1
         }
       }
     ]

--- a/Module/uti/sandbeetlebite.uti.json
+++ b/Module/uti/sandbeetlebite.uti.json
@@ -18,7 +18,7 @@
   },
   "Cost": {
     "type": "dword",
-    "value": 112500
+    "value": 10124
   },
   "Cursed": {
     "type": "byte",
@@ -65,11 +65,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 0
+          "value": 34
         },
         "CostValue": {
           "type": "word",
-          "value": 0
+          "value": 17
         },
         "Param1": {
           "type": "byte",
@@ -81,42 +81,11 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 43
+          "value": 93
         },
         "Subtype": {
           "type": "word",
-          "value": 0
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
-          "value": 4
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 13
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 74
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 0
+          "value": 1
         }
       },
       {
@@ -131,7 +100,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 6
+          "value": 1
         },
         "Param1": {
           "type": "byte",

--- a/Module/uti/sandbtl_skin.uti.json
+++ b/Module/uti/sandbtl_skin.uti.json
@@ -1,0 +1,173 @@
+{
+  "__data_type": "UTI ",
+  "AddCost": {
+    "type": "dword",
+    "value": 0
+  },
+  "BaseItem": {
+    "type": "int",
+    "value": 73
+  },
+  "Charges": {
+    "type": "byte",
+    "value": 0
+  },
+  "Comment": {
+    "type": "cexostring",
+    "value": ""
+  },
+  "Cost": {
+    "type": "dword",
+    "value": 0
+  },
+  "Cursed": {
+    "type": "byte",
+    "value": 0
+  },
+  "DescIdentified": {
+    "type": "cexolocstring",
+    "value": {}
+  },
+  "Description": {
+    "type": "cexolocstring",
+    "value": {
+      "0": ""
+    }
+  },
+  "Identified": {
+    "type": "byte",
+    "value": 1
+  },
+  "LocalizedName": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "Sand Beetle Skin"
+    }
+  },
+  "ModelPart1": {
+    "type": "byte",
+    "value": 1
+  },
+  "PaletteID": {
+    "type": "byte",
+    "value": 14
+  },
+  "Plot": {
+    "type": "byte",
+    "value": 0
+  },
+  "PropertiesList": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 65
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 2
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 80
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 1
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 43
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 40
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 99
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      }
+    ]
+  },
+  "StackSize": {
+    "type": "word",
+    "value": 1
+  },
+  "Stolen": {
+    "type": "byte",
+    "value": 0
+  },
+  "Tag": {
+    "type": "cexostring",
+    "value": "sandbtl_skin"
+  },
+  "TemplateResRef": {
+    "type": "resref",
+    "value": "sandbtl_skin"
+  }
+}

--- a/Module/uti/sanddemonbite.uti.json
+++ b/Module/uti/sanddemonbite.uti.json
@@ -18,7 +18,7 @@
   },
   "Cost": {
     "type": "dword",
-    "value": 50000
+    "value": 18000
   },
   "Cursed": {
     "type": "byte",
@@ -65,11 +65,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 4
+          "value": 34
         },
         "CostValue": {
           "type": "word",
-          "value": 13
+          "value": 27
         },
         "Param1": {
           "type": "byte",
@@ -81,11 +81,11 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 16
+          "value": 93
         },
         "Subtype": {
           "type": "word",
-          "value": 2
+          "value": 1
         }
       },
       {
@@ -100,7 +100,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 3
+          "value": 1
         },
         "Param1": {
           "type": "byte",

--- a/Module/uti/sanddemonhide001.uti.json
+++ b/Module/uti/sanddemonhide001.uti.json
@@ -65,11 +65,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 6
+          "value": 35
         },
         "CostValue": {
           "type": "word",
-          "value": 4
+          "value": 90
         },
         "Param1": {
           "type": "byte",
@@ -81,11 +81,42 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 22
+          "value": 94
         },
         "Subtype": {
           "type": "word",
-          "value": 14
+          "value": 2
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 90
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 1
         }
       },
       {
@@ -127,11 +158,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 5
+          "value": 43
         },
         "CostValue": {
           "type": "word",
-          "value": 70
+          "value": 45
         },
         "Param1": {
           "type": "byte",
@@ -143,11 +174,11 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 20
+          "value": 99
         },
         "Subtype": {
           "type": "word",
-          "value": 5
+          "value": 0
         }
       },
       {
@@ -158,11 +189,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 4
+          "value": 41
         },
         "CostValue": {
           "type": "word",
-          "value": 13
+          "value": 50
         },
         "Param1": {
           "type": "byte",
@@ -174,7 +205,7 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 74
+          "value": 98
         },
         "Subtype": {
           "type": "word",

--- a/Module/uti/sandswimmer_hide.uti.json
+++ b/Module/uti/sandswimmer_hide.uti.json
@@ -1,0 +1,171 @@
+{
+  "__data_type": "UTI ",
+  "AddCost": {
+    "type": "dword",
+    "value": 0
+  },
+  "BaseItem": {
+    "type": "int",
+    "value": 73
+  },
+  "Charges": {
+    "type": "byte",
+    "value": 0
+  },
+  "Comment": {
+    "type": "cexostring",
+    "value": ""
+  },
+  "Cost": {
+    "type": "dword",
+    "value": 0
+  },
+  "Cursed": {
+    "type": "byte",
+    "value": 0
+  },
+  "DescIdentified": {
+    "type": "cexolocstring",
+    "value": {}
+  },
+  "Description": {
+    "type": "cexolocstring",
+    "value": {}
+  },
+  "Identified": {
+    "type": "byte",
+    "value": 0
+  },
+  "LocalizedName": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "Sandswimmer Hide"
+    }
+  },
+  "ModelPart1": {
+    "type": "byte",
+    "value": 1
+  },
+  "PaletteID": {
+    "type": "byte",
+    "value": 14
+  },
+  "Plot": {
+    "type": "byte",
+    "value": 0
+  },
+  "PropertiesList": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 80
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 2
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 65
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 1
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 43
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 39
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 99
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      }
+    ]
+  },
+  "StackSize": {
+    "type": "word",
+    "value": 1
+  },
+  "Stolen": {
+    "type": "byte",
+    "value": 0
+  },
+  "Tag": {
+    "type": "cexostring",
+    "value": "sandswimmer_hide"
+  },
+  "TemplateResRef": {
+    "type": "resref",
+    "value": "sandswimmer_hide"
+  }
+}

--- a/Module/uti/sandswimmerclaw.uti.json
+++ b/Module/uti/sandswimmerclaw.uti.json
@@ -67,11 +67,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 4
+          "value": 34
         },
         "CostValue": {
           "type": "word",
-          "value": 20
+          "value": 19
         },
         "Param1": {
           "type": "byte",
@@ -83,11 +83,42 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 16
+          "value": 93
         },
         "Subtype": {
           "type": "word",
           "value": 2
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 0
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 0
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 103
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 4
         }
       }
     ]

--- a/Module/uti/sandworm_hide.uti.json
+++ b/Module/uti/sandworm_hide.uti.json
@@ -1,0 +1,233 @@
+{
+  "__data_type": "UTI ",
+  "AddCost": {
+    "type": "dword",
+    "value": 0
+  },
+  "BaseItem": {
+    "type": "int",
+    "value": 73
+  },
+  "Charges": {
+    "type": "byte",
+    "value": 0
+  },
+  "Comment": {
+    "type": "cexostring",
+    "value": ""
+  },
+  "Cost": {
+    "type": "dword",
+    "value": 0
+  },
+  "Cursed": {
+    "type": "byte",
+    "value": 0
+  },
+  "DescIdentified": {
+    "type": "cexolocstring",
+    "value": {}
+  },
+  "Description": {
+    "type": "cexolocstring",
+    "value": {}
+  },
+  "Identified": {
+    "type": "byte",
+    "value": 0
+  },
+  "LocalizedName": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "Sand Worm Hide"
+    }
+  },
+  "ModelPart1": {
+    "type": "byte",
+    "value": 1
+  },
+  "PaletteID": {
+    "type": "byte",
+    "value": 14
+  },
+  "Plot": {
+    "type": "byte",
+    "value": 0
+  },
+  "PropertiesList": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 100
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 2
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 100
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 1
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 0
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 0
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 75
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 43
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 50
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 99
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 41
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 100
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 98
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      }
+    ]
+  },
+  "StackSize": {
+    "type": "word",
+    "value": 1
+  },
+  "Stolen": {
+    "type": "byte",
+    "value": 0
+  },
+  "Tag": {
+    "type": "cexostring",
+    "value": "sandworm_hide"
+  },
+  "TemplateResRef": {
+    "type": "resref",
+    "value": "sandworm_hide"
+  }
+}

--- a/Module/uti/sandwormbite.uti.json
+++ b/Module/uti/sandwormbite.uti.json
@@ -34,7 +34,7 @@
   },
   "Identified": {
     "type": "byte",
-    "value": 1
+    "value": 0
   },
   "LocalizedName": {
     "type": "cexolocstring",
@@ -65,11 +65,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 2
+          "value": 34
         },
         "CostValue": {
           "type": "word",
-          "value": 10
+          "value": 49
         },
         "Param1": {
           "type": "byte",
@@ -81,11 +81,11 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 56
+          "value": 93
         },
         "Subtype": {
           "type": "word",
-          "value": 0
+          "value": 1
         }
       },
       {
@@ -112,42 +112,11 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 43
+          "value": 103
         },
         "Subtype": {
           "type": "word",
-          "value": 0
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
-          "value": 4
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 15
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 74
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 0
+          "value": 1
         }
       }
     ]

--- a/Module/uti/shockstick.uti.json
+++ b/Module/uti/shockstick.uti.json
@@ -1,0 +1,184 @@
+{
+  "__data_type": "UTI ",
+  "AddCost": {
+    "type": "dword",
+    "value": 45
+  },
+  "BaseItem": {
+    "type": "int",
+    "value": 1
+  },
+  "Charges": {
+    "type": "byte",
+    "value": 0
+  },
+  "Comment": {
+    "type": "cexostring",
+    "value": "1"
+  },
+  "Cost": {
+    "type": "dword",
+    "value": 75
+  },
+  "Cursed": {
+    "type": "byte",
+    "value": 0
+  },
+  "DescIdentified": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "A Shock Stick delivers an electric charge to the victim, so long as it is held against them.  Fighting with one against someone trying to kill you isn't much like a normal fight... it's a matter of staying in close contact until the other party is subdued.  While trying not to die."
+    }
+  },
+  "Description": {
+    "type": "cexolocstring",
+    "value": {
+      "0": ""
+    }
+  },
+  "Identified": {
+    "type": "byte",
+    "value": 1
+  },
+  "LocalizedName": {
+    "id": 166,
+    "type": "cexolocstring",
+    "value": {
+      "0": "Shock Stick"
+    }
+  },
+  "ModelPart1": {
+    "type": "byte",
+    "value": 61
+  },
+  "ModelPart2": {
+    "type": "byte",
+    "value": 221
+  },
+  "ModelPart3": {
+    "type": "byte",
+    "value": 214
+  },
+  "PaletteID": {
+    "type": "byte",
+    "value": 36
+  },
+  "Plot": {
+    "type": "byte",
+    "value": 0
+  },
+  "PropertiesList": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 34
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 1
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 93
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 5
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 0
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 0
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 103
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 4
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 33
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 1
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 100
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 6
+        }
+      }
+    ]
+  },
+  "StackSize": {
+    "type": "word",
+    "value": 1
+  },
+  "Stolen": {
+    "type": "byte",
+    "value": 0
+  },
+  "Tag": {
+    "type": "cexostring",
+    "value": "shockstick"
+  },
+  "TemplateResRef": {
+    "type": "resref",
+    "value": "shockstick"
+  }
+}

--- a/Module/uti/swampvinethorns.uti.json
+++ b/Module/uti/swampvinethorns.uti.json
@@ -69,7 +69,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 20
+          "value": 10
         },
         "Param1": {
           "type": "byte",

--- a/Module/uti/tusken_gaffi.uti.json
+++ b/Module/uti/tusken_gaffi.uti.json
@@ -38,7 +38,7 @@
   },
   "Identified": {
     "type": "byte",
-    "value": 1
+    "value": 0
   },
   "LocalizedName": {
     "id": 1544,
@@ -78,11 +78,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 4
+          "value": 34
         },
         "CostValue": {
           "type": "word",
-          "value": 7
+          "value": 18
         },
         "Param1": {
           "type": "byte",
@@ -94,104 +94,11 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 16
+          "value": 93
         },
         "Subtype": {
           "type": "word",
           "value": 1
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
-          "value": 4
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 7
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 16
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 2
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
-          "value": 2
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 5
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 6
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 0
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
-          "value": 4
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 10
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 74
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 0
         }
       }
     ]

--- a/Module/uti/tusken_skin.uti.json
+++ b/Module/uti/tusken_skin.uti.json
@@ -1,0 +1,204 @@
+{
+  "__data_type": "UTI ",
+  "AddCost": {
+    "type": "dword",
+    "value": 0
+  },
+  "BaseItem": {
+    "type": "int",
+    "value": 73
+  },
+  "Charges": {
+    "type": "byte",
+    "value": 0
+  },
+  "Comment": {
+    "type": "cexostring",
+    "value": ""
+  },
+  "Cost": {
+    "type": "dword",
+    "value": 0
+  },
+  "Cursed": {
+    "type": "byte",
+    "value": 0
+  },
+  "DescIdentified": {
+    "type": "cexolocstring",
+    "value": {}
+  },
+  "Description": {
+    "type": "cexolocstring",
+    "value": {
+      "0": ""
+    }
+  },
+  "Identified": {
+    "type": "byte",
+    "value": 1
+  },
+  "LocalizedName": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "Tusken Raider Skin"
+    }
+  },
+  "ModelPart1": {
+    "type": "byte",
+    "value": 1
+  },
+  "PaletteID": {
+    "type": "byte",
+    "value": 14
+  },
+  "Plot": {
+    "type": "byte",
+    "value": 0
+  },
+  "PropertiesList": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 72
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 2
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 72
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 1
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 43
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 36
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 99
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 41
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 50
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 98
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      }
+    ]
+  },
+  "StackSize": {
+    "type": "word",
+    "value": 1
+  },
+  "Stolen": {
+    "type": "byte",
+    "value": 0
+  },
+  "Tag": {
+    "type": "cexostring",
+    "value": "tusken_skin"
+  },
+  "TemplateResRef": {
+    "type": "resref",
+    "value": "tusken_skin"
+  }
+}

--- a/Module/uti/tuskenblasterrif.uti.json
+++ b/Module/uti/tuskenblasterrif.uti.json
@@ -75,11 +75,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 4
+          "value": 34
         },
         "CostValue": {
           "type": "word",
-          "value": 15
+          "value": 19
         },
         "Param1": {
           "type": "byte",
@@ -91,42 +91,11 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 16
+          "value": 93
         },
         "Subtype": {
           "type": "word",
-          "value": 0
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
-          "value": 0
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 0
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 38
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 0
+          "value": 1
         }
       },
       {
@@ -154,68 +123,6 @@
         "PropertyName": {
           "type": "word",
           "value": 43
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 0
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
-          "value": 4
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 15
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 74
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 0
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
-          "value": 2
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 7
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 45
         },
         "Subtype": {
           "type": "word",

--- a/Module/uti/v_cairnmog_bite.uti.json
+++ b/Module/uti/v_cairnmog_bite.uti.json
@@ -36,7 +36,7 @@
   },
   "Identified": {
     "type": "byte",
-    "value": 1
+    "value": 0
   },
   "LocalizedName": {
     "type": "cexolocstring",
@@ -67,11 +67,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 2
+          "value": 34
         },
         "CostValue": {
           "type": "word",
-          "value": 4
+          "value": 5
         },
         "Param1": {
           "type": "byte",
@@ -83,42 +83,11 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 56
+          "value": 93
         },
         "Subtype": {
           "type": "word",
-          "value": 0
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
-          "value": 19
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 4
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 77
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 0
+          "value": 1
         }
       }
     ]

--- a/Module/uti/v_cairnmog_pr001.uti.json
+++ b/Module/uti/v_cairnmog_pr001.uti.json
@@ -36,7 +36,7 @@
   },
   "Identified": {
     "type": "byte",
-    "value": 1
+    "value": 0
   },
   "LocalizedName": {
     "id": 90572,
@@ -68,11 +68,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 7
+          "value": 35
         },
         "CostValue": {
           "type": "word",
-          "value": 4
+          "value": 45
         },
         "Param1": {
           "type": "byte",
@@ -84,7 +84,7 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 23
+          "value": 94
         },
         "Subtype": {
           "type": "word",
@@ -99,11 +99,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 22
+          "value": 35
         },
         "CostValue": {
           "type": "word",
-          "value": 3
+          "value": 50
         },
         "Param1": {
           "type": "byte",
@@ -115,11 +115,11 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 24
+          "value": 94
         },
         "Subtype": {
           "type": "word",
-          "value": 10
+          "value": 6
         }
       },
       {
@@ -130,11 +130,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 22
+          "value": 35
         },
         "CostValue": {
           "type": "word",
-          "value": 5
+          "value": 55
         },
         "Param1": {
           "type": "byte",
@@ -146,11 +146,73 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 24
+          "value": 94
         },
         "Subtype": {
           "type": "word",
           "value": 1
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 43
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 32
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 99
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 41
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 50
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 98
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
         }
       }
     ]

--- a/Module/uti/v_cairnmog_prop.uti.json
+++ b/Module/uti/v_cairnmog_prop.uti.json
@@ -36,7 +36,7 @@
   },
   "Identified": {
     "type": "byte",
-    "value": 1
+    "value": 0
   },
   "LocalizedName": {
     "id": 90572,
@@ -68,11 +68,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 6
+          "value": 35
         },
         "CostValue": {
           "type": "word",
-          "value": 1
+          "value": 10
         },
         "Param1": {
           "type": "byte",
@@ -84,7 +84,100 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 22
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 2
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 10
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 1
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 43
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 10
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 99
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 41
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 50
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 98
         },
         "Subtype": {
           "type": "word",

--- a/Module/uti/v_cairnmoga_prop.uti.json
+++ b/Module/uti/v_cairnmoga_prop.uti.json
@@ -1,0 +1,205 @@
+{
+  "__data_type": "UTI ",
+  "AddCost": {
+    "type": "dword",
+    "value": 0
+  },
+  "BaseItem": {
+    "type": "int",
+    "value": 73
+  },
+  "Charges": {
+    "type": "byte",
+    "value": 0
+  },
+  "Comment": {
+    "type": "cexostring",
+    "value": ""
+  },
+  "Cost": {
+    "type": "dword",
+    "value": 0
+  },
+  "Cursed": {
+    "type": "byte",
+    "value": 1
+  },
+  "DescIdentified": {
+    "type": "cexolocstring",
+    "value": {}
+  },
+  "Description": {
+    "type": "cexolocstring",
+    "value": {
+      "0": ""
+    }
+  },
+  "Identified": {
+    "type": "byte",
+    "value": 0
+  },
+  "LocalizedName": {
+    "id": 90572,
+    "type": "cexolocstring",
+    "value": {
+      "0": "Valley Cairnmog Alpha Properties"
+    }
+  },
+  "ModelPart1": {
+    "type": "byte",
+    "value": 1
+  },
+  "PaletteID": {
+    "type": "byte",
+    "value": 14
+  },
+  "Plot": {
+    "type": "byte",
+    "value": 0
+  },
+  "PropertiesList": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 12
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 2
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 12
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 1
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 43
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 12
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 99
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 41
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 50
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 98
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      }
+    ]
+  },
+  "StackSize": {
+    "type": "word",
+    "value": 1
+  },
+  "Stolen": {
+    "type": "byte",
+    "value": 0
+  },
+  "Tag": {
+    "type": "cexostring",
+    "value": "v_cairnmoga_prop"
+  },
+  "TemplateResRef": {
+    "type": "resref",
+    "value": "v_cairnmoga_prop"
+  }
+}

--- a/Module/uti/v_kraptor_skin.uti.json
+++ b/Module/uti/v_kraptor_skin.uti.json
@@ -1,0 +1,204 @@
+{
+  "__data_type": "UTI ",
+  "AddCost": {
+    "type": "dword",
+    "value": 0
+  },
+  "BaseItem": {
+    "type": "int",
+    "value": 73
+  },
+  "Charges": {
+    "type": "byte",
+    "value": 0
+  },
+  "Comment": {
+    "type": "cexostring",
+    "value": ""
+  },
+  "Cost": {
+    "type": "dword",
+    "value": 0
+  },
+  "Cursed": {
+    "type": "byte",
+    "value": 0
+  },
+  "DescIdentified": {
+    "type": "cexolocstring",
+    "value": {}
+  },
+  "Description": {
+    "type": "cexolocstring",
+    "value": {
+      "0": ""
+    }
+  },
+  "Identified": {
+    "type": "byte",
+    "value": 1
+  },
+  "LocalizedName": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "Vellen King Raptor Skin"
+    }
+  },
+  "ModelPart1": {
+    "type": "byte",
+    "value": 1
+  },
+  "PaletteID": {
+    "type": "byte",
+    "value": 14
+  },
+  "Plot": {
+    "type": "byte",
+    "value": 0
+  },
+  "PropertiesList": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 70
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 2
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 100
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 1
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 43
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 50
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 99
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 41
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 250
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 98
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      }
+    ]
+  },
+  "StackSize": {
+    "type": "word",
+    "value": 1
+  },
+  "Stolen": {
+    "type": "byte",
+    "value": 0
+  },
+  "Tag": {
+    "type": "cexostring",
+    "value": "v_kraptor_skin"
+  },
+  "TemplateResRef": {
+    "type": "resref",
+    "value": "v_kraptor_skin"
+  }
+}

--- a/Module/uti/v_nashtah_bite.uti.json
+++ b/Module/uti/v_nashtah_bite.uti.json
@@ -36,7 +36,7 @@
   },
   "Identified": {
     "type": "byte",
-    "value": 1
+    "value": 0
   },
   "LocalizedName": {
     "type": "cexolocstring",
@@ -67,12 +67,12 @@
         },
         "CostTable": {
           "type": "byte",
+          "value": 34
+        },
+        "CostValue": {
+          "type": "word",
           "value": 2
         },
-        "CostValue": {
-          "type": "word",
-          "value": 4
-        },
         "Param1": {
           "type": "byte",
           "value": 255
@@ -83,11 +83,11 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 56
+          "value": 93
         },
         "Subtype": {
           "type": "word",
-          "value": 0
+          "value": 4
         }
       },
       {
@@ -98,11 +98,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 4
+          "value": 0
         },
         "CostValue": {
           "type": "word",
-          "value": 7
+          "value": 0
         },
         "Param1": {
           "type": "byte",
@@ -114,42 +114,11 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 16
+          "value": 103
         },
         "Subtype": {
           "type": "word",
-          "value": 9
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
-          "value": 19
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 3
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 77
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 0
+          "value": 1
         }
       }
     ]

--- a/Module/uti/v_nashtah_p.uti.json
+++ b/Module/uti/v_nashtah_p.uti.json
@@ -36,7 +36,7 @@
   },
   "Identified": {
     "type": "byte",
-    "value": 1
+    "value": 0
   },
   "LocalizedName": {
     "id": 90572,
@@ -68,11 +68,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 7
+          "value": 35
         },
         "CostValue": {
           "type": "word",
-          "value": 1
+          "value": 8
         },
         "Param1": {
           "type": "byte",
@@ -84,131 +84,7 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 23
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 14
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
-          "value": 7
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 1
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 23
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 0
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
-          "value": 7
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 1
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 23
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 16
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
-          "value": 7
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 1
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 23
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 1
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
-          "value": 7
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 1
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 23
+          "value": 94
         },
         "Subtype": {
           "type": "word",
@@ -223,73 +99,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 22
+          "value": 35
         },
         "CostValue": {
-          "type": "word",
-          "value": 4
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 24
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 6
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
-          "value": 22
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 4
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 24
-        },
-        "Subtype": {
           "type": "word",
           "value": 7
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
-          "value": 22
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 4
         },
         "Param1": {
           "type": "byte",
@@ -301,11 +115,11 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 24
+          "value": 94
         },
         "Subtype": {
           "type": "word",
-          "value": 8
+          "value": 1
         }
       },
       {
@@ -316,11 +130,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 22
+          "value": 35
         },
         "CostValue": {
           "type": "word",
-          "value": 4
+          "value": 100
         },
         "Param1": {
           "type": "byte",
@@ -332,11 +146,11 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 24
+          "value": 94
         },
         "Subtype": {
           "type": "word",
-          "value": 9
+          "value": 4
         }
       },
       {
@@ -347,135 +161,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 22
+          "value": 43
         },
         "CostValue": {
-          "type": "word",
-          "value": 4
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 24
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 15
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
-          "value": 22
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 4
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 24
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 10
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
-          "value": 22
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 4
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 24
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 5
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
-          "value": 22
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 4
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 24
-        },
-        "Subtype": {
           "type": "word",
           "value": 11
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
-          "value": 22
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 4
         },
         "Param1": {
           "type": "byte",
@@ -487,11 +177,11 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 24
+          "value": 99
         },
         "Subtype": {
           "type": "word",
-          "value": 12
+          "value": 0
         }
       },
       {
@@ -502,11 +192,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 22
+          "value": 41
         },
         "CostValue": {
           "type": "word",
-          "value": 4
+          "value": 50
         },
         "Param1": {
           "type": "byte",
@@ -518,11 +208,11 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 24
+          "value": 98
         },
         "Subtype": {
           "type": "word",
-          "value": 13
+          "value": 0
         }
       }
     ]

--- a/Module/uti/v_raptor_skin.uti.json
+++ b/Module/uti/v_raptor_skin.uti.json
@@ -1,0 +1,204 @@
+{
+  "__data_type": "UTI ",
+  "AddCost": {
+    "type": "dword",
+    "value": 0
+  },
+  "BaseItem": {
+    "type": "int",
+    "value": 73
+  },
+  "Charges": {
+    "type": "byte",
+    "value": 0
+  },
+  "Comment": {
+    "type": "cexostring",
+    "value": ""
+  },
+  "Cost": {
+    "type": "dword",
+    "value": 0
+  },
+  "Cursed": {
+    "type": "byte",
+    "value": 0
+  },
+  "DescIdentified": {
+    "type": "cexolocstring",
+    "value": {}
+  },
+  "Description": {
+    "type": "cexolocstring",
+    "value": {
+      "0": ""
+    }
+  },
+  "Identified": {
+    "type": "byte",
+    "value": 1
+  },
+  "LocalizedName": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "Vellen Raptor Skin"
+    }
+  },
+  "ModelPart1": {
+    "type": "byte",
+    "value": 1
+  },
+  "PaletteID": {
+    "type": "byte",
+    "value": 14
+  },
+  "Plot": {
+    "type": "byte",
+    "value": 0
+  },
+  "PropertiesList": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 20
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 2
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 30
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 1
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 43
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 25
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 99
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 41
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 50
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 98
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      }
+    ]
+  },
+  "StackSize": {
+    "type": "word",
+    "value": 1
+  },
+  "Stolen": {
+    "type": "byte",
+    "value": 0
+  },
+  "Tag": {
+    "type": "cexostring",
+    "value": "v_raptor_skin"
+  },
+  "TemplateResRef": {
+    "type": "resref",
+    "value": "v_raptor_skin"
+  }
+}

--- a/Module/uti/vellen_claw.uti.json
+++ b/Module/uti/vellen_claw.uti.json
@@ -36,7 +36,7 @@
   },
   "Identified": {
     "type": "byte",
-    "value": 1
+    "value": 0
   },
   "LocalizedName": {
     "type": "cexolocstring",
@@ -67,11 +67,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 2
+          "value": 34
         },
         "CostValue": {
           "type": "word",
-          "value": 2
+          "value": 13
         },
         "Param1": {
           "type": "byte",
@@ -83,11 +83,11 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 56
+          "value": 93
         },
         "Subtype": {
           "type": "word",
-          "value": 0
+          "value": 1
         }
       }
     ]

--- a/Module/uti/vellenking_0001.uti.json
+++ b/Module/uti/vellenking_0001.uti.json
@@ -18,7 +18,7 @@
   },
   "Cost": {
     "type": "dword",
-    "value": 32000
+    "value": 0
   },
   "Cursed": {
     "type": "byte",
@@ -67,11 +67,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 2
+          "value": 34
         },
         "CostValue": {
           "type": "word",
-          "value": 8
+          "value": 39
         },
         "Param1": {
           "type": "byte",
@@ -83,104 +83,11 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 56
+          "value": 93
         },
         "Subtype": {
           "type": "word",
-          "value": 0
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
-          "value": 4
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 8
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 74
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 0
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
-          "value": 19
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 17
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 77
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 0
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
-          "value": 24
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 2
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 48
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 25
+          "value": 1
         }
       }
     ]

--- a/Module/uti/viperbite.uti.json
+++ b/Module/uti/viperbite.uti.json
@@ -34,7 +34,7 @@
   },
   "Identified": {
     "type": "byte",
-    "value": 1
+    "value": 0
   },
   "LocalizedName": {
     "type": "cexolocstring",
@@ -65,11 +65,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 4
+          "value": 34
         },
         "CostValue": {
           "type": "word",
-          "value": 13
+          "value": 3
         },
         "Param1": {
           "type": "byte",
@@ -81,11 +81,11 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 16
+          "value": 93
         },
         "Subtype": {
           "type": "word",
-          "value": 6
+          "value": 4
         }
       }
     ]

--- a/Module/uti/warocas_bite.uti.json
+++ b/Module/uti/warocas_bite.uti.json
@@ -87,7 +87,7 @@
         },
         "Subtype": {
           "type": "word",
-          "value": 0
+          "value": 1
         }
       }
     ]

--- a/Module/uti/womprat_skin.uti.json
+++ b/Module/uti/womprat_skin.uti.json
@@ -1,0 +1,173 @@
+{
+  "__data_type": "UTI ",
+  "AddCost": {
+    "type": "dword",
+    "value": 0
+  },
+  "BaseItem": {
+    "type": "int",
+    "value": 73
+  },
+  "Charges": {
+    "type": "byte",
+    "value": 0
+  },
+  "Comment": {
+    "type": "cexostring",
+    "value": ""
+  },
+  "Cost": {
+    "type": "dword",
+    "value": 0
+  },
+  "Cursed": {
+    "type": "byte",
+    "value": 0
+  },
+  "DescIdentified": {
+    "type": "cexolocstring",
+    "value": {}
+  },
+  "Description": {
+    "type": "cexolocstring",
+    "value": {
+      "0": ""
+    }
+  },
+  "Identified": {
+    "type": "byte",
+    "value": 1
+  },
+  "LocalizedName": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "Womprat Skin"
+    }
+  },
+  "ModelPart1": {
+    "type": "byte",
+    "value": 1
+  },
+  "PaletteID": {
+    "type": "byte",
+    "value": 14
+  },
+  "Plot": {
+    "type": "byte",
+    "value": 0
+  },
+  "PropertiesList": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 60
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 2
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 60
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 1
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 43
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 35
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 99
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      }
+    ]
+  },
+  "StackSize": {
+    "type": "word",
+    "value": 1
+  },
+  "Stolen": {
+    "type": "byte",
+    "value": 0
+  },
+  "Tag": {
+    "type": "cexostring",
+    "value": "womprat_skin"
+  },
+  "TemplateResRef": {
+    "type": "resref",
+    "value": "womprat_skin"
+  }
+}

--- a/Module/uti/ww_gimp_hide.uti.json
+++ b/Module/uti/ww_gimp_hide.uti.json
@@ -1,0 +1,205 @@
+{
+  "__data_type": "UTI ",
+  "AddCost": {
+    "type": "dword",
+    "value": 0
+  },
+  "BaseItem": {
+    "type": "int",
+    "value": 73
+  },
+  "Charges": {
+    "type": "byte",
+    "value": 0
+  },
+  "Comment": {
+    "type": "cexostring",
+    "value": ""
+  },
+  "Cost": {
+    "type": "dword",
+    "value": 0
+  },
+  "Cursed": {
+    "type": "byte",
+    "value": 1
+  },
+  "DescIdentified": {
+    "type": "cexolocstring",
+    "value": {}
+  },
+  "Description": {
+    "type": "cexolocstring",
+    "value": {
+      "0": ""
+    }
+  },
+  "Identified": {
+    "type": "byte",
+    "value": 0
+  },
+  "LocalizedName": {
+    "id": 90572,
+    "type": "cexolocstring",
+    "value": {
+      "0": "Gimpassa Hide"
+    }
+  },
+  "ModelPart1": {
+    "type": "byte",
+    "value": 1
+  },
+  "PaletteID": {
+    "type": "byte",
+    "value": 14
+  },
+  "Plot": {
+    "type": "byte",
+    "value": 0
+  },
+  "PropertiesList": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 5
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 2
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 20
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 1
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 43
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 12
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 99
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 41
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 50
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 98
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      }
+    ]
+  },
+  "StackSize": {
+    "type": "word",
+    "value": 1
+  },
+  "Stolen": {
+    "type": "byte",
+    "value": 0
+  },
+  "Tag": {
+    "type": "cexostring",
+    "value": "ww_gimp_hide"
+  },
+  "TemplateResRef": {
+    "type": "resref",
+    "value": "ww_gimp_hide"
+  }
+}

--- a/Module/uti/ww_outlaw_skin.uti.json
+++ b/Module/uti/ww_outlaw_skin.uti.json
@@ -1,0 +1,204 @@
+{
+  "__data_type": "UTI ",
+  "AddCost": {
+    "type": "dword",
+    "value": 0
+  },
+  "BaseItem": {
+    "type": "int",
+    "value": 73
+  },
+  "Charges": {
+    "type": "byte",
+    "value": 0
+  },
+  "Comment": {
+    "type": "cexostring",
+    "value": ""
+  },
+  "Cost": {
+    "type": "dword",
+    "value": 0
+  },
+  "Cursed": {
+    "type": "byte",
+    "value": 0
+  },
+  "DescIdentified": {
+    "type": "cexolocstring",
+    "value": {}
+  },
+  "Description": {
+    "type": "cexolocstring",
+    "value": {
+      "0": ""
+    }
+  },
+  "Identified": {
+    "type": "byte",
+    "value": 1
+  },
+  "LocalizedName": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "Wildwoods Outlaw Skin"
+    }
+  },
+  "ModelPart1": {
+    "type": "byte",
+    "value": 1
+  },
+  "PaletteID": {
+    "type": "byte",
+    "value": 14
+  },
+  "Plot": {
+    "type": "byte",
+    "value": 0
+  },
+  "PropertiesList": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 5
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 2
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 7
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 1
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 43
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 6
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 99
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 41
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 50
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 98
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      }
+    ]
+  },
+  "StackSize": {
+    "type": "word",
+    "value": 1
+  },
+  "Stolen": {
+    "type": "byte",
+    "value": 0
+  },
+  "Tag": {
+    "type": "cexostring",
+    "value": "ww_outlaw_skin"
+  },
+  "TemplateResRef": {
+    "type": "resref",
+    "value": "ww_outlaw_skin"
+  }
+}

--- a/SWLOR.Game.Server/Core/NWScript/Enum/Item/ItemPropertyType.cs
+++ b/SWLOR.Game.Server/Core/NWScript/Enum/Item/ItemPropertyType.cs
@@ -101,6 +101,7 @@ namespace SWLOR.Game.Server.Core.NWScript.Enum.Item
         UseLimitationPerk = 100,
         ArmorEnhancement = 101,
         WeaponEnhancement = 102,
+        PrimaryStat = 103,
         EnhancementLevel = 104,
         StructureBonus = 105,
 

--- a/SWLOR.Game.Server/Native/GetDamageRoll.cs
+++ b/SWLOR.Game.Server/Native/GetDamageRoll.cs
@@ -141,7 +141,11 @@ namespace SWLOR.Game.Server.Native
 
             if (attackType == (uint) AttackType.Ranged)
             {
-                attackAttribute = weapon == null ? 0 : (int)(dmg / 4);
+                // Throwing weapons should add Strength.  Other ranged types are based on weapon base damage rating. 
+                if (weapon != null && !Item.ThrowingWeaponBaseItemTypes.Contains((BaseItem)weapon.m_nBaseItem))
+                {
+                    attackAttribute = weapon == null ? 0 : (int)(dmg / 3);
+                }
             }
             else if (attackType == (uint) AttackType.Spirit)
             {

--- a/SWLOR.Game.Server/Native/GetDamageRoll.cs
+++ b/SWLOR.Game.Server/Native/GetDamageRoll.cs
@@ -13,6 +13,7 @@ using BaseItem = SWLOR.Game.Server.Core.NWScript.Enum.Item.BaseItem;
 using EquipmentSlot = NWN.Native.API.EquipmentSlot;
 using InventorySlot = SWLOR.Game.Server.Core.NWScript.Enum.InventorySlot;
 using ObjectType = NWN.Native.API.ObjectType;
+using RacialType = SWLOR.Game.Server.Core.NWScript.Enum.RacialType;
 using Random = SWLOR.Game.Server.Service.Random;
 
 namespace SWLOR.Game.Server.Native
@@ -108,6 +109,7 @@ namespace SWLOR.Game.Server.Native
             var dmg = 0f;
             var damage = 0;
             var specializationDMGBonus = 0f;
+            var damageType = -1;
 
             // Calculate attacker's base DMG
             if (attacker != null)
@@ -122,7 +124,7 @@ namespace SWLOR.Game.Server.Native
 
                 if (weapon != null)
                 {
-                    // Iterate over properties and take the highest DMG rating.
+                    // Iterate over properties and take the highest DMG rating.  Also save the damage type.
                     for (var index = 0; index < weapon.m_lstPassiveProperties.Count; index++)
                     {
                         var ip = weapon.GetPassiveProperty(index);
@@ -131,6 +133,7 @@ namespace SWLOR.Game.Server.Native
                             if (ip.m_nCostTableValue > dmg)
                             {
                                 dmg = Combat.GetDMGValueFromItemPropertyCostTableValue(ip.m_nCostTableValue);
+                                damageType = ip.m_nSubType;
                             }
                         }
                     }
@@ -155,7 +158,7 @@ namespace SWLOR.Game.Server.Native
             // Attributes are stored as a byte (uint) - values over 128 are meant to be negative.
             if (attackAttribute > 128) attackAttribute -= 256;
 
-            Log.Write(LogGroup.Attack, "DAMAGE: attacker attribute modifier: " + attackAttribute.ToString());
+            Log.Write(LogGroup.Attack, "DAMAGE: attacker attribute modifier: " + attackAttribute.ToString() + ", damage type " + damageType);
 
             // Add in the specialization damage bonus now.  We don't want to count this for the ranged weapon
             // attack attribute, so it can't happen earlier.
@@ -209,11 +212,24 @@ namespace SWLOR.Game.Server.Native
                 var target = CNWSCreature.FromPointer(pTarget);
                 var damagePower = attackerStats.m_pBaseCreature.CalculateDamagePower(target, bOffHand);
                 float vitality = target.m_pStats.m_nConstitutionModifier;
-                var defense = Stat.GetDefenseNative(target, attackType == (uint) AttackType.Spirit ? CombatDamageType.Force : CombatDamageType.Physical);
+                
+                // 0 is invalid.  Old items (not updated with the new stat) may return this value. 
+                if (damageType == -1 || damageType == 0)
+                {
+                    damageType = (int)(attackType == (uint)AttackType.Spirit ? CombatDamageType.Force : CombatDamageType.Physical);
+                }
 
-                Log.Write(LogGroup.Attack, "DAMAGE: attacker damage attribute: " + dmg.ToString() + " defender defense attribute: " + defense.ToString());
+                var defense = Stat.GetDefenseNative(target, (CombatDamageType) damageType);
+
+                Log.Write(LogGroup.Attack, "DAMAGE: attacker damage attribute: " + dmg.ToString() + " defender defense attribute: " + defense.ToString() + ", defender racial type " + target.m_nPrePolymorphRacialType);
                 damage = Combat.CalculateDamage(dmg, attackAttribute, defense, vitality, critical) ;
                                 
+                // Apply droid bonus for electrical damage.
+                if (target.m_pStats.m_nRace == (ushort) RacialType.Robot && damageType == (ushort)CombatDamageType.Electrical)
+                {
+                    damage *= 2;
+                }
+
                 // Apply NWN mechanics to damage reduction
                 damage = target.DoDamageImmunity(attacker, damage, damageFlags, 0, 1);
                 damage = target.DoDamageResistance(attacker, damage, damageFlags, 0, 1, 1);

--- a/SWLOR.Game.Server/Service/Skill.cs
+++ b/SWLOR.Game.Server/Service/Skill.cs
@@ -141,11 +141,11 @@ namespace SWLOR.Game.Server.Service
                 }
             }
 
-            Apply(10, 6);
-            Apply(20, 6);
-            Apply(30, 6);
-            Apply(40, 6);
-            Apply(50, 6);
+            Apply(10, 8);
+            Apply(20, 8);
+            Apply(30, 8);
+            Apply(40, 8);
+            Apply(50, 8);
         }
 
         /// <summary>


### PR DESCRIPTION
Phew.
* Every creature has been updated and details recorded in the revamp sheet World NPCs tab.  Scripts all checked, and fixed in two cases.
* Attack and damage calculations now respect the Primary Stat and Damage property subtypes.
* Attack subtype is now used for resistance calculations.
* Electrical attacks do double damage to droids (racial type Robot).

New functionality tested but I've hardly begun to test all the new NPCs - that's mainly one for beta testing, though I'll likely crack on a bit myself in Jan.  

Only one restriction.  GetDamageRoll returns just a number, and the engine treats it as physical damage.  I'm not sure whether we have a way to signal damage as a different type back to the engine to display (say) electrical rather than physical.  Not a big deal, but would be more intuitive to players to see (say) magical damage when Force is used, or Acid damage when poison is used.