### PR TITLE
Fix creature aggro, holonet warnings

### DIFF
--- a/SWLOR.Game.Server/Service/AI.cs
+++ b/SWLOR.Game.Server/Service/AI.cs
@@ -520,7 +520,7 @@ namespace SWLOR.Game.Server.Service
             var isSeen = GetLastPerceptionSeen();
             var isVanished = GetLastPerceptionVanished();
 
-            if (GetIsPC(lastPerceived)) return;
+            if (GetIsPC(lastPerceived) || GetIsDead(lastPerceived)) return;
             var isSameFaction = GetFactionEqual(self, lastPerceived);
             if (!isSameFaction) return;
 

--- a/SWLOR.Game.Server/Service/AI.cs
+++ b/SWLOR.Game.Server/Service/AI.cs
@@ -107,6 +107,7 @@ namespace SWLOR.Game.Server.Service
         {
             ExecuteScript("crea_death_bef", OBJECT_SELF);
             RemoveFromAlliesCache();
+            RemoveEffectByTag(OBJECT_SELF, "AGGRO_AOE"); // Removes aggro AOE on dead creatures
             ExecuteScript("cdef_c2_default7", OBJECT_SELF);
             ExecuteScript("crea_death_aft", OBJECT_SELF);
         }

--- a/SWLOR.Game.Server/Service/AI.cs
+++ b/SWLOR.Game.Server/Service/AI.cs
@@ -107,7 +107,6 @@ namespace SWLOR.Game.Server.Service
         {
             ExecuteScript("crea_death_bef", OBJECT_SELF);
             RemoveFromAlliesCache();
-            RemoveEffectByTag(OBJECT_SELF, "AGGRO_AOE"); // Removes aggro AOE on dead creatures
             ExecuteScript("cdef_c2_default7", OBJECT_SELF);
             ExecuteScript("crea_death_aft", OBJECT_SELF);
         }

--- a/SWLOR.Game.Server/Service/Communication.cs
+++ b/SWLOR.Game.Server/Service/Communication.cs
@@ -137,37 +137,6 @@ namespace SWLOR.Game.Server.Service
                 return;
             }
 
-
-            if (channel == ChatChannel.PlayerShout &&
-                GetIsPC(sender) &&
-                !GetIsDM(sender) &&
-                !GetIsDMPossessed(sender))
-            {
-                var playerId = GetObjectUUID(sender);
-                var dbPlayer = DB.Get<Player>(playerId);
-
-                if (!dbPlayer.Settings.IsHolonetEnabled)
-                {
-                    SendMessageToPC(sender, "You have disabled the holonet and cannot send this message.");
-                    return;
-                }
-
-                // 5 minute wait in between Holonet messages.
-                var lastHolonet = GetLocalString(sender, "HOLONET_LAST_SEND");
-                var now = DateTime.UtcNow;
-                if (!string.IsNullOrWhiteSpace(lastHolonet))
-                {
-                    var dateTime = DateTime.ParseExact(lastHolonet, "yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
-                    if (now <= dateTime.AddMinutes(HolonetDelayMinutes))
-                    {
-                        SendMessageToPC(sender, $"Holonet messages may only be sent once per {HolonetDelayMinutes} minutes.");
-                        return;
-                    }
-                }
-
-                SetLocalString(sender, "HOLONET_LAST_SEND", now.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture));
-            }
-
             var chatComponents = new List<CommunicationComponent>();
 
             // Quick early out - if we start with "//" or "((", this is an OOC message.
@@ -221,6 +190,36 @@ namespace SWLOR.Game.Server.Service
                         component.Blue = 0;
                     }
                 }
+            }
+
+            if (channel == ChatChannel.PlayerShout &&
+                GetIsPC(sender) &&
+                !GetIsDM(sender) &&
+                !GetIsDMPossessed(sender))
+            {
+                var playerId = GetObjectUUID(sender);
+                var dbPlayer = DB.Get<Player>(playerId);
+
+                if (!dbPlayer.Settings.IsHolonetEnabled)
+                {
+                    SendMessageToPC(sender, "You have disabled the holonet and cannot send this message.");
+                    return;
+                }
+
+                // 5 minute wait in between Holonet messages.
+                var lastHolonet = GetLocalString(sender, "HOLONET_LAST_SEND");
+                var now = DateTime.UtcNow;
+                if (!string.IsNullOrWhiteSpace(lastHolonet))
+                {
+                    var dateTime = DateTime.ParseExact(lastHolonet, "yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
+                    if (now <= dateTime.AddMinutes(HolonetDelayMinutes))
+                    {
+                        SendMessageToPC(sender, $"Holonet messages may only be sent once per {HolonetDelayMinutes} minutes.");
+                        return;
+                    }
+                }
+
+                SetLocalString(sender, "HOLONET_LAST_SEND", now.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture));
             }
 
 

--- a/SWLOR.Game.Server/Service/Enmity.cs
+++ b/SWLOR.Game.Server/Service/Enmity.cs
@@ -128,6 +128,10 @@ namespace SWLOR.Game.Server.Service
         /// <param name="amount">The amount of enmity to adjust by</param>
         public static void ModifyEnmity(uint creature, uint enemy, int amount)
         {
+            // Enmity shouldn't matter if you're dead.
+            if (GetIsDead(creature) || GetIsDead(enemy))
+                return;
+
             // Players cannot be placed on an enmity table against each other.
             if (GetIsPC(creature) && GetIsPC(enemy))
                 return;

--- a/SWLOR.Game.Server/Service/Loot.cs
+++ b/SWLOR.Game.Server/Service/Loot.cs
@@ -254,6 +254,7 @@ namespace SWLOR.Game.Server.Service
         {
             var self = OBJECT_SELF;
             SetIsDestroyable(false);
+            RemoveEffectByTag(self, "AGGRO_AOE"); // Dead creatures don't need aggro!
 
             var area = GetArea(self);
             var position = GetPosition(self);

--- a/SWLOR.Game.Server/Service/Loot.cs
+++ b/SWLOR.Game.Server/Service/Loot.cs
@@ -254,7 +254,6 @@ namespace SWLOR.Game.Server.Service
         {
             var self = OBJECT_SELF;
             SetIsDestroyable(false);
-            RemoveEffectByTag(self, "AGGRO_AOE"); // Dead creatures don't need aggro!
 
             var area = GetArea(self);
             var position = GetPosition(self);


### PR DESCRIPTION
- Enemies no longer consider allied corpses as allies for the purposes of sharing aggro
- Enemy corpses no longer gain enmity after dying

Those two changes above fix the current bug where corpses left on the ground will cause enemies to aggro from across the map, seemingly at random.

- Chat macros for chat commands no longer trigger Holonet warnings / put the Holonet on cooldown