### PR TITLE
Mandalorian Upgrade + Fixes

### DIFF
--- a/Module/are/manda_facility.are.json
+++ b/Module/are/manda_facility.are.json
@@ -11169,7 +11169,7 @@
   },
   "Version": {
     "type": "dword",
-    "value": 48
+    "value": 49
   },
   "Width": {
     "type": "int",

--- a/Module/are/manda_facility.are.json
+++ b/Module/are/manda_facility.are.json
@@ -11169,7 +11169,7 @@
   },
   "Version": {
     "type": "dword",
-    "value": 49
+    "value": 50
   },
   "Width": {
     "type": "int",

--- a/Module/are/manda_facility.are.json
+++ b/Module/are/manda_facility.are.json
@@ -11169,7 +11169,7 @@
   },
   "Version": {
     "type": "dword",
-    "value": 46
+    "value": 48
   },
   "Width": {
     "type": "int",

--- a/Module/are/ooc_area.are.json
+++ b/Module/are/ooc_area.are.json
@@ -2225,7 +2225,7 @@
   },
   "Version": {
     "type": "dword",
-    "value": 36
+    "value": 37
   },
   "Width": {
     "type": "int",

--- a/Module/are/viscarawildwoods.are.json
+++ b/Module/are/viscarawildwoods.are.json
@@ -44193,7 +44193,7 @@
   },
   "Version": {
     "type": "dword",
-    "value": 33
+    "value": 34
   },
   "Width": {
     "type": "int",

--- a/Module/gic/viscarawildwoods.gic.json
+++ b/Module/gic/viscarawildwoods.gic.json
@@ -561,6 +561,62 @@
           "type": "cexostring",
           "value": ""
         }
+      },
+      {
+        "__struct_id": 5,
+        "Comment": {
+          "type": "cexostring",
+          "value": ""
+        }
+      },
+      {
+        "__struct_id": 5,
+        "Comment": {
+          "type": "cexostring",
+          "value": ""
+        }
+      },
+      {
+        "__struct_id": 5,
+        "Comment": {
+          "type": "cexostring",
+          "value": ""
+        }
+      },
+      {
+        "__struct_id": 5,
+        "Comment": {
+          "type": "cexostring",
+          "value": ""
+        }
+      },
+      {
+        "__struct_id": 5,
+        "Comment": {
+          "type": "cexostring",
+          "value": ""
+        }
+      },
+      {
+        "__struct_id": 5,
+        "Comment": {
+          "type": "cexostring",
+          "value": ""
+        }
+      },
+      {
+        "__struct_id": 5,
+        "Comment": {
+          "type": "cexostring",
+          "value": ""
+        }
+      },
+      {
+        "__struct_id": 5,
+        "Comment": {
+          "type": "cexostring",
+          "value": ""
+        }
       }
     ]
   }

--- a/Module/git/viscarawildwoods.git.json
+++ b/Module/git/viscarawildwoods.git.json
@@ -7153,69 +7153,6 @@
         "LocalizedName": {
           "type": "cexolocstring",
           "value": {
-            "0": "Viscara - Wildwoods Outlaw"
-          }
-        },
-        "MapNote": {
-          "type": "cexolocstring",
-          "value": {}
-        },
-        "MapNoteEnabled": {
-          "type": "byte",
-          "value": 0
-        },
-        "Tag": {
-          "type": "cexostring",
-          "value": "VISCARA_WILDWOODS_LOOTERS"
-        },
-        "TemplateResRef": {
-          "type": "resref",
-          "value": "v_wildwd_looter"
-        },
-        "XOrientation": {
-          "type": "float",
-          "value": -0.9329947829246521
-        },
-        "XPosition": {
-          "type": "float",
-          "value": 169.5370025634766
-        },
-        "YOrientation": {
-          "type": "float",
-          "value": -0.3598898351192474
-        },
-        "YPosition": {
-          "type": "float",
-          "value": 117.398078918457
-        },
-        "ZPosition": {
-          "type": "float",
-          "value": 0.09792518615722656
-        }
-      },
-      {
-        "__struct_id": 5,
-        "Appearance": {
-          "type": "byte",
-          "value": 2
-        },
-        "Description": {
-          "type": "cexolocstring",
-          "value": {
-            "0": ""
-          }
-        },
-        "HasMapNote": {
-          "type": "byte",
-          "value": 0
-        },
-        "LinkedTo": {
-          "type": "cexostring",
-          "value": ""
-        },
-        "LocalizedName": {
-          "type": "cexolocstring",
-          "value": {
             "0": "Viscara - Wildwoods Gimpassa"
           }
         },
@@ -7254,69 +7191,6 @@
         "ZPosition": {
           "type": "float",
           "value": 0.1606540679931641
-        }
-      },
-      {
-        "__struct_id": 5,
-        "Appearance": {
-          "type": "byte",
-          "value": 2
-        },
-        "Description": {
-          "type": "cexolocstring",
-          "value": {
-            "0": ""
-          }
-        },
-        "HasMapNote": {
-          "type": "byte",
-          "value": 0
-        },
-        "LinkedTo": {
-          "type": "cexostring",
-          "value": ""
-        },
-        "LocalizedName": {
-          "type": "cexolocstring",
-          "value": {
-            "0": "Viscara - Wildwoods Outlaw"
-          }
-        },
-        "MapNote": {
-          "type": "cexolocstring",
-          "value": {}
-        },
-        "MapNoteEnabled": {
-          "type": "byte",
-          "value": 0
-        },
-        "Tag": {
-          "type": "cexostring",
-          "value": "VISCARA_WILDWOODS_LOOTERS"
-        },
-        "TemplateResRef": {
-          "type": "resref",
-          "value": "v_wildwd_looter"
-        },
-        "XOrientation": {
-          "type": "float",
-          "value": -0.9238795042037964
-        },
-        "XPosition": {
-          "type": "float",
-          "value": 168.8549194335938
-        },
-        "YOrientation": {
-          "type": "float",
-          "value": 0.3826834261417389
-        },
-        "YPosition": {
-          "type": "float",
-          "value": 112.8411636352539
-        },
-        "ZPosition": {
-          "type": "float",
-          "value": 0.2293534278869629
         }
       },
       {
@@ -9014,6 +8888,636 @@
         "ZPosition": {
           "type": "float",
           "value": 0.1417824923992157
+        }
+      },
+      {
+        "__struct_id": 5,
+        "Appearance": {
+          "type": "byte",
+          "value": 2
+        },
+        "Description": {
+          "type": "cexolocstring",
+          "value": {
+            "0": ""
+          }
+        },
+        "HasMapNote": {
+          "type": "byte",
+          "value": 0
+        },
+        "LinkedTo": {
+          "type": "cexostring",
+          "value": ""
+        },
+        "LocalizedName": {
+          "type": "cexolocstring",
+          "value": {
+            "0": "Viscara - Wildwoods Mandalorian Scout"
+          }
+        },
+        "MapNote": {
+          "type": "cexolocstring",
+          "value": {}
+        },
+        "MapNoteEnabled": {
+          "type": "byte",
+          "value": 0
+        },
+        "Tag": {
+          "type": "cexostring",
+          "value": "VISCARA_WILDWOODS_MANDO_SCOUT"
+        },
+        "TemplateResRef": {
+          "type": "resref",
+          "value": "v_wildwd_mando_s"
+        },
+        "XOrientation": {
+          "type": "float",
+          "value": -0.9238795042037964
+        },
+        "XPosition": {
+          "type": "float",
+          "value": 169.5746765136719
+        },
+        "YOrientation": {
+          "type": "float",
+          "value": 0.3826834261417389
+        },
+        "YPosition": {
+          "type": "float",
+          "value": 112.4407577514648
+        },
+        "ZPosition": {
+          "type": "float",
+          "value": 0.009147167205810547
+        }
+      },
+      {
+        "__struct_id": 5,
+        "Appearance": {
+          "type": "byte",
+          "value": 2
+        },
+        "Description": {
+          "type": "cexolocstring",
+          "value": {
+            "0": ""
+          }
+        },
+        "HasMapNote": {
+          "type": "byte",
+          "value": 0
+        },
+        "LinkedTo": {
+          "type": "cexostring",
+          "value": ""
+        },
+        "LocalizedName": {
+          "type": "cexolocstring",
+          "value": {
+            "0": "Viscara - Wildwoods Mandalorian Scout"
+          }
+        },
+        "MapNote": {
+          "type": "cexolocstring",
+          "value": {}
+        },
+        "MapNoteEnabled": {
+          "type": "byte",
+          "value": 0
+        },
+        "Tag": {
+          "type": "cexostring",
+          "value": "VISCARA_WILDWOODS_MANDO_SCOUT"
+        },
+        "TemplateResRef": {
+          "type": "resref",
+          "value": "v_wildwd_mando_s"
+        },
+        "XOrientation": {
+          "type": "float",
+          "value": -0.8700871467590332
+        },
+        "XPosition": {
+          "type": "float",
+          "value": 169.2222137451172
+        },
+        "YOrientation": {
+          "type": "float",
+          "value": -0.4928979575634003
+        },
+        "YPosition": {
+          "type": "float",
+          "value": 116.7128753662109
+        },
+        "ZPosition": {
+          "type": "float",
+          "value": 0.1006717681884766
+        }
+      },
+      {
+        "__struct_id": 5,
+        "Appearance": {
+          "type": "byte",
+          "value": 2
+        },
+        "Description": {
+          "type": "cexolocstring",
+          "value": {
+            "0": ""
+          }
+        },
+        "HasMapNote": {
+          "type": "byte",
+          "value": 0
+        },
+        "LinkedTo": {
+          "type": "cexostring",
+          "value": ""
+        },
+        "LocalizedName": {
+          "type": "cexolocstring",
+          "value": {
+            "0": "Viscara - Wildwoods Mandalorian Hunter"
+          }
+        },
+        "MapNote": {
+          "type": "cexolocstring",
+          "value": {}
+        },
+        "MapNoteEnabled": {
+          "type": "byte",
+          "value": 0
+        },
+        "Tag": {
+          "type": "cexostring",
+          "value": "VISCARA_WILDWOODS_MANDO_HUNTER"
+        },
+        "TemplateResRef": {
+          "type": "resref",
+          "value": "v_wildwd_mando_h"
+        },
+        "XOrientation": {
+          "type": "float",
+          "value": -0.9972904324531555
+        },
+        "XPosition": {
+          "type": "float",
+          "value": 292.2688293457031
+        },
+        "YOrientation": {
+          "type": "float",
+          "value": 0.07356461137533188
+        },
+        "YPosition": {
+          "type": "float",
+          "value": 165.2815704345703
+        },
+        "ZPosition": {
+          "type": "float",
+          "value": 0.0374075248837471
+        }
+      },
+      {
+        "__struct_id": 5,
+        "Appearance": {
+          "type": "byte",
+          "value": 2
+        },
+        "Description": {
+          "type": "cexolocstring",
+          "value": {
+            "0": ""
+          }
+        },
+        "HasMapNote": {
+          "type": "byte",
+          "value": 0
+        },
+        "LinkedTo": {
+          "type": "cexostring",
+          "value": ""
+        },
+        "LocalizedName": {
+          "type": "cexolocstring",
+          "value": {
+            "0": "Viscara - Wildwoods Mandalorian Scout"
+          }
+        },
+        "MapNote": {
+          "type": "cexolocstring",
+          "value": {}
+        },
+        "MapNoteEnabled": {
+          "type": "byte",
+          "value": 0
+        },
+        "Tag": {
+          "type": "cexostring",
+          "value": "VISCARA_WILDWOODS_MANDO_SCOUT"
+        },
+        "TemplateResRef": {
+          "type": "resref",
+          "value": "v_wildwd_mando_s"
+        },
+        "XOrientation": {
+          "type": "float",
+          "value": -0.9415440559387207
+        },
+        "XPosition": {
+          "type": "float",
+          "value": 287.8318176269531
+        },
+        "YOrientation": {
+          "type": "float",
+          "value": 0.3368898332118988
+        },
+        "YPosition": {
+          "type": "float",
+          "value": 167.0232238769531
+        },
+        "ZPosition": {
+          "type": "float",
+          "value": 0.1388818621635437
+        }
+      },
+      {
+        "__struct_id": 5,
+        "Appearance": {
+          "type": "byte",
+          "value": 2
+        },
+        "Description": {
+          "type": "cexolocstring",
+          "value": {
+            "0": ""
+          }
+        },
+        "HasMapNote": {
+          "type": "byte",
+          "value": 0
+        },
+        "LinkedTo": {
+          "type": "cexostring",
+          "value": ""
+        },
+        "LocalizedName": {
+          "type": "cexolocstring",
+          "value": {
+            "0": "Viscara - Wildwoods Mandalorian Scout"
+          }
+        },
+        "MapNote": {
+          "type": "cexolocstring",
+          "value": {}
+        },
+        "MapNoteEnabled": {
+          "type": "byte",
+          "value": 0
+        },
+        "Tag": {
+          "type": "cexostring",
+          "value": "VISCARA_WILDWOODS_MANDO_SCOUT"
+        },
+        "TemplateResRef": {
+          "type": "resref",
+          "value": "v_wildwd_mando_s"
+        },
+        "XOrientation": {
+          "type": "float",
+          "value": -0.903989315032959
+        },
+        "XPosition": {
+          "type": "float",
+          "value": 288.2724304199219
+        },
+        "YOrientation": {
+          "type": "float",
+          "value": -0.4275550842285156
+        },
+        "YPosition": {
+          "type": "float",
+          "value": 163.252685546875
+        },
+        "ZPosition": {
+          "type": "float",
+          "value": 0.1562887579202652
+        }
+      },
+      {
+        "__struct_id": 5,
+        "Appearance": {
+          "type": "byte",
+          "value": 2
+        },
+        "Description": {
+          "type": "cexolocstring",
+          "value": {
+            "0": ""
+          }
+        },
+        "HasMapNote": {
+          "type": "byte",
+          "value": 0
+        },
+        "LinkedTo": {
+          "type": "cexostring",
+          "value": ""
+        },
+        "LocalizedName": {
+          "type": "cexolocstring",
+          "value": {
+            "0": "Viscara - Wildwoods Mandalorian Hunter"
+          }
+        },
+        "MapNote": {
+          "type": "cexolocstring",
+          "value": {}
+        },
+        "MapNoteEnabled": {
+          "type": "byte",
+          "value": 0
+        },
+        "Tag": {
+          "type": "cexostring",
+          "value": "VISCARA_WILDWOODS_MANDO_HUNTER"
+        },
+        "TemplateResRef": {
+          "type": "resref",
+          "value": "v_wildwd_mando_h"
+        },
+        "XOrientation": {
+          "type": "float",
+          "value": 0.0
+        },
+        "XPosition": {
+          "type": "float",
+          "value": 189.2857208251953
+        },
+        "YOrientation": {
+          "type": "float",
+          "value": 1.0
+        },
+        "YPosition": {
+          "type": "float",
+          "value": 210.8301696777344
+        },
+        "ZPosition": {
+          "type": "float",
+          "value": 5.960464477539063e-008
+        }
+      },
+      {
+        "__struct_id": 5,
+        "Appearance": {
+          "type": "byte",
+          "value": 2
+        },
+        "Description": {
+          "type": "cexolocstring",
+          "value": {
+            "0": ""
+          }
+        },
+        "HasMapNote": {
+          "type": "byte",
+          "value": 0
+        },
+        "LinkedTo": {
+          "type": "cexostring",
+          "value": ""
+        },
+        "LocalizedName": {
+          "type": "cexolocstring",
+          "value": {
+            "0": "Viscara - Wildwoods Mandalorian Scout"
+          }
+        },
+        "MapNote": {
+          "type": "cexolocstring",
+          "value": {}
+        },
+        "MapNoteEnabled": {
+          "type": "byte",
+          "value": 0
+        },
+        "Tag": {
+          "type": "cexostring",
+          "value": "VISCARA_WILDWOODS_MANDO_SCOUT"
+        },
+        "TemplateResRef": {
+          "type": "resref",
+          "value": "v_wildwd_mando_s"
+        },
+        "XOrientation": {
+          "type": "float",
+          "value": 0.290284663438797
+        },
+        "XPosition": {
+          "type": "float",
+          "value": 190.9592590332031
+        },
+        "YOrientation": {
+          "type": "float",
+          "value": 0.9569403529167175
+        },
+        "YPosition": {
+          "type": "float",
+          "value": 208.6573486328125
+        },
+        "ZPosition": {
+          "type": "float",
+          "value": -0.06044310331344605
+        }
+      },
+      {
+        "__struct_id": 5,
+        "Appearance": {
+          "type": "byte",
+          "value": 2
+        },
+        "Description": {
+          "type": "cexolocstring",
+          "value": {
+            "0": ""
+          }
+        },
+        "HasMapNote": {
+          "type": "byte",
+          "value": 0
+        },
+        "LinkedTo": {
+          "type": "cexostring",
+          "value": ""
+        },
+        "LocalizedName": {
+          "type": "cexolocstring",
+          "value": {
+            "0": "Viscara - Wildwoods Mandalorian Scout"
+          }
+        },
+        "MapNote": {
+          "type": "cexolocstring",
+          "value": {}
+        },
+        "MapNoteEnabled": {
+          "type": "byte",
+          "value": 0
+        },
+        "Tag": {
+          "type": "cexostring",
+          "value": "VISCARA_WILDWOODS_MANDO_SCOUT"
+        },
+        "TemplateResRef": {
+          "type": "resref",
+          "value": "v_wildwd_mando_s"
+        },
+        "XOrientation": {
+          "type": "float",
+          "value": 0.0
+        },
+        "XPosition": {
+          "type": "float",
+          "value": 191.2754058837891
+        },
+        "YOrientation": {
+          "type": "float",
+          "value": 1.0
+        },
+        "YPosition": {
+          "type": "float",
+          "value": 212.5604705810547
+        },
+        "ZPosition": {
+          "type": "float",
+          "value": 0.1179957836866379
+        }
+      },
+      {
+        "__struct_id": 5,
+        "Appearance": {
+          "type": "byte",
+          "value": 2
+        },
+        "Description": {
+          "type": "cexolocstring",
+          "value": {
+            "0": ""
+          }
+        },
+        "HasMapNote": {
+          "type": "byte",
+          "value": 0
+        },
+        "LinkedTo": {
+          "type": "cexostring",
+          "value": ""
+        },
+        "LocalizedName": {
+          "type": "cexolocstring",
+          "value": {
+            "0": "Viscara - Wildwoods Mandalorian Hunter"
+          }
+        },
+        "MapNote": {
+          "type": "cexolocstring",
+          "value": {}
+        },
+        "MapNoteEnabled": {
+          "type": "byte",
+          "value": 0
+        },
+        "Tag": {
+          "type": "cexostring",
+          "value": "VISCARA_WILDWOODS_MANDO_HUNTER"
+        },
+        "TemplateResRef": {
+          "type": "resref",
+          "value": "v_wildwd_mando_h"
+        },
+        "XOrientation": {
+          "type": "float",
+          "value": -0.9807853102684021
+        },
+        "XPosition": {
+          "type": "float",
+          "value": 134.8077850341797
+        },
+        "YOrientation": {
+          "type": "float",
+          "value": -0.1950902044773102
+        },
+        "YPosition": {
+          "type": "float",
+          "value": 269.5105590820313
+        },
+        "ZPosition": {
+          "type": "float",
+          "value": -0.01804447174072266
+        }
+      },
+      {
+        "__struct_id": 5,
+        "Appearance": {
+          "type": "byte",
+          "value": 2
+        },
+        "Description": {
+          "type": "cexolocstring",
+          "value": {
+            "0": ""
+          }
+        },
+        "HasMapNote": {
+          "type": "byte",
+          "value": 0
+        },
+        "LinkedTo": {
+          "type": "cexostring",
+          "value": ""
+        },
+        "LocalizedName": {
+          "type": "cexolocstring",
+          "value": {
+            "0": "Viscara - Wildwoods Mandalorian Scout"
+          }
+        },
+        "MapNote": {
+          "type": "cexolocstring",
+          "value": {}
+        },
+        "MapNoteEnabled": {
+          "type": "byte",
+          "value": 0
+        },
+        "Tag": {
+          "type": "cexostring",
+          "value": "VISCARA_WILDWOODS_MANDO_SCOUT"
+        },
+        "TemplateResRef": {
+          "type": "resref",
+          "value": "v_wildwd_mando_s"
+        },
+        "XOrientation": {
+          "type": "float",
+          "value": -0.8032076358795166
+        },
+        "XPosition": {
+          "type": "float",
+          "value": 135.3408355712891
+        },
+        "YOrientation": {
+          "type": "float",
+          "value": -0.5956991910934448
+        },
+        "YPosition": {
+          "type": "float",
+          "value": 265.8529052734375
+        },
+        "ZPosition": {
+          "type": "float",
+          "value": -0.2671293020248413
         }
       }
     ]

--- a/Module/itp/creaturepalcus.itp.json
+++ b/Module/itp/creaturepalcus.itp.json
@@ -10280,6 +10280,25 @@
                     },
                     "NAME": {
                       "type": "cexostring",
+                      "value": "Mandalorian Hunter"
+                    },
+                    "RESREF": {
+                      "type": "resref",
+                      "value": "man_hunter"
+                    }
+                  },
+                  {
+                    "__struct_id": 0,
+                    "CR": {
+                      "type": "float",
+                      "value": 4.0
+                    },
+                    "FACTION": {
+                      "type": "cexostring",
+                      "value": "Hostile"
+                    },
+                    "NAME": {
+                      "type": "cexostring",
                       "value": "Mandalorian Ranger"
                     },
                     "RESREF": {
@@ -10304,6 +10323,25 @@
                     "RESREF": {
                       "type": "resref",
                       "value": "man_ranger_2"
+                    }
+                  },
+                  {
+                    "__struct_id": 0,
+                    "CR": {
+                      "type": "float",
+                      "value": 3.0
+                    },
+                    "FACTION": {
+                      "type": "cexostring",
+                      "value": "Hostile"
+                    },
+                    "NAME": {
+                      "type": "cexostring",
+                      "value": "Mandalorian Scout"
+                    },
+                    "RESREF": {
+                      "type": "resref",
+                      "value": "man_scout"
                     }
                   },
                   {

--- a/Module/itp/itempalcus.itp.json
+++ b/Module/itp/itempalcus.itp.json
@@ -6684,6 +6684,17 @@
                     "__struct_id": 0,
                     "NAME": {
                       "type": "cexostring",
+                      "value": "Mandalorian Scout Skin"
+                    },
+                    "RESREF": {
+                      "type": "resref",
+                      "value": "mando_scout_skin"
+                    }
+                  },
+                  {
+                    "__struct_id": 0,
+                    "NAME": {
+                      "type": "cexostring",
                       "value": "Mandalorian War Hero Skin"
                     },
                     "RESREF": {

--- a/Module/itp/itempalcus.itp.json
+++ b/Module/itp/itempalcus.itp.json
@@ -3803,6 +3803,17 @@
                     "__struct_id": 0,
                     "NAME": {
                       "type": "cexostring",
+                      "value": "[NPC] Mandalorian Armor Red"
+                    },
+                    "RESREF": {
+                      "type": "resref",
+                      "value": "man_armor_npc_r"
+                    }
+                  },
+                  {
+                    "__struct_id": 0,
+                    "NAME": {
+                      "type": "cexostring",
                       "value": "[NPC] Mandalorian Helmet"
                     },
                     "RESREF": {
@@ -3825,11 +3836,33 @@
                     "__struct_id": 0,
                     "NAME": {
                       "type": "cexostring",
+                      "value": "[NPC] Mandalorian Helmet Red"
+                    },
+                    "RESREF": {
+                      "type": "resref",
+                      "value": "man_helm_npc_r"
+                    }
+                  },
+                  {
+                    "__struct_id": 0,
+                    "NAME": {
+                      "type": "cexostring",
                       "value": "[NPC] Mandalorian War Hero Armor"
                     },
                     "RESREF": {
                       "type": "resref",
                       "value": "man_larmor_npc"
+                    }
+                  },
+                  {
+                    "__struct_id": 0,
+                    "NAME": {
+                      "type": "cexostring",
+                      "value": "[NPC] Mandalorian War Hero Helm"
+                    },
+                    "RESREF": {
+                      "type": "resref",
+                      "value": "man_helm_npc001"
                     }
                   },
                   {
@@ -6623,6 +6656,17 @@
                     "RESREF": {
                       "type": "resref",
                       "value": "dmnpckoyees"
+                    }
+                  },
+                  {
+                    "__struct_id": 0,
+                    "NAME": {
+                      "type": "cexostring",
+                      "value": "Mandalorian Hunter Skin"
+                    },
+                    "RESREF": {
+                      "type": "resref",
+                      "value": "mando_htr_skin"
                     }
                   },
                   {
@@ -29246,6 +29290,17 @@
                           "__struct_id": 0,
                           "NAME": {
                             "type": "cexostring",
+                            "value": "[NPC] Mandalorian Knife"
+                          },
+                          "RESREF": {
+                            "type": "resref",
+                            "value": "npc_mando_knife"
+                          }
+                        },
+                        {
+                          "__struct_id": 0,
+                          "NAME": {
+                            "type": "cexostring",
                             "value": "Archetype Knife"
                           },
                           "RESREF": {
@@ -29905,6 +29960,17 @@
                           "__struct_id": 0,
                           "NAME": {
                             "type": "cexostring",
+                            "value": "Captain Electroblade"
+                          },
+                          "RESREF": {
+                            "type": "resref",
+                            "value": "cap_eblade"
+                          }
+                        },
+                        {
+                          "__struct_id": 0,
+                          "NAME": {
+                            "type": "cexostring",
                             "value": "Captain Longsword"
                           },
                           "RESREF": {
@@ -30174,6 +30240,17 @@
                           "RESREF": {
                             "type": "resref",
                             "value": "mando_blade"
+                          }
+                        },
+                        {
+                          "__struct_id": 0,
+                          "NAME": {
+                            "type": "cexostring",
+                            "value": "Mandalorian Electroblade"
+                          },
+                          "RESREF": {
+                            "type": "resref",
+                            "value": "mando_eblade"
                           }
                         },
                         {
@@ -30945,6 +31022,17 @@
                     "__struct_id": 0,
                     "NAME": {
                       "type": "cexostring",
+                      "value": "Captain Twin Electroblade"
+                    },
+                    "RESREF": {
+                      "type": "resref",
+                      "value": "cap_sabstaff"
+                    }
+                  },
+                  {
+                    "__struct_id": 0,
+                    "NAME": {
+                      "type": "cexostring",
                       "value": "Carbide Staff"
                     },
                     "RESREF": {
@@ -31214,6 +31302,17 @@
                     "RESREF": {
                       "type": "resref",
                       "value": "mando_twinblade"
+                    }
+                  },
+                  {
+                    "__struct_id": 0,
+                    "NAME": {
+                      "type": "cexostring",
+                      "value": "Mandalorian Twin Electroblade"
+                    },
+                    "RESREF": {
+                      "type": "resref",
+                      "value": "mando_sabstaff"
                     }
                   },
                   {
@@ -32230,6 +32329,17 @@
                     "RESREF": {
                       "type": "resref",
                       "value": "byysk_spear"
+                    }
+                  },
+                  {
+                    "__struct_id": 0,
+                    "NAME": {
+                      "type": "cexostring",
+                      "value": "Captain Spear"
+                    },
+                    "RESREF": {
+                      "type": "resref",
+                      "value": "cap_spear"
                     }
                   },
                   {

--- a/Module/itp/waypointpalcus.itp.json
+++ b/Module/itp/waypointpalcus.itp.json
@@ -296,6 +296,28 @@
                     "__struct_id": 0,
                     "NAME": {
                       "type": "cexostring",
+                      "value": "Viscara - Wildwoods Mandalorian Hunter"
+                    },
+                    "RESREF": {
+                      "type": "resref",
+                      "value": "v_wildwd_mando_h"
+                    }
+                  },
+                  {
+                    "__struct_id": 0,
+                    "NAME": {
+                      "type": "cexostring",
+                      "value": "Viscara - Wildwoods Mandalorian Scout"
+                    },
+                    "RESREF": {
+                      "type": "resref",
+                      "value": "v_wildwd_mando_s"
+                    }
+                  },
+                  {
+                    "__struct_id": 0,
+                    "NAME": {
+                      "type": "cexostring",
                       "value": "Viscara - Wildwoods Outlaw"
                     },
                     "RESREF": {

--- a/Module/utc/man_hunter.utc.json
+++ b/Module/utc/man_hunter.utc.json
@@ -90,7 +90,7 @@
   },
   "ChallengeRating": {
     "type": "float",
-    "value": 5.0
+    "value": 4.0
   },
   "ClassList": {
     "type": "list",
@@ -103,7 +103,7 @@
         },
         "ClassLevel": {
           "type": "short",
-          "value": 1
+          "value": 4
         }
       }
     ]
@@ -130,7 +130,7 @@
   },
   "Con": {
     "type": "byte",
-    "value": 19
+    "value": 20
   },
   "Conversation": {
     "type": "resref",
@@ -138,11 +138,11 @@
   },
   "CRAdjust": {
     "type": "int",
-    "value": 0
+    "value": -1
   },
   "CurrentHitPoints": {
     "type": "short",
-    "value": 120
+    "value": 85
   },
   "DecayTime": {
     "type": "dword",
@@ -155,12 +155,12 @@
   "Description": {
     "type": "cexolocstring",
     "value": {
-      "0": "\"Here's why you can't exterminate us, aruetii. We're not huddled in one place- we span the galaxy. We need no lords or leaders, so you can't destroy our command. We can live without technology, so we can fight with our bare hands. We have no species or bloodline, so we can rebuild our ranks with others who want to join us. We're more than just a people or an army, aruetii. We're a culture. We're an idea. And you can't kill ideas, but we can certainly kill you.\" - Mandalore the Destroyer"
+      "0": "\"There's always a war going on somewhere, always has been, always will be. It's why Mandalorians have never gone out of business.\"\\nClad in distinctive Neo-Crusader light armor, this disparate group of breakaway Mandalorians have entrenched themselves in the eastern Wildwoods, routinely sending out hunting parties to harass Veles."
     }
   },
   "Dex": {
     "type": "byte",
-    "value": 15
+    "value": 24
   },
   "Disarmable": {
     "type": "byte",
@@ -173,28 +173,28 @@
         "__struct_id": 1,
         "EquippedRes": {
           "type": "resref",
-          "value": "man_helm_npc"
+          "value": "man_helm_npc_r"
         }
       },
       {
         "__struct_id": 2,
         "EquippedRes": {
           "type": "resref",
-          "value": "man_armor_npc"
+          "value": "man_armor_npc_r"
         }
       },
       {
         "__struct_id": 16,
         "EquippedRes": {
           "type": "resref",
-          "value": "npc_mando_blade"
+          "value": "npc_mando_rifle"
         }
       },
       {
         "__struct_id": 131072,
         "EquippedRes": {
           "type": "resref",
-          "value": "mando_war_skin"
+          "value": "mando_htr_skin"
         }
       }
     ]
@@ -231,7 +231,21 @@
         "__struct_id": 1,
         "Feat": {
           "type": "word",
+          "value": 1347
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
           "value": 10
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1588
         }
       },
       {
@@ -259,7 +273,14 @@
         "__struct_id": 1,
         "Feat": {
           "type": "word",
-          "value": 1137
+          "value": 1336
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1337
         }
       },
       {
@@ -267,20 +288,6 @@
         "Feat": {
           "type": "word",
           "value": 32
-        }
-      },
-      {
-        "__struct_id": 1,
-        "Feat": {
-          "type": "word",
-          "value": 1126
-        }
-      },
-      {
-        "__struct_id": 1,
-        "Feat": {
-          "type": "word",
-          "value": 1127
         }
       },
       {
@@ -309,7 +316,7 @@
   "FirstName": {
     "type": "cexolocstring",
     "value": {
-      "0": "Mandalorian Warrior"
+      "0": "Mandalorian Hunter"
     }
   },
   "fortbonus": {
@@ -318,7 +325,7 @@
   },
   "Gender": {
     "type": "byte",
-    "value": 1
+    "value": 0
   },
   "GoodEvil": {
     "type": "byte",
@@ -326,7 +333,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 120
+    "value": 85
   },
   "Int": {
     "type": "byte",
@@ -360,7 +367,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 124
+    "value": 105
   },
   "NaturalAC": {
     "type": "byte",
@@ -388,7 +395,7 @@
   },
   "PortraitId": {
     "type": "word",
-    "value": 1037
+    "value": 3558
   },
   "Race": {
     "type": "byte",
@@ -653,7 +660,7 @@
   },
   "SoundSetFile": {
     "type": "word",
-    "value": 930
+    "value": 923
   },
   "SpecAbilityList": {
     "type": "list",
@@ -662,7 +669,7 @@
         "__struct_id": 4,
         "Spell": {
           "type": "word",
-          "value": 299
+          "value": 844
         },
         "SpellCasterLevel": {
           "type": "byte",
@@ -681,7 +688,7 @@
   },
   "Str": {
     "type": "byte",
-    "value": 20
+    "value": 14
   },
   "Subrace": {
     "type": "cexostring",
@@ -689,7 +696,7 @@
   },
   "Tag": {
     "type": "cexostring",
-    "value": "man_warrior_2"
+    "value": "man_hunter"
   },
   "Tail_New": {
     "type": "dword",
@@ -701,7 +708,7 @@
   },
   "TemplateResRef": {
     "type": "resref",
-    "value": "man_warrior_2"
+    "value": "man_hunter"
   },
   "VarTable": {
     "type": "list",
@@ -718,7 +725,7 @@
         },
         "Value": {
           "type": "cexostring",
-          "value": "VISCARA_MANDALORIAN_WARRIOR,75,2"
+          "value": "VISCARA_MANDALORIAN_HUNTER,75,2"
         }
       },
       {
@@ -733,7 +740,7 @@
         },
         "Value": {
           "type": "int",
-          "value": 6
+          "value": 7
         }
       },
       {
@@ -748,7 +755,7 @@
         },
         "Value": {
           "type": "cexostring",
-          "value": "VISCARA_MANDALORIAN_WARRIOR_RARES,10,1"
+          "value": "VISCARA_MANDALORIAN_HUNTER_RARES,10,1"
         }
       },
       {
@@ -763,7 +770,7 @@
         },
         "Value": {
           "type": "cexostring",
-          "value": "VISCARA_MANDALORIAN_WARRIOR_TAGS,50,1"
+          "value": "VISCARA_MANDALORIAN_HUNTER_TAGS,50,1"
         }
       }
     ]

--- a/Module/utc/man_leader.utc.json
+++ b/Module/utc/man_leader.utc.json
@@ -173,7 +173,7 @@
         "__struct_id": 1,
         "EquippedRes": {
           "type": "resref",
-          "value": "man_helm_npc"
+          "value": "man_helm_npc001"
         }
       },
       {
@@ -821,7 +821,7 @@
         },
         "Value": {
           "type": "cexostring",
-          "value": "VISCARA_MANDALORIAN_LEADER,95,1"
+          "value": "VISCARA_MANDALORIAN_LEADER,100,1"
         }
       },
       {
@@ -836,7 +836,7 @@
         },
         "Value": {
           "type": "cexostring",
-          "value": "VISCARA_MANDALORIAN_LEADER,30,1"
+          "value": "VISCARA_MANDALORIAN_LEADER,50,1"
         }
       },
       {
@@ -852,6 +852,21 @@
         "Value": {
           "type": "cexostring",
           "value": "VISCARA_MANDALORIAN_LEADER_RARES,5,1"
+        }
+      },
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "LOOT_TABLE_4"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 3
+        },
+        "Value": {
+          "type": "cexostring",
+          "value": "VISCARA_MANDALORIAN_LEADER_TAGS,100,1"
         }
       }
     ]

--- a/Module/utc/man_ranger_1.utc.json
+++ b/Module/utc/man_ranger_1.utc.json
@@ -718,7 +718,7 @@
         },
         "Value": {
           "type": "cexostring",
-          "value": "VISCARA_MANDALORIAN_RANGER,40,2"
+          "value": "VISCARA_MANDALORIAN_RANGER,75,2"
         }
       },
       {
@@ -748,7 +748,22 @@
         },
         "Value": {
           "type": "cexostring",
-          "value": "VISCARA_MANDALORIAN_RANGER_RARES,5,1"
+          "value": "VISCARA_MANDALORIAN_RANGER_RARES,10,1"
+        }
+      },
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "LOOT_TABLE_3"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 3
+        },
+        "Value": {
+          "type": "cexostring",
+          "value": "VISCARA_MANDALORIAN_RANGER_TAGS,50,1"
         }
       }
     ]

--- a/Module/utc/man_ranger_2.utc.json
+++ b/Module/utc/man_ranger_2.utc.json
@@ -718,7 +718,7 @@
         },
         "Value": {
           "type": "cexostring",
-          "value": "VISCARA_MANDALORIAN_RANGER,40,2"
+          "value": "VISCARA_MANDALORIAN_RANGER,75,2"
         }
       },
       {
@@ -748,7 +748,22 @@
         },
         "Value": {
           "type": "cexostring",
-          "value": "VISCARA_MANDALORIAN_RANGER_RARES,5,1"
+          "value": "VISCARA_MANDALORIAN_RANGER_RARES,10,1"
+        }
+      },
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "LOOT_TABLE_3"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 3
+        },
+        "Value": {
+          "type": "cexostring",
+          "value": "VISCARA_MANDALORIAN_RANGER_TAGS,50,1"
         }
       }
     ]

--- a/Module/utc/man_scout.utc.json
+++ b/Module/utc/man_scout.utc.json
@@ -2,7 +2,7 @@
   "__data_type": "UTC ",
   "Appearance_Head": {
     "type": "byte",
-    "value": 1
+    "value": 134
   },
   "Appearance_Type": {
     "type": "word",
@@ -90,7 +90,7 @@
   },
   "ChallengeRating": {
     "type": "float",
-    "value": 5.0
+    "value": 3.0
   },
   "ClassList": {
     "type": "list",
@@ -103,7 +103,7 @@
         },
         "ClassLevel": {
           "type": "short",
-          "value": 1
+          "value": 5
         }
       }
     ]
@@ -130,7 +130,7 @@
   },
   "Con": {
     "type": "byte",
-    "value": 19
+    "value": 14
   },
   "Conversation": {
     "type": "resref",
@@ -138,11 +138,11 @@
   },
   "CRAdjust": {
     "type": "int",
-    "value": 0
+    "value": -2
   },
   "CurrentHitPoints": {
     "type": "short",
-    "value": 120
+    "value": 60
   },
   "DecayTime": {
     "type": "dword",
@@ -155,12 +155,12 @@
   "Description": {
     "type": "cexolocstring",
     "value": {
-      "0": "\"Here's why you can't exterminate us, aruetii. We're not huddled in one place- we span the galaxy. We need no lords or leaders, so you can't destroy our command. We can live without technology, so we can fight with our bare hands. We have no species or bloodline, so we can rebuild our ranks with others who want to join us. We're more than just a people or an army, aruetii. We're a culture. We're an idea. And you can't kill ideas, but we can certainly kill you.\" - Mandalore the Destroyer"
+      "0": "\"There's always a war going on somewhere, always has been, always will be. It's why Mandalorians have never gone out of business.\"\\nClad in distinctive Neo-Crusader light armor, this disparate group of breakaway Mandalorians have entrenched themselves in the eastern Wildwoods, routinely sending out hunting parties to harass Veles."
     }
   },
   "Dex": {
     "type": "byte",
-    "value": 15
+    "value": 16
   },
   "Disarmable": {
     "type": "byte",
@@ -187,7 +187,7 @@
         "__struct_id": 16,
         "EquippedRes": {
           "type": "resref",
-          "value": "npc_mando_blade"
+          "value": "npc_mando_knife"
         }
       },
       {
@@ -238,6 +238,20 @@
         "__struct_id": 1,
         "Feat": {
           "type": "word",
+          "value": 1143
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
+          "value": 1144
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Feat": {
+          "type": "word",
           "value": 1089
         }
       },
@@ -259,35 +273,7 @@
         "__struct_id": 1,
         "Feat": {
           "type": "word",
-          "value": 1137
-        }
-      },
-      {
-        "__struct_id": 1,
-        "Feat": {
-          "type": "word",
           "value": 32
-        }
-      },
-      {
-        "__struct_id": 1,
-        "Feat": {
-          "type": "word",
-          "value": 1126
-        }
-      },
-      {
-        "__struct_id": 1,
-        "Feat": {
-          "type": "word",
-          "value": 1127
-        }
-      },
-      {
-        "__struct_id": 1,
-        "Feat": {
-          "type": "word",
-          "value": 106
         }
       },
       {
@@ -309,7 +295,7 @@
   "FirstName": {
     "type": "cexolocstring",
     "value": {
-      "0": "Mandalorian Warrior"
+      "0": "Mandalorian Scout"
     }
   },
   "fortbonus": {
@@ -318,7 +304,7 @@
   },
   "Gender": {
     "type": "byte",
-    "value": 1
+    "value": 0
   },
   "GoodEvil": {
     "type": "byte",
@@ -326,7 +312,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 120
+    "value": 60
   },
   "Int": {
     "type": "byte",
@@ -360,7 +346,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 124
+    "value": 70
   },
   "NaturalAC": {
     "type": "byte",
@@ -653,27 +639,11 @@
   },
   "SoundSetFile": {
     "type": "word",
-    "value": 930
+    "value": 922
   },
   "SpecAbilityList": {
     "type": "list",
-    "value": [
-      {
-        "__struct_id": 4,
-        "Spell": {
-          "type": "word",
-          "value": 299
-        },
-        "SpellCasterLevel": {
-          "type": "byte",
-          "value": 0
-        },
-        "SpellFlags": {
-          "type": "byte",
-          "value": 1
-        }
-      }
-    ]
+    "value": []
   },
   "StartingPackage": {
     "type": "byte",
@@ -681,7 +651,7 @@
   },
   "Str": {
     "type": "byte",
-    "value": 20
+    "value": 12
   },
   "Subrace": {
     "type": "cexostring",
@@ -689,7 +659,7 @@
   },
   "Tag": {
     "type": "cexostring",
-    "value": "man_warrior_2"
+    "value": "man_scout"
   },
   "Tail_New": {
     "type": "dword",
@@ -701,7 +671,7 @@
   },
   "TemplateResRef": {
     "type": "resref",
-    "value": "man_warrior_2"
+    "value": "man_scout"
   },
   "VarTable": {
     "type": "list",
@@ -718,22 +688,7 @@
         },
         "Value": {
           "type": "cexostring",
-          "value": "VISCARA_MANDALORIAN_WARRIOR,75,2"
-        }
-      },
-      {
-        "__struct_id": 0,
-        "Name": {
-          "type": "cexostring",
-          "value": "QUEST_NPC_GROUP_ID"
-        },
-        "Type": {
-          "type": "dword",
-          "value": 1
-        },
-        "Value": {
-          "type": "int",
-          "value": 6
+          "value": "VISCARA_MANDALORIAN_SCOUT,75,2"
         }
       },
       {
@@ -748,7 +703,7 @@
         },
         "Value": {
           "type": "cexostring",
-          "value": "VISCARA_MANDALORIAN_WARRIOR_RARES,10,1"
+          "value": "VISCARA_MANDALORIAN_SCOUT_RARES,10,1"
         }
       },
       {
@@ -763,7 +718,7 @@
         },
         "Value": {
           "type": "cexostring",
-          "value": "VISCARA_MANDALORIAN_WARRIOR_TAGS,50,1"
+          "value": "VISCARA_MANDALORIAN_SCOUT_TAGS,25,1"
         }
       }
     ]

--- a/Module/utc/man_warrior_1.utc.json
+++ b/Module/utc/man_warrior_1.utc.json
@@ -718,7 +718,7 @@
         },
         "Value": {
           "type": "cexostring",
-          "value": "VISCARA_MANDALORIAN_WARRIOR,40,2"
+          "value": "VISCARA_MANDALORIAN_WARRIOR,75,2"
         }
       },
       {
@@ -748,7 +748,22 @@
         },
         "Value": {
           "type": "cexostring",
-          "value": "VISCARA_MANDALORIAN_WARRIOR_RARES,5,1"
+          "value": "VISCARA_MANDALORIAN_WARRIOR_RARES,10,1"
+        }
+      },
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "LOOT_TABLE_3"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 3
+        },
+        "Value": {
+          "type": "cexostring",
+          "value": "VISCARA_MANDALORIAN_WARRIOR_TAGS,50,1"
         }
       }
     ]

--- a/Module/uti/cap_eblade.uti.json
+++ b/Module/uti/cap_eblade.uti.json
@@ -2,11 +2,11 @@
   "__data_type": "UTI ",
   "AddCost": {
     "type": "dword",
-    "value": 199
+    "value": 248
   },
   "BaseItem": {
     "type": "int",
-    "value": 52
+    "value": 525
   },
   "Charges": {
     "type": "byte",
@@ -14,22 +14,19 @@
   },
   "Comment": {
     "type": "cexostring",
-    "value": "1"
+    "value": ""
   },
   "Cost": {
     "type": "dword",
-    "value": 200
+    "value": 250
   },
   "Cursed": {
     "type": "byte",
     "value": 0
   },
   "DescIdentified": {
-    "id": 48931,
     "type": "cexolocstring",
-    "value": {
-      "0": ""
-    }
+    "value": {}
   },
   "Description": {
     "type": "cexolocstring",
@@ -42,19 +39,26 @@
     "value": 1
   },
   "LocalizedName": {
-    "id": 48930,
     "type": "cexolocstring",
     "value": {
-      "0": "Mandalorian Ring"
+      "0": "Captain Electroblade"
     }
   },
   "ModelPart1": {
     "type": "byte",
-    "value": 25
+    "value": 52
+  },
+  "ModelPart2": {
+    "type": "byte",
+    "value": 172
+  },
+  "ModelPart3": {
+    "type": "byte",
+    "value": 251
   },
   "PaletteID": {
     "type": "byte",
-    "value": 22
+    "value": 36
   },
   "Plot": {
     "type": "byte",
@@ -71,11 +75,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 35
+          "value": 2
         },
         "CostValue": {
           "type": "word",
-          "value": 3
+          "value": 1
         },
         "Param1": {
           "type": "byte",
@@ -87,11 +91,11 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 94
+          "value": 56
         },
         "Subtype": {
           "type": "word",
-          "value": 2
+          "value": 0
         }
       },
       {
@@ -102,11 +106,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 35
+          "value": 34
         },
         "CostValue": {
           "type": "word",
-          "value": 4
+          "value": 13
         },
         "Param1": {
           "type": "byte",
@@ -118,42 +122,11 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 94
+          "value": 93
         },
         "Subtype": {
           "type": "word",
           "value": 1
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
-          "value": 37
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 15
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 90
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 0
         }
       },
       {
@@ -184,7 +157,38 @@
         },
         "Subtype": {
           "type": "word",
-          "value": 104
+          "value": 18
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 0
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 0
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 83
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 2
         }
       }
     ]
@@ -199,10 +203,10 @@
   },
   "Tag": {
     "type": "cexostring",
-    "value": "mando_ring"
+    "value": "cap_eblade"
   },
   "TemplateResRef": {
     "type": "resref",
-    "value": "mando_ring"
+    "value": "cap_eblade"
   }
 }

--- a/Module/uti/cap_gswd.uti.json
+++ b/Module/uti/cap_gswd.uti.json
@@ -2,7 +2,7 @@
   "__data_type": "UTI ",
   "AddCost": {
     "type": "dword",
-    "value": 0
+    "value": 248
   },
   "BaseItem": {
     "type": "int",
@@ -18,7 +18,7 @@
   },
   "Cost": {
     "type": "dword",
-    "value": 2
+    "value": 250
   },
   "Cursed": {
     "type": "byte",
@@ -76,11 +76,42 @@
         },
         "CostTable": {
           "type": "byte",
+          "value": 2
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 1
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 56
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
           "value": 34
         },
         "CostValue": {
           "type": "word",
-          "value": 10
+          "value": 24
         },
         "Param1": {
           "type": "byte",

--- a/Module/uti/cap_katar.uti.json
+++ b/Module/uti/cap_katar.uti.json
@@ -2,7 +2,7 @@
   "__data_type": "UTI ",
   "AddCost": {
     "type": "dword",
-    "value": 0
+    "value": 248
   },
   "BaseItem": {
     "type": "int",
@@ -18,7 +18,7 @@
   },
   "Cost": {
     "type": "dword",
-    "value": 2
+    "value": 250
   },
   "Cursed": {
     "type": "byte",
@@ -75,11 +75,42 @@
         },
         "CostTable": {
           "type": "byte",
+          "value": 2
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 1
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 56
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
           "value": 34
         },
         "CostValue": {
           "type": "word",
-          "value": 9
+          "value": 12
         },
         "Param1": {
           "type": "byte",

--- a/Module/uti/cap_knife.uti.json
+++ b/Module/uti/cap_knife.uti.json
@@ -2,7 +2,7 @@
   "__data_type": "UTI ",
   "AddCost": {
     "type": "dword",
-    "value": 0
+    "value": 198
   },
   "BaseItem": {
     "type": "int",
@@ -18,7 +18,7 @@
   },
   "Cost": {
     "type": "dword",
-    "value": 2
+    "value": 200
   },
   "Cursed": {
     "type": "byte",
@@ -74,11 +74,73 @@
         },
         "CostTable": {
           "type": "byte",
+          "value": 2
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 1
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 56
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
           "value": 34
         },
         "CostValue": {
           "type": "word",
-          "value": 8
+          "value": 2
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 93
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 5
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 34
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 10
         },
         "Param1": {
           "type": "byte",

--- a/Module/uti/cap_longsword.uti.json
+++ b/Module/uti/cap_longsword.uti.json
@@ -2,7 +2,7 @@
   "__data_type": "UTI ",
   "AddCost": {
     "type": "dword",
-    "value": 0
+    "value": 248
   },
   "BaseItem": {
     "type": "int",
@@ -18,7 +18,7 @@
   },
   "Cost": {
     "type": "dword",
-    "value": 2
+    "value": 250
   },
   "Cursed": {
     "type": "byte",
@@ -76,11 +76,42 @@
         },
         "CostTable": {
           "type": "byte",
+          "value": 2
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 1
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 56
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
           "value": 34
         },
         "CostValue": {
           "type": "word",
-          "value": 9
+          "value": 14
         },
         "Param1": {
           "type": "byte",

--- a/Module/uti/cap_pistol.uti.json
+++ b/Module/uti/cap_pistol.uti.json
@@ -2,7 +2,7 @@
   "__data_type": "UTI ",
   "AddCost": {
     "type": "dword",
-    "value": 0
+    "value": 248
   },
   "BaseItem": {
     "type": "int",
@@ -18,7 +18,7 @@
   },
   "Cost": {
     "type": "dword",
-    "value": 2
+    "value": 250
   },
   "Cursed": {
     "type": "byte",
@@ -74,11 +74,42 @@
         },
         "CostTable": {
           "type": "byte",
+          "value": 2
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 1
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 56
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
           "value": 34
         },
         "CostValue": {
           "type": "word",
-          "value": 9
+          "value": 13
         },
         "Param1": {
           "type": "byte",

--- a/Module/uti/cap_rifle.uti.json
+++ b/Module/uti/cap_rifle.uti.json
@@ -2,7 +2,7 @@
   "__data_type": "UTI ",
   "AddCost": {
     "type": "dword",
-    "value": 0
+    "value": 248
   },
   "BaseItem": {
     "type": "int",
@@ -18,7 +18,7 @@
   },
   "Cost": {
     "type": "dword",
-    "value": 2
+    "value": 250
   },
   "Cursed": {
     "type": "byte",
@@ -76,11 +76,42 @@
         },
         "CostTable": {
           "type": "byte",
+          "value": 2
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 1
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 56
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
           "value": 34
         },
         "CostValue": {
           "type": "word",
-          "value": 10
+          "value": 15
         },
         "Param1": {
           "type": "byte",

--- a/Module/uti/cap_sabstaff.uti.json
+++ b/Module/uti/cap_sabstaff.uti.json
@@ -2,11 +2,11 @@
   "__data_type": "UTI ",
   "AddCost": {
     "type": "dword",
-    "value": 199
+    "value": 248
   },
   "BaseItem": {
     "type": "int",
-    "value": 52
+    "value": 537
   },
   "Charges": {
     "type": "byte",
@@ -18,18 +18,15 @@
   },
   "Cost": {
     "type": "dword",
-    "value": 200
+    "value": 250
   },
   "Cursed": {
     "type": "byte",
     "value": 0
   },
   "DescIdentified": {
-    "id": 48931,
     "type": "cexolocstring",
-    "value": {
-      "0": ""
-    }
+    "value": {}
   },
   "Description": {
     "type": "cexolocstring",
@@ -42,19 +39,27 @@
     "value": 1
   },
   "LocalizedName": {
-    "id": 48930,
+    "id": 172,
     "type": "cexolocstring",
     "value": {
-      "0": "Mandalorian Ring"
+      "0": "Captain Twin Electroblade"
     }
   },
   "ModelPart1": {
     "type": "byte",
-    "value": 25
+    "value": 31
+  },
+  "ModelPart2": {
+    "type": "byte",
+    "value": 33
+  },
+  "ModelPart3": {
+    "type": "byte",
+    "value": 12
   },
   "PaletteID": {
     "type": "byte",
-    "value": 22
+    "value": 46
   },
   "Plot": {
     "type": "byte",
@@ -71,11 +76,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 35
+          "value": 2
         },
         "CostValue": {
           "type": "word",
-          "value": 3
+          "value": 1
         },
         "Param1": {
           "type": "byte",
@@ -87,11 +92,11 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 94
+          "value": 56
         },
         "Subtype": {
           "type": "word",
-          "value": 2
+          "value": 0
         }
       },
       {
@@ -102,11 +107,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 35
+          "value": 34
         },
         "CostValue": {
           "type": "word",
-          "value": 4
+          "value": 14
         },
         "Param1": {
           "type": "byte",
@@ -118,42 +123,11 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 94
+          "value": 93
         },
         "Subtype": {
           "type": "word",
           "value": 1
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
-          "value": 37
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 15
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 90
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 0
         }
       },
       {
@@ -184,7 +158,38 @@
         },
         "Subtype": {
           "type": "word",
-          "value": 104
+          "value": 46
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 0
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 0
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 83
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 2
         }
       }
     ]
@@ -199,10 +204,10 @@
   },
   "Tag": {
     "type": "cexostring",
-    "value": "mando_ring"
+    "value": "cap_sabstaff"
   },
   "TemplateResRef": {
     "type": "resref",
-    "value": "mando_ring"
+    "value": "cap_sabstaff"
   }
 }

--- a/Module/uti/cap_sabstaff.uti.json
+++ b/Module/uti/cap_sabstaff.uti.json
@@ -111,7 +111,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 14
+          "value": 13
         },
         "Param1": {
           "type": "byte",

--- a/Module/uti/cap_shuriken.uti.json
+++ b/Module/uti/cap_shuriken.uti.json
@@ -2,7 +2,7 @@
   "__data_type": "UTI ",
   "AddCost": {
     "type": "dword",
-    "value": 0
+    "value": 250
   },
   "BaseItem": {
     "type": "int",
@@ -18,7 +18,7 @@
   },
   "Cost": {
     "type": "dword",
-    "value": 0
+    "value": 250
   },
   "Cursed": {
     "type": "byte",
@@ -66,11 +66,42 @@
         },
         "CostTable": {
           "type": "byte",
+          "value": 2
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 1
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 56
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
           "value": 34
         },
         "CostValue": {
           "type": "word",
-          "value": 8
+          "value": 9
         },
         "Param1": {
           "type": "byte",

--- a/Module/uti/cap_spear.uti.json
+++ b/Module/uti/cap_spear.uti.json
@@ -2,11 +2,11 @@
   "__data_type": "UTI ",
   "AddCost": {
     "type": "dword",
-    "value": 199
+    "value": 248
   },
   "BaseItem": {
     "type": "int",
-    "value": 52
+    "value": 58
   },
   "Charges": {
     "type": "byte",
@@ -18,43 +18,46 @@
   },
   "Cost": {
     "type": "dword",
-    "value": 200
+    "value": 250
   },
   "Cursed": {
     "type": "byte",
     "value": 0
   },
   "DescIdentified": {
-    "id": 48931,
     "type": "cexolocstring",
-    "value": {
-      "0": ""
-    }
+    "value": {}
   },
   "Description": {
     "type": "cexolocstring",
-    "value": {
-      "0": ""
-    }
+    "value": {}
   },
   "Identified": {
     "type": "byte",
     "value": 1
   },
   "LocalizedName": {
-    "id": 48930,
+    "id": 1552,
     "type": "cexolocstring",
     "value": {
-      "0": "Mandalorian Ring"
+      "0": "Captain Spear"
     }
   },
   "ModelPart1": {
     "type": "byte",
-    "value": 25
+    "value": 41
+  },
+  "ModelPart2": {
+    "type": "byte",
+    "value": 21
+  },
+  "ModelPart3": {
+    "type": "byte",
+    "value": 41
   },
   "PaletteID": {
     "type": "byte",
-    "value": 22
+    "value": 51
   },
   "Plot": {
     "type": "byte",
@@ -71,11 +74,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 35
+          "value": 2
         },
         "CostValue": {
           "type": "word",
-          "value": 3
+          "value": 1
         },
         "Param1": {
           "type": "byte",
@@ -87,11 +90,11 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 94
+          "value": 56
         },
         "Subtype": {
           "type": "word",
-          "value": 2
+          "value": 0
         }
       },
       {
@@ -102,11 +105,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 35
+          "value": 34
         },
         "CostValue": {
           "type": "word",
-          "value": 4
+          "value": 24
         },
         "Param1": {
           "type": "byte",
@@ -118,42 +121,11 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 94
+          "value": 93
         },
         "Subtype": {
           "type": "word",
           "value": 1
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
-          "value": 37
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 15
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 90
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 0
         }
       },
       {
@@ -184,7 +156,7 @@
         },
         "Subtype": {
           "type": "word",
-          "value": 104
+          "value": 34
         }
       }
     ]
@@ -199,10 +171,10 @@
   },
   "Tag": {
     "type": "cexostring",
-    "value": "mando_ring"
+    "value": "cap_spear"
   },
   "TemplateResRef": {
     "type": "resref",
-    "value": "mando_ring"
+    "value": "cap_spear"
   }
 }

--- a/Module/uti/cap_staff.uti.json
+++ b/Module/uti/cap_staff.uti.json
@@ -2,7 +2,7 @@
   "__data_type": "UTI ",
   "AddCost": {
     "type": "dword",
-    "value": 0
+    "value": 248
   },
   "BaseItem": {
     "type": "int",
@@ -18,7 +18,7 @@
   },
   "Cost": {
     "type": "dword",
-    "value": 2
+    "value": 250
   },
   "Cursed": {
     "type": "byte",
@@ -74,11 +74,42 @@
         },
         "CostTable": {
           "type": "byte",
+          "value": 2
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 1
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 56
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
           "value": 34
         },
         "CostValue": {
           "type": "word",
-          "value": 8
+          "value": 13
         },
         "Param1": {
           "type": "byte",

--- a/Module/uti/cap_twinblade.uti.json
+++ b/Module/uti/cap_twinblade.uti.json
@@ -2,7 +2,7 @@
   "__data_type": "UTI ",
   "AddCost": {
     "type": "dword",
-    "value": 0
+    "value": 248
   },
   "BaseItem": {
     "type": "int",
@@ -18,7 +18,7 @@
   },
   "Cost": {
     "type": "dword",
-    "value": 2
+    "value": 250
   },
   "Cursed": {
     "type": "byte",
@@ -74,11 +74,42 @@
         },
         "CostTable": {
           "type": "byte",
+          "value": 2
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 1
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 56
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
           "value": 34
         },
         "CostValue": {
           "type": "word",
-          "value": 9
+          "value": 13
         },
         "Param1": {
           "type": "byte",

--- a/Module/uti/m_plexiplate.uti.json
+++ b/Module/uti/m_plexiplate.uti.json
@@ -71,7 +71,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 3
+          "value": 1
         },
         "Param1": {
           "type": "byte",
@@ -102,7 +102,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 5
+          "value": 15
         },
         "Param1": {
           "type": "byte",
@@ -133,7 +133,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 10
+          "value": 30
         },
         "Param1": {
           "type": "byte",

--- a/Module/uti/man_armor_npc.uti.json
+++ b/Module/uti/man_armor_npc.uti.json
@@ -6,19 +6,19 @@
   },
   "ArmorPart_Belt": {
     "type": "byte",
-    "value": 106
+    "value": 218
   },
   "ArmorPart_LBicep": {
     "type": "byte",
-    "value": 75
+    "value": 247
   },
   "ArmorPart_LFArm": {
     "type": "byte",
-    "value": 75
+    "value": 244
   },
   "ArmorPart_LFoot": {
     "type": "byte",
-    "value": 245
+    "value": 200
   },
   "ArmorPart_LHand": {
     "type": "byte",
@@ -26,35 +26,35 @@
   },
   "ArmorPart_LShin": {
     "type": "byte",
-    "value": 75
+    "value": 227
   },
   "ArmorPart_LShoul": {
     "type": "byte",
-    "value": 101
+    "value": 249
   },
   "ArmorPart_LThigh": {
     "type": "byte",
-    "value": 161
+    "value": 231
   },
   "ArmorPart_Neck": {
     "type": "byte",
-    "value": 3
+    "value": 100
   },
   "ArmorPart_Pelvis": {
     "type": "byte",
-    "value": 75
+    "value": 232
   },
   "ArmorPart_RBicep": {
     "type": "byte",
-    "value": 75
+    "value": 247
   },
   "ArmorPart_RFArm": {
     "type": "byte",
-    "value": 75
+    "value": 244
   },
   "ArmorPart_RFoot": {
     "type": "byte",
-    "value": 245
+    "value": 200
   },
   "ArmorPart_RHand": {
     "type": "byte",
@@ -66,19 +66,19 @@
   },
   "ArmorPart_RShin": {
     "type": "byte",
-    "value": 75
+    "value": 227
   },
   "ArmorPart_RShoul": {
     "type": "byte",
-    "value": 102
+    "value": 249
   },
   "ArmorPart_RThigh": {
     "type": "byte",
-    "value": 161
+    "value": 231
   },
   "ArmorPart_Torso": {
     "type": "byte",
-    "value": 75
+    "value": 247
   },
   "BaseItem": {
     "type": "int",
@@ -90,11 +90,11 @@
   },
   "Cloth1Color": {
     "type": "byte",
-    "value": 127
+    "value": 139
   },
   "Cloth2Color": {
     "type": "byte",
-    "value": 127
+    "value": 139
   },
   "Comment": {
     "type": "cexostring",
@@ -122,11 +122,11 @@
   },
   "Leather1Color": {
     "type": "byte",
-    "value": 127
+    "value": 139
   },
   "Leather2Color": {
     "type": "byte",
-    "value": 127
+    "value": 139
   },
   "LocalizedName": {
     "id": 12838,
@@ -137,11 +137,11 @@
   },
   "Metal1Color": {
     "type": "byte",
-    "value": 7
+    "value": 138
   },
   "Metal2Color": {
     "type": "byte",
-    "value": 2
+    "value": 138
   },
   "PaletteID": {
     "type": "byte",

--- a/Module/uti/man_armor_npc_r.uti.json
+++ b/Module/uti/man_armor_npc_r.uti.json
@@ -6,19 +6,19 @@
   },
   "ArmorPart_Belt": {
     "type": "byte",
-    "value": 198
+    "value": 218
   },
   "ArmorPart_LBicep": {
     "type": "byte",
-    "value": 75
+    "value": 247
   },
   "ArmorPart_LFArm": {
     "type": "byte",
-    "value": 75
+    "value": 244
   },
   "ArmorPart_LFoot": {
     "type": "byte",
-    "value": 107
+    "value": 200
   },
   "ArmorPart_LHand": {
     "type": "byte",
@@ -26,35 +26,35 @@
   },
   "ArmorPart_LShin": {
     "type": "byte",
-    "value": 166
+    "value": 227
   },
   "ArmorPart_LShoul": {
     "type": "byte",
-    "value": 186
+    "value": 249
   },
   "ArmorPart_LThigh": {
     "type": "byte",
-    "value": 75
+    "value": 231
   },
   "ArmorPart_Neck": {
     "type": "byte",
-    "value": 1
+    "value": 100
   },
   "ArmorPart_Pelvis": {
     "type": "byte",
-    "value": 106
+    "value": 232
   },
   "ArmorPart_RBicep": {
     "type": "byte",
-    "value": 75
+    "value": 247
   },
   "ArmorPart_RFArm": {
     "type": "byte",
-    "value": 75
+    "value": 244
   },
   "ArmorPart_RFoot": {
     "type": "byte",
-    "value": 107
+    "value": 200
   },
   "ArmorPart_RHand": {
     "type": "byte",
@@ -66,19 +66,19 @@
   },
   "ArmorPart_RShin": {
     "type": "byte",
-    "value": 166
+    "value": 227
   },
   "ArmorPart_RShoul": {
     "type": "byte",
-    "value": 186
+    "value": 249
   },
   "ArmorPart_RThigh": {
     "type": "byte",
-    "value": 75
+    "value": 231
   },
   "ArmorPart_Torso": {
     "type": "byte",
-    "value": 75
+    "value": 247
   },
   "BaseItem": {
     "type": "int",
@@ -90,11 +90,11 @@
   },
   "Cloth1Color": {
     "type": "byte",
-    "value": 23
+    "value": 91
   },
   "Cloth2Color": {
     "type": "byte",
-    "value": 23
+    "value": 91
   },
   "Comment": {
     "type": "cexostring",
@@ -114,7 +114,9 @@
   },
   "Description": {
     "type": "cexolocstring",
-    "value": {}
+    "value": {
+      "0": ""
+    }
   },
   "Identified": {
     "type": "byte",
@@ -122,26 +124,26 @@
   },
   "Leather1Color": {
     "type": "byte",
-    "value": 23
+    "value": 99
   },
   "Leather2Color": {
     "type": "byte",
-    "value": 23
+    "value": 99
   },
   "LocalizedName": {
     "id": 12838,
     "type": "cexolocstring",
     "value": {
-      "0": "[NPC] Mandalorian War Hero Armor"
+      "0": "[NPC] Mandalorian Armor Red"
     }
   },
   "Metal1Color": {
     "type": "byte",
-    "value": 95
+    "value": 91
   },
   "Metal2Color": {
     "type": "byte",
-    "value": 135
+    "value": 91
   },
   "PaletteID": {
     "type": "byte",
@@ -165,10 +167,10 @@
   },
   "Tag": {
     "type": "cexostring",
-    "value": "man_larmor_npc"
+    "value": "man_armor_npc_r"
   },
   "TemplateResRef": {
     "type": "resref",
-    "value": "man_larmor_npc"
+    "value": "man_armor_npc_r"
   }
 }

--- a/Module/uti/man_helm_npc001.uti.json
+++ b/Module/uti/man_helm_npc001.uti.json
@@ -48,7 +48,7 @@
   },
   "Leather1Color": {
     "type": "byte",
-    "value": 25
+    "value": 23
   },
   "Leather2Color": {
     "type": "byte",
@@ -58,12 +58,12 @@
     "id": 90531,
     "type": "cexolocstring",
     "value": {
-      "0": "[NPC] Mandalorian Helmet"
+      "0": "[NPC] Mandalorian War Hero Helm"
     }
   },
   "Metal1Color": {
     "type": "byte",
-    "value": 138
+    "value": 95
   },
   "Metal2Color": {
     "type": "byte",
@@ -71,7 +71,7 @@
   },
   "ModelPart1": {
     "type": "byte",
-    "value": 113
+    "value": 110
   },
   "PaletteID": {
     "type": "byte",
@@ -99,6 +99,6 @@
   },
   "TemplateResRef": {
     "type": "resref",
-    "value": "man_helm_npc"
+    "value": "man_helm_npc001"
   }
 }

--- a/Module/uti/man_helm_npc_r.uti.json
+++ b/Module/uti/man_helm_npc_r.uti.json
@@ -14,11 +14,11 @@
   },
   "Cloth1Color": {
     "type": "byte",
-    "value": 138
+    "value": 91
   },
   "Cloth2Color": {
     "type": "byte",
-    "value": 137
+    "value": 91
   },
   "Comment": {
     "type": "cexostring",
@@ -48,26 +48,26 @@
   },
   "Leather1Color": {
     "type": "byte",
-    "value": 25
+    "value": 91
   },
   "Leather2Color": {
     "type": "byte",
-    "value": 103
+    "value": 91
   },
   "LocalizedName": {
     "id": 90531,
     "type": "cexolocstring",
     "value": {
-      "0": "[NPC] Mandalorian Helmet"
+      "0": "[NPC] Mandalorian Helmet Red"
     }
   },
   "Metal1Color": {
     "type": "byte",
-    "value": 138
+    "value": 90
   },
   "Metal2Color": {
     "type": "byte",
-    "value": 139
+    "value": 91
   },
   "ModelPart1": {
     "type": "byte",
@@ -95,10 +95,10 @@
   },
   "Tag": {
     "type": "cexostring",
-    "value": "man_helm_npc"
+    "value": "man_helm_npc_r"
   },
   "TemplateResRef": {
     "type": "resref",
-    "value": "man_helm_npc"
+    "value": "man_helm_npc_r"
   }
 }

--- a/Module/uti/mando_armor.uti.json
+++ b/Module/uti/mando_armor.uti.json
@@ -2,7 +2,7 @@
   "__data_type": "UTI ",
   "AddCost": {
     "type": "dword",
-    "value": 0
+    "value": 199
   },
   "ArmorPart_Belt": {
     "type": "byte",
@@ -102,7 +102,7 @@
   },
   "Cost": {
     "type": "dword",
-    "value": 1
+    "value": 200
   },
   "Cursed": {
     "type": "byte",
@@ -170,7 +170,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 1
+          "value": 7
         },
         "Param1": {
           "type": "byte",
@@ -201,7 +201,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 3
+          "value": 8
         },
         "Param1": {
           "type": "byte",
@@ -232,7 +232,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 10
+          "value": 35
         },
         "Param1": {
           "type": "byte",
@@ -263,7 +263,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 1
+          "value": 2
         },
         "Param1": {
           "type": "byte",

--- a/Module/uti/mando_belt.uti.json
+++ b/Module/uti/mando_belt.uti.json
@@ -2,7 +2,7 @@
   "__data_type": "UTI ",
   "AddCost": {
     "type": "dword",
-    "value": 0
+    "value": 199
   },
   "BaseItem": {
     "type": "int",
@@ -18,7 +18,7 @@
   },
   "Cost": {
     "type": "dword",
-    "value": 1
+    "value": 200
   },
   "Cursed": {
     "type": "byte",
@@ -75,7 +75,38 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 1
+          "value": 3
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 2
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 4
         },
         "Param1": {
           "type": "byte",
@@ -106,7 +137,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 10
+          "value": 15
         },
         "Param1": {
           "type": "byte",
@@ -137,7 +168,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 1
+          "value": 2
         },
         "Param1": {
           "type": "byte",

--- a/Module/uti/mando_blade.uti.json
+++ b/Module/uti/mando_blade.uti.json
@@ -80,7 +80,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 3
+          "value": 2
         },
         "Param1": {
           "type": "byte",

--- a/Module/uti/mando_blade.uti.json
+++ b/Module/uti/mando_blade.uti.json
@@ -2,7 +2,7 @@
   "__data_type": "UTI ",
   "AddCost": {
     "type": "dword",
-    "value": 0
+    "value": 148
   },
   "BaseItem": {
     "type": "int",
@@ -18,7 +18,7 @@
   },
   "Cost": {
     "type": "dword",
-    "value": 2
+    "value": 150
   },
   "Cursed": {
     "type": "byte",
@@ -68,6 +68,37 @@
   "PropertiesList": {
     "type": "list",
     "value": [
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 34
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 3
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 93
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 6
+        }
+      },
       {
         "__struct_id": 0,
         "ChanceAppear": {

--- a/Module/uti/mando_bracer.uti.json
+++ b/Module/uti/mando_bracer.uti.json
@@ -2,7 +2,7 @@
   "__data_type": "UTI ",
   "AddCost": {
     "type": "dword",
-    "value": 0
+    "value": 199
   },
   "BaseItem": {
     "type": "int",
@@ -18,7 +18,7 @@
   },
   "Cost": {
     "type": "dword",
-    "value": 1
+    "value": 200
   },
   "Cursed": {
     "type": "byte",
@@ -75,7 +75,38 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 1
+          "value": 4
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 2
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 7
         },
         "Param1": {
           "type": "byte",
@@ -106,7 +137,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 10
+          "value": 15
         },
         "Param1": {
           "type": "byte",
@@ -137,7 +168,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 1
+          "value": 2
         },
         "Param1": {
           "type": "byte",

--- a/Module/uti/mando_cloak.uti.json
+++ b/Module/uti/mando_cloak.uti.json
@@ -2,7 +2,7 @@
   "__data_type": "UTI ",
   "AddCost": {
     "type": "dword",
-    "value": 0
+    "value": 199
   },
   "BaseItem": {
     "type": "int",
@@ -26,7 +26,7 @@
   },
   "Cost": {
     "type": "dword",
-    "value": 1
+    "value": 200
   },
   "Cursed": {
     "type": "byte",
@@ -97,7 +97,38 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 1
+          "value": 3
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 2
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 4
         },
         "Param1": {
           "type": "byte",
@@ -128,7 +159,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 10
+          "value": 15
         },
         "Param1": {
           "type": "byte",
@@ -159,7 +190,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 1
+          "value": 2
         },
         "Param1": {
           "type": "byte",

--- a/Module/uti/mando_eblade.uti.json
+++ b/Module/uti/mando_eblade.uti.json
@@ -2,11 +2,11 @@
   "__data_type": "UTI ",
   "AddCost": {
     "type": "dword",
-    "value": 199
+    "value": 148
   },
   "BaseItem": {
     "type": "int",
-    "value": 52
+    "value": 525
   },
   "Charges": {
     "type": "byte",
@@ -14,22 +14,19 @@
   },
   "Comment": {
     "type": "cexostring",
-    "value": "1"
+    "value": ""
   },
   "Cost": {
     "type": "dword",
-    "value": 200
+    "value": 150
   },
   "Cursed": {
     "type": "byte",
     "value": 0
   },
   "DescIdentified": {
-    "id": 48931,
     "type": "cexolocstring",
-    "value": {
-      "0": ""
-    }
+    "value": {}
   },
   "Description": {
     "type": "cexolocstring",
@@ -42,19 +39,26 @@
     "value": 1
   },
   "LocalizedName": {
-    "id": 48930,
     "type": "cexolocstring",
     "value": {
-      "0": "Mandalorian Ring"
+      "0": "Mandalorian Electroblade"
     }
   },
   "ModelPart1": {
     "type": "byte",
-    "value": 25
+    "value": 141
+  },
+  "ModelPart2": {
+    "type": "byte",
+    "value": 131
+  },
+  "ModelPart3": {
+    "type": "byte",
+    "value": 183
   },
   "PaletteID": {
     "type": "byte",
-    "value": 22
+    "value": 36
   },
   "Plot": {
     "type": "byte",
@@ -71,11 +75,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 35
+          "value": 34
         },
         "CostValue": {
           "type": "word",
-          "value": 3
+          "value": 2
         },
         "Param1": {
           "type": "byte",
@@ -87,11 +91,11 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 94
+          "value": 93
         },
         "Subtype": {
           "type": "word",
-          "value": 2
+          "value": 5
         }
       },
       {
@@ -102,11 +106,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 35
+          "value": 34
         },
         "CostValue": {
           "type": "word",
-          "value": 4
+          "value": 11
         },
         "Param1": {
           "type": "byte",
@@ -118,42 +122,11 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 94
+          "value": 93
         },
         "Subtype": {
           "type": "word",
           "value": 1
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
-          "value": 37
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 15
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 90
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 0
         }
       },
       {
@@ -184,7 +157,38 @@
         },
         "Subtype": {
           "type": "word",
-          "value": 104
+          "value": 18
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 0
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 0
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 83
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 2
         }
       }
     ]
@@ -199,10 +203,10 @@
   },
   "Tag": {
     "type": "cexostring",
-    "value": "mando_ring"
+    "value": "mando_eblade"
   },
   "TemplateResRef": {
     "type": "resref",
-    "value": "mando_ring"
+    "value": "mando_eblade"
   }
 }

--- a/Module/uti/mando_gswd.uti.json
+++ b/Module/uti/mando_gswd.uti.json
@@ -2,7 +2,7 @@
   "__data_type": "UTI ",
   "AddCost": {
     "type": "dword",
-    "value": 0
+    "value": 148
   },
   "BaseItem": {
     "type": "int",
@@ -18,7 +18,7 @@
   },
   "Cost": {
     "type": "dword",
-    "value": 2
+    "value": 150
   },
   "Cursed": {
     "type": "byte",
@@ -76,11 +76,73 @@
         },
         "CostTable": {
           "type": "byte",
+          "value": 45
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 1
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 111
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
           "value": 34
         },
         "CostValue": {
           "type": "word",
-          "value": 23
+          "value": 3
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 93
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 5
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 34
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 18
         },
         "Param1": {
           "type": "byte",

--- a/Module/uti/mando_gswd.uti.json
+++ b/Module/uti/mando_gswd.uti.json
@@ -76,42 +76,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 45
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 1
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 111
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 0
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
           "value": 34
         },
         "CostValue": {
           "type": "word",
-          "value": 3
+          "value": 6
         },
         "Param1": {
           "type": "byte",
@@ -142,7 +111,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 18
+          "value": 16
         },
         "Param1": {
           "type": "byte",

--- a/Module/uti/mando_helmet.uti.json
+++ b/Module/uti/mando_helmet.uti.json
@@ -2,7 +2,7 @@
   "__data_type": "UTI ",
   "AddCost": {
     "type": "dword",
-    "value": 0
+    "value": 199
   },
   "BaseItem": {
     "type": "int",
@@ -26,7 +26,7 @@
   },
   "Cost": {
     "type": "dword",
-    "value": 1
+    "value": 200
   },
   "Cursed": {
     "type": "byte",
@@ -98,7 +98,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 1
+          "value": 5
         },
         "Param1": {
           "type": "byte",
@@ -129,7 +129,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 1
+          "value": 6
         },
         "Param1": {
           "type": "byte",
@@ -160,7 +160,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 10
+          "value": 20
         },
         "Param1": {
           "type": "byte",
@@ -191,7 +191,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 1
+          "value": 2
         },
         "Param1": {
           "type": "byte",
@@ -218,7 +218,7 @@
   },
   "Stolen": {
     "type": "byte",
-    "value": 0
+    "value": 1
   },
   "Tag": {
     "type": "cexostring",

--- a/Module/uti/mando_htr_skin.uti.json
+++ b/Module/uti/mando_htr_skin.uti.json
@@ -2,11 +2,11 @@
   "__data_type": "UTI ",
   "AddCost": {
     "type": "dword",
-    "value": 199
+    "value": 0
   },
   "BaseItem": {
     "type": "int",
-    "value": 52
+    "value": 73
   },
   "Charges": {
     "type": "byte",
@@ -14,22 +14,19 @@
   },
   "Comment": {
     "type": "cexostring",
-    "value": "1"
+    "value": ""
   },
   "Cost": {
     "type": "dword",
-    "value": 200
+    "value": 0
   },
   "Cursed": {
     "type": "byte",
     "value": 0
   },
   "DescIdentified": {
-    "id": 48931,
     "type": "cexolocstring",
-    "value": {
-      "0": ""
-    }
+    "value": {}
   },
   "Description": {
     "type": "cexolocstring",
@@ -42,19 +39,18 @@
     "value": 1
   },
   "LocalizedName": {
-    "id": 48930,
     "type": "cexolocstring",
     "value": {
-      "0": "Mandalorian Ring"
+      "0": "Mandalorian Hunter Skin"
     }
   },
   "ModelPart1": {
     "type": "byte",
-    "value": 25
+    "value": 1
   },
   "PaletteID": {
     "type": "byte",
-    "value": 22
+    "value": 14
   },
   "Plot": {
     "type": "byte",
@@ -71,11 +67,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 35
+          "value": 43
         },
         "CostValue": {
           "type": "word",
-          "value": 3
+          "value": 14
         },
         "Param1": {
           "type": "byte",
@@ -87,69 +83,7 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 94
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 2
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
-          "value": 35
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 4
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 94
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 1
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
-          "value": 37
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 15
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 90
+          "value": 99
         },
         "Subtype": {
           "type": "word",
@@ -164,11 +98,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 33
+          "value": 41
         },
         "CostValue": {
           "type": "word",
-          "value": 2
+          "value": 50
         },
         "Param1": {
           "type": "byte",
@@ -180,11 +114,11 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 100
+          "value": 98
         },
         "Subtype": {
           "type": "word",
-          "value": 104
+          "value": 0
         }
       }
     ]
@@ -199,10 +133,10 @@
   },
   "Tag": {
     "type": "cexostring",
-    "value": "mando_ring"
+    "value": "mando_htr_skin"
   },
   "TemplateResRef": {
     "type": "resref",
-    "value": "mando_ring"
+    "value": "mando_htr_skin"
   }
 }

--- a/Module/uti/mando_katar.uti.json
+++ b/Module/uti/mando_katar.uti.json
@@ -2,7 +2,7 @@
   "__data_type": "UTI ",
   "AddCost": {
     "type": "dword",
-    "value": 0
+    "value": 148
   },
   "BaseItem": {
     "type": "int",
@@ -18,7 +18,7 @@
   },
   "Cost": {
     "type": "dword",
-    "value": 2
+    "value": 150
   },
   "Cursed": {
     "type": "byte",
@@ -79,7 +79,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 11
+          "value": 10
         },
         "Param1": {
           "type": "byte",
@@ -96,6 +96,37 @@
         "Subtype": {
           "type": "word",
           "value": 1
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 34
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 2
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 93
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 4
         }
       },
       {

--- a/Module/uti/mando_knife.uti.json
+++ b/Module/uti/mando_knife.uti.json
@@ -2,7 +2,7 @@
   "__data_type": "UTI ",
   "AddCost": {
     "type": "dword",
-    "value": 0
+    "value": 148
   },
   "BaseItem": {
     "type": "int",
@@ -18,7 +18,7 @@
   },
   "Cost": {
     "type": "dword",
-    "value": 2
+    "value": 150
   },
   "Cursed": {
     "type": "byte",
@@ -66,6 +66,37 @@
   "PropertiesList": {
     "type": "list",
     "value": [
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 34
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 4
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 93
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 6
+        }
+      },
       {
         "__struct_id": 0,
         "ChanceAppear": {

--- a/Module/uti/mando_leggings.uti.json
+++ b/Module/uti/mando_leggings.uti.json
@@ -2,7 +2,7 @@
   "__data_type": "UTI ",
   "AddCost": {
     "type": "dword",
-    "value": 0
+    "value": 199
   },
   "BaseItem": {
     "type": "int",
@@ -18,7 +18,7 @@
   },
   "Cost": {
     "type": "dword",
-    "value": 1
+    "value": 200
   },
   "Cursed": {
     "type": "byte",
@@ -81,7 +81,38 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 1
+          "value": 4
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 2
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 7
         },
         "Param1": {
           "type": "byte",
@@ -112,7 +143,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 10
+          "value": 15
         },
         "Param1": {
           "type": "byte",
@@ -143,7 +174,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 1
+          "value": 2
         },
         "Param1": {
           "type": "byte",

--- a/Module/uti/mando_necklace.uti.json
+++ b/Module/uti/mando_necklace.uti.json
@@ -2,7 +2,7 @@
   "__data_type": "UTI ",
   "AddCost": {
     "type": "dword",
-    "value": 0
+    "value": 199
   },
   "BaseItem": {
     "type": "int",
@@ -18,7 +18,7 @@
   },
   "Cost": {
     "type": "dword",
-    "value": 1
+    "value": 200
   },
   "Cursed": {
     "type": "byte",
@@ -75,7 +75,38 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 1
+          "value": 3
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 2
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 4
         },
         "Param1": {
           "type": "byte",
@@ -106,7 +137,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 10
+          "value": 15
         },
         "Param1": {
           "type": "byte",
@@ -137,7 +168,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 1
+          "value": 2
         },
         "Param1": {
           "type": "byte",

--- a/Module/uti/mando_pistol.uti.json
+++ b/Module/uti/mando_pistol.uti.json
@@ -2,7 +2,7 @@
   "__data_type": "UTI ",
   "AddCost": {
     "type": "dword",
-    "value": 0
+    "value": 148
   },
   "BaseItem": {
     "type": "int",
@@ -18,7 +18,7 @@
   },
   "Cost": {
     "type": "dword",
-    "value": 2
+    "value": 150
   },
   "Cursed": {
     "type": "byte",
@@ -66,6 +66,37 @@
   "PropertiesList": {
     "type": "list",
     "value": [
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 34
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 2
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 93
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 3
+        }
+      },
       {
         "__struct_id": 0,
         "ChanceAppear": {

--- a/Module/uti/mando_rifle.uti.json
+++ b/Module/uti/mando_rifle.uti.json
@@ -2,7 +2,7 @@
   "__data_type": "UTI ",
   "AddCost": {
     "type": "dword",
-    "value": 0
+    "value": 148
   },
   "BaseItem": {
     "type": "int",
@@ -18,7 +18,7 @@
   },
   "Cost": {
     "type": "dword",
-    "value": 2
+    "value": 150
   },
   "Cursed": {
     "type": "byte",
@@ -68,6 +68,37 @@
   "PropertiesList": {
     "type": "list",
     "value": [
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 34
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 2
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 93
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 3
+        }
+      },
       {
         "__struct_id": 0,
         "ChanceAppear": {

--- a/Module/uti/mando_sabstaff.uti.json
+++ b/Module/uti/mando_sabstaff.uti.json
@@ -80,7 +80,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 3
+          "value": 2
         },
         "Param1": {
           "type": "byte",

--- a/Module/uti/mando_sabstaff.uti.json
+++ b/Module/uti/mando_sabstaff.uti.json
@@ -2,11 +2,11 @@
   "__data_type": "UTI ",
   "AddCost": {
     "type": "dword",
-    "value": 199
+    "value": 148
   },
   "BaseItem": {
     "type": "int",
-    "value": 52
+    "value": 537
   },
   "Charges": {
     "type": "byte",
@@ -18,18 +18,15 @@
   },
   "Cost": {
     "type": "dword",
-    "value": 200
+    "value": 150
   },
   "Cursed": {
     "type": "byte",
     "value": 0
   },
   "DescIdentified": {
-    "id": 48931,
     "type": "cexolocstring",
-    "value": {
-      "0": ""
-    }
+    "value": {}
   },
   "Description": {
     "type": "cexolocstring",
@@ -42,19 +39,27 @@
     "value": 1
   },
   "LocalizedName": {
-    "id": 48930,
+    "id": 172,
     "type": "cexolocstring",
     "value": {
-      "0": "Mandalorian Ring"
+      "0": "Mandalorian Twin Electroblade"
     }
   },
   "ModelPart1": {
     "type": "byte",
-    "value": 25
+    "value": 11
+  },
+  "ModelPart2": {
+    "type": "byte",
+    "value": 11
+  },
+  "ModelPart3": {
+    "type": "byte",
+    "value": 21
   },
   "PaletteID": {
     "type": "byte",
-    "value": 22
+    "value": 46
   },
   "Plot": {
     "type": "byte",
@@ -71,7 +76,7 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 35
+          "value": 34
         },
         "CostValue": {
           "type": "word",
@@ -87,11 +92,11 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 94
+          "value": 93
         },
         "Subtype": {
           "type": "word",
-          "value": 2
+          "value": 5
         }
       },
       {
@@ -102,11 +107,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 35
+          "value": 34
         },
         "CostValue": {
           "type": "word",
-          "value": 4
+          "value": 11
         },
         "Param1": {
           "type": "byte",
@@ -118,42 +123,11 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 94
+          "value": 93
         },
         "Subtype": {
           "type": "word",
           "value": 1
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
-          "value": 37
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 15
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 90
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 0
         }
       },
       {
@@ -184,7 +158,38 @@
         },
         "Subtype": {
           "type": "word",
-          "value": 104
+          "value": 46
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 0
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 0
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 83
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 2
         }
       }
     ]
@@ -199,10 +204,10 @@
   },
   "Tag": {
     "type": "cexostring",
-    "value": "mando_ring"
+    "value": "mando_sabstaff"
   },
   "TemplateResRef": {
     "type": "resref",
-    "value": "mando_ring"
+    "value": "mando_sabstaff"
   }
 }

--- a/Module/uti/mando_scout_skin.uti.json
+++ b/Module/uti/mando_scout_skin.uti.json
@@ -2,11 +2,11 @@
   "__data_type": "UTI ",
   "AddCost": {
     "type": "dword",
-    "value": 248
+    "value": 0
   },
   "BaseItem": {
     "type": "int",
-    "value": 1
+    "value": 73
   },
   "Charges": {
     "type": "byte",
@@ -14,11 +14,11 @@
   },
   "Comment": {
     "type": "cexostring",
-    "value": "1"
+    "value": ""
   },
   "Cost": {
     "type": "dword",
-    "value": 250
+    "value": 0
   },
   "Cursed": {
     "type": "byte",
@@ -39,27 +39,18 @@
     "value": 1
   },
   "LocalizedName": {
-    "id": 166,
     "type": "cexolocstring",
     "value": {
-      "0": "Captain Longsword"
+      "0": "Mandalorian Scout Skin"
     }
   },
   "ModelPart1": {
     "type": "byte",
-    "value": 19
-  },
-  "ModelPart2": {
-    "type": "byte",
-    "value": 91
-  },
-  "ModelPart3": {
-    "type": "byte",
-    "value": 11
+    "value": 1
   },
   "PaletteID": {
     "type": "byte",
-    "value": 36
+    "value": 14
   },
   "Plot": {
     "type": "byte",
@@ -76,11 +67,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 2
+          "value": 43
         },
         "CostValue": {
           "type": "word",
-          "value": 1
+          "value": 10
         },
         "Param1": {
           "type": "byte",
@@ -92,7 +83,7 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 56
+          "value": 99
         },
         "Subtype": {
           "type": "word",
@@ -107,11 +98,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 34
+          "value": 41
         },
         "CostValue": {
           "type": "word",
-          "value": 13
+          "value": 50
         },
         "Param1": {
           "type": "byte",
@@ -123,42 +114,11 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 93
+          "value": 98
         },
         "Subtype": {
           "type": "word",
-          "value": 1
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
-          "value": 33
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 2
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
           "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 100
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 6
         }
       }
     ]
@@ -173,10 +133,10 @@
   },
   "Tag": {
     "type": "cexostring",
-    "value": "cap_longsword"
+    "value": "mando_scout_skin"
   },
   "TemplateResRef": {
     "type": "resref",
-    "value": "cap_longsword"
+    "value": "mando_scout_skin"
   }
 }

--- a/Module/uti/mando_shield.uti.json
+++ b/Module/uti/mando_shield.uti.json
@@ -2,7 +2,7 @@
   "__data_type": "UTI ",
   "AddCost": {
     "type": "dword",
-    "value": 0
+    "value": 199
   },
   "BaseItem": {
     "type": "int",
@@ -18,7 +18,7 @@
   },
   "Cost": {
     "type": "dword",
-    "value": 1
+    "value": 200
   },
   "Cursed": {
     "type": "byte",
@@ -75,7 +75,38 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 1
+          "value": 3
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 94
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 2
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 35
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 4
         },
         "Param1": {
           "type": "byte",
@@ -137,7 +168,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 1
+          "value": 2
         },
         "Param1": {
           "type": "byte",

--- a/Module/uti/mando_shuriken.uti.json
+++ b/Module/uti/mando_shuriken.uti.json
@@ -2,7 +2,7 @@
   "__data_type": "UTI ",
   "AddCost": {
     "type": "dword",
-    "value": 0
+    "value": 150
   },
   "BaseItem": {
     "type": "int",
@@ -18,7 +18,7 @@
   },
   "Cost": {
     "type": "dword",
-    "value": 0
+    "value": 150
   },
   "Cursed": {
     "type": "byte",
@@ -87,6 +87,37 @@
         "Subtype": {
           "type": "word",
           "value": 1
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 34
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 2
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 93
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 4
         }
       },
       {

--- a/Module/uti/mando_spear.uti.json
+++ b/Module/uti/mando_spear.uti.json
@@ -2,7 +2,7 @@
   "__data_type": "UTI ",
   "AddCost": {
     "type": "dword",
-    "value": 0
+    "value": 148
   },
   "BaseItem": {
     "type": "int",
@@ -18,7 +18,7 @@
   },
   "Cost": {
     "type": "dword",
-    "value": 2
+    "value": 150
   },
   "Cursed": {
     "type": "byte",
@@ -78,7 +78,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 17
+          "value": 20
         },
         "Param1": {
           "type": "byte",
@@ -95,6 +95,37 @@
         "Subtype": {
           "type": "word",
           "value": 1
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 34
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 4
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 93
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 4
         }
       },
       {

--- a/Module/uti/mando_staff.uti.json
+++ b/Module/uti/mando_staff.uti.json
@@ -2,7 +2,7 @@
   "__data_type": "UTI ",
   "AddCost": {
     "type": "dword",
-    "value": 0
+    "value": 148
   },
   "BaseItem": {
     "type": "int",
@@ -18,7 +18,7 @@
   },
   "Cost": {
     "type": "dword",
-    "value": 2
+    "value": 150
   },
   "Cursed": {
     "type": "byte",
@@ -76,11 +76,42 @@
         },
         "CostTable": {
           "type": "byte",
+          "value": 45
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 1
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 111
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 0
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
           "value": 34
         },
         "CostValue": {
           "type": "word",
-          "value": 3
+          "value": 10
         },
         "Param1": {
           "type": "byte",
@@ -111,7 +142,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 1
+          "value": 2
         },
         "Param1": {
           "type": "byte",

--- a/Module/uti/mando_staff.uti.json
+++ b/Module/uti/mando_staff.uti.json
@@ -76,37 +76,6 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 45
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 1
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 111
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 0
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
           "value": 34
         },
         "CostValue": {
@@ -128,6 +97,37 @@
         "Subtype": {
           "type": "word",
           "value": 1
+        }
+      },
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 34
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 3
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 93
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 4
         }
       },
       {

--- a/Module/uti/mando_twinblade.uti.json
+++ b/Module/uti/mando_twinblade.uti.json
@@ -2,7 +2,7 @@
   "__data_type": "UTI ",
   "AddCost": {
     "type": "dword",
-    "value": 0
+    "value": 148
   },
   "BaseItem": {
     "type": "int",
@@ -18,7 +18,7 @@
   },
   "Cost": {
     "type": "dword",
-    "value": 2
+    "value": 150
   },
   "Cursed": {
     "type": "byte",
@@ -66,6 +66,37 @@
   "PropertiesList": {
     "type": "list",
     "value": [
+      {
+        "__struct_id": 0,
+        "ChanceAppear": {
+          "type": "byte",
+          "value": 100
+        },
+        "CostTable": {
+          "type": "byte",
+          "value": 34
+        },
+        "CostValue": {
+          "type": "word",
+          "value": 2
+        },
+        "Param1": {
+          "type": "byte",
+          "value": 255
+        },
+        "Param1Value": {
+          "type": "byte",
+          "value": 0
+        },
+        "PropertyName": {
+          "type": "word",
+          "value": 93
+        },
+        "Subtype": {
+          "type": "word",
+          "value": 5
+        }
+      },
       {
         "__struct_id": 0,
         "ChanceAppear": {

--- a/Module/uti/nash_scale.uti.json
+++ b/Module/uti/nash_scale.uti.json
@@ -104,7 +104,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 5
+          "value": 15
         },
         "Param1": {
           "type": "byte",
@@ -135,7 +135,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 10
+          "value": 30
         },
         "Param1": {
           "type": "byte",

--- a/Module/uti/npc_mando_knife.uti.json
+++ b/Module/uti/npc_mando_knife.uti.json
@@ -2,11 +2,11 @@
   "__data_type": "UTI ",
   "AddCost": {
     "type": "dword",
-    "value": 199
+    "value": 0
   },
   "BaseItem": {
     "type": "int",
-    "value": 52
+    "value": 22
   },
   "Charges": {
     "type": "byte",
@@ -18,18 +18,15 @@
   },
   "Cost": {
     "type": "dword",
-    "value": 200
+    "value": 2
   },
   "Cursed": {
     "type": "byte",
-    "value": 0
+    "value": 1
   },
   "DescIdentified": {
-    "id": 48931,
     "type": "cexolocstring",
-    "value": {
-      "0": ""
-    }
+    "value": {}
   },
   "Description": {
     "type": "cexolocstring",
@@ -42,19 +39,27 @@
     "value": 1
   },
   "LocalizedName": {
-    "id": 48930,
+    "id": 191,
     "type": "cexolocstring",
     "value": {
-      "0": "Mandalorian Ring"
+      "0": "[NPC] Mandalorian Knife"
     }
   },
   "ModelPart1": {
     "type": "byte",
-    "value": 25
+    "value": 41
+  },
+  "ModelPart2": {
+    "type": "byte",
+    "value": 61
+  },
+  "ModelPart3": {
+    "type": "byte",
+    "value": 28
   },
   "PaletteID": {
     "type": "byte",
-    "value": 22
+    "value": 34
   },
   "Plot": {
     "type": "byte",
@@ -71,11 +76,11 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 35
+          "value": 34
         },
         "CostValue": {
           "type": "word",
-          "value": 3
+          "value": 8
         },
         "Param1": {
           "type": "byte",
@@ -87,11 +92,11 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 94
+          "value": 93
         },
         "Subtype": {
           "type": "word",
-          "value": 2
+          "value": 1
         }
       },
       {
@@ -102,7 +107,7 @@
         },
         "CostTable": {
           "type": "byte",
-          "value": 35
+          "value": 34
         },
         "CostValue": {
           "type": "word",
@@ -118,42 +123,11 @@
         },
         "PropertyName": {
           "type": "word",
-          "value": 94
+          "value": 93
         },
         "Subtype": {
           "type": "word",
-          "value": 1
-        }
-      },
-      {
-        "__struct_id": 0,
-        "ChanceAppear": {
-          "type": "byte",
-          "value": 100
-        },
-        "CostTable": {
-          "type": "byte",
-          "value": 37
-        },
-        "CostValue": {
-          "type": "word",
-          "value": 15
-        },
-        "Param1": {
-          "type": "byte",
-          "value": 255
-        },
-        "Param1Value": {
-          "type": "byte",
-          "value": 0
-        },
-        "PropertyName": {
-          "type": "word",
-          "value": 90
-        },
-        "Subtype": {
-          "type": "word",
-          "value": 0
+          "value": 4
         }
       },
       {
@@ -184,7 +158,7 @@
         },
         "Subtype": {
           "type": "word",
-          "value": 104
+          "value": 12
         }
       }
     ]
@@ -199,10 +173,10 @@
   },
   "Tag": {
     "type": "cexostring",
-    "value": "mando_ring"
+    "value": "npc_mando_knife"
   },
   "TemplateResRef": {
     "type": "resref",
-    "value": "mando_ring"
+    "value": "npc_mando_knife"
   }
 }

--- a/Module/uti/npc_mando_knife.uti.json
+++ b/Module/uti/npc_mando_knife.uti.json
@@ -80,7 +80,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 8
+          "value": 12
         },
         "Param1": {
           "type": "byte",

--- a/Module/utw/v_wildwd_mando_h.utw.json
+++ b/Module/utw/v_wildwd_mando_h.utw.json
@@ -1,0 +1,51 @@
+{
+  "__data_type": "UTW ",
+  "Appearance": {
+    "type": "byte",
+    "value": 2
+  },
+  "Comment": {
+    "type": "cexostring",
+    "value": ""
+  },
+  "Description": {
+    "type": "cexolocstring",
+    "value": {
+      "0": ""
+    }
+  },
+  "HasMapNote": {
+    "type": "byte",
+    "value": 0
+  },
+  "LinkedTo": {
+    "type": "cexostring",
+    "value": ""
+  },
+  "LocalizedName": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "Viscara - Wildwoods Mandalorian Hunter"
+    }
+  },
+  "MapNote": {
+    "type": "cexolocstring",
+    "value": {}
+  },
+  "MapNoteEnabled": {
+    "type": "byte",
+    "value": 0
+  },
+  "PaletteID": {
+    "type": "byte",
+    "value": 0
+  },
+  "Tag": {
+    "type": "cexostring",
+    "value": "VISCARA_WILDWOODS_MANDO_HUNTER"
+  },
+  "TemplateResRef": {
+    "type": "resref",
+    "value": "v_wildwd_mando_h"
+  }
+}

--- a/Module/utw/v_wildwd_mando_s.utw.json
+++ b/Module/utw/v_wildwd_mando_s.utw.json
@@ -1,0 +1,51 @@
+{
+  "__data_type": "UTW ",
+  "Appearance": {
+    "type": "byte",
+    "value": 2
+  },
+  "Comment": {
+    "type": "cexostring",
+    "value": ""
+  },
+  "Description": {
+    "type": "cexolocstring",
+    "value": {
+      "0": ""
+    }
+  },
+  "HasMapNote": {
+    "type": "byte",
+    "value": 0
+  },
+  "LinkedTo": {
+    "type": "cexostring",
+    "value": ""
+  },
+  "LocalizedName": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "Viscara - Wildwoods Mandalorian Scout"
+    }
+  },
+  "MapNote": {
+    "type": "cexolocstring",
+    "value": {}
+  },
+  "MapNoteEnabled": {
+    "type": "byte",
+    "value": 0
+  },
+  "PaletteID": {
+    "type": "byte",
+    "value": 0
+  },
+  "Tag": {
+    "type": "cexostring",
+    "value": "VISCARA_WILDWOODS_MANDO_SCOUT"
+  },
+  "TemplateResRef": {
+    "type": "resref",
+    "value": "v_wildwd_mando_s"
+  }
+}

--- a/SWLOR.Game.Server/Feature/LootTableDefinition/CZ220LootTableDefinition.cs
+++ b/SWLOR.Game.Server/Feature/LootTableDefinition/CZ220LootTableDefinition.cs
@@ -68,6 +68,7 @@ namespace SWLOR.Game.Server.Feature.LootTableDefinition
         private void DroidRares()
         {
             _builder.Create("CZ220_LOOT_DROID_RARES")
+                .IsRare()
                 .AddItem("map_22", 50, 1, true);
         }
 
@@ -90,6 +91,7 @@ namespace SWLOR.Game.Server.Feature.LootTableDefinition
         private void ColicoidExperimentRares()
         {
             _builder.Create("CZ220_LOOT_COLICOID_RARES")
+                .IsRare()
                 .AddItem("bag_dirty", 1, 1, true)
                 .AddItem("map_22", 3, 1, true);
         }

--- a/SWLOR.Game.Server/Feature/LootTableDefinition/HutlarLootTableDefinition.cs
+++ b/SWLOR.Game.Server/Feature/LootTableDefinition/HutlarLootTableDefinition.cs
@@ -68,6 +68,7 @@ namespace SWLOR.Game.Server.Feature.LootTableDefinition
 
 
             _builder.Create("HUTLAR_BYYSK_RARES")
+                .IsRare()
                 .AddItem("map_025", 20, 1, true)
                 .AddItem("map_026", 20, 1, true)
                 .AddItem("citrine", 5, 1, true);

--- a/SWLOR.Game.Server/Feature/LootTableDefinition/MonCalaLootTableDefinition.cs
+++ b/SWLOR.Game.Server/Feature/LootTableDefinition/MonCalaLootTableDefinition.cs
@@ -53,6 +53,7 @@ namespace SWLOR.Game.Server.Feature.LootTableDefinition
                 .AddGold(20, 20);
 
             _builder.Create("MONCALA_AMPHIHYDRUS_RARES")
+                .IsRare()
                 .AddItem("map_028", 4, 1, true)
                 .AddItem("map_029", 4, 1, true)
                 .AddItem("agate", 1, 1, true);
@@ -79,6 +80,7 @@ namespace SWLOR.Game.Server.Feature.LootTableDefinition
                 .AddGold(40, 20);
 
             _builder.Create("MONCALA_ECOTERRORIST_RARES")
+                .IsRare()
                 .AddItem("map_027", 3, 1, true)
                 .AddItem("map_59", 1, 1, true)
                 .AddItem("map_60", 1, 1, true)
@@ -140,6 +142,7 @@ namespace SWLOR.Game.Server.Feature.LootTableDefinition
                 .AddGold(80, 10);
 
             _builder.Create("MONCALA_ECOTERRORIST_LEADER_RARES")
+                .IsRare()
                 .AddItem("map_027", 1, 1, true)
                 .AddItem("citrine", 1, 1, true)
                 .AddItem("rruchi", 1, 1, true)

--- a/SWLOR.Game.Server/Feature/LootTableDefinition/TatooineLootTableDefinition.cs
+++ b/SWLOR.Game.Server/Feature/LootTableDefinition/TatooineLootTableDefinition.cs
@@ -99,6 +99,7 @@ namespace SWLOR.Game.Server.Feature.LootTableDefinition
                 .AddItem("ruby", 2, 1, true);
 
             _builder.Create("TATOOINE_TUSKEN_RAIDER_RARES")
+                .IsRare()
                 .AddItem("map_038", 20, 1, true)
                 .AddItem("map_036", 1, 1, true);
         }
@@ -129,6 +130,7 @@ namespace SWLOR.Game.Server.Feature.LootTableDefinition
                 .AddItem("hyphae_wood", 2, 1, true);
 
             _builder.Create("TATOOINE_TUSKEN_ELITE_RARES")
+                .IsRare()
                 .AddItem("map_038", 20, 1, true)
                 .AddItem("map_036", 1, 1, true);
         }

--- a/SWLOR.Game.Server/Feature/LootTableDefinition/ViscaraLootTableDefinition.cs
+++ b/SWLOR.Game.Server/Feature/LootTableDefinition/ViscaraLootTableDefinition.cs
@@ -13,6 +13,8 @@ namespace SWLOR.Game.Server.Feature.LootTableDefinition
             MandalorianLeader();
             MandalorianRanger();
             MandalorianWarrior();
+            MandalorianHunter();
+            MandalorianScout();
             Outlaw();
             Gimpassa();
             Kinrath();
@@ -50,6 +52,7 @@ namespace SWLOR.Game.Server.Feature.LootTableDefinition
                 .AddItem("damaryllia", 10)
                 .AddItem("jade", 20)
                 .AddItem("agate", 20)
+                .AddItem("mando_twinblade", 5)
                 .AddItem("mando_shield", 5)
                 .AddItem("mando_cloak", 5)
                 .AddItem("mando_belt", 5)
@@ -60,17 +63,21 @@ namespace SWLOR.Game.Server.Feature.LootTableDefinition
                 .AddItem("mando_bracer", 5)
                 .AddItem("mando_leggings", 5);
 
+            _builder.Create("VISCARA_MANDALORIAN_LEADER_TAGS")
+                .AddItem("man_tags", 50)
+                .AddItem("m_polearm_parts", 10)
+                .AddItem("m_ls_parts", 10);
+
             _builder.Create("VISCARA_MANDALORIAN_LEADER_RARES")
-                .AddItem("map_048", 20, 1, true);
+                .AddItem("map_048", 10)
+                .AddItem("m_ls_parts", 20);
         }
 
         private void MandalorianWarrior()
         {
             _builder.Create("VISCARA_MANDALORIAN_WARRIOR")
                 .AddItem("elec_flawed", 20)
-                .AddItem("fiberp_flawed", 20)
                 .AddItem("herb_m", 20)
-                .AddItem("man_tags", 10)
                 .AddItem("med_supplies", 3, 3)
                 .AddItem("stim_pack", 3, 3)
                 .AddItem("mando_blade", 5)
@@ -79,38 +86,104 @@ namespace SWLOR.Game.Server.Feature.LootTableDefinition
                 .AddItem("mando_spear", 5)
                 .AddItem("mando_katar", 5)
                 .AddItem("mando_staff", 5)
+                .AddItem("mando_sabstaff", 5)
+                .AddItem("mando_eblade", 5)
                 .AddItem("mando_twinblade", 5)
                 .AddItem("bubble_choc", 8)
                 .AddGold(30, 10);
 
+            _builder.Create("VISCARA_MANDALORIAN_WARRIOR_TAGS")
+                .AddItem("man_tags", 50)
+                .AddItem("m_lvibro_parts", 10)
+                .AddItem("m_vibro_parts", 10)
+                .AddItem("m_polearm_parts", 10);
+
             _builder.Create("VISCARA_MANDALORIAN_WARRIOR_RARES")
-                .AddItem("map_048", 20, 1, true)
-                .AddItem("jade", 4, 1, true)
-                .AddItem("agate", 4, 1, true)
-                .AddItem("m_plexiplate", 4, 1, true);
+                .AddItem("m_plexiplate", 20, 1, true)
+                .AddItem("map_048", 10, 1, true)
+                .AddItem("jade", 5, 1, true)
+                .AddItem("agate", 5, 1, true);
         }
 
         private void MandalorianRanger()
         {
             _builder.Create("VISCARA_MANDALORIAN_RANGER")
                 .AddItem("elec_flawed", 20)
-                .AddItem("fiberp_flawed", 20)
                 .AddItem("herb_m", 20)
-                .AddItem("man_tags", 10)
                 .AddItem("med_supplies", 3, 3)
                 .AddItem("stim_pack", 3, 3)
                 .AddItem("mando_shuriken", 5)
                 .AddItem("mando_pistol", 5)
                 .AddItem("mando_rifle", 5)
+                .AddItem("mando_knife", 5)
                 .AddItem("b_flour", 8)
                 .AddItem("sweet_butter", 2, 1, true)
                 .AddGold(30, 10);
 
+            _builder.Create("VISCARA_MANDALORIAN_RANGER_TAGS")
+                .AddItem("man_tags", 50)
+                .AddItem("m_blast_parts", 15)
+                .AddItem("m_vibro_parts", 5);
+
             _builder.Create("VISCARA_MANDALORIAN_RANGER_RARES")
-                .AddItem("map_048", 20, 1, true)
-                .AddItem("jade", 4, 1, true)
-                .AddItem("agate", 4, 1, true)
-                .AddItem("m_plexiplate", 4, 1, true);
+                .AddItem("m_plexiplate", 20, 1, true)
+                .AddItem("map_048", 10, 1, true)
+                .AddItem("jade", 5, 1, true)
+                .AddItem("agate", 5, 1, true);
+        }
+
+        private void MandalorianHunter()
+        {
+            _builder.Create("VISCARA_MANDALORIAN_HUNTER")
+                .AddItem("elec_flawed", 20)
+                .AddItem("herb_m", 20)
+                .AddItem("med_supplies", 3, 3)
+                .AddItem("stim_pack", 3, 3)
+                .AddItem("mando_shuriken", 5)
+                .AddItem("mando_pistol", 5)
+                .AddItem("mando_rifle", 5)
+                .AddItem("lth_ruined", 5)
+                .AddItem("lth_flawed", 5)
+                .AddItem("gimp_shell", 1, 1)
+                .AddItem("gimp_tooth", 1)
+                .AddItem("gimp_blood", 1)
+                .AddItem("gimp_meat", 1)
+                .AddGold(30, 10);
+
+            _builder.Create("VISCARA_MANDALORIAN_HUNTER_TAGS")
+                .AddItem("man_tags", 50)
+                .AddItem("m_blast_parts", 15)
+                .AddItem("m_vibro_parts", 5);
+
+            _builder.Create("VISCARA_MANDALORIAN_HUNTER_RARES")
+                .AddItem("m_plexiplate", 20, 1, true)
+                .AddItem("map_053", 10, 1, true)
+                .AddItem("jade", 5, 1, true)
+                .AddItem("agate", 5, 1, true);
+        }
+
+        private void MandalorianScout()
+        {
+            _builder.Create("VISCARA_MANDALORIAN_SCOUT")
+                .AddItem("elec_flawed", 20)
+                .AddItem("herb_m", 20)
+                .AddItem("fiberp_flawed", 15)
+                .AddItem("mando_knife", 5)
+                .AddItem("med_supplies", 3, 3)
+                .AddItem("stim_pack", 3, 3)
+                .AddItem("kinrath_limb", 5)
+                .AddItem("kinrath_meat", 5)
+                .AddGold(30, 10);
+
+            _builder.Create("VISCARA_MANDALORIAN_SCOUT_TAGS")
+                .AddItem("man_tags", 50)
+                .AddItem("m_lvibro_parts", 10)
+                .AddItem("m_vibro_parts", 10)
+                .AddItem("m_polearm_parts", 10);
+
+            _builder.Create("VISCARA_MANDALORIAN_SCOUT_RARES")
+                .AddItem("m_plexiplate", 10, 1, true)
+                .AddItem("map_053", 10, 1, true);
         }
 
         private void MandalorianCrate()
@@ -118,15 +191,19 @@ namespace SWLOR.Game.Server.Feature.LootTableDefinition
             _builder.Create("VISCARA_MANDALORIAN_CRATE")
                 .AddItem("herb_m", 30)
                 .AddItem("elec_flawed", 20)
-                .AddItem("fiberp_flawed", 20)
-                .AddItem("man_tags", 5)
                 .AddItem("med_supplies", 3, 3)
                 .AddItem("stim_pack", 3, 3)
                 .AddItem("jade", 1, 1, true)
                 .AddItem("agate", 1, 1, true)
-                .AddItem("m_plexiplate", 1, 1, true)
+                .AddItem("m_plexiplate", 10, 1, true)
+                .AddItem("m_ls_parts", 5, 1, true)
+                .AddItem("m_lvibro_parts", 10)
+                .AddItem("m_vibro_parts", 10)
+                .AddItem("m_polearm_parts", 10)
+                .AddItem("m_blast_parts", 10)
                 .AddItem("v_honey", 5)
-                .AddItem("sweet_butter", 2, 1, true)
+                .AddItem("sweet_butter", 10)
+                .AddItem("b_flour", 10)
                 .AddGold(30, 10);
 
         }

--- a/SWLOR.Game.Server/Feature/LootTableDefinition/ViscaraLootTableDefinition.cs
+++ b/SWLOR.Game.Server/Feature/LootTableDefinition/ViscaraLootTableDefinition.cs
@@ -41,6 +41,7 @@ namespace SWLOR.Game.Server.Feature.LootTableDefinition
                 .AddItem("kath_meat_1", 15);
 
             _builder.Create("VISCARA_KATH_HOUND_RARES")
+                .IsRare()
                 .AddItem("kath_blood", 2, 1, true)
                 .AddItem("k_hound_claw", 1, 1, true);
         }
@@ -69,6 +70,7 @@ namespace SWLOR.Game.Server.Feature.LootTableDefinition
                 .AddItem("m_ls_parts", 10);
 
             _builder.Create("VISCARA_MANDALORIAN_LEADER_RARES")
+                .IsRare()
                 .AddItem("map_048", 10)
                 .AddItem("m_ls_parts", 20);
         }
@@ -99,6 +101,7 @@ namespace SWLOR.Game.Server.Feature.LootTableDefinition
                 .AddItem("m_polearm_parts", 10);
 
             _builder.Create("VISCARA_MANDALORIAN_WARRIOR_RARES")
+                .IsRare()
                 .AddItem("m_plexiplate", 20, 1, true)
                 .AddItem("map_048", 10, 1, true)
                 .AddItem("jade", 5, 1, true)
@@ -126,6 +129,7 @@ namespace SWLOR.Game.Server.Feature.LootTableDefinition
                 .AddItem("m_vibro_parts", 5);
 
             _builder.Create("VISCARA_MANDALORIAN_RANGER_RARES")
+                .IsRare()
                 .AddItem("m_plexiplate", 20, 1, true)
                 .AddItem("map_048", 10, 1, true)
                 .AddItem("jade", 5, 1, true)
@@ -156,6 +160,7 @@ namespace SWLOR.Game.Server.Feature.LootTableDefinition
                 .AddItem("m_vibro_parts", 5);
 
             _builder.Create("VISCARA_MANDALORIAN_HUNTER_RARES")
+                .IsRare()
                 .AddItem("m_plexiplate", 20, 1, true)
                 .AddItem("map_053", 10, 1, true)
                 .AddItem("jade", 5, 1, true)
@@ -182,6 +187,7 @@ namespace SWLOR.Game.Server.Feature.LootTableDefinition
                 .AddItem("m_polearm_parts", 10);
 
             _builder.Create("VISCARA_MANDALORIAN_SCOUT_RARES")
+                .IsRare()
                 .AddItem("m_plexiplate", 10, 1, true)
                 .AddItem("map_053", 10, 1, true);
         }
@@ -226,6 +232,7 @@ namespace SWLOR.Game.Server.Feature.LootTableDefinition
                 .AddGold(20, 10);
 
             _builder.Create("VISCARA_OUTLAW_RARES")
+                .IsRare()
                 .AddItem("map_053", 20, 1, true);
         }
 
@@ -280,6 +287,7 @@ namespace SWLOR.Game.Server.Feature.LootTableDefinition
                 .AddItem("flesh_boots", 5);
 
             _builder.Create("VISCARA_VELLEN_FLESHLEADER_RARES")
+                .IsRare()
                 .AddItem("map_041", 20, 1, true)
                 .AddItem("map_045", 5, 1, true);
         }
@@ -299,6 +307,7 @@ namespace SWLOR.Game.Server.Feature.LootTableDefinition
 
 
             _builder.Create("VISCARA_VELLEN_FLESHEATER_RARES")
+                .IsRare()
                 .AddItem("map_041", 20, 1, true)
                 .AddItem("map_045", 5, 1, true)
                 .AddItem("babonsch", 5, 1, true);
@@ -344,6 +353,7 @@ namespace SWLOR.Game.Server.Feature.LootTableDefinition
                 .AddItem("waro_leg", 10, 1, true);
 
             _builder.Create("VISCARA_WAROCAS_RARES")
+                .IsRare()
                 .AddItem("waro_leg", 1, 1, true);
         }
 
@@ -370,6 +380,7 @@ namespace SWLOR.Game.Server.Feature.LootTableDefinition
                 .AddItem("agate", 1, 1, true);
 
             _builder.Create("VISCARA_CRYSTAL_SPIDER_RARES")
+                .IsRare()
                 .AddItem("map_039", 20, 1, true);
         }
     }

--- a/SWLOR.Game.Server/Feature/QuestDefinition/HuntersGuildQuestDefinition.cs
+++ b/SWLOR.Game.Server/Feature/QuestDefinition/HuntersGuildQuestDefinition.cs
@@ -58,7 +58,7 @@ namespace SWLOR.Game.Server.Feature.QuestDefinition
             // Tier 2 (Rank 1)
             BuildItemTask("hun_tsk_200", "herb_m", 6, 1);
             BuildItemTask("hun_tsk_201", "m_blast_parts", 6, 1);
-            BuildItemTask("hun_tsk_202", "man_tags", 6, 1);
+            BuildItemTask("hun_tsk_202", "man_tags", 10, 1);
             BuildItemTask("hun_tsk_203", "m_lvibro_parts", 6, 1);
             BuildKillTask("hun_tsk_204", NPCGroupType.Viscara_MandalorianLeader, 1, 1);
             BuildItemTask("hun_tsk_205", "m_ls_parts", 6, 1);

--- a/SWLOR.Game.Server/Feature/QuestDefinition/ViscaraQuestDefinition.cs
+++ b/SWLOR.Game.Server/Feature/QuestDefinition/ViscaraQuestDefinition.cs
@@ -424,6 +424,8 @@ namespace SWLOR.Game.Server.Feature.QuestDefinition
                 .AddItemReward("cap_shuriken", 1)
                 .AddItemReward("cap_twinblade", 1)
                 .AddItemReward("cap_rifle", 1)
+                .AddItemReward("cap_sabstaff", 1)
+                .AddItemReward("cap_eblade", 1)
 
                 .OnAcceptAction((player, sourceObject) =>
                 {

--- a/SWLOR.Game.Server/Feature/SpawnDefinition/ViscaraSpawnDefinition.cs
+++ b/SWLOR.Game.Server/Feature/SpawnDefinition/ViscaraSpawnDefinition.cs
@@ -13,6 +13,8 @@ namespace SWLOR.Game.Server.Feature.SpawnDefinition
             Wildlands();
             MandalorianRaiders();
             MandalorianLeader();
+            MandalorianHunter();
+            MandalorianScout();
             WildwoodsLooters();
             WildwoodsKinrath();
             WildwoodsGimpassa();
@@ -69,6 +71,24 @@ namespace SWLOR.Game.Server.Feature.SpawnDefinition
         {
             _builder.Create("VISCARA_MANDALORIAN_LEADER", "Mandalorian Leader")
                 .AddSpawn(ObjectType.Creature, "man_leader")
+                .WithFrequency(100)
+                .RandomlyWalks()
+                .ReturnsHome();
+        }
+
+        private void MandalorianHunter()
+        {
+            _builder.Create("VISCARA_WILDWOODS_MANDO_HUNTER", "Mandalorian Hunter")
+                .AddSpawn(ObjectType.Creature, "man_hunter")
+                .WithFrequency(100)
+                .RandomlyWalks()
+                .ReturnsHome();
+        }
+
+        private void MandalorianScout()
+        {
+            _builder.Create("VISCARA_WILDWOODS_MANDO_SCOUT", "Mandalorian Scout")
+                .AddSpawn(ObjectType.Creature, "man_scout")
                 .WithFrequency(100)
                 .RandomlyWalks()
                 .ReturnsHome();

--- a/SWLOR.Game.Server/Service/Loot.cs
+++ b/SWLOR.Game.Server/Service/Loot.cs
@@ -121,7 +121,7 @@ namespace SWLOR.Game.Server.Service
 
             var lootList = new List<uint>();
             var table = GetLootTableByName(lootTableName);
-            if (treasureHunterLevel > 0 && Regex.Match(lootTableName, "_RARES").Success)
+            if (treasureHunterLevel > 0 && table.IsRare)
             {
                 chance += treasureHunterLevel * 10;
             }

--- a/SWLOR.Game.Server/Service/Loot.cs
+++ b/SWLOR.Game.Server/Service/Loot.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using SWLOR.Game.Server.Core;
 using SWLOR.Game.Server.Core.NWScript.Enum;
 using SWLOR.Game.Server.Service.LogService;
@@ -120,6 +121,10 @@ namespace SWLOR.Game.Server.Service
 
             var lootList = new List<uint>();
             var table = GetLootTableByName(lootTableName);
+            if (treasureHunterLevel > 0 && Regex.Match(lootTableName, "_RARES").Success)
+            {
+                chance += treasureHunterLevel * 10;
+            }
             for (int x = 1; x <= attempts; x++)
             {
                 if (Random.D100(1) > chance) continue;

--- a/SWLOR.Game.Server/Service/Loot.cs
+++ b/SWLOR.Game.Server/Service/Loot.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 using SWLOR.Game.Server.Core;
 using SWLOR.Game.Server.Core.NWScript.Enum;
 using SWLOR.Game.Server.Service.LogService;

--- a/SWLOR.Game.Server/Service/LootService/LootTable.cs
+++ b/SWLOR.Game.Server/Service/LootService/LootTable.cs
@@ -6,6 +6,8 @@ namespace SWLOR.Game.Server.Service.LootService
 {
     public class LootTable : List<LootTableItem>
     {
+        public bool IsRare { get; set; }
+
         /// <summary>
         /// Retrieves a random item from the loot table.
         /// Throws an exception if there are no items in the loot table.

--- a/SWLOR.Game.Server/Service/LootService/LootTableBuilder.cs
+++ b/SWLOR.Game.Server/Service/LootService/LootTableBuilder.cs
@@ -23,6 +23,17 @@ namespace SWLOR.Game.Server.Service.LootService
         }
 
         /// <summary>
+        /// Marks the loot table as rare which will increase the chance the table is used if a player has tagged a creature with Treasure Hunter during combat.
+        /// </summary>
+        /// <returns>A loot table builder with the configured settings.</returns>
+        public LootTableBuilder IsRare()
+        {
+            ActiveTable.IsRare = true;
+
+            return this;
+        }
+
+        /// <summary>
         /// Adds an item to this loot table.
         /// </summary>
         /// <param name="resref">The resref of the item</param>


### PR DESCRIPTION
_"You must be new in this galaxy. There's always a war going on somewhere, always has been, always will be. It's why Mandalorians have never gone out of business."_

![image](https://user-images.githubusercontent.com/6022823/182014473-04ac1a16-fce0-43e5-9390-d8a64966d993.png)

The Viscaran Mandalorians have emerged from their bunker, sending raiding parties into the Wildwoods to probe at the defenses of their neighbors. Armed with improved weapons and donning Neo-Crusader armor, these Mandalorians represent the ever-growing hostility of the war-torn frontier; and the profit one might reap if one survives the risks.

**Added**:
 - Mandalorian Hunter and Mandalorian Scout NPCs to the eastern Wildwoods. Moving in small squads, these scouts are lightly armed compared to their bunker brethren but no less dangerous.
 - Mandalorian Staff, Electroblade, Twin Electroblade; Captain Staff, Electroblade, and Twin Electroblade

**Changed**:
 - Mandalorian NPCs in Viscara now wear Neo-Crusader armor (see picture above) rather than the previous kitbashed outfit.
 - Looted Mandalorian weapons and armor, as well as Captain reward weapons from the quest **The Mandalorian Leader** have seen their stats improved dramatically. A detailed breakdown is below, but in general, Mandalorian weapons offer a mild damage increase and elemental damage over their Tier 2 predecessors, while Captain weapons eschew an elemental bonus for an accuracy increase. Guardian/Mando armor dropped by the War Hero acts similarly as a stepping stone between Titan and Quark tier heavy armor.
 - Loot Tables across the board for Mandalorians and their crates have seen an uplift similar to that in #1452
   - Quest items (plexiplate, weapon parts, dog tags) are significantly more likely to drop, and some have been shifted to a separate drop table so as to not severely impact non-quest drops.
 - Loot tables marked as 'rare' now have their roll chance increased by levels in Treasure Hunter.
 - Increased the required # of dog tags for the Hunters' Guild from 6 to 10.
 - Sweet Butter is no longer marked as a rare drop in Mandalorian Crates, thus Treasure Hunter will no longer cause all crates to be filled with nothing but butter.

**Fixed**:
  - Mandalorian / Captain weapons being Tier 1 - Tier 2 equivalent (see above).
  - Hunters' Guild parts not spawning; All parts now appear in crates; melee weapon parts appear on scouts and warriors, blaster and vibro parts appear on hunters and rangers, and polearm/lightsaber parts can appear on the War Hero.
  - (Hopefully) fixed the bug where you could complete the Mandalorian Leader quest without a reward, due to a missing weapon definition.
  - Captain / Mandalorian weapons not having a sell value. Their base value is now 250 / 150 cr respectively.

**Removed**:
  - Flawed fiberplast spawn from Warrior / Ranger loot tables. Mandalorian Scouts (in the Wildwoods) now have a chance of dropping it instead.

**Mandalorian Weapons**
Weapons dropped by Mandalorians on Viscara require Tier 2 of the necessary proficiency. In general, they are an improvement on Titan weapons, boasting a moderate increase in physical damage with an additional amount of elemental damage.

- Mandalorian Knife: 8 Phys / 4 Ice
- Mandalorian Great Blade: 16 Phys / 6 Elec
- Mandalorian Blade: 11 Phys / 2 Ice
- Mandalorian Electroblade: 11 Phys / 2 Elec
- Mandalorian Katar: 10 Phys / 2 Poison
- Mandalorian Staff: 10 Phys / 3 Poison
- Mandalorian Twinblade: 11 Phys / 2 Elec
- Mandalorian Twin Electroblade: 11 Phys / 2 Elec
- Mandalorian Spear: 20 Phys / 4 Poison
- Mandalorian Pistol: 11 Phys /  2 Fire
- Mandalorian Rifle: 13 Phys / 2 Fire
- Mandalorian Shuriken: 8 Phys / 2 Poison

**Captain Weapons**
Weapons given as a one-time reward for completing **The Mandalorian Leader**. As a counter-weight to Mandalorian weapons, these are more mundane and reliable options.

- Captain Knife: 10 Phys / 2 Elec; +1 Accuracy
- Captain Great Sword: 24 Phys; +1 Accuracy
- Captain Electroblade: 13 Phys; +1 Accuracy
- Captain Longsword: 13 Phys; +1 Accuracy
- Captain Katar: 12 Phys; +1 Accuracy
- Captain Staff: 13 Phys; +1 Accuracy
- Captain Twin Blade: 13 Phys; +1 Accuracy
- Captain Twin Electroblade: 13 Phys; +1 Accuracy
- Captain Spear: 24 Phys; +1 Accuracy
- Captain Pistol: 13 Phys; +1 Accuracy
- Captain Rifle: 15 Phys; +1 Accuracy
- Captain Shuriken: 9 Phys; +1 Accuracy

**Mandalorian / Guardian Armor**
Dropped as rare rewards from the Mandalorian War Hero, this heavy armor serves as a considerable upgrade to Titan-tier armor.

- Guardian Armor: 7F / 8P, +35 HP
- Guardian Helmet: 5F / 6P, +20 HP
- Guardian Bracer: 4F / 7P, +15 HP
- Guardian Leggings: 4F / 7P, +15 HP
- Mandalorian Shield: 3F / 4P, +10 HP
- Mandalorian Belt: 3F / 4P, +15 HP
- Mandalorian Cloak: 3F / 4P, +15 HP
- Mandalorian Necklace: 3F / 4P, +15 HP
- Mandalorian Ring: 3F / 4P, +15 HP

**Wildwoods Mandalorians**
 - Mandalorian Hunter (lvl 14), 105 HP
   - 14 MGT / 24 PER / 20 VIT / 10 AGI / 10 WIL
   - Ranged; Rifle, 33 DMG (Phys), Crippling Shot I, Frag Grenade I
 - Mandalorian Scout (lvl 10), 70 HP
   - 12 MGT / 16 PER / 14 VIT / 10 AGI / 10 WIL
   - Melee; Knife, 16 DMG (12 Phys / 4 Poison), Power Attack