### PR TITLE
Implement XP/Combat Point changes

### DIFF
--- a/SWLOR.Game.Server/Feature/AbilityDefinition/FirstAid/MedKitAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/FirstAid/MedKitAbilityDefinition.cs
@@ -54,7 +54,8 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.FirstAid
             TakeMedicalSupplies(activator);
 
             Enmity.ModifyEnmityOnAll(activator, 250 + amount);
-            if(CombatPoint.AddCombatPointToAllTagged(activator, SkillType.FirstAid, 3) == 0)
+            CombatPoint.AddCombatPointToAllTagged(activator, SkillType.FirstAid, 3);
+            if (CombatPoint.GetTaggedCreatureCount(activator) == 0)
             {
                 // Scale XP to the thing we just fought -- only give XP if we're not in combat.
                 // Retrieve the level of our recent enemy from the CombatPoint service, and use the Skill service 

--- a/SWLOR.Game.Server/Service/CombatPoint.cs
+++ b/SWLOR.Game.Server/Service/CombatPoint.cs
@@ -111,17 +111,17 @@ namespace SWLOR.Game.Server.Service
 
                     var areaBonus = GetLocalInt(GetArea(npc), "AREA_XP_BONUS_PERCENTAGE") * 0.01f;
 
-                    foreach (CombatPointCategory cpCategory in Enum.GetValues(typeof(CombatPointCategory)))
+                    foreach (CombatPointCategoryType cpCategory in Enum.GetValues(typeof(CombatPointCategoryType)))
                     {
                         var validSkills = skillsWithCP
-                            .Where(x => Skill.GetSkillDetails(x.Key).XPType == cpCategory)
+                            .Where(x => Skill.GetSkillDetails(x.Key).CombatPointCategory == cpCategory)
                             .ToDictionary(x => x.Key, y => y.Value);
 
                         // Base amount of XP is determined by the player's highest-leveled skill rank in each XP category versus the creature's level.
-                        if (cpCategory != CombatPointCategory.Exempt)
+                        if (cpCategory != CombatPointCategoryType.Exempt)
                         {
                             var validCPs = cpList
-                                .Where(x => Skill.GetSkillDetails(x.Key).XPType == cpCategory);
+                                .Where(x => Skill.GetSkillDetails(x.Key).CombatPointCategory == cpCategory);
                             if (!validCPs.Any()) continue;
                             if (!validSkills.Any()) continue;
 
@@ -290,23 +290,37 @@ namespace SWLOR.Game.Server.Service
         }
 
         /// <summary>
+        /// Retrieves the count of creatures tagged by a given player.
+        /// </summary>
+        /// <param name="player">The player to check for tagged NPCs.</param>
+        /// <returns>
+        /// Number of creatures tagged by the player. 
+        /// 0 is none, -1 if the player is not initialized in the playerToCreatureTracker.
+        /// </returns>
+        public static int GetTaggedCreatureCount(uint player)
+        {
+            if (!_playerToCreatureTracker.ContainsKey(player))
+                return -1;
+
+            return _playerToCreatureTracker[player].Count;
+        }
+
+        /// <summary>
         /// Adds a combat point for a player to all NPCs s/he is currently tagged on.
         /// </summary>
         /// <param name="player">The player to receiving the point.</param>
         /// <param name="skill">The skill to associate with the point.</param>
         /// <param name="amount">The number of points to add.</param>
         /// <returns>Number of creatures tagged by the player, -1 if the tracker has expired or is unavailable.</returns>
-        public static int AddCombatPointToAllTagged(uint player, SkillType skill, int amount = 1)
+        public static void AddCombatPointToAllTagged(uint player, SkillType skill, int amount = 1)
         {
-            if (!_playerToCreatureTracker.ContainsKey(player)) 
-                return -1;
+            if (!_playerToCreatureTracker.ContainsKey(player))
+                return;
 
             foreach (var creature in _playerToCreatureTracker[player])
             {
                 AddCombatPoint(player, creature, skill, amount);
             }
-
-            return _playerToCreatureTracker[player].Count;
         }
 
         /// <summary>

--- a/SWLOR.Game.Server/Service/CombatPoint.cs
+++ b/SWLOR.Game.Server/Service/CombatPoint.cs
@@ -311,7 +311,6 @@ namespace SWLOR.Game.Server.Service
         /// <param name="player">The player to receiving the point.</param>
         /// <param name="skill">The skill to associate with the point.</param>
         /// <param name="amount">The number of points to add.</param>
-        /// <returns>Number of creatures tagged by the player, -1 if the tracker has expired or is unavailable.</returns>
         public static void AddCombatPointToAllTagged(uint player, SkillType skill, int amount = 1)
         {
             if (!_playerToCreatureTracker.ContainsKey(player))

--- a/SWLOR.Game.Server/Service/Enmity.cs
+++ b/SWLOR.Game.Server/Service/Enmity.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using SWLOR.Game.Server.Core;
 using SWLOR.Game.Server.Core.NWNX;
+using CombatPoint = SWLOR.Game.Server.Service.CombatPoint;
 
 namespace SWLOR.Game.Server.Service
 {
@@ -166,6 +167,10 @@ namespace SWLOR.Game.Server.Service
 
             // Update this creature's list of enemies.
             _creatureToEnemies[creature] = enemyList;
+
+            // If one creature is a player, add the NPC to the Combat Point tracker.
+            if (GetIsPC(creature)) { CombatPoint.AddPlayerToNPCReferenceToCache(creature, enemy); }
+            else if (GetIsPC(enemy)) { CombatPoint.AddPlayerToNPCReferenceToCache(enemy, creature); }
 
             // In the event that this enemy does not have a target, immediately start attacking this creature.
             if (GetAttackTarget(enemy) == OBJECT_INVALID)

--- a/SWLOR.Game.Server/Service/SkillService/CombatPointCategory.cs
+++ b/SWLOR.Game.Server/Service/SkillService/CombatPointCategory.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace SWLOR.Game.Server.Service.SkillService
+{
+    public enum CombatPointCategoryType
+    {
+        Exempt = 0,
+        Utility = 1,
+        Weapon = 2
+    }
+
+}

--- a/SWLOR.Game.Server/Service/SkillService/SkillCategoryType.cs
+++ b/SWLOR.Game.Server/Service/SkillService/SkillCategoryType.cs
@@ -16,6 +16,13 @@ namespace SWLOR.Game.Server.Service.SkillService
         Languages = 4,
     }
 
+    public enum CombatPointCategory
+    {
+        Exempt = 0,
+        Utility = 1,
+        Weapons = 2
+    }
+
     public class SkillCategoryAttribute : Attribute
     {
         public string Name { get; set; }

--- a/SWLOR.Game.Server/Service/SkillService/SkillCategoryType.cs
+++ b/SWLOR.Game.Server/Service/SkillService/SkillCategoryType.cs
@@ -16,13 +16,6 @@ namespace SWLOR.Game.Server.Service.SkillService
         Languages = 4,
     }
 
-    public enum CombatPointCategory
-    {
-        Exempt = 0,
-        Utility = 1,
-        Weapons = 2
-    }
-
     public class SkillCategoryAttribute : Attribute
     {
         public string Name { get; set; }

--- a/SWLOR.Game.Server/Service/SkillService/SkillType.cs
+++ b/SWLOR.Game.Server/Service/SkillService/SkillType.cs
@@ -20,7 +20,8 @@ namespace SWLOR.Game.Server.Service.SkillService
             true,
             "Ability to use one-handed weapons like vibroblades, finesse vibroblades, and lightsabers.",
             true,
-            false)]
+            false,
+            CombatPointCategory.Weapons)]
         OneHanded = 1,
 
         [Skill(SkillCategoryType.Combat,
@@ -29,7 +30,8 @@ namespace SWLOR.Game.Server.Service.SkillService
             true,
             "Ability to use heavy weapons like heavy vibroblades, polearms, and saberstaffs in combat.",
             true,
-            false)]
+            false,
+            CombatPointCategory.Weapons)]
         TwoHanded = 2,
 
         [Skill(SkillCategoryType.Combat,
@@ -37,7 +39,8 @@ namespace SWLOR.Game.Server.Service.SkillService
             true,
             "Ability to fight using katars and staves in combat.",
             true,
-            false)]
+            false,
+            CombatPointCategory.Weapons)]
         MartialArts = 3,
 
         [Skill(SkillCategoryType.Combat,
@@ -46,7 +49,8 @@ namespace SWLOR.Game.Server.Service.SkillService
             true,
             "Ability to use ranged weapons like pistols, cannons, and rifles in combat.",
             true,
-            false)]
+            false,
+            CombatPointCategory.Weapons)]
         Ranged = 4,
 
         [Skill(SkillCategoryType.Combat,
@@ -56,6 +60,7 @@ namespace SWLOR.Game.Server.Service.SkillService
             "Ability to use Force abilities.",
             true,
             false,
+            CombatPointCategory.Utility,
             CharacterType.ForceSensitive)]
         Force = 5,
 
@@ -300,6 +305,7 @@ namespace SWLOR.Game.Server.Service.SkillService
             "Ability to use grenades, bombs, and other electronics.",
             true,
             false,
+            CombatPointCategory.Utility,
             CharacterType.Standard)]
         Devices = 33,
     }
@@ -315,6 +321,8 @@ namespace SWLOR.Game.Server.Service.SkillService
         public bool IsShownInCraftMenu { get; set; }
         public CharacterType CharacterTypeRestriction { get; set; }
 
+        public CombatPointCategory XPType { get; set; } 
+
         public SkillAttribute(
             SkillCategoryType category,
             string name,
@@ -323,6 +331,7 @@ namespace SWLOR.Game.Server.Service.SkillService
             string description,
             bool contributesToSkillCap,
             bool isShownInCraftMenu,
+            CombatPointCategory xpType = CombatPointCategory.Exempt,
             CharacterType characterTypeRestriction = CharacterType.Invalid)
         {
             Category = category;
@@ -333,6 +342,7 @@ namespace SWLOR.Game.Server.Service.SkillService
             ContributesToSkillCap = contributesToSkillCap;
             IsShownInCraftMenu = isShownInCraftMenu;
             CharacterTypeRestriction = characterTypeRestriction;
+            XPType = xpType;
         }
     }
 }

--- a/SWLOR.Game.Server/Service/SkillService/SkillType.cs
+++ b/SWLOR.Game.Server/Service/SkillService/SkillType.cs
@@ -21,7 +21,7 @@ namespace SWLOR.Game.Server.Service.SkillService
             "Ability to use one-handed weapons like vibroblades, finesse vibroblades, and lightsabers.",
             true,
             false,
-            CombatPointCategory.Weapons)]
+            CombatPointCategoryType.Weapon)]
         OneHanded = 1,
 
         [Skill(SkillCategoryType.Combat,
@@ -31,7 +31,7 @@ namespace SWLOR.Game.Server.Service.SkillService
             "Ability to use heavy weapons like heavy vibroblades, polearms, and saberstaffs in combat.",
             true,
             false,
-            CombatPointCategory.Weapons)]
+            CombatPointCategoryType.Weapon)]
         TwoHanded = 2,
 
         [Skill(SkillCategoryType.Combat,
@@ -40,7 +40,7 @@ namespace SWLOR.Game.Server.Service.SkillService
             "Ability to fight using katars and staves in combat.",
             true,
             false,
-            CombatPointCategory.Weapons)]
+            CombatPointCategoryType.Weapon)]
         MartialArts = 3,
 
         [Skill(SkillCategoryType.Combat,
@@ -50,7 +50,7 @@ namespace SWLOR.Game.Server.Service.SkillService
             "Ability to use ranged weapons like pistols, cannons, and rifles in combat.",
             true,
             false,
-            CombatPointCategory.Weapons)]
+            CombatPointCategoryType.Weapon)]
         Ranged = 4,
 
         [Skill(SkillCategoryType.Combat,
@@ -60,7 +60,7 @@ namespace SWLOR.Game.Server.Service.SkillService
             "Ability to use Force abilities.",
             true,
             false,
-            CombatPointCategory.Utility,
+            CombatPointCategoryType.Utility,
             CharacterType.ForceSensitive)]
         Force = 5,
 
@@ -305,7 +305,7 @@ namespace SWLOR.Game.Server.Service.SkillService
             "Ability to use grenades, bombs, and other electronics.",
             true,
             false,
-            CombatPointCategory.Utility,
+            CombatPointCategoryType.Utility,
             CharacterType.Standard)]
         Devices = 33,
     }
@@ -321,7 +321,7 @@ namespace SWLOR.Game.Server.Service.SkillService
         public bool IsShownInCraftMenu { get; set; }
         public CharacterType CharacterTypeRestriction { get; set; }
 
-        public CombatPointCategory XPType { get; set; } 
+        public CombatPointCategoryType CombatPointCategory { get; set; } 
 
         public SkillAttribute(
             SkillCategoryType category,
@@ -331,7 +331,7 @@ namespace SWLOR.Game.Server.Service.SkillService
             string description,
             bool contributesToSkillCap,
             bool isShownInCraftMenu,
-            CombatPointCategory xpType = CombatPointCategory.Exempt,
+            CombatPointCategoryType combatPointCategory = CombatPointCategoryType.Exempt,
             CharacterType characterTypeRestriction = CharacterType.Invalid)
         {
             Category = category;
@@ -342,7 +342,7 @@ namespace SWLOR.Game.Server.Service.SkillService
             ContributesToSkillCap = contributesToSkillCap;
             IsShownInCraftMenu = isShownInCraftMenu;
             CharacterTypeRestriction = characterTypeRestriction;
-            XPType = xpType;
+            CombatPointCategory = combatPointCategory;
         }
     }
 }


### PR DESCRIPTION
Closes #1446 

This PR prevents over-leveled Force / Devices from affecting weapon skill XP gain and vice versa; it also exempts First Aid from affecting either category. The First Aid `Med Kit` ability now no longer directly gives XP for use, unless it is explicitly used out-of-combat up to two minutes after an engagement. It will still provide combat points -> XP on kill when used in combat.

Weapon Skills: One-Handed, Two-Handed, Martial Arts, Ranged
Utility: Force, Devices
Exempt: First Aid, Armor

XP gain is still based on highest skill level of its category vs. the enemy fought, so using a level 50 One-Handed weapon and a level 5 Two-Handed weapon against a level 20 enemy will still result in no XP gained for weapons; the difference now is that Force, Devices, and First Aid XP will be unaffected.