### PR TITLE
Add prefix {PC} to PC instanced areas

### DIFF
--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/ManageApartmentViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/ManageApartmentViewModel.cs
@@ -394,7 +394,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
                 DB.Set(apartment);
 
                 var instance = Property.GetRegisteredInstance(apartment.Id);
-                SetName(instance.Area, CustomName);
+                SetName(instance.Area, "{PC} " + CustomName);
 
                 Instruction = $"Saved successfully.";
                 InstructionColor = _green;

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/ShipManagementViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/ShipManagementViewModel.cs
@@ -1064,7 +1064,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
                 DB.Set(ship);
 
                 var instance = Property.GetRegisteredInstance(property.Id);
-                SetName(instance.Area, property.CustomName);
+                SetName(instance.Area, "{PC} " + property.CustomName);
 
                 // Update the UI with the new ship details.
                 ShipCountRegistered = $"Ships: {dbPlayerShips.Count + 1} / {Space.MaxRegisteredShips}";
@@ -1140,10 +1140,11 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             var dbShip = DB.Get<PlayerShip>(shipId);
             var dbProperty = DB.Get<WorldProperty>(dbShip.PropertyId);
             var instance = Property.GetRegisteredInstance(dbShip.PropertyId);
-            SetName(instance.Area, ShipName);
 
             dbProperty.CustomName = ShipName;
             DB.Set(dbProperty);
+
+            SetName(instance.Area, "{PC} " + ShipName);
 
             ShipNames[SelectedShipIndex] = ShipName;
         };

--- a/SWLOR.Game.Server/Service/Property.cs
+++ b/SWLOR.Game.Server/Service/Property.cs
@@ -2048,7 +2048,7 @@ namespace SWLOR.Game.Server.Service
                 var targetArea = CreateArea(layout.AreaInstanceResref);
                 RegisterInstance(property.Id, targetArea, property.Layout);
                 
-                SetName(targetArea, property.CustomName);
+                SetName(targetArea, "{PC} " + property.CustomName);
 
                 if (layout.OnSpawnAction != null)
                 {

--- a/SWLOR.Game.Server/Service/PropertyService/StructureChangedAction.cs
+++ b/SWLOR.Game.Server/Service/PropertyService/StructureChangedAction.cs
@@ -134,7 +134,7 @@ namespace SWLOR.Game.Server.Service.PropertyService
                 DB.Set(interior);
 
                 var instance = Property.GetRegisteredInstance(interiorId);
-                SetName(instance.Area, property.CustomName);
+                SetName(instance.Area, "{PC} " + property.CustomName);
             }
         }
 


### PR DESCRIPTION
This changes the names of PC instanced areas to have the prefix {PC} before them, which ought to push them to the bottom of the DM Chooser for easier navigation by DMs.