### PR TITLE
Before and after event hooks for creatures

### DIFF
--- a/SWLOR.Game.Server/Feature/AchievementProgression.cs
+++ b/SWLOR.Game.Server/Feature/AchievementProgression.cs
@@ -25,7 +25,7 @@ namespace SWLOR.Game.Server.Feature
         /// <summary>
         /// Handles the Kill Enemy line of achievements.
         /// </summary>
-        [NWNEventHandler("crea_death")]
+        [NWNEventHandler("crea_death_bef")]
         public static void KillEnemy()
         {
             var killer = GetLastKiller();

--- a/SWLOR.Game.Server/Feature/CreatureDeathAnimation.cs
+++ b/SWLOR.Game.Server/Feature/CreatureDeathAnimation.cs
@@ -7,7 +7,7 @@ namespace SWLOR.Game.Server.Feature
 {
     public static class CreatureDeathAnimation
     {
-        [NWNEventHandler("crea_death")]
+        [NWNEventHandler("crea_death_aft")]
         public static void OnDeath()
         {
             var creature = OBJECT_SELF;

--- a/SWLOR.Game.Server/Feature/ItemDefinition/SpeederItemDefinition.cs
+++ b/SWLOR.Game.Server/Feature/ItemDefinition/SpeederItemDefinition.cs
@@ -58,7 +58,7 @@ namespace SWLOR.Game.Server.Feature.ItemDefinition
         /// Play a matching animation that lasts the duration of the stun.
         /// Set pheno to normal, tailtype to none and movement rate back to normal after.
         /// </summary>
-        [NWNEventHandler("crea_damaged")]
+        [NWNEventHandler("crea_damaged_bef")]
         public static void AttackedDismount()
         {
             var player = OBJECT_SELF; ;

--- a/SWLOR.Game.Server/Service/AI.cs
+++ b/SWLOR.Game.Server/Service/AI.cs
@@ -21,9 +21,11 @@ namespace SWLOR.Game.Server.Service
         [NWNEventHandler("crea_heartbeat")]
         public static void CreatureHeartbeat()
         {
+            ExecuteScript("crea_hb_bef", OBJECT_SELF);
             RestoreCreatureStats();
             ProcessRandomWalkFlag();
             ExecuteScript("cdef_c2_default1", OBJECT_SELF);
+            ExecuteScript("crea_hb_aft", OBJECT_SELF);
         }
 
         /// <summary>
@@ -32,9 +34,11 @@ namespace SWLOR.Game.Server.Service
         [NWNEventHandler("crea_perception")]
         public static void CreaturePerception()
         {
+            ExecuteScript("crea_perc_bef", OBJECT_SELF);
             // This is a stripped-down version of the default NWN perception event.
             // We handle most of our perception logic with the aggro aura effect.
             ProcessCreatureAllies();
+            ExecuteScript("crea_perc_aft", OBJECT_SELF);
         }
 
         /// <summary>
@@ -45,8 +49,10 @@ namespace SWLOR.Game.Server.Service
         {
             if (!Activity.IsBusy(OBJECT_SELF))
             {
+                ExecuteScript("crea_rndend_bef", OBJECT_SELF);
                 ProcessPerkAI();
                 ExecuteScript("cdef_c2_default3", OBJECT_SELF);
+                ExecuteScript("crea_rndend_aft", OBJECT_SELF);
             }
         }
 
@@ -56,6 +62,7 @@ namespace SWLOR.Game.Server.Service
         [NWNEventHandler("crea_convo")]
         public static void CreatureConversation()
         {
+            ExecuteScript("crea_convo_bef", OBJECT_SELF);
             ExecuteScript("cdef_c2_default4", OBJECT_SELF);
 
             var conversation = GetLocalString(OBJECT_SELF, "CONVERSATION");
@@ -64,6 +71,7 @@ namespace SWLOR.Game.Server.Service
                 var talker = GetLastSpeaker();
                 Dialog.StartConversation(talker, OBJECT_SELF, conversation);
             }
+            ExecuteScript("crea_convo_aft", OBJECT_SELF);
         }
 
         /// <summary>
@@ -72,7 +80,9 @@ namespace SWLOR.Game.Server.Service
         [NWNEventHandler("crea_attacked")]
         public static void CreaturePhysicalAttacked()
         {
+            ExecuteScript("crea_attack_bef", OBJECT_SELF);
             ExecuteScript("cdef_c2_default5", OBJECT_SELF);
+            ExecuteScript("crea_attack_aft", OBJECT_SELF);
         }
 
         /// <summary>
@@ -81,7 +91,9 @@ namespace SWLOR.Game.Server.Service
         [NWNEventHandler("crea_damaged")]
         public static void CreatureDamaged()
         {
+            ExecuteScript("crea_damaged_bef", OBJECT_SELF);
             ExecuteScript("cdef_c2_default6", OBJECT_SELF);
+            ExecuteScript("crea_damaged_aft", OBJECT_SELF);
         }
 
         /// <summary>
@@ -90,8 +102,10 @@ namespace SWLOR.Game.Server.Service
         [NWNEventHandler("crea_death")]
         public static void CreatureDeath()
         {
+            ExecuteScript("crea_death_bef", OBJECT_SELF);
             RemoveFromAlliesCache();
             ExecuteScript("cdef_c2_default7", OBJECT_SELF);
+            ExecuteScript("crea_death_aft", OBJECT_SELF);
         }
 
         /// <summary>
@@ -100,7 +114,9 @@ namespace SWLOR.Game.Server.Service
         [NWNEventHandler("crea_disturb")]
         public static void CreatureDisturbed()
         {
+            ExecuteScript("crea_disturb_bef", OBJECT_SELF);
             ExecuteScript("cdef_c2_default8", OBJECT_SELF);
+            ExecuteScript("crea_disturb_aft", OBJECT_SELF);
         }
 
         /// <summary>
@@ -109,9 +125,11 @@ namespace SWLOR.Game.Server.Service
         [NWNEventHandler("crea_spawn")]
         public static void CreatureSpawn()
         {
+            ExecuteScript("crea_spawn_bef", OBJECT_SELF);
             LoadCreatureStats();
             LoadAggroEffect();
             ExecuteScript("cdef_c2_default9", OBJECT_SELF);
+            ExecuteScript("crea_spawn_aft", OBJECT_SELF);
         }
 
         /// <summary>
@@ -120,7 +138,9 @@ namespace SWLOR.Game.Server.Service
         [NWNEventHandler("crea_rested")]
         public static void CreatureRested()
         {
+            ExecuteScript("crea_rested_bef", OBJECT_SELF);
             ExecuteScript("cdef_c2_defaulta", OBJECT_SELF);
+            ExecuteScript("crea_rested_aft", OBJECT_SELF);
         }
 
         /// <summary>
@@ -129,7 +149,9 @@ namespace SWLOR.Game.Server.Service
         [NWNEventHandler("crea_spellcastat")]
         public static void CreatureSpellCastAt()
         {
+            ExecuteScript("crea_splcast_bef", OBJECT_SELF);
             ExecuteScript("cdef_c2_defaultb", OBJECT_SELF);
+            ExecuteScript("crea_splcast_aft", OBJECT_SELF);
         }
 
         /// <summary>
@@ -138,7 +160,9 @@ namespace SWLOR.Game.Server.Service
         [NWNEventHandler("crea_userdef")]
         public static void CreatureUserDefined()
         {
+            ExecuteScript("crea_userdef_bef", OBJECT_SELF);
             ExecuteScript("cdef_c2_defaultd", OBJECT_SELF);
+            ExecuteScript("crea_userdef_aft", OBJECT_SELF);
         }
 
         /// <summary>
@@ -147,7 +171,9 @@ namespace SWLOR.Game.Server.Service
         [NWNEventHandler("crea_blocked")]
         public static void CreatureBlocked()
         {
+            ExecuteScript("crea_block_bef", OBJECT_SELF);
             ExecuteScript("cdef_c2_defaulte", OBJECT_SELF);
+            ExecuteScript("crea_block_aft", OBJECT_SELF);
         }
 
         /// <summary>

--- a/SWLOR.Game.Server/Service/CombatPoint.cs
+++ b/SWLOR.Game.Server/Service/CombatPoint.cs
@@ -55,7 +55,7 @@ namespace SWLOR.Game.Server.Service
         /// When a creature dies, skill XP is given to all players who contributed during battle.
         /// Then, those combat points are cleared out.
         /// </summary>
-        [NWNEventHandler("crea_death")]
+        [NWNEventHandler("crea_death_aft")]
         public static void OnCreatureDeath()
         {
             // Clears the combat point cache information for an NPC and all player associated.

--- a/SWLOR.Game.Server/Service/Enmity.cs
+++ b/SWLOR.Game.Server/Service/Enmity.cs
@@ -17,7 +17,7 @@ namespace SWLOR.Game.Server.Service
         /// <summary>
         /// When an enemy is damaged, increase enmity toward that creature by the amount of damage dealt.
         /// </summary>
-        [NWNEventHandler("crea_damaged")]
+        [NWNEventHandler("crea_damaged_bef")]
         public static void CreatureDamaged()
         {
             var enemy = OBJECT_SELF;
@@ -30,7 +30,7 @@ namespace SWLOR.Game.Server.Service
         /// <summary>
         /// When a creature attacks an enemy, increase enmity by 1.
         /// </summary>
-        [NWNEventHandler("crea_attacked")]
+        [NWNEventHandler("crea_attack_bef")]
         public static void CreatureAttacked()
         {
             var enemy = OBJECT_SELF;
@@ -42,7 +42,7 @@ namespace SWLOR.Game.Server.Service
         /// <summary>
         /// When a creature dies, remove all enmity tables it is associated with.
         /// </summary>
-        [NWNEventHandler("crea_death")]
+        [NWNEventHandler("crea_death_aft")]
         public static void CreatureDeath()
         {
             var enemy = OBJECT_SELF;

--- a/SWLOR.Game.Server/Service/Loot.cs
+++ b/SWLOR.Game.Server/Service/Loot.cs
@@ -51,7 +51,7 @@ namespace SWLOR.Game.Server.Service
         /// When a creature spawns, items which can be stolen are spawned and marked as undroppable.
         /// These items are only available with the Thief ability "Steal" and related perks.
         /// </summary>
-        [NWNEventHandler("crea_spawn")]
+        [NWNEventHandler("crea_spawn_bef")]
         public static void SpawnStealLoot()
         {
             var creature = OBJECT_SELF;
@@ -145,7 +145,7 @@ namespace SWLOR.Game.Server.Service
         /// <summary>
         /// When a creature dies, loot tables are spawned based on local variables.
         /// </summary>
-        [NWNEventHandler("crea_death")]
+        [NWNEventHandler("crea_death_bef")]
         public static void SpawnLoot()
         {
             var creature = OBJECT_SELF;
@@ -247,7 +247,7 @@ namespace SWLOR.Game.Server.Service
         /// Handles creating a corpse placeable on a creature's death, copying its inventory to the placeable,
         /// and changing the name of the placeable to match the creature.
         /// </summary>
-        [NWNEventHandler("crea_death")]
+        [NWNEventHandler("crea_death_bef")]
         public static void ProcessCorpse()
         {
             var self = OBJECT_SELF;

--- a/SWLOR.Game.Server/Service/Quest.cs
+++ b/SWLOR.Game.Server/Service/Quest.cs
@@ -253,7 +253,7 @@ namespace SWLOR.Game.Server.Service
         /// <summary>
         /// When an NPC is killed, any objectives for quests a player currently has active will be updated.
         /// </summary>
-        [NWNEventHandler("crea_death")]
+        [NWNEventHandler("crea_death_bef")]
         public static void ProgressKillTargetObjectives()
         {
             var creature = OBJECT_SELF;

--- a/SWLOR.Game.Server/Service/Space.cs
+++ b/SWLOR.Game.Server/Service/Space.cs
@@ -1109,7 +1109,7 @@ namespace SWLOR.Game.Server.Service
         /// <summary>
         /// When a creature spawns, track it in the cache.
         /// </summary>
-        [NWNEventHandler("crea_spawn")]
+        [NWNEventHandler("crea_spawn_bef")]
         public static void CreatureSpawn()
         {
             var creature = OBJECT_SELF;
@@ -1187,7 +1187,7 @@ namespace SWLOR.Game.Server.Service
         /// <summary>
         /// When a creature dies, remove it from the cache.
         /// </summary>
-        [NWNEventHandler("crea_death")]
+        [NWNEventHandler("crea_death_aft")]
         public static void CreatureDeath()
         {
             var creature = OBJECT_SELF;

--- a/SWLOR.Game.Server/Service/Spawn.cs
+++ b/SWLOR.Game.Server/Service/Spawn.cs
@@ -347,11 +347,11 @@ namespace SWLOR.Game.Server.Service
 
         /// <summary>
         /// When a creature dies, its details need to be queued up for a respawn.
-        /// NOTE: plc_death and crea_death will not trigger if the object is 'killed'
+        /// NOTE: plc_death and crea_death_aft will not trigger if the object is 'killed'
         /// via DestroyObject.  Call this method directly if you need to use DestroyObject
         /// on a respawning object.
         /// </summary>
-        [NWNEventHandler("crea_death")]
+        [NWNEventHandler("crea_death_aft")]
         [NWNEventHandler("plc_death")]
         public static void QueueRespawn()
         {

--- a/SWLOR.Game.Server/Service/Stat.cs
+++ b/SWLOR.Game.Server/Service/Stat.cs
@@ -548,7 +548,7 @@ namespace SWLOR.Game.Server.Service
         /// <summary>
         /// When a creature spawns, load its relevant defense information based on their equipment.
         /// </summary>
-        [NWNEventHandler("crea_spawn")]
+        [NWNEventHandler("crea_spawn_bef")]
         public static void LoadNPCDefense()
         {
             var creature = OBJECT_SELF;
@@ -577,7 +577,7 @@ namespace SWLOR.Game.Server.Service
             }
         }
 
-        [NWNEventHandler("crea_death")]
+        [NWNEventHandler("crea_death_aft")]
         public static void ClearNPCDefense()
         {
             if (_npcDefenses.ContainsKey(OBJECT_SELF))


### PR DESCRIPTION
Hook up "before" and "after" events for creature events. Switch all references to use one or the other. This will help ensure cleanup occurs in the after event, but the data is still available in the "before" events.