### PR TITLE
Nerfed Space NPC's. No more Dark Souls level difficulty.

### DIFF
--- a/SWLOR.Game.Server/Feature/SpaceObjectDefinition/NPCSpaceObjectDefinition.cs
+++ b/SWLOR.Game.Server/Feature/SpaceObjectDefinition/NPCSpaceObjectDefinition.cs
@@ -36,12 +36,10 @@ namespace SWLOR.Game.Server.Feature.SpaceObjectDefinition
                 .ItemTag("NPC_Nightmare")
                 .ShipModule("ion_cann_1")
                 .ShipModule("com_laser_1")
-                .ShipModule("com_laser_1")
                 .ShipModule("shld_boost_1");
 
             _builder.Create("pirate_ferron")
                 .ItemTag("NPC_Ferron")
-                .ShipModule("com_laser_1")
                 .ShipModule("com_laser_1")
                 .ShipModule("msl_launch_1")
                 .ShipModule("msl_launch_1");
@@ -53,12 +51,10 @@ namespace SWLOR.Game.Server.Feature.SpaceObjectDefinition
                 .ItemTag("NPC_Storm")
                 .ShipModule("msl_launch_2")
                 .ShipModule("msl_launch_2")
-                .ShipModule("msl_launch_2")
                 .ShipModule("msl_launch_2");
 
             _builder.Create("pirate_ranger")
                 .ItemTag("NPC_Ranger")
-                .ShipModule("ion_cann_2")
                 .ShipModule("ion_cann_2")
                 .ShipModule("ion_cann_2")
                 .ShipModule("msl_launch_2");
@@ -70,20 +66,13 @@ namespace SWLOR.Game.Server.Feature.SpaceObjectDefinition
                 .ItemTag("NPC_Hammer")
                 .ShipModule("com_laser_3")
                 .ShipModule("com_laser_3")
-                .ShipModule("com_laser_3")
-                .ShipModule("com_laser_3")
-                .ShipModule("com_laser_3")
-                .ShipModule("tgt_sys_3")
-                .ShipModule("shld_boost_3");
+                .ShipModule("com_laser_3");
 
             _builder.Create("pirate_drake")
                 .ItemTag("NPC_Drake")
                 .ShipModule("ion_cann_3")
-                .ShipModule("com_laser_3")
-                .ShipModule("com_laser_3")
                 .ShipModule("msl_launch_3")
                 .ShipModule("msl_launch_3")
-                .ShipModule("tgt_sys_3")
                 .ShipModule("shld_boost_3");
         }
 
@@ -94,17 +83,12 @@ namespace SWLOR.Game.Server.Feature.SpaceObjectDefinition
                 .ShipModule("ion_cann_4")
                 .ShipModule("ion_cann_4")
                 .ShipModule("ion_cann_4")
-                .ShipModule("ion_cann_4")
-                .ShipModule("ion_cann_4")
                 .ShipModule("tgt_sys_4")
                 .ShipModule("shld_boost_4");
 
             _builder.Create("pirate_eleyna")
                 .ItemTag("NPC_Eleyna")
-                .ShipModule("ion_cann_4")
-                .ShipModule("ion_cann_4")
-                .ShipModule("msl_launch_4")
-                .ShipModule("msl_launch_4")
+                .ShipModule("com_laser_4")
                 .ShipModule("msl_launch_4")
                 .ShipModule("msl_launch_4")
                 .ShipModule("tgt_sys_4")


### PR DESCRIPTION
Sorry for the previous sloppy pull request. I've gotten things synced back up properly and will ensure it stays that way.

This deletes a few lines in NPCSpaceObjectDefinition.cs, basically keeping t1 NPC's at 2 weapons, t2-t4 at 3 weapons, and t5 NPC's at 3 weapons plus some extra modules. This means 2 attacks per round (roughly) for t1, 3 for t2-t4, and 3 attacks for t5 with some enhanced stats elsewhere. This should be well in line with what PC's are able to handle, as it's basically where they were before albeit with some minor tweaks. For example, the higher number of missile launchers available to NPC's should mean NPC's are better able to contend with groups of players, which will keep logi-type ships on their toes during events.