### PR TITLE
Updated Bothan IDs

### DIFF
--- a/SWLOR.Game.Server/Feature/AppearanceDefinition/RacialAppearance/BothanRacialAppearanceDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AppearanceDefinition/RacialAppearance/BothanRacialAppearanceDefinition.cs
@@ -2,7 +2,7 @@
 {
     public class BothanRacialAppearanceDefinition: RacialAppearanceBaseDefinition
     {
-        public override int[] MaleHeads { get; } = {40, 41, 43, 50, 51, 52};
-        public override int[] FemaleHeads { get; } = {109, 162};
+        public override int[] MaleHeads { get; } = {31, 32, 33, 34, 40, 41, 43, 50, 51, 52};
+        public override int[] FemaleHeads { get; } = {12, 13, 14, 15, 16, 17, 18, 19, 20, 109, 162};
     }
 }


### PR DESCRIPTION
Added new Head IDs for Bothans.

- Male: 31,32,33,34
- Female: 12,13,14,15,16,17,18,19,20