### PR TITLE
Fix missing recipe, smithing quests, resource spawns

### DIFF
--- a/SWLOR.Game.Server/Feature/QuestDefinition/SmitheryGuildQuestDefinition.cs
+++ b/SWLOR.Game.Server/Feature/QuestDefinition/SmitheryGuildQuestDefinition.cs
@@ -164,8 +164,8 @@ namespace SWLOR.Game.Server.Feature.QuestDefinition
             BuildItemTask(builder, "smth_tsk_616", "ar_helmet", 1, 3);
             BuildItemTask(builder, "smth_tsk_617", "ar_bracer", 1, 3);
             BuildItemTask(builder, "smth_tsk_618", "ar_leggings", 1, 3);
-            BuildItemTask(builder, "smth_tsk_619", "gr_gloak", 1, 3);
-            BuildItemTask(builder, "smth_tsk_620", "gr_belt", 1, 3);
+            BuildItemTask(builder, "smth_tsk_619", "gre_cloak", 1, 3);
+            BuildItemTask(builder, "smth_tsk_620", "gre_belt", 1, 3);
             BuildItemTask(builder, "smth_tsk_621", "gr_ring", 1, 3);
             BuildItemTask(builder, "smth_tsk_622", "gr_necklace", 1, 3);
             BuildItemTask(builder, "smth_tsk_623", "gr_tunic", 1, 3);

--- a/SWLOR.Game.Server/Feature/RecipeDefinition/FabricationRecipeDefinition/FurnitureRecipes.cs
+++ b/SWLOR.Game.Server/Feature/RecipeDefinition/FabricationRecipeDefinition/FurnitureRecipes.cs
@@ -687,7 +687,7 @@ namespace SWLOR.Game.Server.Feature.RecipeDefinition.FabricationRecipeDefinition
 				.Component("fine_wood", 4)
 				.Component("ref_scordspar", 2);
 
-			// Bed, Low
+			// Bed, Medical/Exam
 			_builder.Create(RecipeType.BedMedicalExam, SkillType.Fabrication)
 				.Category(RecipeCategoryType.Beds)
 				.Resref("structure_0137")

--- a/SWLOR.Game.Server/Feature/RecipeDefinition/FabricationRecipeDefinition/FurnitureRecipes.cs
+++ b/SWLOR.Game.Server/Feature/RecipeDefinition/FabricationRecipeDefinition/FurnitureRecipes.cs
@@ -643,8 +643,8 @@ namespace SWLOR.Game.Server.Feature.RecipeDefinition.FabricationRecipeDefinition
 				.Component("fine_wood", 4)
 				.Component("fiberp_flawed", 2);
 
-            // Fridge, Dark
-            _builder.Create(RecipeType.FridgeDark, SkillType.Fabrication)
+			// Fridge, Dark
+			_builder.Create(RecipeType.FridgeDark, SkillType.Fabrication)
                 .Category(RecipeCategoryType.Electronics)
                 .Resref("structure_0217")
                 .Level(16)
@@ -680,6 +680,17 @@ namespace SWLOR.Game.Server.Feature.RecipeDefinition.FabricationRecipeDefinition
 			_builder.Create(RecipeType.BedHighBackBlue, SkillType.Fabrication)
 				.Category(RecipeCategoryType.Beds)
 				.Resref("structure_0136")
+				.Level(17)
+				.Quantity(1)
+				.RequirementPerk(PerkType.FurnitureBlueprints, 2)
+				.EnhancementSlots(RecipeEnhancementType.Structure, 1)
+				.Component("fine_wood", 4)
+				.Component("ref_scordspar", 2);
+
+			// Bed, Low
+			_builder.Create(RecipeType.BedMedicalExam, SkillType.Fabrication)
+				.Category(RecipeCategoryType.Beds)
+				.Resref("structure_0137")
 				.Level(17)
 				.Quantity(1)
 				.RequirementPerk(PerkType.FurnitureBlueprints, 2)

--- a/SWLOR.Game.Server/Feature/SpawnDefinition/KorribanResourceSpawnDefinition.cs
+++ b/SWLOR.Game.Server/Feature/SpawnDefinition/KorribanResourceSpawnDefinition.cs
@@ -72,6 +72,9 @@ namespace SWLOR.Game.Server.Feature.SpawnDefinition
                 .AddSpawn(ObjectType.Placeable, "herbs_patch_2")
                 .WithFrequency(10)
 
+                .AddSpawn(ObjectType.Placeable, "patch_veggies2")
+                .WithFrequency(10)
+
                 .AddSpawn(ObjectType.Placeable, "plagionite_vein")
                 .WithFrequency(2);
         }

--- a/SWLOR.Game.Server/Feature/SpawnDefinition/MonCalaResourceSpawnDefinition.cs
+++ b/SWLOR.Game.Server/Feature/SpawnDefinition/MonCalaResourceSpawnDefinition.cs
@@ -29,11 +29,15 @@ namespace SWLOR.Game.Server.Feature.SpawnDefinition
                 .AddSpawn(ObjectType.Placeable, "ancient_tree")
                 .WithFrequency(70)
 
+                .AddSpawn(ObjectType.Placeable, "herbs_patch_2")
+                .WithFrequency(10)
                 .AddSpawn(ObjectType.Placeable, "herbs_patch_3")
                 .WithFrequency(30)
 
-                .AddSpawn(ObjectType.Placeable, "patch_veggies3")
+                .AddSpawn(ObjectType.Placeable, "patch_veggies2")
                 .WithFrequency(10)
+                .AddSpawn(ObjectType.Placeable, "patch_veggies3")
+                .WithFrequency(30)
 
                 .AddSpawn(ObjectType.Placeable, "fiberp_bush_2")
                 .WithFrequency(20)
@@ -49,11 +53,15 @@ namespace SWLOR.Game.Server.Feature.SpawnDefinition
                 .AddSpawn(ObjectType.Placeable, "plagionite_vein")
                 .WithFrequency(20)
 
+                .AddSpawn(ObjectType.Placeable, "herbs_patch_2")
+                .WithFrequency(10)
                 .AddSpawn(ObjectType.Placeable, "herbs_patch_3")
                 .WithFrequency(30)
 
-                .AddSpawn(ObjectType.Placeable, "patch_veggies3")
+                .AddSpawn(ObjectType.Placeable, "patch_veggies2")
                 .WithFrequency(10)
+                .AddSpawn(ObjectType.Placeable, "patch_veggies3")
+                .WithFrequency(30)
 
                 .AddSpawn(ObjectType.Placeable, "oak_tree")
                 .WithFrequency(10)

--- a/SWLOR.Game.Server/Feature/SpawnDefinition/TatooineResourceSpawnDefinition.cs
+++ b/SWLOR.Game.Server/Feature/SpawnDefinition/TatooineResourceSpawnDefinition.cs
@@ -27,19 +27,23 @@ namespace SWLOR.Game.Server.Feature.SpawnDefinition
                 .WithFrequency(10)
 
                 .AddSpawn(ObjectType.Placeable, "jasioclase_vein")
-                .WithFrequency(5)
+                .WithFrequency(10)
 
                 .AddSpawn(ObjectType.Placeable, "herbs_patch_4")
                 .WithFrequency(30)
+                .AddSpawn(ObjectType.Placeable, "herbs_patch_5")
+                .WithFrequency(10)
 
                 .AddSpawn(ObjectType.Placeable, "patch_veggies4")
                 .WithFrequency(10)
+                .AddSpawn(ObjectType.Placeable, "patch_veggies5")
+                .WithFrequency(5)
 
                 .AddSpawn(ObjectType.Placeable, "fiberp_bush_3")
                 .WithFrequency(40)
 
                 .AddSpawn(ObjectType.Placeable, "fiberp_bush_4")
-                .WithFrequency(10)
+                .WithFrequency(20)
 
                 .AddSpawn(ObjectType.Placeable, "fiberp_bush_5")
                 .WithFrequency(5);

--- a/SWLOR.Game.Server/Feature/SpawnDefinition/ViscaraResourceSpawnDefinition.cs
+++ b/SWLOR.Game.Server/Feature/SpawnDefinition/ViscaraResourceSpawnDefinition.cs
@@ -47,10 +47,10 @@ namespace SWLOR.Game.Server.Feature.SpawnDefinition
                 .AddSpawn(ObjectType.Placeable, "scordspar_vein")
                 .WithFrequency(60)
 
-                .AddSpawn(ObjectType.Placeable, "herbs_patch")
+                .AddSpawn(ObjectType.Placeable, "herbs_patch2")
                 .WithFrequency(10)
 
-                .AddSpawn(ObjectType.Placeable, "patch_veggies")
+                .AddSpawn(ObjectType.Placeable, "patch_veggies2")
                 .WithFrequency(5)
 
                 .AddSpawn(ObjectType.Placeable, "fiberp_bush_1")
@@ -75,10 +75,10 @@ namespace SWLOR.Game.Server.Feature.SpawnDefinition
                 .AddSpawn(ObjectType.Placeable, "scordspar_vein")
                 .WithFrequency(25)
 
-                .AddSpawn(ObjectType.Placeable, "herbs_patch")
+                .AddSpawn(ObjectType.Placeable, "herbs_patch2")
                 .WithFrequency(10)
 
-                .AddSpawn(ObjectType.Placeable, "patch_veggies")
+                .AddSpawn(ObjectType.Placeable, "patch_veggies2")
                 .WithFrequency(5)
 
                 .AddSpawn(ObjectType.Placeable, "tree")
@@ -141,10 +141,10 @@ namespace SWLOR.Game.Server.Feature.SpawnDefinition
                 .AddSpawn(ObjectType.Placeable, "tree")
                 .WithFrequency(20)
 
-                .AddSpawn(ObjectType.Placeable, "herbs_patch")
+                .AddSpawn(ObjectType.Placeable, "herbs_patch2")
                 .WithFrequency(10)
 
-                .AddSpawn(ObjectType.Placeable, "patch_veggies")
+                .AddSpawn(ObjectType.Placeable, "patch_veggies2")
                 .WithFrequency(5)
 
                 .AddSpawn(ObjectType.Placeable, "oak_tree")


### PR DESCRIPTION
- Fixed blank smithing quests for Tier 4 / Rank 3 smithing
- Added missing medical exam bed recipe
- Added T2 vegetable spawn to Korriban Caverns
- Added T2 herb/veggie spawns to Mon Calamari, Viscara Deep Mtns, Mountain Valley, and Swamplands
- Added T5 herb/veggie spawns to Tatooine Arid Hilly Desert
- Increased jasioclase spawn % slightly