### PR TITLE
Fix targeted abilities switching attack targets

### DIFF
--- a/SWLOR.Game.Server/Feature/UsePerkFeat.cs
+++ b/SWLOR.Game.Server/Feature/UsePerkFeat.cs
@@ -293,9 +293,10 @@ namespace SWLOR.Game.Server.Feature
             // This mitigates the issue where a melee fighter's combat is disrupted for using an ability.
             if (GetCurrentAction(activator) == ActionType.AttackObject)
             {
+                var attackTarget = GetAttackTarget(activator);
                 DelayCommand(activationDelay + 0.1f, () =>
                 {
-                    AssignCommand(activator, () => ActionAttack(target));
+                    AssignCommand(activator, () => ActionAttack(attackTarget));
                 });
             }
         }


### PR DESCRIPTION
Currently if you use an ability while attacking, your attack target will be switched to the target of the ability.
This is problematic in cases where you use an ability like Med Kit on a friendly while in combat, as your attack target will be switched to the friendly. Now, the attack will be set to your last attack target before using the ability instead.