### PR TITLE
Suggestion: Remove CD Key and Player GSID from HoloNet broadcasts and DM Shouts

### DIFF
--- a/SWLOR.Game.Server/Feature/ChatCommandDefinition/DMChatCommand.cs
+++ b/SWLOR.Game.Server/Feature/ChatCommandDefinition/DMChatCommand.cs
@@ -870,7 +870,7 @@ namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
                     for (var onlinePlayer = GetFirstPC(); GetIsObjectValid(onlinePlayer); onlinePlayer = GetNextPC())
                         ChatPlugin.SendMessage(ChatChannel.DMShout, message, user, onlinePlayer);
                     
-                    var authorName = $"{GetName(user)} ({GetPCPlayerName(user)}) [{GetPCPublicCDKey(user)}]";
+                    var authorName = $"{GetName(user)}";
                     Task.Run(async () =>
                     {
                         using (var client = new DiscordWebhookClient(url))

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/HoloNetViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/HoloNetViewModel.cs
@@ -57,7 +57,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
 
                 AssignCommand(Player, () => TakeGoldFromCreature(BroadcastPrice, Player, true));
 
-                var authorName = $"{GetName(Player)} ({GetPCPlayerName(Player)}) [{GetPCPublicCDKey(Player)}]";
+                var authorName = $"{GetName(Player)}";
 
                 Task.Run(async () =>
                 {


### PR DESCRIPTION
Remove CD Key and Player GSID from HoloNet broadcasts and DM Shouts. It kind of kills immersion, and looks very ugly, especially the in-game HoloNet message. If a player abuses it to post something inappropriate, the message can be deleted and the player dealt with. Since player log-in names and CD keys are tracked in the server/console logs, a particularly egregious ban-worthy violation or abuse could be dealt with from there.