### PR TITLE
Tweak ranged perk definitions, combat log

### DIFF
--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Ranged/TranquilizerShotAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Ranged/TranquilizerShotAbilityDefinition.cs
@@ -56,15 +56,19 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Ranged
                     break;
                 case 3:
                     var count = 0;
-                    var creature = GetFirstObjectInShape(Shape.Cone, RadiusSize.Colossal, GetLocation(target), true, ObjectType.Creature);
+                    var creature = GetFirstObjectInShape(Shape.SpellCone, RadiusSize.Colossal, GetLocation(target), true, ObjectType.Creature);
                     while (GetIsObjectValid(creature) && count < 3)
                     {
+                        if(creature == activator) {
+                            creature = GetNextObjectInShape(Shape.SpellCone, RadiusSize.Colossal, GetLocation(target), true, ObjectType.Creature);
+                            continue;
+                        }
                         Enmity.ModifyEnmity(activator, creature, enmity);
                         StatusEffect.Apply(activator, creature, StatusEffectType.Tranquilize, 12f);
                         CombatPoint.AddCombatPoint(activator, creature, SkillType.Ranged, 3);
                         count++;
 
-                        creature = GetNextObjectInShape(Shape.Cone, RadiusSize.Colossal, GetLocation(target), true, ObjectType.Creature);
+                        creature = GetNextObjectInShape(Shape.SpellCone, RadiusSize.Colossal, GetLocation(target), true, ObjectType.Creature);
                     }
                     break;
                 default:

--- a/SWLOR.Game.Server/Feature/PerkDefinition/RangedPerkDefinition.cs
+++ b/SWLOR.Game.Server/Feature/PerkDefinition/RangedPerkDefinition.cs
@@ -47,12 +47,12 @@ namespace SWLOR.Game.Server.Feature.PerkDefinition
                 .Name("Rapid Shot")
 
                 .AddPerkLevel()
-                .Description("Grants 1 additional attack with ranged weapons.")
+                .Description("Grants 1 additional attack with pistols and rifles.")
                 .Price(3)
                 .RequirementSkill(SkillType.Ranged, 15)
 
                 .AddPerkLevel()
-                .Description("Grants 2 additional attacks with ranged weapons.")
+                .Description("Grants 2 additional attacks with pistols and rifles.")
                 .Price(5)
                 .RequirementSkill(SkillType.Ranged, 35)
                 
@@ -86,7 +86,7 @@ namespace SWLOR.Game.Server.Feature.PerkDefinition
                 .Name("Rapid Reload")
 
                 .AddPerkLevel()
-                .Description("You receive the same number of attacks with a rifle as you would if you were using a pistol.")
+                .Description("Allows Rifles to gain attacks per round via the Rapid Shot and Rifle Mastery perks.")
                 .Price(3)
                 .RequirementSkill(SkillType.Ranged, 15)
                 .GrantsFeat(FeatType.RapidReload);
@@ -466,7 +466,7 @@ namespace SWLOR.Game.Server.Feature.PerkDefinition
                 .Name("Improved Critical - Rifles")
 
                 .AddPerkLevel()
-                .Description("Improves the critical hit chance when using a rifles.")
+                .Description("Improves the critical hit chance when using rifles.")
                 .Price(3)
                 .RequirementSkill(SkillType.Ranged, 25)
                 .GrantsFeat(FeatType.ImprovedCriticalRifles);
@@ -567,7 +567,7 @@ namespace SWLOR.Game.Server.Feature.PerkDefinition
                 .GrantsFeat(FeatType.TranquilizerShot2)
 
                 .AddPerkLevel()
-                .Description("Your next attack will tranquilize all creatures within 5 meters of your target for up to 12 seconds. Damage will break the effect prematurely.")
+                .Description("Your next attack will tranquilize up to three creatures in a cone for up to 12 seconds. Damage will break the effect prematurely.")
                 .Price(3)
                 .RequirementSkill(SkillType.Ranged, 45)
                 .RequirementCharacterType(CharacterType.Standard)

--- a/SWLOR.Game.Server/Feature/ShipModuleDefinition/CombatLaserModuleDefinition.cs
+++ b/SWLOR.Game.Server/Feature/ShipModuleDefinition/CombatLaserModuleDefinition.cs
@@ -94,7 +94,7 @@ namespace SWLOR.Game.Server.Feature.ShipModuleDefinition
                     }
 
                     var attackId = isHit ? 1 : 4;
-                    var combatLogMessage = Combat.BuildCombatLogMessage(GetName(activator), GetName(target), attackId, chanceToHit);
+                    var combatLogMessage = Combat.BuildCombatLogMessage(activator, target, attackId, chanceToHit);
                     Messaging.SendMessageNearbyToPlayers(target, combatLogMessage, 60f);
 
                     Enmity.ModifyEnmity(activator, target, damage);

--- a/SWLOR.Game.Server/Feature/ShipModuleDefinition/IonCannonModuleDefinition.cs
+++ b/SWLOR.Game.Server/Feature/ShipModuleDefinition/IonCannonModuleDefinition.cs
@@ -107,7 +107,7 @@ namespace SWLOR.Game.Server.Feature.ShipModuleDefinition
                     }
 
                     var attackId = isHit ? 1 : 4;
-                    var combatLogMessage = Combat.BuildCombatLogMessage(GetName(activator), GetName(target), attackId, chanceToHit);
+                    var combatLogMessage = Combat.BuildCombatLogMessage(activator, target, attackId, chanceToHit);
                     Messaging.SendMessageNearbyToPlayers(target, combatLogMessage, 60f);
 
                     Enmity.ModifyEnmity(activator, target, damage);

--- a/SWLOR.Game.Server/Feature/ShipModuleDefinition/MissileLauncherModuleDefinition.cs
+++ b/SWLOR.Game.Server/Feature/ShipModuleDefinition/MissileLauncherModuleDefinition.cs
@@ -56,7 +56,7 @@ namespace SWLOR.Game.Server.Feature.ShipModuleDefinition
             }
 
             var attackId = isHit ? 1 : 4;
-            var combatLogMessage = Combat.BuildCombatLogMessage(GetName(activator), GetName(target), attackId, chanceToHit);
+            var combatLogMessage = Combat.BuildCombatLogMessage(activator, target, attackId, chanceToHit);
             Messaging.SendMessageNearbyToPlayers(target, combatLogMessage, 60f);
             CombatPoint.AddCombatPoint(activator, target, SkillType.Piloting);
         }

--- a/SWLOR.Game.Server/Native/ResolveAttackRoll.cs
+++ b/SWLOR.Game.Server/Native/ResolveAttackRoll.cs
@@ -332,9 +332,9 @@ namespace SWLOR.Game.Server.Native
             attacker.ResolveDefensiveEffects(defender, isHit ? 1 : 0);
 
             Log.Write(LogGroup.Attack, $"Building combat log message");
-            var message = Combat.BuildCombatLogMessage(
-                (attacker.GetFirstName().GetSimple() + " " + attacker.GetLastName().GetSimple()).Trim(),
-                (defender.GetFirstName().GetSimple() + " " + defender.GetLastName().GetSimple()).Trim(),
+            var message = Combat.BuildCombatLogMessageNative(
+                attacker,
+                defender,
                 pAttackData.m_nAttackResult,
                 hitRate);
             attacker.SendFeedbackString(new CExoString(message));

--- a/SWLOR.Game.Server/Service/Combat.cs
+++ b/SWLOR.Game.Server/Service/Combat.cs
@@ -254,14 +254,14 @@ namespace SWLOR.Game.Server.Service
         /// <summary>
         /// Builds a combat log message based on the provided information.
         /// </summary>
-        /// <param name="attackerName">The name of the attacker</param>
-        /// <param name="defenderName">The name of the defender</param>
+        /// <param name="attacker">The id of the attacker</param>
+        /// <param name="defender">The id of the defender</param>
         /// <param name="attackResultType">The type of result. 1, 7 = Hit, 3 = Critical, 4 = Miss</param>
         /// <param name="chanceToHit">The percent chance to hit</param>
         /// <returns></returns>
         public static string BuildCombatLogMessage(
-            string attackerName,
-            string defenderName,
+            uint attacker,
+            uint defender,
             int attackResultType,
             int chanceToHit)
         {
@@ -281,8 +281,49 @@ namespace SWLOR.Game.Server.Service
                     break;
             }
 
-            var coloredAttackerName = ColorToken.Custom(attackerName, 153, 255, 255);
-            return ColorToken.Combat($"{coloredAttackerName} attacks {defenderName}{type} : ({chanceToHit}% chance to hit)");
+            var attackerName = GetIsPC(attacker) ? ColorToken.GetNamePCColor(attacker) : ColorToken.GetNameNPCColor(attacker);
+            var defenderName = GetIsPC(defender) ? ColorToken.GetNamePCColor(defender) : ColorToken.GetNameNPCColor(defender);
+
+            return ColorToken.Combat($"{attackerName} attacks {defenderName}{type} : ({chanceToHit}% chance to hit)");
+        }
+
+        /// <summary>
+        /// Builds a combat log message based on the provided information, for native contexts.
+        /// </summary>
+        /// <param name="attacker">The CNWSCreature of the attacker</param>
+        /// <param name="defender">The CNWSCreature of the defender</param>
+        /// <param name="attackResultType">The type of result. 1, 7 = Hit, 3 = Critical, 4 = Miss</param>
+        /// <param name="chanceToHit">The percent chance to hit</param>
+        /// <returns></returns>
+        public static string BuildCombatLogMessageNative(
+            CNWSCreature attacker,
+            CNWSCreature defender,
+            int attackResultType,
+            int chanceToHit)
+        {
+            var type = string.Empty;
+
+            switch (attackResultType)
+            {
+                case 1:
+                case 7:
+                    type = ": *hit*";
+                    break;
+                case 3:
+                    type = ": *critical*";
+                    break;
+                case 4:
+                    type = ": *miss*";
+                    break;
+            }
+
+            var attackerName = (attacker.GetFirstName().GetSimple() + " " + attacker.GetLastName().GetSimple()).Trim();
+            var defenderName = (defender.GetFirstName().GetSimple() + " " + attacker.GetLastName().GetSimple()).Trim();
+
+            attackerName = Convert.ToBoolean(attacker.m_bPlayerCharacter) ? ColorToken.Custom(attackerName, 153, 255, 255) : ColorToken.Custom(attackerName, 204, 153, 204);
+            defenderName = Convert.ToBoolean(defender.m_bPlayerCharacter) ? ColorToken.Custom(defenderName, 153, 255, 255) : ColorToken.Custom(defenderName, 204, 153, 204);
+
+            return ColorToken.Combat($"{attackerName} attacks {defenderName}{type} : ({chanceToHit}% chance to hit)");
         }
 
         /// <summary>


### PR DESCRIPTION
- Tweaks Tranquilizer Shot III to specify that it targets three creatures in a cone
  - Prevents Tranq. III from hitting the user of the ability, and changes from Cone to SpellCone to avoid potential bugs
- Specify that Rapid Shot only works with Pistols and Rifles
- Specify that Rapid Reload allows Rifles to gain APR, but does not give APR itself
- Tweaks combat log to be more clear between PC and NPC to-hit rolls, see below: 

![image](https://user-images.githubusercontent.com/6022823/182042577-d829a0ec-d4ce-4ae1-9be8-397dd0d28a7a.png)