### PR TITLE
Increase T0 hunter drop rates; remove plot protection on dropped items

### DIFF
--- a/Module/utc/kath_hound.utc.json
+++ b/Module/utc/kath_hound.utc.json
@@ -527,7 +527,7 @@
         },
         "Value": {
           "type": "cexostring",
-          "value": "VISCARA_KATH_HOUND,40,2"
+          "value": "VISCARA_KATH_HOUND,75,2"
         }
       },
       {
@@ -542,7 +542,7 @@
         },
         "Value": {
           "type": "cexostring",
-          "value": "VISCARA_KATH_HOUND_RARES,5,1"
+          "value": "VISCARA_KATH_HOUND_RARES,20,1"
         }
       }
     ]

--- a/Module/utc/mynock.utc.json
+++ b/Module/utc/mynock.utc.json
@@ -514,7 +514,7 @@
         },
         "Value": {
           "type": "cexostring",
-          "value": "CZ220_LOOT_MYNOCK,60,2"
+          "value": "CZ220_LOOT_MYNOCK,75,2"
         }
       },
       {

--- a/Module/utc/warocas.utc.json
+++ b/Module/utc/warocas.utc.json
@@ -543,7 +543,7 @@
         },
         "Value": {
           "type": "cexostring",
-          "value": "VISCARA_WAROCAS,40,2"
+          "value": "VISCARA_WAROCAS,75,2"
         }
       },
       {
@@ -558,7 +558,7 @@
         },
         "Value": {
           "type": "cexostring",
-          "value": "VISCARA_WAROCAS_RARES,5,1"
+          "value": "VISCARA_WAROCAS_RARES,10,1"
         }
       }
     ]

--- a/Module/uti/k_hound_claw.uti.json
+++ b/Module/uti/k_hound_claw.uti.json
@@ -58,7 +58,7 @@
   },
   "Plot": {
     "type": "byte",
-    "value": 1
+    "value": 0
   },
   "PropertiesList": {
     "type": "list",

--- a/Module/uti/k_hound_fur.uti.json
+++ b/Module/uti/k_hound_fur.uti.json
@@ -58,7 +58,7 @@
   },
   "Plot": {
     "type": "byte",
-    "value": 1
+    "value": 0
   },
   "PropertiesList": {
     "type": "list",

--- a/Module/uti/k_hound_tooth.uti.json
+++ b/Module/uti/k_hound_tooth.uti.json
@@ -58,7 +58,7 @@
   },
   "Plot": {
     "type": "byte",
-    "value": 1
+    "value": 0
   },
   "PropertiesList": {
     "type": "list",

--- a/Module/uti/warocas_beak.uti.json
+++ b/Module/uti/warocas_beak.uti.json
@@ -58,7 +58,7 @@
   },
   "Plot": {
     "type": "byte",
-    "value": 1
+    "value": 0
   },
   "PropertiesList": {
     "type": "list",

--- a/SWLOR.Game.Server/Feature/LootTableDefinition/ViscaraLootTableDefinition.cs
+++ b/SWLOR.Game.Server/Feature/LootTableDefinition/ViscaraLootTableDefinition.cs
@@ -33,13 +33,13 @@ namespace SWLOR.Game.Server.Feature.LootTableDefinition
         private void KathHound()
         {
             _builder.Create("VISCARA_KATH_HOUND")
-                .AddItem("k_hound_fur", 20)
-                .AddItem("k_hound_tooth", 20)
-                .AddItem("lth_ruined", 20)
-                .AddItem("kath_meat_1", 15)
-                .AddItem("kath_blood", 5);
+                .AddItem("k_hound_fur", 25)
+                .AddItem("k_hound_tooth", 25)
+                .AddItem("lth_ruined", 15)
+                .AddItem("kath_meat_1", 15);
 
             _builder.Create("VISCARA_KATH_HOUND_RARES")
+                .AddItem("kath_blood", 2, 1, true)
                 .AddItem("k_hound_claw", 1, 1, true);
         }
 
@@ -260,10 +260,10 @@ namespace SWLOR.Game.Server.Feature.LootTableDefinition
         private void Warocas()
         {
             _builder.Create("VISCARA_WAROCAS")
-                .AddItem("warocas_beak", 20)
+                .AddItem("warocas_beak", 10)
                 .AddItem("waro_feathers", 15)
                 .AddItem("lth_ruined", 20)
-                .AddItem("warocas_meat", 15)
+                .AddItem("warocas_meat", 20)
                 .AddItem("waro_leg", 10, 1, true);
 
             _builder.Create("VISCARA_WAROCAS_RARES")


### PR DESCRIPTION
Increases the chance of rolling for loot for Mynocks, Kath Hounds, and Warocas; also normalizes the weighting of their drops somewhat, and makes some of the remaining useless items sellable by removing plot protection.

Specifically, this changes:
- Mynock loot drop chance increased from 2x 60% -> 2x 75%
    - This reduces the chance of getting no loot from 16% down to ~6%
    - Increases the chances of getting Mynock Teeth, meaning you should get a roughly equal amount of wings and teeth.
- Kath Hound / Warocas loot drop chance increased from 2x 40% -> 2x 75%
    - This reduces the chance of getting no loot from 36% (!!!) -> ~6%
    - Along with weight/table changes, this decreases the expected kills to complete one set of Kath/Warocas tasks down from ~55 to around 20 (warocas) / 25 (Kath).
- Kath Hound Blood moved to rare drop table, rare drop chance for Kath Hounds increased from 5% to 20%.
    - The only 'rare' drop Kath Hounds had was their claw, which is currently useless. It is now sellable, and will drop (slightly) more often.
    - Kath Blood also drops slightly more often as well, but no longer takes up a weighting spot used by fur/teeth/meat/leather.
- Warocas 'rare drop table' chance increased from 5% to 10%.
    - Warocas' only rare drop was a second (or third, technically) chance at a Warocas Leg. Bumping this up brings its drop chance in line with the Spine, which seems reasonable.