### PR TITLE
Fix Gas/Fire bomb damage, Kolto device stacking, and Throw Saber

### DIFF
--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/ExplosiveBaseAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/ExplosiveBaseAbilityDefinition.cs
@@ -5,6 +5,7 @@ using SWLOR.Game.Server.Core.NWScript.Enum;
 using SWLOR.Game.Server.Service;
 using SWLOR.Game.Server.Service.AbilityService;
 using SWLOR.Game.Server.Service.PerkService;
+using SWLOR.Game.Server.Service.SkillService;
 using Random = SWLOR.Game.Server.Service.Random;
 
 namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
@@ -96,6 +97,10 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
             var activatorLocation = GetLocation(activator);
             var delay = GetDistanceBetweenLocations(activatorLocation, targetLocation) / 18f;
 
+            var attackerStat = GetAbilityScore(activator, AbilityType.Perception);
+            var attack = Stat.GetAttack(activator, AbilityType.Perception, SkillType.Devices);
+            var dmgBonus = Combat.GetAbilityDamageBonus(activator, SkillType.Devices);
+
             DelayCommand(delay, () =>
             {
                 ApplyEffectAtLocation(
@@ -103,6 +108,14 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
                     EffectAreaOfEffect(aoe, enterScript, heartbeatScript), 
                     targetLocation, 
                     duration);
+
+                var AOEObject = GetNearestObjectToLocation(targetLocation, ObjectType.AreaOfEffect);
+                if(AOEObject != OBJECT_INVALID)
+                {
+                    SetLocalInt(AOEObject, "DEVICE_ACC", attackerStat);
+                    SetLocalInt(AOEObject, "DEVICE_ATK", attack);
+                    SetLocalInt(AOEObject, "DEVICE_DMG", dmgBonus);
+                }
 
             });
 

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/GasBombAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/GasBombAbilityDefinition.cs
@@ -16,16 +16,9 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
 
         private static void ApplyEffect(uint creature, int dmg)
         {
-            var activator = GetAreaOfEffectCreator(OBJECT_SELF);
-            var attackerStat = 0;
-            var attack = 0;
-
-            if(activator != OBJECT_INVALID)
-            {
-                attackerStat = GetAbilityScore(activator, AbilityType.Perception);
-                attack = Stat.GetAttack(activator, AbilityType.Perception, SkillType.Devices);
-                dmg += Combat.GetAbilityDamageBonus(activator, SkillType.Devices);
-            }
+            var attackerStat = GetLocalInt(OBJECT_SELF, "DEVICE_ACC");
+            var attack = GetLocalInt(OBJECT_SELF, "DEVICE_ATK");
+            dmg += GetLocalInt(OBJECT_SELF, "DEVICE_DMG");
 
             var defense = Stat.GetDefense(creature, CombatDamageType.Physical, AbilityType.Vitality);
             var defenderStat = GetAbilityScore(creature, AbilityType.Vitality);

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/GasBombAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/GasBombAbilityDefinition.cs
@@ -16,9 +16,15 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
 
         private static void ApplyEffect(uint creature, int dmg)
         {
+            var activator = GetAreaOfEffectCreator(OBJECT_SELF);
+            dmg += Combat.GetAbilityDamageBonus(activator, SkillType.Devices);
+
+            var attackerStat = GetAbilityScore(activator, AbilityType.Perception);
+            var attack = Stat.GetAttack(activator, AbilityType.Perception, SkillType.Devices);
+
             var defense = Stat.GetDefense(creature, CombatDamageType.Physical, AbilityType.Vitality);
             var defenderStat = GetAbilityScore(creature, AbilityType.Vitality);
-            var damage = Combat.CalculateDamage(0, dmg, 0, defense, defenderStat, 0);
+            var damage = Combat.CalculateDamage(attack, dmg, attackerStat, defense, defenderStat, 0);
 
             ApplyEffectToObject(DurationType.Instant, EffectDamage(damage, DamageType.Acid), creature);
         }

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/GasBombAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/GasBombAbilityDefinition.cs
@@ -17,10 +17,15 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
         private static void ApplyEffect(uint creature, int dmg)
         {
             var activator = GetAreaOfEffectCreator(OBJECT_SELF);
-            dmg += Combat.GetAbilityDamageBonus(activator, SkillType.Devices);
+            var attackerStat = 0;
+            var attack = 0;
 
-            var attackerStat = GetAbilityScore(activator, AbilityType.Perception);
-            var attack = Stat.GetAttack(activator, AbilityType.Perception, SkillType.Devices);
+            if(activator != OBJECT_INVALID)
+            {
+                attackerStat = GetAbilityScore(activator, AbilityType.Perception);
+                attack = Stat.GetAttack(activator, AbilityType.Perception, SkillType.Devices);
+                dmg += Combat.GetAbilityDamageBonus(activator, SkillType.Devices);
+            }
 
             var defense = Stat.GetDefense(creature, CombatDamageType.Physical, AbilityType.Vitality);
             var defenderStat = GetAbilityScore(creature, AbilityType.Vitality);

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/IncendiaryBombAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/IncendiaryBombAbilityDefinition.cs
@@ -15,12 +15,18 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
 
         private static void ApplyEffect(uint creature, int dmg)
         {
+            var activator = GetAreaOfEffectCreator(OBJECT_SELF);
+            dmg += Combat.GetAbilityDamageBonus(activator, SkillType.Devices);
+
+            var attackerStat = GetAbilityScore(activator, AbilityType.Perception);
+            var attack = Stat.GetAttack(activator, AbilityType.Perception, SkillType.Devices);
+
             var defense = Stat.GetDefense(creature, CombatDamageType.Physical, AbilityType.Vitality);
             var defenderStat = GetAbilityScore(creature, AbilityType.Vitality);
             var damage = Combat.CalculateDamage(
-                0,
+                attack,
                 dmg, 
-                0, 
+                attackerStat, 
                 defense, 
                 defenderStat, 
                 0);

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/IncendiaryBombAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/IncendiaryBombAbilityDefinition.cs
@@ -16,10 +16,15 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
         private static void ApplyEffect(uint creature, int dmg)
         {
             var activator = GetAreaOfEffectCreator(OBJECT_SELF);
-            dmg += Combat.GetAbilityDamageBonus(activator, SkillType.Devices);
+            var attackerStat = 0;
+            var attack = 0;
 
-            var attackerStat = GetAbilityScore(activator, AbilityType.Perception);
-            var attack = Stat.GetAttack(activator, AbilityType.Perception, SkillType.Devices);
+            if (activator != OBJECT_INVALID)
+            {
+                attackerStat = GetAbilityScore(activator, AbilityType.Perception);
+                attack = Stat.GetAttack(activator, AbilityType.Perception, SkillType.Devices);
+                dmg += Combat.GetAbilityDamageBonus(activator, SkillType.Devices);
+            }
 
             var defense = Stat.GetDefense(creature, CombatDamageType.Physical, AbilityType.Vitality);
             var defenderStat = GetAbilityScore(creature, AbilityType.Vitality);

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/IncendiaryBombAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/IncendiaryBombAbilityDefinition.cs
@@ -15,16 +15,9 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
 
         private static void ApplyEffect(uint creature, int dmg)
         {
-            var activator = GetAreaOfEffectCreator(OBJECT_SELF);
-            var attackerStat = 0;
-            var attack = 0;
-
-            if (activator != OBJECT_INVALID)
-            {
-                attackerStat = GetAbilityScore(activator, AbilityType.Perception);
-                attack = Stat.GetAttack(activator, AbilityType.Perception, SkillType.Devices);
-                dmg += Combat.GetAbilityDamageBonus(activator, SkillType.Devices);
-            }
+            var attackerStat = GetLocalInt(OBJECT_SELF, "DEVICE_ACC");
+            var attack = GetLocalInt(OBJECT_SELF, "DEVICE_ATK");
+            dmg += GetLocalInt(OBJECT_SELF, "DEVICE_DMG");
 
             var defense = Stat.GetDefense(creature, CombatDamageType.Physical, AbilityType.Vitality);
             var defenderStat = GetAbilityScore(creature, AbilityType.Vitality);

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/KoltoBombAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/KoltoBombAbilityDefinition.cs
@@ -14,7 +14,19 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
 
         private static void ApplyEffect(uint creature, int hpRegen)
         {
-            ApplyEffectToObject(DurationType.Temporary, EffectRegenerate(hpRegen, 6f), creature, 6f);
+
+            Effect eff = GetFirstEffect(creature);
+            while (GetIsEffectValid(eff))
+            {
+                if (GetEffectTag(eff) == "kolto_regen")
+                    RemoveEffect(creature, eff);
+                eff = GetNextEffect(creature);
+            }
+
+            Effect eKolto = EffectRegenerate(hpRegen, 6f);
+            eKolto = TagEffect(eKolto, "kolto_regen");
+
+            ApplyEffectToObject(DurationType.Temporary, eKolto, creature, 6f);
         }
 
         [NWNEventHandler("grenade_kolt1_en")]

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/KoltoBombAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/KoltoBombAbilityDefinition.cs
@@ -15,13 +15,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
         private static void ApplyEffect(uint creature, int hpRegen)
         {
 
-            Effect eff = GetFirstEffect(creature);
-            while (GetIsEffectValid(eff))
-            {
-                if (GetEffectTag(eff) == "kolto_regen")
-                    RemoveEffect(creature, eff);
-                eff = GetNextEffect(creature);
-            }
+            RemoveEffectByTag(creature, "kolto_regen"); // Get rid of any regen effects to prevent stacking
 
             Effect eKolto = EffectRegenerate(hpRegen, 6f);
             eKolto = TagEffect(eKolto, "kolto_regen");

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/KoltoGrenadeAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/KoltoGrenadeAbilityDefinition.cs
@@ -37,14 +37,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
             if (!GetFactionEqual(activator, target))
                 return;
 
-            // Check if target already has a regen effect; if so, remove it
-            Effect eff = GetFirstEffect(activator);
-            while(GetIsEffectValid(eff))
-            {
-                if (GetEffectTag(eff) == "kolto_regen")
-                    RemoveEffect(activator, eff);
-                eff = GetNextEffect(activator);
-            }
+            RemoveEffectByTag(target, "kolto_regen"); // Get rid of any regen effects to prevent stacking
 
             Effect eKolto = EffectRegenerate(regenAmount, 6f);
             eKolto = TagEffect(eKolto, "kolto_regen");

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/KoltoGrenadeAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/KoltoGrenadeAbilityDefinition.cs
@@ -37,7 +37,19 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
             if (!GetFactionEqual(activator, target))
                 return;
 
-            ApplyEffectToObject(DurationType.Temporary, EffectRegenerate(regenAmount, 6f), target, 45f);
+            // Check if target already has a regen effect; if so, remove it
+            Effect eff = GetFirstEffect(activator);
+            while(GetIsEffectValid(eff))
+            {
+                if (GetEffectTag(eff) == "kolto_regen")
+                    RemoveEffect(activator, eff);
+                eff = GetNextEffect(activator);
+            }
+
+            Effect eKolto = EffectRegenerate(regenAmount, 6f);
+            eKolto = TagEffect(eKolto, "kolto_regen");
+
+            ApplyEffectToObject(DurationType.Temporary, eKolto, target, 45f);
             ApplyEffectToObject(DurationType.Instant, EffectVisualEffect(VisualEffect.Vfx_Imp_Healing_G), target);
 
             CombatPoint.AddCombatPointToAllTagged(activator, SkillType.Devices, 3);

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Force/ThrowLightsaberAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Force/ThrowLightsaberAbilityDefinition.cs
@@ -75,6 +75,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
 
             dmg += Combat.GetAbilityDamageBonus(activator, SkillType.Force);
             var attack = Stat.GetAttack(activator, AbilityType.Willpower, SkillType.Force);
+            CombatPoint.AddCombatPoint(activator, target, SkillType.Force, 3);
 
             // apply to target
             DelayCommand(delay, () =>
@@ -89,7 +90,6 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                     defenderStat, 
                     0);
                 ApplyEffectToObject(DurationType.Instant, EffectLinkEffects(EffectVisualEffect(VisualEffect.Vfx_Imp_Sonic), EffectDamage(damage, DamageType.Sonic)), target);
-                CombatPoint.AddCombatPoint(activator, target, SkillType.Force, 3);
                 Enmity.ModifyEnmity(activator, target, damage + 200 * level);
             });
                         


### PR DESCRIPTION
Fixes https://github.com/zunath/SWLOR_NWN/issues/1451#issuecomment-1196165738, https://github.com/zunath/SWLOR_NWN/issues/1451#issuecomment-1197505016

- Gas and Incendiary Bombs now properly deal damage; yes, this includes to the user!
- Kolto Grenades and Bombs now will refresh Regeneration applied to a target, rather than stacking a new regen effect.
- Throw Lightsaber now no longer fails to give you XP if you one-shot enemies with it.

