### PR TITLE
DM SetScale Command

### DIFF
--- a/SWLOR.Game.Server/Feature/ChatCommandDefinition/DMChatCommand.cs
+++ b/SWLOR.Game.Server/Feature/ChatCommandDefinition/DMChatCommand.cs
@@ -52,6 +52,7 @@ namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
             CreatureManager();
             Broadcast();
             SetScale();
+            GetScale();
 
             return _builder.Build();
         }
@@ -916,7 +917,7 @@ namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
                     }
 
                     // Amount is outside of our allowed range?
-                    if (value < 0.1 || value > MaxAmount)
+                    if (value < 0.1f || value > MaxAmount)
                     {
                         return "Please specify a value between 0.1 and " + MaxAmount + ".";
                     }
@@ -926,16 +927,32 @@ namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
                 .Action((user, target, location, args) =>
                 {
                     // Allows the scale value to be a decimal number.
-                    float finalvalue = float.TryParse(args[0], out var value) ? value : 1;
+                    var finalValue = float.TryParse(args[0], out var value) ? value : 1f;
 
-                    // Ensures that the decimal number does not go beyond the third decimal place.
-                    finalvalue = (float)Math.Truncate(finalvalue * 1000) / 1000;
+                    SetObjectVisualTransform(target, ObjectVisualTransform.Scale, finalValue);
 
-                    SetObjectVisualTransform(target, ObjectVisualTransform.Scale, finalvalue);
+                    // Lets the DM know what he set the scale to, but round it to the third decimal place.
+                    var targetName = GetName(target);
+                    string shownValue = finalValue.ToString("0.###");
 
-                    // Lets the DM know what he set the scale to.
-                    var targetname = GetName(target);
-                    SendMessageToPC(user, $"{targetname} scaled to {finalvalue}.");
+                    SendMessageToPC(user, $"{targetName} scaled to {shownValue}.");
+                });
+        }
+
+        private void GetScale()
+        {
+            _builder.Create("getscale")
+                .Description("Gets an object's scale.")
+                .Permissions(AuthorizationLevel.DM, AuthorizationLevel.Admin)
+                .AvailableToAllOnTestEnvironment()
+                .RequiresTarget()
+                .Action((user, target, location, args) =>
+                {
+                    var targetScale = GetObjectVisualTransform(target, ObjectVisualTransform.Scale);
+                    var targetName = GetName(target);
+                    string shownScale = targetScale.ToString("0.###");
+
+                    SendMessageToPC(user, $"{targetName} has a scale of {shownScale}.");
                 });
         }
     }

--- a/SWLOR.Game.Server/Feature/ChatCommandDefinition/DMChatCommand.cs
+++ b/SWLOR.Game.Server/Feature/ChatCommandDefinition/DMChatCommand.cs
@@ -933,7 +933,7 @@ namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
 
                     // Lets the DM know what he set the scale to, but round it to the third decimal place.
                     var targetName = GetName(target);
-                    string shownValue = finalValue.ToString("0.###");
+                    var shownValue = finalValue.ToString("0.###");
 
                     SendMessageToPC(user, $"{targetName} scaled to {shownValue}.");
                 });
@@ -950,7 +950,7 @@ namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
                 {
                     var targetScale = GetObjectVisualTransform(target, ObjectVisualTransform.Scale);
                     var targetName = GetName(target);
-                    string shownScale = targetScale.ToString("0.###");
+                    var shownScale = targetScale.ToString("0.###");
 
                     SendMessageToPC(user, $"{targetName} has a scale of {shownScale}.");
                 });

--- a/SWLOR.Game.Server/Feature/ChatCommandDefinition/DMChatCommand.cs
+++ b/SWLOR.Game.Server/Feature/ChatCommandDefinition/DMChatCommand.cs
@@ -16,7 +16,6 @@ using SWLOR.Game.Server.Core.NWNX;
 using System.Threading.Tasks;
 using Discord;
 using Discord.Webhook;
-using NRediSearch.QueryBuilder;
 
 namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
 {


### PR DESCRIPTION
Inserts a new DM command to let a DM set the scale of an object. Decimal numbers work up to the 3rd decimal point. Object cannot be scaled smaller than 0.1 or larger than 50. It will tell the DM the name of the object that was scaled as well as the value of the scaling. Validates included to ensure that if it's not a number, it'd tell the DM to specify a value between 0.1 and 50.