### PR TITLE
Add placeholder resource/creature spawns to Hutlar Frozen Wastes/Caves

### DIFF
--- a/SWLOR.Game.Server/Feature/SpawnDefinition/HutlarResourceSpawnDefinition.cs
+++ b/SWLOR.Game.Server/Feature/SpawnDefinition/HutlarResourceSpawnDefinition.cs
@@ -11,6 +11,8 @@ namespace SWLOR.Game.Server.Feature.SpawnDefinition
         {
             QionTundra();
             Valley();
+            Wastes();
+            FrozenCave();
 
             return _builder.Build();
         }
@@ -58,6 +60,48 @@ namespace SWLOR.Game.Server.Feature.SpawnDefinition
                 .WithFrequency(40)
                 .AddSpawn(ObjectType.Placeable, "fiberp_bush_4")
                 .WithFrequency(10);
+        }
+
+        private void Wastes()
+        {
+            _builder.Create("RESOURCES_HUTLAR_WASTES")
+                .AddSpawn(ObjectType.Placeable, "plagionite_vein")
+                .WithFrequency(40)
+                .AddSpawn(ObjectType.Placeable, "keromber_vein")
+                .WithFrequency(10)
+
+                .AddSpawn(ObjectType.Placeable, "ancient_tree")
+                .WithFrequency(20)
+                .AddSpawn(ObjectType.Placeable, "aracia_tree")
+                .WithFrequency(5)
+
+                .AddSpawn(ObjectType.Placeable, "patch_veggies3")
+                .WithFrequency(20)
+                .AddSpawn(ObjectType.Placeable, "patch_veggies4")
+                .WithFrequency(5)
+                .AddSpawn(ObjectType.Placeable, "fiberp_bush_3")
+                .WithFrequency(20)
+                .AddSpawn(ObjectType.Placeable, "fiberp_bush_4")
+                .WithFrequency(5);
+        }
+
+        private void FrozenCave()
+        {
+            _builder.Create("RESOURCES_FROZEN_CAVE")
+                .AddSpawn(ObjectType.Placeable, "plagionite_vein")
+                .WithFrequency(20)
+                .AddSpawn(ObjectType.Placeable, "keromber_vein")
+                .WithFrequency(5)
+
+                .AddSpawn(ObjectType.Placeable, "patch_veggies3")
+                .WithFrequency(5)
+                .AddSpawn(ObjectType.Placeable, "patch_veggies4")
+                .WithFrequency(2)
+                .AddSpawn(ObjectType.Placeable, "fiberp_bush_3")
+                .WithFrequency(40)
+                .AddSpawn(ObjectType.Placeable, "fiberp_bush_4")
+                .WithFrequency(10);
+
         }
     }
 }

--- a/SWLOR.Game.Server/Feature/SpawnDefinition/HutlarSpawnDefinition.cs
+++ b/SWLOR.Game.Server/Feature/SpawnDefinition/HutlarSpawnDefinition.cs
@@ -12,6 +12,8 @@ namespace SWLOR.Game.Server.Feature.SpawnDefinition
             Byysk();
             QionAnimals();
             Valley();
+            Wastes();
+            FrozenCave();
 
             return _builder.Build();
         }
@@ -54,6 +56,34 @@ namespace SWLOR.Game.Server.Feature.SpawnDefinition
 
                 .AddSpawn(ObjectType.Creature, "qion_tiger")
                 .WithFrequency(8)
+                .RandomlyWalks()
+                .ReturnsHome();
+        }
+
+        private void Wastes()
+        {
+            _builder.Create("HUTLAR_WASTES", "Hutlar Wastes")
+                .AddSpawn(ObjectType.Creature, "qion_tiger")
+                .WithFrequency(8)
+                .RandomlyWalks()
+                .ReturnsHome();
+        }
+
+        private void FrozenCave()
+        {
+            _builder.Create("HUTLAR_FROZEN_CAVE", "Hutlar Frozen Cave")
+                .AddSpawn(ObjectType.Creature, "byysk_warrior")
+                .WithFrequency(10)
+                .RandomlyWalks()
+                .ReturnsHome()
+
+                .AddSpawn(ObjectType.Creature, "byysk_warrior2")
+                .WithFrequency(10)
+                .RandomlyWalks()
+                .ReturnsHome()
+
+                .AddSpawn(ObjectType.Creature, "qion_tiger")
+                .WithFrequency(5)
                 .RandomlyWalks()
                 .ReturnsHome();
         }


### PR DESCRIPTION
Hutlar Wastes and Frozen Caves currently have no spawn tables defined, so they're completely empty (and throwing errors!). This adds some vaguely-sensible spawns based on what already exists and is available for Hutlar, though they should probably be tweaked/replaced down the road with more fitting choices.