### PR TITLE
Fix completed tasks showing as ACCEPTED on refresh

### DIFF
--- a/SWLOR.Game.Server/Feature/DialogDefinition/GuildMasterDialog.cs
+++ b/SWLOR.Game.Server/Feature/DialogDefinition/GuildMasterDialog.cs
@@ -153,7 +153,7 @@ namespace SWLOR.Game.Server.Feature.DialogDefinition
                 var status = ColorToken.Green("{ACCEPTED}");
                 // Player has never accepted the quest, or they've already completed it at least once and can accept it again.
                 if (!dbPlayer.Quests.ContainsKey(task.QuestId) ||
-                    (dbPlayer.Quests[task.QuestId].DateLastCompleted == null && dbPlayer.Quests[task.QuestId].TimesCompleted > 0))
+                    (dbPlayer.Quests[task.QuestId].DateLastCompleted != null && dbPlayer.Quests[task.QuestId].TimesCompleted > 0))
                 {
                     status = ColorToken.Yellow("{Available}");
                 }


### PR DESCRIPTION
Fixes bug listed here: https://github.com/zunath/SWLOR_NWN/issues/1451#issuecomment-1196165884

Available would only be shown if the quest was never taken, or if it was competed before... and the DateLastCompleted was null, which was impossible.