### PR TITLE
Unapologetic Whirlwind and Anti-Evasion Buffs

### DIFF
--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Ranged/ExplosiveTossAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Ranged/ExplosiveTossAbilityDefinition.cs
@@ -77,7 +77,12 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Ranged
                         defense, 
                         defenderStat, 
                         0);
-                    ApplyEffectToObject(DurationType.Instant, EffectDamage(damage, DamageType.Slashing), creature);
+
+                    var dTarget = creature;
+                    DelayCommand(0.1f, () =>
+                    {
+                        ApplyEffectToObject(DurationType.Instant, EffectDamage(damage, DamageType.Slashing), dTarget);
+                    });
 
                     CombatPoint.AddCombatPoint(activator, creature, SkillType.Ranged, 3);
                     Enmity.ModifyEnmity(activator, creature, 250 * level + damage);

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/TwoHanded/CircleSlashAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/TwoHanded/CircleSlashAbilityDefinition.cs
@@ -66,27 +66,34 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.TwoHanded
             }
 
             var count = 0;
-            var creature = GetFirstObjectInShape(Shape.Sphere, RadiusSize.Small, GetLocation(activator), true);
+            var creature = GetFirstObjectInShape(Shape.Sphere, RadiusSize.Large, GetLocation(activator), true);
             while (GetIsObjectValid(creature) && count < 3)
             {
-                var attackerStat = GetAbilityScore(activator, stat);
-                var attack = Stat.GetAttack(activator, stat, SkillType.TwoHanded);
-                var defense = Stat.GetDefense(target, CombatDamageType.Physical, AbilityType.Vitality);
-                var defenderStat = GetAbilityScore(target, AbilityType.Vitality);
-                var damage = Combat.CalculateDamage(
-                    attack, 
-                    dmg, 
-                    attackerStat, 
-                    defense, 
-                    defenderStat, 
-                    0);
-                ApplyEffectToObject(DurationType.Instant, EffectDamage(damage, DamageType.Slashing), target);
+                if (GetIsReactionTypeHostile(creature, activator))
+                {
+                    var attackerStat = GetAbilityScore(activator, stat);
+                    var attack = Stat.GetAttack(activator, stat, SkillType.TwoHanded);
+                    var defense = Stat.GetDefense(target, CombatDamageType.Physical, AbilityType.Vitality);
+                    var defenderStat = GetAbilityScore(target, AbilityType.Vitality);
+                    var damage = Combat.CalculateDamage(
+                        attack,
+                        dmg,
+                        attackerStat,
+                        defense,
+                        defenderStat,
+                        0);
 
-                CombatPoint.AddCombatPoint(activator, creature, SkillType.TwoHanded, 3);
-                Enmity.ModifyEnmity(activator, creature, 250 * level + damage);
+                    var dTarget = creature;
 
-                creature = GetNextObjectInShape(Shape.Sphere, RadiusSize.Small, GetLocation(activator), true);
-                count++;
+                    DelayCommand(0.1f, () =>
+                        ApplyEffectToObject(DurationType.Instant, EffectDamage(damage, DamageType.Slashing), dTarget));
+
+                    CombatPoint.AddCombatPoint(activator, creature, SkillType.TwoHanded, 3);
+                    Enmity.ModifyEnmity(activator, creature, 250 * level + damage);
+                    count++;
+                }
+
+                creature = GetNextObjectInShape(Shape.Sphere, RadiusSize.Large, GetLocation(activator), true);
             }
 
             AssignCommand(activator, () => ActionPlayAnimation(Animation.Whirlwind));
@@ -100,7 +107,6 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.TwoHanded
                 .HasActivationDelay(0.5f)
                 .RequirementStamina(3)
                 .IsCastedAbility()
-                .IsHostileAbility()
                 .UnaffectedByHeavyArmor()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
@@ -113,7 +119,6 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.TwoHanded
                 .HasActivationDelay(0.5f)
                 .RequirementStamina(4)
                 .IsCastedAbility()
-                .IsHostileAbility()
                 .UnaffectedByHeavyArmor()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
@@ -126,7 +131,6 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.TwoHanded
                 .HasActivationDelay(0.5f)
                 .RequirementStamina(5)
                 .IsCastedAbility()
-                .IsHostileAbility()
                 .UnaffectedByHeavyArmor()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/TwoHanded/SpinningWhirlAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/TwoHanded/SpinningWhirlAbilityDefinition.cs
@@ -60,27 +60,33 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.TwoHanded
             dmg += Combat.GetAbilityDamageBonus(activator, SkillType.TwoHanded);
 
             var count = 0;
-            var creature = GetFirstObjectInShape(Shape.Sphere, RadiusSize.Small, GetLocation(activator), true, ObjectType.Creature);
+            var creature = GetFirstObjectInShape(Shape.Sphere, RadiusSize.Large, GetLocation(activator), true, ObjectType.Creature);
             while (GetIsObjectValid(creature) && count < 3)
             {
-                var attackerStat = GetAbilityScore(activator, AbilityType.Might);
-                var attack = Stat.GetAttack(activator, AbilityType.Might, SkillType.TwoHanded);
-                var defense = Stat.GetDefense(target, CombatDamageType.Physical, AbilityType.Vitality);
-                var defenderStat = GetAbilityScore(creature, AbilityType.Vitality);
-                var damage = Combat.CalculateDamage(
-                    attack, 
-                    dmg, 
-                    attackerStat, 
-                    defense, 
-                    defenderStat, 
-                    0);
-                ApplyEffectToObject(DurationType.Instant, EffectDamage(damage, DamageType.Slashing), target);
+                if(GetIsReactionTypeHostile(creature, activator))
+                {
+                    var attackerStat = GetAbilityScore(activator, AbilityType.Might);
+                    var attack = Stat.GetAttack(activator, AbilityType.Might, SkillType.TwoHanded);
+                    var defense = Stat.GetDefense(target, CombatDamageType.Physical, AbilityType.Vitality);
+                    var defenderStat = GetAbilityScore(creature, AbilityType.Vitality);
+                    var damage = Combat.CalculateDamage(
+                        attack,
+                        dmg,
+                        attackerStat,
+                        defense,
+                        defenderStat,
+                        0);
 
-                CombatPoint.AddCombatPoint(activator, creature, SkillType.TwoHanded, 3);
-                Enmity.ModifyEnmity(activator, creature, 250 * level + damage);
+                    var dTarget = creature;
 
-                creature = GetNextObjectInShape(Shape.Sphere, RadiusSize.Small, GetLocation(activator), true, ObjectType.Creature);
-                count++;
+                    DelayCommand(0.1f, () =>
+                        ApplyEffectToObject(DurationType.Instant, EffectDamage(damage, DamageType.Slashing), dTarget));
+
+                    CombatPoint.AddCombatPoint(activator, creature, SkillType.TwoHanded, 3);
+                    Enmity.ModifyEnmity(activator, creature, 250 * level + damage);
+                    count++;
+                }
+                creature = GetNextObjectInShape(Shape.Sphere, RadiusSize.Large, GetLocation(activator), true, ObjectType.Creature);
             }
 
             AssignCommand(activator, () => ActionPlayAnimation(Animation.Whirlwind));
@@ -94,7 +100,6 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.TwoHanded
                 .HasActivationDelay(0.5f)
                 .RequirementStamina(3)
                 .IsCastedAbility()
-                .IsHostileAbility()
                 .UnaffectedByHeavyArmor()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
@@ -107,7 +112,6 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.TwoHanded
                 .HasActivationDelay(0.5f)
                 .RequirementStamina(5)
                 .IsCastedAbility()
-                .IsHostileAbility()
                 .UnaffectedByHeavyArmor()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
@@ -120,7 +124,6 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.TwoHanded
                 .HasActivationDelay(0.5f)
                 .RequirementStamina(8)
                 .IsCastedAbility()
-                .IsHostileAbility()
                 .UnaffectedByHeavyArmor()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);

--- a/SWLOR.Game.Server/Feature/StatusEffectDefinition/DamageStatusEffectDefinition.cs
+++ b/SWLOR.Game.Server/Feature/StatusEffectDefinition/DamageStatusEffectDefinition.cs
@@ -48,7 +48,7 @@ namespace SWLOR.Game.Server.Feature.StatusEffectDefinition
                     var decreasedAC = EffectACDecrease(2);
 
                     ApplyEffectToObject(DurationType.Instant, damage, target);
-                    ApplyEffectToObject(DurationType.Temporary, decreasedAC, target, 1.0f);
+                    ApplyEffectToObject(DurationType.Temporary, decreasedAC, target, 6.0f);
 
                 });
         }

--- a/SWLOR.Game.Server/Service/Combat.cs
+++ b/SWLOR.Game.Server/Service/Combat.cs
@@ -318,7 +318,7 @@ namespace SWLOR.Game.Server.Service
             }
 
             var attackerName = (attacker.GetFirstName().GetSimple() + " " + attacker.GetLastName().GetSimple()).Trim();
-            var defenderName = (defender.GetFirstName().GetSimple() + " " + attacker.GetLastName().GetSimple()).Trim();
+            var defenderName = (defender.GetFirstName().GetSimple() + " " + defender.GetLastName().GetSimple()).Trim();
 
             attackerName = Convert.ToBoolean(attacker.m_bPlayerCharacter) ? ColorToken.Custom(attackerName, 153, 255, 255) : ColorToken.Custom(attackerName, 204, 153, 204);
             defenderName = Convert.ToBoolean(defender.m_bPlayerCharacter) ? ColorToken.Custom(defenderName, 153, 255, 255) : ColorToken.Custom(defenderName, 204, 153, 204);

--- a/SWLOR.Game.Server/Service/Stat.cs
+++ b/SWLOR.Game.Server/Service/Stat.cs
@@ -1209,11 +1209,16 @@ namespace SWLOR.Game.Server.Service
             // Note: The DEX offset is unnecessary for the native call.
             var ac = creature.m_pStats.m_nACArmorBase +
                      creature.m_pStats.m_nACNaturalBase +
-                     creature.m_pStats.m_nACArmorMod +
-                     creature.m_pStats.m_nACDeflectionMod +
-                     creature.m_pStats.m_nACDodgeMod +
-                     creature.m_pStats.m_nACNaturalMod +
-                     creature.m_pStats.m_nACShieldMod;
+                     creature.m_pStats.m_nACArmorMod -
+                     creature.m_pStats.m_nACArmorNeg +
+                     creature.m_pStats.m_nACDeflectionMod -
+                     creature.m_pStats.m_nACDeflectionNeg +
+                     creature.m_pStats.m_nACDodgeMod -
+                     creature.m_pStats.m_nACDodgeNeg +
+                     creature.m_pStats.m_nACNaturalMod -
+                     creature.m_pStats.m_nACNaturalNeg +
+                     creature.m_pStats.m_nACShieldMod -
+                     creature.m_pStats.m_nACShieldNeg;
 
             Log.Write(LogGroup.Attack, $"Native Evasion AC = {ac}");
 


### PR DESCRIPTION
- Fixed a bug where evasion-lowering abilities (Saber Strike, Force Spark, Cross Cut, etc.) did not lower the enemy's evasion.
- Increased the range of Circle Slash and Spinning Whirl from 1.67m to 5m
- Removed hostile check on both abilities, so it can be self-casted
- Both abilities now properly hit up to three targets in the sphere, rather than the same enemy multiple times (or nothing at all)

- Fixed the wrong last name being sent in combat logs
- Increased the AC reduction duration on poison status ticks from 1 second to 6 seconds