### PR TITLE
Fix Power Attack not applying accuracy or displaying damage

### DIFF
--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/CharacterSheetViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/CharacterSheetViewModel.cs
@@ -404,7 +404,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
                 var damageAbility = Item.GetWeaponDamageAbilityType(itemType);
                 var damageStat = GetAbilityScore(Player, damageAbility);
                 var skillRank = dbPlayer.Skills[skill].Rank;
-                var dmg = Item.GetDMG(item) + Combat.GetDoublehandDMGBonus(Player);
+                var dmg = Item.GetDMG(item) + Combat.GetDoublehandDMGBonus(Player) + Combat.GetPowerAttackDMGBonus(Player);
                 var dmgText = $"{dmg} DMG";
                 var attack = Stat.GetAttack(Player, damageAbility, skill);
                 var defense = Stat.CalculateDefense(damageStat, skillRank, 0);

--- a/SWLOR.Game.Server/Feature/PerkDefinition/TwoHandedPerkDefinition.cs
+++ b/SWLOR.Game.Server/Feature/PerkDefinition/TwoHandedPerkDefinition.cs
@@ -55,13 +55,13 @@ namespace SWLOR.Game.Server.Feature.PerkDefinition
                 .Name("Power Attack")
 
                 .AddPerkLevel()
-                .Description("Grants the Power Attack feat which grants a +3 DMG bonus at the cost of -5 to attack roll. [Cross Skill]")
+                .Description("Grants the Power Attack feat which grants a +3 DMG bonus at the cost of -5 to accuracy. [Cross Skill]")
                 .Price(3)
                 .RequirementSkill(SkillType.TwoHanded, 15)
                 .GrantsFeat(FeatType.PowerAttack)
 
                 .AddPerkLevel()
-                .Description("Grants the Improved Power Attack feat which grants a +6 DMG bonus at the cost of -10 to attack roll. [Cross Skill]")
+                .Description("Grants the Improved Power Attack feat which grants a +6 DMG bonus at the cost of -10 to accuracy. [Cross Skill]")
                 .Price(4)
                 .RequirementSkill(SkillType.TwoHanded, 25)
                 .RequirementCharacterType(CharacterType.Standard)

--- a/SWLOR.Game.Server/Native/ResolveAttackRoll.cs
+++ b/SWLOR.Game.Server/Native/ResolveAttackRoll.cs
@@ -247,6 +247,19 @@ namespace SWLOR.Game.Server.Native
                 Log.Write(LogGroup.Attack, logMessage);
             }
 
+            // Combat Mode - Power Attack (-5 TH)
+            if (attacker.m_nCombatMode == 2)
+            {
+                accuracyModifiers -= 5;
+                Log.Write(LogGroup.Attack, "Applying Power Attack penalty: -5");
+            }
+            // Combat Mode - Improved Power Attack (-10 TH)
+            else if (attacker.m_nCombatMode == 3)
+            {
+                accuracyModifiers -= 10;
+                Log.Write(LogGroup.Attack, "Applying Imp. Power Attack penalty: -10");
+            }
+
             // End modifiers
             //---------------------------------------------------------------------------------------------
             //---------------------------------------------------------------------------------------------

--- a/SWLOR.Game.Server/Service/Combat.cs
+++ b/SWLOR.Game.Server/Service/Combat.cs
@@ -320,6 +320,20 @@ namespace SWLOR.Game.Server.Service
         }
 
         /// <summary>
+        /// Retrieves the DMG bonus granted by Power Attack.
+        /// </summary>
+        /// <param name="attacker">The attacker to check.</param>
+        /// <returns>The DMG bonus, or 0 if Power Attack is not enabled.</returns>
+        public static int GetPowerAttackDMGBonus(uint attacker)
+        {
+            if (GetActionMode(attacker, ActionMode.PowerAttack))
+                return 3;
+            else if (GetActionMode(attacker, ActionMode.ImprovedPowerAttack))
+                return 6;
+            return 0;
+        }
+
+        /// <summary>
         /// Retrieves the DMG bonus granted by doublehand.
         /// If attacker does not meet the requirements of Doublehand, 0 will be returned.
         /// Must be called from within a native context.

--- a/SWLOR.Game.Server/Service/Stat.cs
+++ b/SWLOR.Game.Server/Service/Stat.cs
@@ -1030,6 +1030,12 @@ namespace SWLOR.Game.Server.Service
             // Accuracy increases granted by effects
             accuracyBonus = CalculateEffectAccuracy(creature, accuracyBonus);
 
+            // Power Attack to-hit penalty
+            if (GetActionMode(creature, ActionMode.PowerAttack))
+                accuracyBonus -= 5;
+            else if (GetActionMode(creature, ActionMode.ImprovedPowerAttack))
+                accuracyBonus -= 10;
+
             return stat * 3 + skillLevel + accuracyBonus;
         }
 


### PR DESCRIPTION
Fixes https://github.com/zunath/SWLOR_NWN/issues/1451#issuecomment-1196166376

Power Attack damage was properly being added to base weapon damage, but not displayed anywhere, nor applying a to-hit malus. Damage is now displayed on the Character Sheet when enabled, and to-hit accuracy is appropriately reduced (and should also be displayed).