### PR TITLE
Crash fix and deflect feedback

### DIFF
--- a/SWLOR.Game.Server/Service/ColorToken.cs
+++ b/SWLOR.Game.Server/Service/ColorToken.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using NWN.Native.API;
+using System;
 
 namespace SWLOR.Game.Server.Service
 {
@@ -265,6 +266,21 @@ namespace SWLOR.Game.Server.Service
         {
             var name = GetName(oNPC);
             return TokenStart(204, 153, 204) + name + TokenEnd();
+        }
+
+        ///////////////////////////////////////////////////////////////////////////////
+        // _.GetNameNPCColor()
+        //
+        // Returns the name of creature in either light blue or purple, if the creature
+        // is a PC or an NPC. 
+        //
+
+        public static string GetNameColorNative(CNWSCreature creature)
+        {
+            var creatureName = (creature.GetFirstName().GetSimple() + " " + creature.GetLastName().GetSimple()).Trim();
+            return Convert.ToBoolean(creature.m_bPlayerCharacter) 
+                ? Custom(creatureName, 153, 255, 255) 
+                : Custom(creatureName, 204, 153, 204);
         }
 
     }

--- a/SWLOR.Game.Server/Service/Combat.cs
+++ b/SWLOR.Game.Server/Service/Combat.cs
@@ -312,13 +312,13 @@ namespace SWLOR.Game.Server.Service
                 case 4:
                     type = ": *miss*";
                     break;
+                case 2:
+                    type = ": *deflect*";
+                    break;
             }
 
-            var attackerName = (attacker.GetFirstName().GetSimple() + " " + attacker.GetLastName().GetSimple()).Trim();
-            var defenderName = (defender.GetFirstName().GetSimple() + " " + defender.GetLastName().GetSimple()).Trim();
-
-            attackerName = Convert.ToBoolean(attacker.m_bPlayerCharacter) ? ColorToken.Custom(attackerName, 153, 255, 255) : ColorToken.Custom(attackerName, 204, 153, 204);
-            defenderName = Convert.ToBoolean(defender.m_bPlayerCharacter) ? ColorToken.Custom(defenderName, 153, 255, 255) : ColorToken.Custom(defenderName, 204, 153, 204);
+            var attackerName = ColorToken.GetNameColorNative(attacker);
+            var defenderName = ColorToken.GetNameColorNative(defender);
 
             return ColorToken.Combat($"{attackerName} attacks {defenderName}{type} : ({chanceToHit}% chance to hit)");
         }


### PR DESCRIPTION
 - Fixes a server crash / segfault caused by plot-tagged creatures being hit with a critical hit
 - Gives feedback to players when a deflect roll is made