### PR TITLE
Fix stat gains, Wildwoods NPCs, refinery XP, and item stacking

### DIFF
--- a/Module/are/viscarawildwoods.are.json
+++ b/Module/are/viscarawildwoods.are.json
@@ -44193,7 +44193,7 @@
   },
   "Version": {
     "type": "dword",
-    "value": 34
+    "value": 35
   },
   "Width": {
     "type": "int",

--- a/Module/git/viscarawildwoods.git.json
+++ b/Module/git/viscarawildwoods.git.json
@@ -9253,7 +9253,7 @@
         },
         "XPosition": {
           "type": "float",
-          "value": 189.2857208251953
+          "value": 161.3250732421875
         },
         "YOrientation": {
           "type": "float",
@@ -9261,11 +9261,11 @@
         },
         "YPosition": {
           "type": "float",
-          "value": 210.8301696777344
+          "value": 187.6181945800781
         },
         "ZPosition": {
           "type": "float",
-          "value": 5.960464477539063e-008
+          "value": 0.2618160247802734
         }
       },
       {
@@ -9316,7 +9316,7 @@
         },
         "XPosition": {
           "type": "float",
-          "value": 190.9592590332031
+          "value": 162.9986114501953
         },
         "YOrientation": {
           "type": "float",
@@ -9324,11 +9324,11 @@
         },
         "YPosition": {
           "type": "float",
-          "value": 208.6573486328125
+          "value": 185.4453735351563
         },
         "ZPosition": {
           "type": "float",
-          "value": -0.06044310331344605
+          "value": 0.2013721466064453
         }
       },
       {
@@ -9379,7 +9379,7 @@
         },
         "XPosition": {
           "type": "float",
-          "value": 191.2754058837891
+          "value": 163.3147583007813
         },
         "YOrientation": {
           "type": "float",
@@ -9387,11 +9387,11 @@
         },
         "YPosition": {
           "type": "float",
-          "value": 212.5604705810547
+          "value": 189.3484954833984
         },
         "ZPosition": {
           "type": "float",
-          "value": 0.1179957836866379
+          "value": 0.3798141181468964
         }
       },
       {

--- a/Module/itp/creaturepalcus.itp.json
+++ b/Module/itp/creaturepalcus.itp.json
@@ -10410,7 +10410,7 @@
                     "__struct_id": 0,
                     "CR": {
                       "type": "float",
-                      "value": 4.0
+                      "value": 0.125
                     },
                     "FACTION": {
                       "type": "cexostring",
@@ -10418,7 +10418,7 @@
                     },
                     "NAME": {
                       "type": "cexostring",
-                      "value": "Gimpassa"
+                      "value": "Gimpassa Hatchling"
                     },
                     "RESREF": {
                       "type": "resref",

--- a/Module/itp/itempalcus.itp.json
+++ b/Module/itp/itempalcus.itp.json
@@ -19536,6 +19536,17 @@
                     "__struct_id": 0,
                     "NAME": {
                       "type": "cexostring",
+                      "value": "Mandalorian Electroblade Parts"
+                    },
+                    "RESREF": {
+                      "type": "resref",
+                      "value": "m_ls_parts"
+                    }
+                  },
+                  {
+                    "__struct_id": 0,
+                    "NAME": {
+                      "type": "cexostring",
                       "value": "Mandalorian Electronics"
                     },
                     "RESREF": {
@@ -19552,17 +19563,6 @@
                     "RESREF": {
                       "type": "resref",
                       "value": "m_lvibro_parts"
-                    }
-                  },
-                  {
-                    "__struct_id": 0,
-                    "NAME": {
-                      "type": "cexostring",
-                      "value": "Mandalorian Lightsaber Parts"
-                    },
-                    "RESREF": {
-                      "type": "resref",
-                      "value": "m_ls_parts"
                     }
                   },
                   {

--- a/Module/utc/man_hunter.utc.json
+++ b/Module/utc/man_hunter.utc.json
@@ -130,7 +130,7 @@
   },
   "Con": {
     "type": "byte",
-    "value": 20
+    "value": 16
   },
   "Conversation": {
     "type": "resref",
@@ -142,7 +142,7 @@
   },
   "CurrentHitPoints": {
     "type": "short",
-    "value": 85
+    "value": 88
   },
   "DecayTime": {
     "type": "dword",
@@ -160,7 +160,7 @@
   },
   "Dex": {
     "type": "byte",
-    "value": 24
+    "value": 20
   },
   "Disarmable": {
     "type": "byte",
@@ -333,11 +333,11 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 85
+    "value": 88
   },
   "Int": {
     "type": "byte",
-    "value": 10
+    "value": 12
   },
   "Interruptable": {
     "type": "byte",
@@ -367,7 +367,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 105
+    "value": 100
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/ww_gimpassa.utc.json
+++ b/Module/utc/ww_gimpassa.utc.json
@@ -14,7 +14,7 @@
   },
   "ChallengeRating": {
     "type": "float",
-    "value": 4.0
+    "value": 0.125
   },
   "ClassList": {
     "type": "list",
@@ -50,7 +50,7 @@
   },
   "CurrentHitPoints": {
     "type": "short",
-    "value": 300
+    "value": 100
   },
   "DecayTime": {
     "type": "dword",
@@ -126,7 +126,7 @@
   "FirstName": {
     "type": "cexolocstring",
     "value": {
-      "0": "Gimpassa"
+      "0": "Gimpassa Hatchling"
     }
   },
   "fortbonus": {
@@ -143,11 +143,11 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 300
+    "value": 100
   },
   "Int": {
     "type": "byte",
-    "value": 18
+    "value": 16
   },
   "Interruptable": {
     "type": "byte",
@@ -177,7 +177,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 330
+    "value": 130
   },
   "NaturalAC": {
     "type": "byte",
@@ -584,6 +584,6 @@
   },
   "Wis": {
     "type": "byte",
-    "value": 18
+    "value": 16
   }
 }

--- a/Module/uti/cornucopia.uti.json
+++ b/Module/uti/cornucopia.uti.json
@@ -6,7 +6,7 @@
   },
   "BaseItem": {
     "type": "int",
-    "value": 307
+    "value": 540
   },
   "Charges": {
     "type": "byte",

--- a/Module/uti/dried_bonito.uti.json
+++ b/Module/uti/dried_bonito.uti.json
@@ -6,7 +6,7 @@
   },
   "BaseItem": {
     "type": "int",
-    "value": 311
+    "value": 539
   },
   "Charges": {
     "type": "byte",

--- a/Module/uti/gimp_bite.uti.json
+++ b/Module/uti/gimp_bite.uti.json
@@ -71,7 +71,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 24
+          "value": 22
         },
         "Param1": {
           "type": "byte",

--- a/Module/uti/k_hound_claw.uti.json
+++ b/Module/uti/k_hound_claw.uti.json
@@ -28,7 +28,7 @@
     "id": 90753,
     "type": "cexolocstring",
     "value": {
-      "0": ""
+      "0": "The claws of a Kath Hound are one of the few sharp things about them -- and make for a primitive, yet effective whetstone in a pinch."
     }
   },
   "Description": {

--- a/Module/uti/k_hound_fur.uti.json
+++ b/Module/uti/k_hound_fur.uti.json
@@ -6,7 +6,7 @@
   },
   "BaseItem": {
     "type": "int",
-    "value": 24
+    "value": 536
   },
   "Charges": {
     "type": "byte",
@@ -28,7 +28,7 @@
     "id": 90753,
     "type": "cexolocstring",
     "value": {
-      "0": ""
+      "0": "Thick, matted fur of a Kath Hound. A Viscaran fashion statement, if such a thing were to exist."
     }
   },
   "Description": {

--- a/Module/uti/k_hound_tooth.uti.json
+++ b/Module/uti/k_hound_tooth.uti.json
@@ -28,7 +28,7 @@
     "id": 90753,
     "type": "cexolocstring",
     "value": {
-      "0": ""
+      "0": "A tooth taken from a Kath Hound."
     }
   },
   "Description": {

--- a/Module/uti/kath_blood.uti.json
+++ b/Module/uti/kath_blood.uti.json
@@ -26,7 +26,9 @@
   },
   "DescIdentified": {
     "type": "cexolocstring",
-    "value": {}
+    "value": {
+      "0": "Blood from a Kath Hound."
+    }
   },
   "Description": {
     "type": "cexolocstring",

--- a/Module/uti/kath_meat_1.uti.json
+++ b/Module/uti/kath_meat_1.uti.json
@@ -26,7 +26,9 @@
   },
   "DescIdentified": {
     "type": "cexolocstring",
-    "value": {}
+    "value": {
+      "0": "Meat from a Kath Hound. "
+    }
   },
   "Description": {
     "type": "cexolocstring",

--- a/Module/uti/m_blast_parts.uti.json
+++ b/Module/uti/m_blast_parts.uti.json
@@ -6,7 +6,7 @@
   },
   "BaseItem": {
     "type": "int",
-    "value": 517
+    "value": 528
   },
   "Charges": {
     "type": "byte",
@@ -26,7 +26,9 @@
   },
   "DescIdentified": {
     "type": "cexolocstring",
-    "value": {}
+    "value": {
+      "0": "The non-functional remains of a Mandalorian blaster. "
+    }
   },
   "Description": {
     "type": "cexolocstring",
@@ -46,7 +48,7 @@
   },
   "ModelPart1": {
     "type": "byte",
-    "value": 82
+    "value": 177
   },
   "PaletteID": {
     "type": "byte",

--- a/Module/uti/m_ls_parts.uti.json
+++ b/Module/uti/m_ls_parts.uti.json
@@ -6,7 +6,7 @@
   },
   "BaseItem": {
     "type": "int",
-    "value": 517
+    "value": 530
   },
   "Charges": {
     "type": "byte",
@@ -26,7 +26,9 @@
   },
   "DescIdentified": {
     "type": "cexolocstring",
-    "value": {}
+    "value": {
+      "0": "Emitters and reinforcements designed for a Mandalorian electro-blade."
+    }
   },
   "Description": {
     "type": "cexolocstring",
@@ -41,12 +43,12 @@
   "LocalizedName": {
     "type": "cexolocstring",
     "value": {
-      "0": "Mandalorian Lightsaber Parts"
+      "0": "Mandalorian Electroblade Parts"
     }
   },
   "ModelPart1": {
     "type": "byte",
-    "value": 82
+    "value": 213
   },
   "PaletteID": {
     "type": "byte",

--- a/Module/uti/m_lvibro_parts.uti.json
+++ b/Module/uti/m_lvibro_parts.uti.json
@@ -6,7 +6,7 @@
   },
   "BaseItem": {
     "type": "int",
-    "value": 517
+    "value": 531
   },
   "Charges": {
     "type": "byte",
@@ -26,7 +26,9 @@
   },
   "DescIdentified": {
     "type": "cexolocstring",
-    "value": {}
+    "value": {
+      "0": "The remains of a Mandalorian war blade. "
+    }
   },
   "Description": {
     "type": "cexolocstring",
@@ -46,7 +48,7 @@
   },
   "ModelPart1": {
     "type": "byte",
-    "value": 82
+    "value": 183
   },
   "PaletteID": {
     "type": "byte",

--- a/Module/uti/m_polearm_parts.uti.json
+++ b/Module/uti/m_polearm_parts.uti.json
@@ -6,7 +6,7 @@
   },
   "BaseItem": {
     "type": "int",
-    "value": 517
+    "value": 530
   },
   "Charges": {
     "type": "byte",
@@ -26,7 +26,9 @@
   },
   "DescIdentified": {
     "type": "cexolocstring",
-    "value": {}
+    "value": {
+      "0": "The damaged blade and reinforcements for a Mandalorian war-spear."
+    }
   },
   "Description": {
     "type": "cexolocstring",
@@ -46,7 +48,7 @@
   },
   "ModelPart1": {
     "type": "byte",
-    "value": 82
+    "value": 68
   },
   "PaletteID": {
     "type": "byte",

--- a/Module/uti/m_vibro_parts.uti.json
+++ b/Module/uti/m_vibro_parts.uti.json
@@ -6,7 +6,7 @@
   },
   "BaseItem": {
     "type": "int",
-    "value": 517
+    "value": 528
   },
   "Charges": {
     "type": "byte",
@@ -26,7 +26,9 @@
   },
   "DescIdentified": {
     "type": "cexolocstring",
-    "value": {}
+    "value": {
+      "0": "Miscellaneous components salvaged from a Mandalorian Vibroblade."
+    }
   },
   "Description": {
     "type": "cexolocstring",
@@ -46,7 +48,7 @@
   },
   "ModelPart1": {
     "type": "byte",
-    "value": 82
+    "value": 217
   },
   "PaletteID": {
     "type": "byte",

--- a/Module/uti/man_tags.uti.json
+++ b/Module/uti/man_tags.uti.json
@@ -6,7 +6,7 @@
   },
   "BaseItem": {
     "type": "int",
-    "value": 517
+    "value": 536
   },
   "Charges": {
     "type": "byte",

--- a/Module/uti/man_tags.uti.json
+++ b/Module/uti/man_tags.uti.json
@@ -26,7 +26,9 @@
   },
   "DescIdentified": {
     "type": "cexolocstring",
-    "value": {}
+    "value": {
+      "0": "A set of common dog tags belonging to a Mandalorian warrior."
+    }
   },
   "Description": {
     "type": "cexolocstring",
@@ -46,7 +48,7 @@
   },
   "ModelPart1": {
     "type": "byte",
-    "value": 39
+    "value": 181
   },
   "PaletteID": {
     "type": "byte",

--- a/Module/uti/mynock_meat.uti.json
+++ b/Module/uti/mynock_meat.uti.json
@@ -26,7 +26,9 @@
   },
   "DescIdentified": {
     "type": "cexolocstring",
-    "value": {}
+    "value": {
+      "0": "Stringy and sinewy meat of a Mynock. Smells faintly of burnt electronics."
+    }
   },
   "Description": {
     "type": "cexolocstring",

--- a/Module/uti/mynock_tooth.uti.json
+++ b/Module/uti/mynock_tooth.uti.json
@@ -27,7 +27,7 @@
   "DescIdentified": {
     "type": "cexolocstring",
     "value": {
-      "0": ""
+      "0": "A tooth from a Mynock, capable of shearing through wires, internal hull plating, and the insurance policies of many Corellian freighters."
     }
   },
   "Description": {

--- a/Module/uti/mynock_wing.uti.json
+++ b/Module/uti/mynock_wing.uti.json
@@ -27,7 +27,7 @@
   "DescIdentified": {
     "type": "cexolocstring",
     "value": {
-      "0": ""
+      "0": "The wing of a Mynock."
     }
   },
   "Description": {

--- a/Module/uti/waro_feathers.uti.json
+++ b/Module/uti/waro_feathers.uti.json
@@ -6,7 +6,7 @@
   },
   "BaseItem": {
     "type": "int",
-    "value": 24
+    "value": 538
   },
   "Charges": {
     "type": "byte",
@@ -18,7 +18,7 @@
   },
   "Cost": {
     "type": "dword",
-    "value": 21
+    "value": 22
   },
   "Cursed": {
     "type": "byte",
@@ -28,7 +28,7 @@
     "id": 90753,
     "type": "cexolocstring",
     "value": {
-      "0": ""
+      "0": "The main spinal column of a Warocas, or at least what's left of it. Ick."
     }
   },
   "Description": {
@@ -50,7 +50,7 @@
   },
   "ModelPart1": {
     "type": "byte",
-    "value": 95
+    "value": 1
   },
   "PaletteID": {
     "type": "byte",

--- a/Module/uti/waro_leg.uti.json
+++ b/Module/uti/waro_leg.uti.json
@@ -28,7 +28,7 @@
     "id": 90753,
     "type": "cexolocstring",
     "value": {
-      "0": ""
+      "0": "The remains of a Warocas' leg, rushing o'er the wildlands of Viscara no longer."
     }
   },
   "Description": {

--- a/Module/uti/warocas_beak.uti.json
+++ b/Module/uti/warocas_beak.uti.json
@@ -6,7 +6,7 @@
   },
   "BaseItem": {
     "type": "int",
-    "value": 24
+    "value": 536
   },
   "Charges": {
     "type": "byte",
@@ -28,7 +28,7 @@
     "id": 90753,
     "type": "cexolocstring",
     "value": {
-      "0": ""
+      "0": "The intact beak of a Warocas. Makes a constant clacking noise jumbling around in your pack."
     }
   },
   "Description": {

--- a/Module/uti/warocas_meat.uti.json
+++ b/Module/uti/warocas_meat.uti.json
@@ -26,7 +26,9 @@
   },
   "DescIdentified": {
     "type": "cexolocstring",
-    "value": {}
+    "value": {
+      "0": "A large flank of meat cut from a Warocas."
+    }
   },
   "Description": {
     "type": "cexolocstring",

--- a/Module/uti/ww_gimp_hide.uti.json
+++ b/Module/uti/ww_gimp_hide.uti.json
@@ -72,7 +72,7 @@
         },
         "CostValue": {
           "type": "word",
-          "value": 12
+          "value": 8
         },
         "Param1": {
           "type": "byte",

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/RefineryViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/RefineryViewModel.cs
@@ -328,7 +328,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
                     // Spawn the refined item onto the player.
                     CreateItemOnObject(refinedItem.RefinedItemResref, Player, stackSize);
 
-                    xp += refinedItem.XPGranted;
+                    xp += refinedItem.XPGranted * stackSize;
                 }
 
                 DeleteLocalBool(Player, "IS_REFINING");

--- a/SWLOR.Game.Server/Native/GetDamageRoll.cs
+++ b/SWLOR.Game.Server/Native/GetDamageRoll.cs
@@ -224,7 +224,7 @@ namespace SWLOR.Game.Server.Native
                 if (targetObject.m_nObjectType == (int)ObjectType.Creature)
                 {
                     var target = CNWSCreature.FromPointer(pTarget);
-                    int defenderStat = target.m_pStats.m_nConstitutionBase;
+                    int defenderStat = target.m_pStats.GetCONStat();
                     var damagePower = attackerStats.m_pBaseCreature.CalculateDamagePower(target, bOffHand);
                     var defense = Stat.GetDefenseNative(target, damageType, AbilityType.Vitality);
 
@@ -460,12 +460,12 @@ namespace SWLOR.Game.Server.Native
             if (Item.LightsaberBaseItemTypes.Contains((BaseItem)weapon.m_nBaseItem))
             {
                 if (Ability.IsAbilityToggled(playerId, AbilityToggleType.StrongStyleLightsaber))
-                    return attacker.m_pStats.m_nStrengthBase;
+                    return attacker.m_pStats.GetSTRStat();
             }
             else if (Item.SaberstaffBaseItemTypes.Contains((BaseItem)weapon.m_nBaseItem))
             {
                 if (Ability.IsAbilityToggled(playerId, AbilityToggleType.StrongStyleSaberstaff))
-                    return attacker.m_pStats.m_nStrengthBase;
+                    return attacker.m_pStats.GetSTRStat();
             }
 
             return -1;

--- a/SWLOR.Game.Server/Native/ResolveAttackRoll.cs
+++ b/SWLOR.Game.Server/Native/ResolveAttackRoll.cs
@@ -275,8 +275,8 @@ namespace SWLOR.Game.Server.Native
             if (isHit)
             {
                 var criticalStat = attackType == (uint)AttackType.Ranged
-                    ? attackerStats.m_nIntelligenceBase
-                    : attackerStats.m_nDexterityBase;
+                    ? attackerStats.GetINTStat()
+                    : attackerStats.GetDEXStat();
                 var criticalRoll = Random.Next(1, 100);
                 var criticalBonus = HasImprovedCritical(attacker, weapon) == 1 ? 5 : 0;
                 if (attackerStats.HasFeat((ushort)FeatType.PrecisionAim2) == 1)
@@ -284,7 +284,7 @@ namespace SWLOR.Game.Server.Native
                 else if (attackerStats.HasFeat((ushort)FeatType.PrecisionAim1) == 1)
                     criticalBonus += 2;
 
-                var criticalRate = Combat.CalculateCriticalRate(criticalStat, defender.m_pStats.m_nIntelligenceBase, criticalBonus);
+                var criticalRate = Combat.CalculateCriticalRate(criticalStat, defender.m_pStats.GetINTStat(), criticalBonus);
 
                 // Critical
                 if (criticalRoll <= criticalRate)
@@ -625,8 +625,8 @@ namespace SWLOR.Game.Server.Native
 
             switch (weaponAccuracy)
             {
-                case AbilityType.Perception when attacker.m_pStats.m_nWisdomBase > attacker.m_pStats.m_nDexterityBase:
-                case AbilityType.Agility when attacker.m_pStats.m_nWisdomBase > attacker.m_pStats.m_nIntelligenceBase:
+                case AbilityType.Perception when attacker.m_pStats.GetWISStat() > attacker.m_pStats.GetDEXStat():
+                case AbilityType.Agility when attacker.m_pStats.GetWISStat() > attacker.m_pStats.GetINTStat():
                     return AbilityType.Willpower;
                 default:
                     return AbilityType.Invalid;

--- a/SWLOR.Game.Server/Service/Stat.cs
+++ b/SWLOR.Game.Server/Service/Stat.cs
@@ -916,22 +916,22 @@ namespace SWLOR.Game.Server.Service
             switch (statType)
             {
                 case AbilityType.Might:
-                    stat = creature.m_pStats.m_nStrengthBase;
+                    stat = creature.m_pStats.GetSTRStat();
                     break;
                 case AbilityType.Perception:
-                    stat = creature.m_pStats.m_nDexterityBase;
+                    stat = creature.m_pStats.GetDEXStat();
                     break;
                 case AbilityType.Vitality:
-                    stat = creature.m_pStats.m_nConstitutionBase;
+                    stat = creature.m_pStats.GetCONStat();
                     break;
                 case AbilityType.Willpower:
-                    stat = creature.m_pStats.m_nWisdomBase;
+                    stat = creature.m_pStats.GetWISStat();
                     break;
                 case AbilityType.Agility:
-                    stat = creature.m_pStats.m_nIntelligenceBase;
+                    stat = creature.m_pStats.GetINTStat();
                     break;
                 case AbilityType.Social:
-                    stat = creature.m_pStats.m_nCharismaBase;
+                    stat = creature.m_pStats.GetCHAStat();
                     break;
                 default:
                     stat = 0;


### PR DESCRIPTION
Fixes accuracy, attack (damage), defense, and evasion during combat not taking modified stats into account, such as MGT/PER/VIT from Combat Enhancement.

- Makes Dried Bonito, Cornucopia, Mando Weapon Parts and Dog Tags, Warocas Beaks and Spines, and Kath Hound Fur stackable. Adds descriptions to Mando Weapon Parts, Dog Tags, Warocas Parts, Kath Hound Parts, and Mynock Parts. 

- Nerfs the Gimpassa to levels similar to that of the Crystal Spiders, renames it "Gimpassa Hatchling".
  - 330 HP -> 130 HP
  - AGI 18 -> 16
  - WIL 18 -> 16
  - Level 12 -> 8
 
- Nerfs the Mando Hunter to levels similar to the Mando Ranger
  - PER 24 -> 20
  - HP 105 -> 100
  - AGI 10 -> 12
  - VIT 20 -> 16

- Moved the northern most Mando patrol south to avoid camping the Jedi temple entrance

- Fixed the refinery giving the wrong amount of XP for refining ore.