### PR TITLE
Combat bug fixes

### DIFF
--- a/SWLOR.Game.Server/Core/Bioware/BiowarePosition.cs
+++ b/SWLOR.Game.Server/Core/Bioware/BiowarePosition.cs
@@ -91,6 +91,9 @@ namespace SWLOR.Game.Server.Core.Bioware
             // X/Y so that we're taking angle relative to the Y axis (X is opposite, Y adjacent)
             var angle = (float)Math.Atan(diffX / diffY);
 
+            // @@@ PROBABLE BUG - this should probably be NWScript.atan not Math.Atan as the latter
+            // returns a result in radians. 
+
             // atan returns -90 to +90.  We need to turn it into a 360 degree facing based on 
             // whether diffX and diffY are positive.  
             // if diffX and diffY are positive, we should have a facing of 0-90.

--- a/SWLOR.Game.Server/Feature/SaveCharacters.cs
+++ b/SWLOR.Game.Server/Feature/SaveCharacters.cs
@@ -8,6 +8,7 @@ namespace SWLOR.Game.Server.Feature
     {
         /// <summary>
         /// Saves characters every minute unless they're currently preoccupied (barter)
+        /// Also cleans up some combat state while we're cycling through all players anyway.
         /// </summary>
         [NWNEventHandler("mod_heartbeat")]
         public static void HandleSaveCharacters()
@@ -22,6 +23,13 @@ namespace SWLOR.Game.Server.Feature
                     if (GetLocalBool(player, "IS_BARTERING")) continue;
 
                     ExportSingleCharacter(player);
+
+                    // Clear combat state.
+                    if (!GetIsInCombat(player))
+                    {
+                        DeleteLocalFloat(player, "ATTACK_ORIENTATION_X");
+                        DeleteLocalFloat(player, "ATTACK_ORIENTATION_Y");
+                    }
                 }
 
                 tick = 0;

--- a/SWLOR.Game.Server/Feature/SaveCharacters.cs
+++ b/SWLOR.Game.Server/Feature/SaveCharacters.cs
@@ -8,7 +8,6 @@ namespace SWLOR.Game.Server.Feature
     {
         /// <summary>
         /// Saves characters every minute unless they're currently preoccupied (barter)
-        /// Also cleans up some combat state while we're cycling through all players anyway.
         /// </summary>
         [NWNEventHandler("mod_heartbeat")]
         public static void HandleSaveCharacters()
@@ -23,13 +22,6 @@ namespace SWLOR.Game.Server.Feature
                     if (GetLocalBool(player, "IS_BARTERING")) continue;
 
                     ExportSingleCharacter(player);
-
-                    // Clear combat state.
-                    if (!GetIsInCombat(player))
-                    {
-                        DeleteLocalFloat(player, "ATTACK_ORIENTATION_X");
-                        DeleteLocalFloat(player, "ATTACK_ORIENTATION_Y");
-                    }
                 }
 
                 tick = 0;

--- a/SWLOR.Game.Server/Native/GetDamageRoll.cs
+++ b/SWLOR.Game.Server/Native/GetDamageRoll.cs
@@ -49,10 +49,12 @@ namespace SWLOR.Game.Server.Native
             if (targetObject == null || targetObject.m_idSelf == NWScript.OBJECT_INVALID) return 0;
 
             uint attackType = (uint) AttackType.Melee;
-            // Developer note - the native functions to retrieve a combat round don't work at this point.
             CNWSItem weapon = bOffHand == 1
                     ? attacker.m_pInventory.GetItemInSlot((uint)EquipmentSlot.LeftHand)
                     : attacker.m_pInventory.GetItemInSlot((uint)EquipmentSlot.RightHand);
+
+            // Twin blades need special handling. 
+            if (bOffHand == 1 && weapon == null) weapon = attacker.m_pInventory.GetItemInSlot((uint)EquipmentSlot.RightHand); 
 
             if (weapon == null)
             {
@@ -120,6 +122,7 @@ namespace SWLOR.Game.Server.Native
             dmgValues[CombatDamageType.Ice] = 0;
             var physicalDamage = 0;
             var specializationDMGBonus = 0f;
+            var foundDMG = false;
 
             // Calculate attacker's base DMG
             if (attacker != null)
@@ -150,9 +153,16 @@ namespace SWLOR.Game.Server.Native
                             var dmg = dmgValues[(CombatDamageType)damageType];
                             dmg += Combat.GetDMGValueFromItemPropertyCostTableValue(ip.m_nCostTableValue);
                             dmgValues[(CombatDamageType)damageType] = dmg;
+                            foundDMG = true;
                         }
                     }
                 }
+            }
+
+            if (!foundDMG)
+            {
+                // If no properties default to 0.5 physical.
+                dmgValues[CombatDamageType.Physical] = 0.5f;
             }
 
             int attackAttribute = attackerStats.m_nStrengthModifier;

--- a/SWLOR.Game.Server/Native/ResolveAttackRoll.cs
+++ b/SWLOR.Game.Server/Native/ResolveAttackRoll.cs
@@ -317,20 +317,34 @@ namespace SWLOR.Game.Server.Native
                     {
                         modifiers += 5;
                     }
-                    else
+                    else if (weapon != null)
                     {
                         modifiers -= 20;
                     }
                 }
                 else if (range > 40.0f)
                 {
-                    modifiers -= 20;
+                    if (!Item.RifleBaseItemTypes.Contains((BaseItem)weapon.m_nBaseItem))
+                    {
+                        modifiers -= 20;
+                    }
+                    else
+                    {
+                        modifiers -= 10;
+                    }
                 }
                 else if (range > 30.0f)
                 {
-                    modifiers -= 10;
+                    if (!Item.RifleBaseItemTypes.Contains((BaseItem)weapon.m_nBaseItem))
+                    {
+                        modifiers -= 10;
+                    }
+                    else
+                    {
+                        modifiers -= 5;
+                    }
                 }
-                else if (range > 20.0f)
+                else if (range > 20.0f && !Item.RifleBaseItemTypes.Contains((BaseItem)weapon.m_nBaseItem))
                 {
                     modifiers = -5;
                 }
@@ -339,15 +353,37 @@ namespace SWLOR.Game.Server.Native
 
             // Attacking from behind.  Does not apply to Force attacks.
             // Vectors are X=-1 to +1, Y=-1 to +1, Z=0.  
-            // If the absolute difference between the two vectors is less than 0.5, treat as a backstab.
-            var attFacing = attacker.m_vOrientation;
-            var defFacing = defender.m_vOrientation;
+            // If the absolute difference between the two vectors is less than 0.5 radians, treat as a backstab.
+            //
+            // m_vOrientation does not update during combat, even if the creature is moving a lot, turning to attack
+            // etc.  So cache the orientation we have when we attack, and only fall back to m_vOrientation if 
+            // a creature hasn't attacked yet.  Clear these variables on PCs if not in combat in heartbeat.
 
-            if (attackType != (uint)AttackType.Spirit && 
-                (Math.Abs(attFacing.x - defFacing.x) + Math.Abs(attFacing.y-defFacing.y) < 0.5))
+            var defX = defender.m_ScriptVars.GetFloat(new CExoString("ATTACK_ORIENTATION_X"));
+            var defY = defender.m_ScriptVars.GetFloat(new CExoString("ATTACK_ORIENTATION_Y"));
+
+            if (defX == 0.0f && defY == 0.0f)
             {
-                Log.Write(LogGroup.Attack, "Backstab!  Attacker facing: " + attFacing.x + ", " + attFacing.y + "," + attFacing.z + 
-                                           ", Defender facing: " + defFacing.x + ", " + defFacing.y + "," + defFacing.z);
+                Log.Write(LogGroup.Attack, "Defender has not attacked yet, using pre-combat position.");
+                var defFacing = defender.m_vOrientation;
+                defX = (float)defFacing.x;
+                defY = (float)defFacing.y;
+            }
+
+            var attX = defender.m_vPosition.x - attacker.m_vPosition.x;
+            var attY = defender.m_vPosition.y - attacker.m_vPosition.y;
+
+            attacker.m_ScriptVars.SetFloat(new CExoString("ATTACK_ORIENTATION_X"), attX);
+            attacker.m_ScriptVars.SetFloat(new CExoString("ATTACK_ORIENTATION_Y"), attY);
+
+            var delta = Math.Abs(Math.Atan2(attY, attX) - Math.Atan2(defY, defX));
+            Log.Write(LogGroup.Attack, "Attacker facing is " + attX + ", " + attY);
+            Log.Write(LogGroup.Attack, "Defender facing is " + defX + ", " + defY);
+
+            if (attackType != (uint)AttackType.Spirit && delta <= 0.5)
+            {
+                Log.Write(LogGroup.Attack, "Backstab!  Attacker angle (radians): " + Math.Atan2(attY, attX) + 
+                                           ", Defender angle (radians): " + Math.Atan2(defY, defX));
                 modifiers += 30;
             }
 

--- a/SWLOR.Game.Server/Service/Combat.cs
+++ b/SWLOR.Game.Server/Service/Combat.cs
@@ -149,5 +149,21 @@ namespace SWLOR.Game.Server.Service
 
             return (float)(0.15 * pcSkill.Rank);
         }
+
+        /// <summary>
+        /// On module heartbeat, clear a PC's saved combat facing if they are no longer in combat.
+        /// </summary>
+        [NWNEventHandler("interval_pc_6s")]
+        public static void ClearCombatState()
+        {
+            uint player = OBJECT_SELF;
+
+            // Clear combat state.
+            if (!GetIsInCombat(player))
+            {
+                DeleteLocalFloat(player, "ATTACK_ORIENTATION_X");
+                DeleteLocalFloat(player, "ATTACK_ORIENTATION_Y");
+            }
+        }
     }
 }


### PR DESCRIPTION
- Fixed abusable bug in backstab code
- Fixed damage for twin blades
- Restored the default 0.5 DMG for unarmed strike and weapons without a DMG rating.
- Reduced the range penalty for rifles - they're better at longer range than other ranged weapons.