### PR TITLE
Area Manager

### DIFF
--- a/SWLOR.Game.Server/Entity/AreaTemplateObject.cs
+++ b/SWLOR.Game.Server/Entity/AreaTemplateObject.cs
@@ -1,0 +1,31 @@
+﻿namespace SWLOR.Game.Server.Entity
+{
+    public class AreaTemplateObject : EntityBase
+    {
+        [Indexed]
+        public string AreaResref { get; set; }
+        [Indexed]
+        public string AreaTag { get; set; }
+        [Indexed]
+        public string ObjectName { get; set; }
+        public string ObjectData { get; set; }
+        public float LocationX { get; set; }
+        public float LocationY { get; set; }
+        public float LocationZ { get; set; }
+        public float LocationOrientation { get; set; }
+        public AreaTemplateObject(string areaResRef, string areaTag, string name, string data, string locationX, string locationY, string locationZ, string locationOrientation)
+        {
+            AreaResref = areaResRef;
+            AreaTag = areaTag;
+            ObjectName = name;
+            ObjectData = data;
+        }
+        public AreaTemplateObject()
+        {
+            AreaResref = string.Empty;
+            AreaTag = string.Empty;
+            ObjectName = string.Empty;
+            ObjectData = string.Empty;
+        }
+    }
+}

--- a/SWLOR.Game.Server/Entity/TemplateArea.cs
+++ b/SWLOR.Game.Server/Entity/TemplateArea.cs
@@ -1,0 +1,14 @@
+﻿namespace SWLOR.Game.Server.Entity
+{
+    internal class TemplateArea : EntityBase
+    {
+        [Indexed]
+        public string TemplateAreaData { get; set; }
+        [Indexed]
+        public string TemplateAreaName { get; set; }
+        [Indexed]
+        public string TemplateAreaTag { get; set; }
+        [Indexed]
+        public string TemplateAreaResRef { get; set; }
+    }
+}

--- a/SWLOR.Game.Server/Entity/TemplateArea.cs
+++ b/SWLOR.Game.Server/Entity/TemplateArea.cs
@@ -1,14 +1,23 @@
-﻿namespace SWLOR.Game.Server.Entity
+﻿using System.Security.AccessControl;
+
+namespace SWLOR.Game.Server.Entity
 {
     internal class TemplateArea : EntityBase
     {
+        public string Data { get; set; }
         [Indexed]
-        public string TemplateAreaData { get; set; }
+        public string Name { get; set; }
         [Indexed]
-        public string TemplateAreaName { get; set; }
+        public string Tag { get; set; }
         [Indexed]
-        public string TemplateAreaTag { get; set; }
-        [Indexed]
-        public string TemplateAreaResRef { get; set; }
+        public string ResRef { get; set; }
+
+        public TemplateArea()
+        {
+            Data = string.Empty;
+            Name = string.Empty;
+            Tag = string.Empty;
+            ResRef = string.Empty;
+        }
     }
 }

--- a/SWLOR.Game.Server/Feature/ChatCommandDefinition/DMChatCommand.cs
+++ b/SWLOR.Game.Server/Feature/ChatCommandDefinition/DMChatCommand.cs
@@ -51,6 +51,7 @@ namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
             Notes();
             CreatureManager();
             Broadcast();
+            AreaManager();
 
             return _builder.Build();
         }
@@ -888,6 +889,16 @@ namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
                             await client.SendMessageAsync(string.Empty, embeds: new[] { embed.Build() });
                         }
                     });
+                });
+        }
+        private void AreaManager()
+        {
+            _builder.Create("am", "areas")
+                .Description("Toggles the Area Manager window.")
+                .Permissions(AuthorizationLevel.DM, AuthorizationLevel.Admin)
+                .Action((user, target, location, args) =>
+                {
+                    Gui.TogglePlayerWindow(user, GuiWindowType.AreaManager);
                 });
         }
     }

--- a/SWLOR.Game.Server/Feature/ChatCommandDefinition/DMChatCommand.cs
+++ b/SWLOR.Game.Server/Feature/ChatCommandDefinition/DMChatCommand.cs
@@ -893,7 +893,7 @@ namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
         }
         private void AreaManager()
         {
-            _builder.Create("am", "areas")
+            _builder.Create("am", "areamanager")
                 .Description("Toggles the Area Manager window.")
                 .Permissions(AuthorizationLevel.DM, AuthorizationLevel.Admin)
                 .Action((user, target, location, args) =>

--- a/SWLOR.Game.Server/Feature/GuiDefinition/AreaManagerDefinition.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/AreaManagerDefinition.cs
@@ -1,0 +1,382 @@
+﻿using SWLOR.Game.Server.Feature.GuiDefinition.ViewModel;
+using SWLOR.Game.Server.Service.GuiService;
+
+namespace SWLOR.Game.Server.Feature.GuiDefinition
+{
+    public class AreaManagerDefinition : IGuiWindowDefinition
+    {
+        private readonly GuiWindowBuilder<AreaManagerViewModel> _builder = new();
+
+        public GuiConstructedWindow BuildWindow()
+        {
+            _builder.CreateWindow(GuiWindowType.AreaManager)
+                .SetIsResizable(true)
+                .SetIsCollapsible(true)
+                .SetInitialGeometry(0, 0, 975f, 650f)
+                .SetTitle("Area Manager")
+                .BindOnClosed(model => model.OnWindowClose())
+
+                .AddColumn(colSearch =>
+                {
+                    // Main Search - Top Window Row
+                    colSearch.AddRow(row =>
+                    {
+                        row.AddTextEdit()
+                            .SetPlaceholder("Search")
+                            .BindValue(model => model.SearchText);
+
+                        row.AddButton()
+                            .SetText("X")
+                            .SetHeight(35f)
+                            .SetWidth(35f)
+                            .BindOnClicked(model => model.OnClickClearSearch());
+
+                        row.AddButton()
+                            .SetText("Search")
+                            .SetHeight(35f)
+                            .BindOnClicked(model => model.OnClickSearch());
+                    });
+
+                    // Main Window Container - Second Window Row
+                    colSearch.AddRow(row =>
+                    {
+                        row.AddColumn(colAreas =>
+                        {
+                            colAreas.SetHeight(500f);
+                            colAreas.AddRow(row =>
+                            {
+                                row.AddList(template =>
+                                {
+                                    template.AddCell(cell =>
+                                    {
+                                        cell.AddToggleButton()
+                                            .BindText(model => model.AreaNames)
+                                            .BindIsToggled(model => model.AreaToggled)
+                                            .BindOnClicked(model => model.OnSelectArea());
+                                    });
+                                })
+                                    .BindRowCount(model => model.AreaNames);
+                            });
+
+                            colAreas.AddRow(row =>
+                            {
+                                row.AddSpacer();
+
+                                row.AddButton()
+                                    .SetText("Reset Template")
+                                    .SetHeight(35f)
+                                    .BindIsEnabled(model => model.IsResetAreaEnabled)
+                                    .BindOnClicked(model => model.OnClickResetArea());
+
+                                row.AddButton()
+                                    .SetText("Create Template")
+                                    .SetHeight(35f)
+                                    .BindOnClicked(model => model.CreateNewAreaTemplate());
+
+                                row.AddSpacer();
+                            });
+
+                            colAreas.AddRow(row =>
+                            {
+                                row.AddSpacer();
+
+                                row.AddButton()
+                                    .SetText("Goto Template")
+                                    .SetHeight(35f)
+                                    .BindOnClicked(model => model.OnClickGoToArea());
+
+                                row.AddButton()
+                                    .SetText("Delete Template")
+                                    .SetHeight(35f)
+                                    .BindOnClicked(model => model.OnClickDeleteAreaTemplate());
+
+                                row.AddSpacer();
+                            });
+                        });
+
+                        row.AddColumn(colObjects =>
+                        {
+                            colObjects.SetHeight(450f);
+                            colObjects.SetWidth(325f);
+                            colObjects.AddRow(row =>
+                            {
+                                row.AddList(template =>
+                                {
+                                    template.SetHeight(450f);
+
+                                    template.AddCell(cell =>
+                                    {
+                                        cell.AddToggleButton()
+                                            .BindText(model => model.AreaObjectList)
+                                            .BindIsToggled(model => model.AreaObjectToggled)
+                                            .BindOnClicked(model => model.OnSelectAreaObject());
+                                    });
+                                })
+                                .BindRowCount(model => model.AreaObjectList);
+                            });
+
+                            colObjects.AddRow(row =>
+                            {
+                                row.AddButton()
+                                    .SetText("Delete Object")
+                                    .SetHeight(35f)
+                                    .BindIsEnabled(model => model.IsDeleteObjectEnabled)
+                                    .BindOnClicked(model => model.OnClickDeleteObject());
+
+                                row.AddButton()
+                                    .SetText("Goto Object")
+                                    .SetHeight(35f)
+                                    .BindIsEnabled(model => model.IsSelectedObjectPlaceableOrCreature)
+                                    .BindOnClicked(model => model.OnClickGoToObject());
+                            });
+                        });
+
+                        row.AddColumn(colEditor =>
+                        {
+                            colEditor.SetHeight(500f);
+                            colEditor.SetWidth(325f);
+
+                            colEditor.AddRow(rowEditor =>
+                            {
+                                rowEditor.AddTextEdit()
+                                    .BindValue(model => model.SelectedAreaObjectName)
+                                    .BindIsEnabled(model => model.IsSelectedObjectPlaceableOrCreature)
+                                    .SetPlaceholder("Object Name")
+                                    .SetMaxLength(100);
+                            });
+
+                            colEditor.AddRow(rowEditor =>
+                            {
+                                rowEditor.AddLabel()
+                                    .SetText("Position")
+                                    .SetHeight(20f);
+                            });
+
+                            colEditor.AddRow(rowEditor =>
+                            {
+                                rowEditor.AddSpacer();
+
+                                rowEditor.AddButtonImage()
+                                    .SetImageResref("arrow_up")
+                                    .SetTooltip("Y-Axis +")
+                                    .BindOnClicked(model => model.OnYAxisUp())
+                                    .SetWidth(32f)
+                                    .SetHeight(32f)
+                                    .BindIsEnabled(model => model.IsSelectedObjectPlaceableOrCreature);
+
+                                rowEditor.AddButtonImage()
+                                    .SetImageResref("arrow_down")
+                                    .SetTooltip("Y-Axis -")
+                                    .BindOnClicked(model => model.OnYAxisDown())
+                                    .SetWidth(32f)
+                                    .SetHeight(32f)
+                                    .BindIsEnabled(model => model.IsSelectedObjectPlaceableOrCreature);
+
+                                rowEditor.AddButtonImage()
+                                    .SetImageResref("arrow_right")
+                                    .SetTooltip("X-Axis +")
+                                    .BindOnClicked(model => model.OnXAxisUp())
+                                    .SetWidth(32f)
+                                    .SetHeight(32f)
+                                    .BindIsEnabled(model => model.IsSelectedObjectPlaceableOrCreature);
+
+                                rowEditor.AddButtonImage()
+                                    .SetImageResref("arrow_left")
+                                    .SetTooltip("X-Axis -")
+                                    .BindOnClicked(model => model.OnXAxisDown())
+                                    .SetWidth(32f)
+                                    .SetHeight(32f)
+                                    .BindIsEnabled(model => model.IsSelectedObjectPlaceableOrCreature);
+
+                                rowEditor.AddButtonImage()
+                                    .SetImageResref("arrow_zup")
+                                    .SetTooltip("Z-Axis +")
+                                    .BindOnClicked(model => model.OnZAxisUp())
+                                    .SetWidth(32f)
+                                    .SetHeight(32f)
+                                    .BindIsEnabled(model => model.IsSelectedObjectPlaceableOrCreature);
+
+                                rowEditor.AddButtonImage()
+                                    .SetImageResref("arrow_zdown")
+                                    .SetTooltip("Z-Axis -")
+                                    .BindOnClicked(model => model.OnZAxisDown())
+                                    .SetWidth(32f)
+                                    .SetHeight(32f)
+                                    .BindIsEnabled(model => model.IsSelectedObjectPlaceableOrCreature);
+
+                                rowEditor.AddButtonImage()
+                                    .SetImageResref("level")
+                                    .SetTooltip("Z-Axis Reset")
+                                    .BindOnClicked(model => model.OnZAxisReset())
+                                    .SetWidth(32f)
+                                    .SetHeight(32f)
+                                    .BindIsEnabled(model => model.IsSelectedObjectPlaceableOrCreature);
+
+                                rowEditor.AddSpacer();
+                            });
+
+                            colEditor.AddRow(rowEditor =>
+                            {
+                                rowEditor.AddLabel()
+                                    .SetText("Facing")
+                                    .SetHeight(20f);
+                            });
+
+                            colEditor.AddRow(rowEditor =>
+                            {
+                                rowEditor.AddSpacer();
+
+                                rowEditor.AddButtonImage()
+                                    .SetImageResref("clockwise")
+                                    .SetTooltip("Clockwise")
+                                    .BindOnClicked(model => model.OnRotateClockwise())
+                                    .SetWidth(32f)
+                                    .SetHeight(32f)
+                                    .BindIsEnabled(model => model.IsSelectedObjectPlaceableOrCreature);
+
+                                rowEditor.AddButtonImage()
+                                    .SetImageResref("counterclockwise")
+                                    .SetTooltip("Counter-Clockwise")
+                                    .BindOnClicked(model => model.OnRotateCounterClockwise())
+                                    .SetWidth(32f)
+                                    .SetHeight(32f)
+                                    .BindIsEnabled(model => model.IsSelectedObjectPlaceableOrCreature);
+
+                                rowEditor.AddButtonImage()
+                                    .SetImageResref("north")
+                                    .SetTooltip("North")
+                                    .BindOnClicked(model => model.OnSetFacingNorth())
+                                    .SetWidth(32f)
+                                    .SetHeight(32f)
+                                    .BindIsEnabled(model => model.IsSelectedObjectPlaceableOrCreature);
+
+                                rowEditor.AddButtonImage()
+                                    .SetImageResref("south")
+                                    .SetTooltip("South")
+                                    .BindOnClicked(model => model.OnSetFacingSouth())
+                                    .SetWidth(32f)
+                                    .SetHeight(32f)
+                                    .BindIsEnabled(model => model.IsSelectedObjectPlaceableOrCreature);
+
+                                rowEditor.AddButtonImage()
+                                    .SetImageResref("east")
+                                    .SetTooltip("East")
+                                    .BindOnClicked(model => model.OnSetFacingEast())
+                                    .SetWidth(32f)
+                                    .SetHeight(32f)
+                                    .BindIsEnabled(model => model.IsSelectedObjectPlaceableOrCreature);
+
+                                rowEditor.AddButtonImage()
+                                    .SetImageResref("west")
+                                    .SetTooltip("West")
+                                    .BindOnClicked(model => model.OnSetFacingWest())
+                                    .SetWidth(32f)
+                                    .SetHeight(32f)
+                                    .BindIsEnabled(model => model.IsSelectedObjectPlaceableOrCreature);
+
+                                rowEditor.AddSpacer();
+                            });
+
+                            colEditor.AddRow(rowEditor =>
+                            {
+                                rowEditor.AddLabel()
+                                    .SetText("Appearance")
+                                    .SetHeight(20f);
+                            });
+
+                            colEditor.AddRow(rowEditor =>
+                            {
+                                rowEditor.AddTextEdit()
+                                    .SetPlaceholder("Search")
+                                    .SetMaxLength(100)
+                                    .BindIsEnabled(model => model.IsSelectedObjectPlaceableOrCreature)
+                                    .BindValue(model => model.SearchAppearanceText);
+
+                                rowEditor.AddButton()
+                                    .SetText("X")
+                                    .SetHeight(35f)
+                                    .SetWidth(35f)
+                                    .BindIsEnabled(model => model.IsSelectedObjectPlaceableOrCreature)
+                                .BindOnClicked(model => model.OnClickClearAppearanceSearch());
+
+                                rowEditor.AddButton()
+                                    .SetText("Search")
+                                    .SetHeight(35f)
+                                    .BindIsEnabled(model => model.IsSelectedObjectPlaceableOrCreature)
+                                    .BindOnClicked(model => model.OnClickAppearanceSearch());
+                            });
+
+                            colEditor.AddRow(rowEditor =>
+                            {
+                                colEditor.AddRow(row =>
+                                {
+                                    row.SetHeight(200f);
+
+                                    row.AddList(template =>
+                                    {
+                                        template.BindIsEnabled(model => model.IsSelectedObjectPlaceableOrCreature);
+
+                                        template.AddCell(cell =>
+                                        {
+                                            cell.AddToggleButton()
+                                                .BindText(model => model.ObjectAppearanceList)
+                                                .BindIsToggled(model => model.ObjectAppearanceToggled)
+                                                .BindOnClicked(model => model.OnSelectObjectAppearance());
+                                        });
+                                    })
+                                    .BindRowCount(model => model.ObjectAppearanceList);
+                                });
+                            });
+
+                            colEditor.AddRow(rowEditor =>
+                            {
+                                rowEditor.AddSpacer();
+                                rowEditor.AddButton()
+                                    .SetText("<")
+                                    .SetWidth(32f)
+                                    .SetHeight(35f)
+                                    .BindIsEnabled(model => model.IsSelectedObjectPlaceableOrCreature)
+                                    .BindOnClicked(model => model.OnPreviousPageAppearance());
+
+                                rowEditor.AddComboBox()
+                                    .BindOptions(model => model.PageNumbersAppearances)
+                                    .BindIsEnabled(model => model.IsSelectedObjectPlaceableOrCreature)
+                                    .BindSelectedIndex(model => model.SelectedPageIndexAppearances);
+
+                                rowEditor.AddButton()
+                                    .SetText(">")
+                                    .SetWidth(32f)
+                                    .SetHeight(35f)
+                                    .BindIsEnabled(model => model.IsSelectedObjectPlaceableOrCreature)
+                                    .BindOnClicked(model => model.OnNextPageAppearance());
+
+                                rowEditor.AddSpacer();
+                            });
+
+                            colEditor.AddRow(rowEditor =>
+                            {
+                                rowEditor.AddSpacer();
+                            });
+
+                            colEditor.AddRow(rowEditor =>
+                            {
+                                rowEditor.AddButton()
+                                    .SetText("Save Changes")
+                                    .BindOnClicked(model => model.OnSaveObjectChanges())
+                                    .BindIsEnabled(model => model.IsSelectedObjectPlaceableOrCreature)
+                                    .SetHeight(35f);
+
+                                rowEditor.AddButton()
+                                    .SetText("Resave All Objects")
+                                    .SetHeight(35f)
+                                    .BindIsEnabled(model => model.IsResaveAllObjectsEnabled)
+                                    .BindOnClicked(model => model.OnClickResaveAllObjects());
+                            });
+                        });
+                    });
+                });
+
+            return _builder.Build();
+        }       
+    }
+}

--- a/SWLOR.Game.Server/Feature/GuiDefinition/AreaManagerNamingDefinition.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/AreaManagerNamingDefinition.cs
@@ -20,7 +20,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                     col.AddRow(row =>
                     {
                         row.AddLabel()
-                            .SetText("Please type in your new template area's name. Remember, it should not be longer than 40 characters!)")
+                            .SetText($"Please type in your new template area's name. Remember, it should not be longer than {AreaManagerNamingViewModel.MaxTemplateAreaNewNameLength} characters!)")
                             .SetIsVisible(true)
                             .SetWidth(800f);
 

--- a/SWLOR.Game.Server/Feature/GuiDefinition/AreaManagerNamingDefinition.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/AreaManagerNamingDefinition.cs
@@ -1,0 +1,63 @@
+﻿using SWLOR.Game.Server.Feature.GuiDefinition.ViewModel;
+using SWLOR.Game.Server.Service.GuiService;
+
+namespace SWLOR.Game.Server.Feature.GuiDefinition
+{
+    public class AreaManagerNamingDefinition : IGuiWindowDefinition
+    {
+        private readonly GuiWindowBuilder<AreaManagerNamingViewModel> _builder = new();
+
+        public GuiConstructedWindow BuildWindow()
+        {
+            _builder.CreateWindow(GuiWindowType.AreaManagerNaming)
+                .SetIsResizable(true)
+                .SetIsCollapsible(true)
+                .SetInitialGeometry(0, 0, 829f, 453f)
+                .SetTitle("Template Area Naming")
+
+                .AddColumn(col =>
+                {
+                    col.AddRow(row =>
+                    {
+                        row.AddLabel()
+                            .SetText("Please type in your new template area's name. Remember, it should not be longer than 40 characters!)")
+                            .SetIsVisible(true)
+                            .SetWidth(800f);
+
+                        row.SetHeight(20f);
+                    });
+
+                    col.AddRow(row =>
+                    {
+                        row.AddTextEdit()
+                            .SetIsMultiline(true)
+                            .SetMaxLength(AreaManagerNamingViewModel.MaxTemplateAreaNewNameLength)
+                            .BindValue(model => model.TemplateAreaNewName)
+                            .SetIsEnabled(true)
+                            .SetHeight(300f);
+                    });
+
+                    col.AddRow(row =>
+                    {
+                        row.AddSpacer();
+                        row.AddButton()
+                            .BindOnClicked(model => model.OnClickSubmit())
+                            .SetHeight(35f)
+                            .SetText("Set Name")
+                            .SetIsEnabled(true);
+
+                        row.AddButton()
+                            .BindOnClicked(model => model.OnClickCancel())
+                            .SetHeight(35f)
+                            .SetText("Cancel")
+                            .SetIsEnabled(true);
+
+                        row.AddSpacer();
+                    });
+
+                });
+
+            return _builder.Build();
+        }
+    }
+}

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/AreaManagerNamingViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/AreaManagerNamingViewModel.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using SWLOR.Game.Server.Core.NWNX;
+using SWLOR.Game.Server.Entity;
+using SWLOR.Game.Server.Core.NWScript.Enum;
+using SWLOR.Game.Server.Core.NWScript.Enum.Area;
+using SWLOR.Game.Server.Service;
+using SWLOR.Game.Server.Service.GuiService;
+
+namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
+{
+    public class AreaManagerNamingViewModel : GuiViewModelBase<AreaManagerNamingViewModel, GuiPayloadBase>
+    {
+        public string TemplateAreaNewName
+        {
+            get => Get<string>();
+            set => Set(value);
+        }
+
+        public const int MaxTemplateAreaNewNameLength = 40;
+
+        protected override void Initialize(GuiPayloadBase initialPayload)
+        {
+            TemplateAreaNewName = string.Empty;
+            WatchOnClient(model => model.TemplateAreaNewName);
+        }
+
+        public Action OnClickSubmit() => () =>
+        {
+            if (string.IsNullOrWhiteSpace(TemplateAreaNewName))
+            {
+                return;
+            }
+
+            var templateAreaName = "[Template] " + TemplateAreaNewName;
+
+            if (templateAreaName.Length > MaxTemplateAreaNewNameLength)
+            {
+                SendMessageToPC(Player, $"The template area's new name is to long. Please shorten it to no longer than {TemplateAreaNewName} characters and resubmit.");
+                return;
+            }
+
+            var area = GetArea(Player);
+
+            if (AreaManagerViewModel.GetIsTemplateArea(area))
+            {
+                SendMessageToPC(Player, $"Please do not create a template area of a template area. Go to the area that is part of the core module and template that instead.");
+                Gui.TogglePlayerWindow(Player, GuiWindowType.AreaManagerNaming);
+                return;
+            }
+
+            // Stores transition targets to restore after CreateArea is called.
+            for (var x = GetFirstObjectInArea(area); GetIsObjectValid(x); x = GetNextObjectInArea(area))
+            {
+                if (GetTransitionTarget(x) != OBJECT_INVALID)
+                    SetLocalObject(x, "ORIGINAL_TRANSITION_TARGET", GetTransitionTarget(x));
+            }
+
+            // Generating a random number for the area tag allows for duplicates of the same area without messing up the way in which objects are saved
+            // in each template area. It's very improbable that two duplicate areas would have the exact same tag name and randomize the exact same number.
+            // However, it's less improbable that two areas may have the exact same tag names. For example, if a DM names all his template areas "Ziya's Corellian Event Zone 1" then
+            // there's a high chance all his areas would be "tmp_ziyascorelli" since it caps at 16 characters, which could mess up the ways objects are saved
+            // to each template area. By adding a random 3-digit number to each template area's tag, it makes that duplication highly improbable.
+            var randomNumber = Random(999);
+            var targetArea = CreateArea(GetResRef(area), "tmp_" + randomNumber + GetTag(area), templateAreaName);
+            SetLocalBool(targetArea, "IS_TEMPLATE_AREA", true);
+
+            // This creates the area and stores it in the database so that it can be loaded with each module load.
+            var templateAreaTag = GetTag(targetArea);
+            var templateAreaResRef = GetResRef(area);
+
+            var templateArea = new TemplateArea
+            {
+                TemplateAreaName = templateAreaName,
+                TemplateAreaTag = templateAreaTag,
+                TemplateAreaResRef = templateAreaResRef,
+            };
+            DB.Set(templateArea);
+
+            // This deletes all of the creatures, waypoints, and transitions. Since many of our transitions are
+            // placeables with the DESTINATION tag, the GetObjectType(x) == ObjectType.Placeable && GetLocalBool(x, "DESTINATION")) line
+            // deletes placeables that serve as transitions, which would solve bugs like the placeable teleport
+            // in Jim's Cantina surviving to the template area and teleporting people to weird places. 
+            for (var x = GetFirstObjectInArea(targetArea); GetIsObjectValid(x); x = GetNextObjectInArea(targetArea))
+            {
+                var isTeleportPlaceable = GetLocalString(x, "DESTINATION");
+
+                if (GetObjectType(x) == ObjectType.Creature ||
+                    GetObjectType(x) == ObjectType.Waypoint ||
+                    GetObjectType(x) == ObjectType.Trigger ||
+                    (GetObjectType(x) == ObjectType.Placeable && (isTeleportPlaceable != "")))
+                {
+                    DestroyObject(x);
+                }
+
+                if (GetObjectType(x) == ObjectType.Door)
+                {
+                    SetTransitionTarget(x, OBJECT_INVALID);
+                }
+            }
+            var creatorName = GetName(Player);
+            var areaName = GetName(area);
+
+            Console.WriteLine($"{creatorName} has created a new template area named: {areaName}");
+
+            AreaManagerViewModel.CacheTemplateArea(GetResRef(targetArea), targetArea);
+
+            // Restores the transition targets.
+            for (var x = GetFirstObjectInArea(area); GetIsObjectValid(x); x = GetNextObjectInArea(area))
+            {
+                var transitionTarget = GetLocalObject(x, "ORIGINAL_TRANSITION_TARGET");
+                if (transitionTarget != OBJECT_INVALID)
+                {
+                    SetTransitionTarget(transitionTarget, x);
+                    DeleteLocalObject(x, "ORIGINAL_TRANSITION_TARGET");
+                }
+            }
+            Gui.TogglePlayerWindow(Player, GuiWindowType.AreaManagerNaming);
+            Gui.TogglePlayerWindow(Player, GuiWindowType.AreaManager);
+
+            // Sends the creator of the template area to the template area after it's created.
+            var centerHeightOfTemplateArea = GetAreaSize(Dimension.Height, targetArea) / 2f;
+            var centerWidthOfTemplateArea = GetAreaSize(Dimension.Width, targetArea) / 2f;
+            var centerHeightOfTemplateAreaInMeters = centerHeightOfTemplateArea * 10f;
+            var centerWidthOfTemplateAreaInMeters = centerWidthOfTemplateArea * 10f;
+            var vectorOfTemplateArea = Vector3(centerHeightOfTemplateAreaInMeters, centerWidthOfTemplateAreaInMeters, 0.0f);
+            var position = Location(targetArea, vectorOfTemplateArea, 0.0f);
+
+            AssignCommand(Player, () => ActionJumpToLocation(position));
+        };
+
+        public Action OnClickCancel() => () =>
+        {
+            Gui.TogglePlayerWindow(Player, GuiWindowType.AreaManagerNaming);
+        };
+    }
+}

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/AreaManagerNamingViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/AreaManagerNamingViewModel.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using SWLOR.Game.Server.Core.NWNX;
 using SWLOR.Game.Server.Entity;
 using SWLOR.Game.Server.Core.NWScript.Enum;
 using SWLOR.Game.Server.Core.NWScript.Enum.Area;
@@ -16,7 +15,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             set => Set(value);
         }
 
-        public const int MaxTemplateAreaNewNameLength = 40;
+        public const int MaxTemplateAreaNewNameLength = 25;
 
         protected override void Initialize(GuiPayloadBase initialPayload)
         {
@@ -35,7 +34,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
 
             if (templateAreaName.Length > MaxTemplateAreaNewNameLength)
             {
-                SendMessageToPC(Player, $"The template area's new name is to long. Please shorten it to no longer than {TemplateAreaNewName} characters and resubmit.");
+                SendMessageToPC(Player, $"The template area's new name is too long. Please shorten it to no longer than {MaxTemplateAreaNewNameLength} characters and resubmit.");
                 return;
             }
 
@@ -70,9 +69,9 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
 
             var templateArea = new TemplateArea
             {
-                TemplateAreaName = templateAreaName,
-                TemplateAreaTag = templateAreaTag,
-                TemplateAreaResRef = templateAreaResRef,
+                Name = templateAreaName,
+                Tag = templateAreaTag,
+                ResRef = templateAreaResRef,
             };
             DB.Set(templateArea);
 

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/AreaManagerViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/AreaManagerViewModel.cs
@@ -1,0 +1,922 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using SWLOR.Game.Server.Core.NWNX;
+using SWLOR.Game.Server.Core.NWScript.Enum;
+using SWLOR.Game.Server.Core.NWScript.Enum.VisualEffect;
+using SWLOR.Game.Server.Service;
+using SWLOR.Game.Server.Service.GuiService;
+using SWLOR.Game.Server.Service.GuiService.Component;
+using SWLOR.Game.Server.Entity;
+using SWLOR.Game.Server.Service.DBService;
+using Pipelines.Sockets.Unofficial.Arenas;
+using SWLOR.Game.Server.Core.NWScript.Enum.Area;
+
+namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
+{
+    public class AreaManagerViewModel: GuiViewModelBase<AreaManagerViewModel, GuiPayloadBase>
+    {
+        private readonly List<uint> _areas = new();
+        private readonly List<uint> _objects = new();
+        private readonly List<int> _objectAppearanceIds = new();
+        private readonly List<string> _objectAppearanceNames = new();
+
+        private static Dictionary<int, Dictionary<int, string>> _placeableAppearanceByPage { get; } = new();
+        private static Dictionary<int, Dictionary<int, string>> _creatureAppearanceByPage { get; } = new();
+        private static int _totalCountAppearancePlaceables;
+        private static int _totalCountAppearanceCreatures;
+
+        // Despite being greyed out, this private bool is actually used - if deleted, it'll cause a lot of errors.
+        private bool _skipPaginationSearch;
+
+        public string SearchText
+        {
+            get => Get<string>();
+            set => Set(value);
+        }
+        public string SearchAppearanceText
+        {
+            get => Get<string>();
+            set => Set(value);
+        }
+
+        public bool IsDeleteObjectEnabled
+        {
+            get => Get<bool>();
+            set => Set(value);
+        }
+        public bool IsResetAreaEnabled
+        {
+            get => Get<bool>();
+            set => Set(value);
+        }
+        public bool IsResaveAllObjectsEnabled
+        {
+            get => Get<bool>();
+            set => Set(value);
+        }
+        public bool IsSelectedObjectPlaceableOrCreature
+        {
+            get => Get<bool>();
+            set => Set(value);
+        }
+
+        public int SelectedAreaIndex
+        {
+            get => Get<int>();
+            set
+            {
+                Set(value);
+                _objectAppearanceIds.Clear();
+                _objectAppearanceNames.Clear();
+                _placeableAppearanceByPage.Clear();
+                _creatureAppearanceByPage.Clear();
+                ObjectAppearanceList = new GuiBindingList<string>();
+                ObjectAppearanceToggled = new GuiBindingList<bool>();
+                SelectedAreaObjectIndex = -1;
+            }
+        }
+        public int SelectedAreaObjectIndex
+        {
+            get => Get<int>();
+            set 
+            { 
+                Set(value);
+                _objectAppearanceIds.Clear();
+                _objectAppearanceNames.Clear();
+                _placeableAppearanceByPage.Clear();
+                _creatureAppearanceByPage.Clear();
+                ObjectAppearanceList = new GuiBindingList<string>();
+                ObjectAppearanceToggled = new GuiBindingList<bool>();
+            }
+        }
+        public int SelectedAppearanceIndex
+        {
+            get => Get<int>();
+            set => Set(value);
+        }
+
+        public string SelectedAreaObjectName
+        {
+            get => Get<string>();
+            set => Set(value);
+        }
+
+        public GuiBindingList<bool> AreaToggled
+        {
+            get => Get<GuiBindingList<bool>>();
+            set => Set(value);
+        }
+        public GuiBindingList<bool> AreaObjectToggled
+        {
+            get => Get<GuiBindingList<bool>>();
+            set => Set(value);
+        }
+        public GuiBindingList<bool> ObjectAppearanceToggled
+        {
+            get => Get<GuiBindingList<bool>>();
+            set => Set(value);
+        }
+
+        public GuiBindingList<string> AreaResrefs
+        {
+            get => Get<GuiBindingList<string>>();
+            set => Set(value);
+        }
+        public GuiBindingList<string> AreaNames
+        {
+            get => Get<GuiBindingList<string>>();
+            set => Set(value);
+        }
+        public GuiBindingList<string> AreaObjectList
+        {
+            get => Get<GuiBindingList<string>>();
+            set => Set(value);
+        }
+        public GuiBindingList<string> ObjectAppearanceList
+        {
+            get => Get<GuiBindingList<string>>();
+            set => Set(value);
+        }
+
+        public GuiBindingList<GuiComboEntry> PageNumbersAppearances
+        {
+            get => Get<GuiBindingList<GuiComboEntry>>();
+            set => Set(value);
+        }
+
+        public int SelectedPageIndexAppearances
+        {
+            get => Get<int>();
+            set => Set(value);           
+        }
+
+        public static void CacheTemplateArea(string resref, uint area)
+        {
+            Service.AreaTemplate.TemplateAreaByResRef[resref] = area;
+        }
+
+        public static bool GetIsTemplateArea(uint area)
+        {
+            return GetLocalBool(area, "IS_TEMPLATE_AREA");
+        }
+
+        protected override void Initialize(GuiPayloadBase initialPayload)
+        {
+            Init();            
+            Search();
+            WatchOnClient(model => model.SearchText);
+            WatchOnClient(model => model.SearchAppearanceText); 
+            WatchOnClient(model => model.SelectedAreaObjectName);
+            WatchOnClient(model => model.SelectedPageIndexAppearances);
+        }
+
+        public Action OnSelectArea() => () =>
+        {
+            _skipPaginationSearch = true;
+            ClearObjectHighlight();
+
+            if (SelectedAreaIndex > -1)
+                AreaToggled[SelectedAreaIndex] = false;
+
+            if (SelectedAreaObjectIndex > -1)
+            {
+                AreaObjectToggled[SelectedAreaObjectIndex] = false;
+                PlayerPlugin.ApplyLoopingVisualEffectToObject(Player, _objects[SelectedAreaObjectIndex], VisualEffect.None);
+            }
+
+            var index = NuiGetEventArrayIndex();
+            SelectedAreaIndex = index;
+
+            LoadAreaObjectList();
+
+            SelectedAreaObjectName = String.Empty;
+
+            IsDeleteObjectEnabled = false;
+            IsResetAreaEnabled = true;
+            IsResaveAllObjectsEnabled = true;
+
+            AreaToggled[index] = true;
+            _skipPaginationSearch = false;
+        };
+
+        public Action OnSelectAreaObject() => () =>
+        {
+            _skipPaginationSearch = true;
+            ClearObjectHighlight();
+
+            if (SelectedAreaObjectIndex > -1)
+                AreaObjectToggled[SelectedAreaObjectIndex] = false;                
+
+            var index = NuiGetEventArrayIndex();
+            SelectedAreaObjectIndex = index;
+
+            if (GetObjectType(_objects[SelectedAreaObjectIndex]) == ObjectType.Placeable ||
+                GetObjectType(_objects[SelectedAreaObjectIndex]) == ObjectType.Creature)
+            {
+                IsSelectedObjectPlaceableOrCreature = true;
+                PlayerPlugin.ApplyLoopingVisualEffectToObject(Player, _objects[SelectedAreaObjectIndex], VisualEffect.Vfx_Dur_Aura_Green);
+                SelectedAreaObjectName = GetName(_objects[SelectedAreaObjectIndex]);
+            }
+            else
+            {
+                IsSelectedObjectPlaceableOrCreature = false;
+            }
+
+            SearchAppearances(GetObjectType(_objects[SelectedAreaObjectIndex]));
+
+            IsDeleteObjectEnabled = true;
+            AreaObjectToggled[index] = true;
+            _skipPaginationSearch = false;
+        };
+
+        public Action OnClickDeleteObject() => () =>
+        {
+            if (SelectedAreaIndex < 0)
+                return;
+
+            var areaObject = _objects[SelectedAreaObjectIndex];
+            var areaObjectId = GetLocalString(areaObject, "DBID");
+
+            var query = new DBQuery<AreaTemplateObject>()
+                .AddFieldSearch(nameof(AreaTemplateObject.AreaResref), GetResRef(_areas[SelectedAreaIndex]), false)
+                .AddFieldSearch(nameof(AreaTemplateObject.Id), areaObjectId, false)
+                .OrderBy(nameof(AreaTemplateObject.AreaResref));
+            var areaTemplates = DB.Search(query)
+                .ToList();
+
+            foreach (var dbRecord in areaTemplates)
+            {
+                DB.Delete<AreaTemplateObject>(dbRecord.Id);
+            }
+
+            AreaTemplate.RemoveTemplateAreaCustomObjectByArea(_areas[SelectedAreaIndex], areaObject);
+            DestroyObject(areaObject);
+
+            _objects.RemoveAt(SelectedAreaObjectIndex);
+            AreaObjectList.RemoveAt(SelectedAreaObjectIndex);
+            AreaObjectToggled.RemoveAt(SelectedAreaObjectIndex);
+            SelectedAreaObjectIndex = -1;
+            IsDeleteObjectEnabled = false;
+        };
+
+        /// <summary>
+        /// Click this to delete all objects currently in the selected Template Area to reset it.
+        /// </summary>
+        /// <returns></returns>
+        public Action OnClickResetArea() => () =>
+        {
+            if (!(SelectedAreaIndex > -1))
+                return;
+
+            ShowModal($"Are you sure you want to permanently remove all DM spawned objects from '{AreaNames[SelectedAreaIndex]}'", () =>
+            {
+                var query = new DBQuery<AreaTemplateObject>()
+                    .AddFieldSearch(nameof(AreaTemplateObject.AreaResref), GetResRef(_areas[SelectedAreaIndex]), false)
+                    .OrderBy(nameof(AreaTemplateObject.AreaResref));
+                var areaTemplates = DB.Search(query)
+                    .ToList();
+
+                foreach (var dbRecord in areaTemplates)
+                {
+                    DB.Delete<AreaTemplateObject>(dbRecord.Id);
+                }
+
+                foreach (var areaObject in AreaTemplate.GetTemplateAreaCustomObjectsByArea(_areas[SelectedAreaIndex]))
+                {
+                    AreaTemplate.RemoveTemplateAreaCustomObjectByArea(_areas[SelectedAreaIndex], areaObject);
+                    DestroyObject(areaObject);
+                }
+                Search();
+            });
+        };
+
+        public Action OnClickResaveAllObjects() => () =>
+        {
+            ClearObjectHighlight();
+
+            if (!(SelectedAreaIndex > -1))
+                return;
+
+            ShowModal($"Are you sure you want to permanently resave all DM spawned objects in '{AreaNames[SelectedAreaIndex]}'?", () =>
+            {
+                AreaTemplate.ResaveAllAreaTemplateObjectsByArea(_areas[SelectedAreaIndex]);
+                Search();
+            });
+        };
+
+        /// <summary>
+        /// Click this to create a new Template Area. It opens up another GuiWindow that names said new Template Area before creating it.
+        /// </summary>
+        /// <returns></returns>
+
+        public Action CreateNewAreaTemplate() => () =>
+        {
+            ShowModal($"Are you sure you want to create a new template area? Try not to flood the module with too many of those!", () =>
+            {
+                Gui.TogglePlayerWindow(Player, GuiWindowType.AreaManagerNaming);
+            });
+        };
+
+        /// <summary>
+        /// Click this to delete the selected Template Area and all objects saved to it. There's a modal to prevent DMs from accidental deletion, but otherwise, DMs are expected not to abuse this.
+        /// </summary>
+        /// <returns></returns>
+        public Action OnClickDeleteAreaTemplate() => () =>
+        {
+            if (!(SelectedAreaIndex > -1))
+                return;
+
+            ShowModal($"Are you sure you want to permanently delete '{AreaNames[SelectedAreaIndex]}'? The template area cannot be recovered. This action cannot be undone. Please ensure that you are deleting the right area and not another DM's work!", () =>
+            {
+                var query = new DBQuery<AreaTemplateObject>()
+                    .AddFieldSearch(nameof(AreaTemplateObject.AreaResref), GetResRef(_areas[SelectedAreaIndex]), false)
+                    .OrderBy(nameof(AreaTemplateObject.AreaResref));
+                var areaTemplates = DB.Search(query)
+                    .ToList();
+
+                foreach (var dbRecord in areaTemplates)
+                {
+                    DB.Delete<AreaTemplateObject>(dbRecord.Id);
+                }
+
+                foreach (var areaObject in AreaTemplate.GetTemplateAreaCustomObjectsByArea(_areas[SelectedAreaIndex]))
+                {
+                    AreaTemplate.RemoveTemplateAreaCustomObjectByArea(_areas[SelectedAreaIndex], areaObject);
+                    DestroyObject(areaObject);
+                }
+
+                var areaTemplateQuery = new DBQuery<TemplateArea>()
+                    .AddFieldSearch(nameof(TemplateArea.TemplateAreaTag), GetTag(_areas[SelectedAreaIndex]), false);
+                var templateArea = DB.Search(areaTemplateQuery)
+                    .ToList();
+
+                foreach (var dbRecord in templateArea)
+                {
+                    var playerName = GetName(Player);
+                    
+                    DB.Delete<TemplateArea>(dbRecord.Id);
+                    Console.WriteLine($"{playerName} has deleted {dbRecord.TemplateAreaName}");
+                }
+
+                DestroyArea(_areas[SelectedAreaIndex]);
+                Search();
+            });
+        };
+
+        public Action OnClickSearch() => Search;
+
+        public Action OnClickClearSearch() => () =>
+        {
+            SearchText = string.Empty;
+            Search();
+        };
+
+        public Action OnClickAppearanceSearch() => () =>
+        {
+            SelectedPageIndexAppearances = 0;
+            SearchAppearances(GetObjectType(_objects[SelectedAreaObjectIndex]));
+        };
+
+        public Action OnClickClearAppearanceSearch() => () =>
+        {
+            SelectedPageIndexAppearances = 0;
+            SearchAppearanceText = string.Empty;
+            SearchAppearances(GetObjectType(_objects[SelectedAreaObjectIndex]));
+        };
+
+        public Action OnWindowClose() => () =>
+        {
+            ClearObjectHighlight();
+        };
+
+        private void Init()
+        {
+            _skipPaginationSearch = true;
+
+            var areaResrefs = new GuiBindingList<string>();
+            var areaNames = new GuiBindingList<string>();
+            var areaToggled = new GuiBindingList<bool>();
+            var areaObjectList = new GuiBindingList<string>();
+            var areaObjectToggled = new GuiBindingList<bool>();
+
+            _areas.Clear();
+            _objects.Clear();
+
+            AreaResrefs = areaResrefs;
+            AreaNames = areaNames;
+            AreaToggled = areaToggled;
+            AreaObjectList = areaObjectList;
+            AreaObjectToggled = areaObjectToggled;
+
+            SelectedAreaIndex = -1;
+            SelectedAreaObjectIndex = -1;
+            SearchText = string.Empty;
+            SearchAppearanceText = String.Empty;
+
+            _totalCountAppearancePlaceables = 0;
+            _totalCountAppearanceCreatures = 0;
+
+            _skipPaginationSearch = false;
+        }
+
+        private void Search()
+        {
+            _skipPaginationSearch = true;
+
+            ClearObjectHighlight();
+
+            var areaResrefs = new GuiBindingList<string>();
+            var areaNames = new GuiBindingList<string>();
+            var areaToggled = new GuiBindingList<bool>();
+            var areaObjectList = new GuiBindingList<string>();
+            var areaObjectToggled = new GuiBindingList<bool>();
+            var objectAppearanceToggled = new GuiBindingList<bool>();
+
+            _areas.Clear();
+            _objects.Clear();
+
+            AreaToggled.Clear();
+            AreaNames.Clear();
+            AreaResrefs.Clear();
+            AreaObjectList.Clear();
+            AreaObjectToggled.Clear();
+
+            if (string.IsNullOrWhiteSpace(SearchText))
+            {
+                for (var area = GetFirstArea(); GetIsObjectValid(area); area = GetNextArea())
+                {
+                    if (GetIsTemplateArea(area))
+                    {
+                        _areas.Add(area);
+                        areaNames.Add(GetName(area));
+                        areaToggled.Add(false);
+                    }
+                }
+            }
+            else
+            {
+                for (var area = GetFirstArea(); GetIsObjectValid(area); area = GetNextArea())
+                {
+                    if (GetStringUpperCase(GetName(area)).Contains(GetStringUpperCase(SearchText)) && GetIsTemplateArea(area))
+                    {
+                        _areas.Add(area);
+                        areaNames.Add(GetName(area));
+                        areaToggled.Add(false);
+                    }
+                }
+            }
+
+            SelectedAreaIndex = -1;
+            SelectedAreaObjectIndex = -1;
+            SelectedAppearanceIndex = -1;
+
+            SelectedPageIndexAppearances = 0;
+
+            AreaResrefs = areaResrefs;
+            AreaNames = areaNames;
+            AreaToggled = areaToggled;
+            AreaObjectList = areaObjectList;
+            AreaObjectToggled = areaObjectToggled;
+            ObjectAppearanceToggled = objectAppearanceToggled;
+
+            IsDeleteObjectEnabled = false;
+            IsResetAreaEnabled = false;
+            IsResaveAllObjectsEnabled = false;
+
+            SelectedAreaObjectName = String.Empty;
+
+            IsSelectedObjectPlaceableOrCreature = false;
+
+            _skipPaginationSearch = false;
+        }
+
+        public void SearchAppearances(ObjectType objectType)
+        {
+            _objectAppearanceIds.Clear();
+            _objectAppearanceNames.Clear();
+            _placeableAppearanceByPage.Clear();
+            _creatureAppearanceByPage.Clear();
+            ObjectAppearanceToggled.Clear();
+
+            var objectAppearanceList = new GuiBindingList<string>();
+            var objectAppearanceToggled = new GuiBindingList<bool>();
+
+            var pageNumber = 0;
+            var actualRowCount = 0;            
+
+            switch (objectType)
+            {
+                case ObjectType.Placeable:
+                    for (var page = 0; 
+                         page <AreaTemplate.GetPlaceableAppearancePageCount(); 
+                         page++)
+                    {
+                        foreach (var appearance in AreaTemplate.GetPlaceableAppearances(page))
+                        {
+                            if (string.IsNullOrWhiteSpace(SearchAppearanceText))
+                            {
+                                if (actualRowCount > 0)
+                                    if (actualRowCount % AreaTemplate.PageSize == 0) pageNumber++;
+                                    
+                                if (!_placeableAppearanceByPage.ContainsKey(pageNumber))
+                                    _placeableAppearanceByPage[pageNumber] = new Dictionary<int, string>();
+
+                                _placeableAppearanceByPage[pageNumber].Add(appearance.Key, appearance.Value);
+                                actualRowCount++;
+                            }
+                            else
+                            {
+                                if (GetStringUpperCase(appearance.Value).Contains(GetStringUpperCase(SearchAppearanceText)))
+                                {
+                                    if (actualRowCount > 0)
+                                        if (actualRowCount % AreaTemplate.PageSize == 0) pageNumber++;
+                                        
+                                    if (!_placeableAppearanceByPage.ContainsKey(pageNumber))
+                                        _placeableAppearanceByPage[pageNumber] = new Dictionary<int, string>();
+
+                                    _placeableAppearanceByPage[pageNumber].Add(appearance.Key, appearance.Value);
+                                    actualRowCount++;
+                                }
+                            }
+                        }
+                    }
+                    _totalCountAppearancePlaceables = actualRowCount;
+
+                    foreach (var appearance in _placeableAppearanceByPage[SelectedPageIndexAppearances])
+                    {
+                        _objectAppearanceIds.Add(appearance.Key);
+                        _objectAppearanceNames.Add(appearance.Value);
+                        objectAppearanceList.Add(appearance.Value);
+                        objectAppearanceToggled.Add(false);
+                    }
+
+                    UpdatePaginationAppearances(GetObjectType(_objects[SelectedAreaObjectIndex]));
+                    break;
+                case ObjectType.Creature:
+                    for (var page = 0;
+                         page <AreaTemplate.GetCreatureAppearancePageCount();
+                         page++)
+                    {
+                        foreach (var appearance in AreaTemplate.GetCreatureAppearances(page))
+                        {
+                            if (string.IsNullOrWhiteSpace(SearchAppearanceText))
+                            {
+                                if (actualRowCount > 0)
+                                    if (actualRowCount % AreaTemplate.PageSize == 0) pageNumber++;
+
+                                if (!_creatureAppearanceByPage.ContainsKey(pageNumber))
+                                    _creatureAppearanceByPage[pageNumber] = new Dictionary<int, string>();
+
+                                _creatureAppearanceByPage[pageNumber].Add(appearance.Key, appearance.Value);
+                                actualRowCount++;
+                            }
+                            else
+                            {
+                                if (GetStringUpperCase(appearance.Value).Contains(GetStringUpperCase(SearchAppearanceText)))
+                                {
+                                    if (actualRowCount > 0)
+                                        if (actualRowCount % AreaTemplate.PageSize == 0) pageNumber++;
+                                        
+                                    if (!_creatureAppearanceByPage.ContainsKey(pageNumber))
+                                        _creatureAppearanceByPage[pageNumber] = new Dictionary<int, string>();
+
+                                    _creatureAppearanceByPage[pageNumber].Add(appearance.Key, appearance.Value);
+                                    actualRowCount++;
+                                }
+                            }
+                        }
+                    }
+                    _totalCountAppearanceCreatures = actualRowCount;
+
+                    if (_creatureAppearanceByPage[SelectedPageIndexAppearances].Count > 0)
+                    {
+                        foreach (var appearance in _creatureAppearanceByPage[SelectedPageIndexAppearances])
+                        {
+                            _objectAppearanceIds.Add(appearance.Key);
+                            _objectAppearanceNames.Add(appearance.Value);
+                            objectAppearanceList.Add(appearance.Value);
+                            objectAppearanceToggled.Add(false);
+                        }
+                    }
+
+                    UpdatePaginationAppearances(GetObjectType(_objects[SelectedAreaObjectIndex]));
+                    break;
+                default:
+                    break;
+            }
+
+            ObjectAppearanceList = objectAppearanceList;
+            ObjectAppearanceToggled = objectAppearanceToggled;
+        }
+
+        public void UpdatePaginationAppearances(ObjectType objectType)
+        {
+            var pageNumbers = new GuiBindingList<GuiComboEntry>();
+            var totalCount = 0;
+
+            switch (objectType)
+            {
+                case ObjectType.Placeable:
+                    totalCount = _totalCountAppearancePlaceables;
+                    break;
+                case ObjectType.Creature:
+                    totalCount = _totalCountAppearanceCreatures;
+                    break;
+                default:
+                    break;
+            }
+
+            var pages = (int)(totalCount / AreaTemplate.PageSize + (totalCount % AreaTemplate.PageSize == 0 ? 0 : 1));
+
+            // Always add page 1. In the event no structures are available,
+            // it still needs to be displayed.
+            pageNumbers.Add(new GuiComboEntry($"Page 1", 0));
+            for (var x = 2; x <= pages; x++)
+            {
+                pageNumbers.Add(new GuiComboEntry($"Page {x}", x - 1));
+            }
+
+            PageNumbersAppearances = pageNumbers;
+
+            // In the event no results are found, default the index to zero
+            if (pages <= 0)
+                SelectedPageIndexAppearances = 0;
+            // Otherwise, if current page is outside the new page bounds,
+            // set it to the last page in the list.
+            else if (SelectedPageIndexAppearances > pages - 1)
+                SelectedPageIndexAppearances = pages - 1;
+
+            _skipPaginationSearch = false;
+        }
+
+        private void ClearObjectHighlight()
+        {
+            if (SelectedAreaObjectIndex > -1)
+            {
+                PlayerPlugin.ApplyLoopingVisualEffectToObject(Player, _objects[SelectedAreaObjectIndex], VisualEffect.None);
+            }
+        }
+
+        private void LoadAreaObjectList()
+        {
+            _skipPaginationSearch = true;
+
+            if (SelectedAreaIndex < 0)
+                return;
+
+            SelectedPageIndexAppearances = 0;
+
+            var areaObjectList = new GuiBindingList<string>();
+            var areaObjectToggled = new GuiBindingList<bool>();           
+
+            _objects.Clear();
+            foreach (var areaObject in AreaTemplate.GetTemplateAreaCustomObjectsByArea(_areas[SelectedAreaIndex]))
+            {
+                _objects.Add(areaObject);
+                areaObjectList.Add(GetName(areaObject));
+                areaObjectToggled.Add(false);
+            }
+
+            AreaObjectList = areaObjectList;
+            AreaObjectToggled = areaObjectToggled;
+
+            IsDeleteObjectEnabled = false;
+            _skipPaginationSearch = true;
+        }
+
+        public Action OnClickGoToArea() => () =>
+        {
+            if (!(SelectedAreaIndex > -1))
+                return;
+
+            var area = _areas[SelectedAreaIndex];
+            var centerHeightOfTemplateArea = GetAreaSize(Dimension.Height, area) / 2f;
+            var centerWidthOfTemplateArea = GetAreaSize(Dimension.Width, area) / 2f;
+            var centerHeightOfTemplateAreaInMeters = centerHeightOfTemplateArea * 10f;
+            var centerWidthOfTemplateAreaInMeters = centerWidthOfTemplateArea * 10f;
+            var vectorOfTemplateArea = Vector3(centerHeightOfTemplateAreaInMeters, centerWidthOfTemplateAreaInMeters, 0.0f);
+            var position = Location(area, vectorOfTemplateArea, 0.0f);
+
+            AssignCommand(Player, () => ActionJumpToLocation(position));
+        };
+
+        public Action OnClickGoToObject() => () =>
+        {
+            if (SelectedAreaObjectIndex < 0)
+                return;
+
+            var obj = _objects[SelectedAreaObjectIndex];
+            var position = GetLocation(obj);
+
+            AssignCommand(Player, () => ActionJumpToLocation(position));
+        };
+
+        public Action OnRotateClockwise() => () =>
+        {
+            if (SelectedAreaObjectIndex < 0)
+                return;
+
+            var placeable = _objects[SelectedAreaObjectIndex];
+            var facing = GetFacing(placeable) + 20f;
+
+            while (facing > 360f)
+                facing -= 360f;
+
+            AssignCommand(placeable, () => SetFacing(facing));
+        };
+
+        public Action OnRotateCounterClockwise() => () =>
+        {
+            if (SelectedAreaObjectIndex < 0)
+                return;
+
+            var placeable = _objects[SelectedAreaObjectIndex];
+            var facing = GetFacing(placeable) - 20f;
+
+            while (facing > 360f)
+                facing -= 360f;
+
+            AssignCommand(placeable, () => SetFacing(facing));
+        };
+
+        private void AdjustFacing(float facing)
+        {
+            if (SelectedAreaObjectIndex < 0)
+                return;
+
+            var placeable = _objects[SelectedAreaObjectIndex];
+            AssignCommand(placeable, () => SetFacing(facing));
+        }
+
+        public Action OnSetFacingNorth() => () =>
+        {
+            AdjustFacing(90f);
+        };
+
+        public Action OnSetFacingSouth() => () =>
+        {
+            AdjustFacing(270f);
+        };
+
+        public Action OnSetFacingEast() => () =>
+        {
+            AdjustFacing(0f);
+        };
+
+        public Action OnSetFacingWest() => () =>
+        {
+            AdjustFacing(180f);
+        };
+
+        private void AdjustPosition(float x, float y, float z)
+        {
+            if (SelectedAreaObjectIndex < 0)
+                return;
+
+            var placeable = _objects[SelectedAreaObjectIndex];
+            var position = GetPosition(placeable);
+            position.X += x;
+            position.Y += y;
+            position.Z += z;
+
+            ObjectPlugin.SetPosition(placeable, position);
+        }
+
+        public Action OnYAxisUp() => () =>
+        {
+            AdjustPosition(0f, 0.1f, 0f);
+        };
+
+        public Action OnYAxisDown() => () =>
+        {
+            AdjustPosition(0f, -0.1f, 0f);
+        };
+
+        public Action OnXAxisUp() => () =>
+        {
+            AdjustPosition(0.1f, 0f, 0f);
+        };
+
+        public Action OnXAxisDown() => () =>
+        {
+            AdjustPosition(-0.1f, 0f, 0f);
+        };
+
+        public Action OnZAxisUp() => () =>
+        {
+            AdjustPosition(0f, 0f, 0.1f);
+        };
+
+        public Action OnZAxisDown() => () =>
+        {
+            AdjustPosition(0f, 0f, -0.1f);
+        };
+
+        public Action OnZAxisReset() => () =>
+        {
+            if (SelectedAreaObjectIndex < 0)
+                return;
+
+            var placeable = _objects[SelectedAreaObjectIndex];
+            var location = GetLocation(placeable);
+            var position = GetPosition(placeable);
+            var z = GetGroundHeight(location);
+
+            if (z == -6f)
+                return;
+
+            position.Z = z;
+            ObjectPlugin.SetPosition(placeable, position);
+        };
+
+        public Action OnSaveObjectChanges() => () =>
+        {
+            if (SelectedAreaObjectIndex < 0)
+                return;
+
+            var areaObject = _objects[SelectedAreaObjectIndex];
+
+            var areaObjectId = GetLocalString(areaObject, "DBID");
+            var dbObject = DB.Get<AreaTemplateObject>(areaObjectId);
+
+            SetName(areaObject, SelectedAreaObjectName);
+
+            dbObject.ObjectName = GetName(areaObject);
+            dbObject.ObjectData = ObjectPlugin.Serialize(areaObject);
+            dbObject.LocationX = GetPosition(areaObject).X;
+            dbObject.LocationY = GetPosition(areaObject).Y;
+            dbObject.LocationZ = GetPosition(areaObject).Z;
+            dbObject.LocationOrientation = GetFacing(areaObject);
+
+            DB.Set<AreaTemplateObject>(dbObject);
+        };
+
+        public Action OnPreviousPageAppearance() => () =>
+        {
+            _skipPaginationSearch = true;
+            var newPage = SelectedPageIndexAppearances - 1;
+            if (newPage < 0)
+                newPage = 0;
+
+            SelectedPageIndexAppearances = newPage;
+
+            SearchAppearances(GetObjectType(_objects[SelectedAreaObjectIndex]));
+
+            _skipPaginationSearch = false;
+        };
+
+        public Action OnNextPageAppearance() => () =>
+        {
+            _skipPaginationSearch = true;
+            var newPage = SelectedPageIndexAppearances + 1;
+            if (newPage > PageNumbersAppearances.Count - 1)
+                newPage = PageNumbersAppearances.Count - 1;
+
+            SelectedPageIndexAppearances = newPage;
+
+            SearchAppearances(GetObjectType(_objects[SelectedAreaObjectIndex]));
+
+            _skipPaginationSearch = false;
+        };
+
+        public Action OnSelectObjectAppearance() => () =>
+        {
+            if (SelectedAppearanceIndex > -1)
+                ObjectAppearanceToggled[SelectedAppearanceIndex] = false;
+
+            var index = NuiGetEventArrayIndex();
+            SelectedAppearanceIndex = index;
+
+            if (index < 0)
+                return;
+
+            var areaObject = _objects[SelectedAreaObjectIndex];
+            var areaObjectId = GetLocalString(areaObject, "DBID");
+            var dbObject = DB.Get<AreaTemplateObject>(areaObjectId);
+
+            switch (GetObjectType(areaObject))
+            {
+                case ObjectType.Creature:
+                    {
+                        SetCreatureAppearanceType(areaObject, (AppearanceType)_objectAppearanceIds[SelectedAppearanceIndex]);
+                    }
+                    break;
+                case ObjectType.Placeable:
+                    {
+                        ObjectPlugin.SetAppearance(areaObject, _objectAppearanceIds[SelectedAppearanceIndex]);
+                        SendMessageToPC(Player, "Placeable appearance change will only display after exiting and re-entering the area.");
+                    }
+                    break;
+                default:
+                    break;
+            }
+
+            dbObject.ObjectData = ObjectPlugin.Serialize(areaObject);
+
+            DB.Set<AreaTemplateObject>(dbObject);
+
+            ObjectAppearanceToggled[SelectedAppearanceIndex] = true;
+        };
+    }
+}

--- a/SWLOR.Game.Server/SWLOR.Game.Server.csproj
+++ b/SWLOR.Game.Server/SWLOR.Game.Server.csproj
@@ -36,8 +36,4 @@
       <AllOutputs Include="$(OutputPath)$(MSBuildProjectName).deps.json" />
     </ItemGroup>
   </Target>
-
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="cd $(SolutionDir)Build\&#xD;&#xA;SWLOR.CLI.exe -o" />
-  </Target>
 </Project>

--- a/SWLOR.Game.Server/SWLOR.Game.Server.csproj
+++ b/SWLOR.Game.Server/SWLOR.Game.Server.csproj
@@ -36,4 +36,8 @@
       <AllOutputs Include="$(OutputPath)$(MSBuildProjectName).deps.json" />
     </ItemGroup>
   </Target>
+
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="cd $(SolutionDir)Build\&#xD;&#xA;SWLOR.CLI.exe -o" />
+  </Target>
 </Project>

--- a/SWLOR.Game.Server/Service/AreaTemplate.cs
+++ b/SWLOR.Game.Server/Service/AreaTemplate.cs
@@ -1,0 +1,307 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using SWLOR.Game.Server.Core.NWNX;
+using SWLOR.Game.Server.Core;
+using SWLOR.Game.Server.Core.NWScript.Enum;
+using SWLOR.Game.Server.Entity;
+using SWLOR.Game.Server.Service.DBService;
+using SWLOR.Game.Server.Service.GuiService;
+using SWLOR.Game.Server.Core.NWScript.Enum.Area;
+
+namespace SWLOR.Game.Server.Service
+{
+    public class AreaTemplate
+    {
+        public static Dictionary<string, uint> TemplateAreaByResRef { get; } = new();
+        private static Dictionary<uint, List<uint>> TemplateAreaCustomObjectsByArea { get; } = new();
+        private static Dictionary<int, Dictionary<int, string>> PlaceableAppearanceByPage { get; } = new();
+        private static Dictionary<int, Dictionary<int, string>> CreatureAppearanceByPage { get; } = new();
+
+        public static int TotalCountAppearancePlaceables { get; set; }
+        public static int TotalCountAppearanceCreatures { get; set; }
+
+        public const int PageSize = 50;
+
+        public static int GetPlaceableAppearancePageCount()
+        {
+            return PlaceableAppearanceByPage.Count;
+        }
+
+        public static int GetCreatureAppearancePageCount()
+        {
+            return CreatureAppearanceByPage.Count;
+        }
+
+        [NWNEventHandler("mod_cache")]
+        public static void CacheAppearances()
+        {
+            TotalCountAppearancePlaceables = 0;
+            TotalCountAppearanceCreatures = 0;            
+
+            var rowCount = UtilPlugin.Get2DARowCount("placeables");
+            var pageNumber = 0;
+            var actualRowCount = 0;
+
+            for (int row = 0; row < rowCount; row++)
+            {
+                var entry = Get2DAString("placeables", "Label", row);
+
+                if (entry != "****" && !string.IsNullOrWhiteSpace(entry))
+                {
+                    if (actualRowCount > 0 && actualRowCount % PageSize == 0) pageNumber++;
+
+                    if (!PlaceableAppearanceByPage.ContainsKey(pageNumber))
+                        PlaceableAppearanceByPage[pageNumber] = new Dictionary<int, string>();
+
+                    PlaceableAppearanceByPage[pageNumber].Add(row, entry);
+                    actualRowCount++;                 
+                }
+            }
+            TotalCountAppearancePlaceables = actualRowCount;
+            Console.WriteLine($"Loaded {PlaceableAppearanceByPage.Count} placeable appearance pages ({AreaTemplate.PageSize} per page)  into cache.");
+
+            rowCount = UtilPlugin.Get2DARowCount("appearance");
+            pageNumber = 0;
+            actualRowCount = 0;
+
+            for (int row = 0; row < rowCount; row++)
+            {
+                var entry = Get2DAString("appearance", "Label", row);
+
+                if (entry != "****" && !string.IsNullOrWhiteSpace(entry))
+                {
+                    if (actualRowCount > 0 && actualRowCount % PageSize == 0) pageNumber++;
+
+                    if (!CreatureAppearanceByPage.ContainsKey(pageNumber))
+                        CreatureAppearanceByPage[pageNumber] = new Dictionary<int, string>();
+
+                    CreatureAppearanceByPage[pageNumber].Add(row, entry);
+                    actualRowCount++;
+                }
+            }
+            TotalCountAppearanceCreatures = actualRowCount;
+            Console.WriteLine($"Loaded {CreatureAppearanceByPage.Count} creature appearance pages ({AreaTemplate.PageSize} per page)  into cache.");
+        }
+
+        [NWNEventHandler("mod_exit")]
+        public static void OnModuleExit()
+        {
+            //return;
+
+            // For some reason I can't determine, the below is not actually working.
+            // I.E. The visual effect is not removed.
+            // The intent is to just have the OnClose GUI binding for this window called
+            // so that selected Object Highlight effect is cleaned up.
+            var player = GetExitingObject();
+            Console.WriteLine("Toggling Area Manager window before client disconnect. Name = " + GetName(player));
+            Gui.TogglePlayerWindow(player, GuiWindowType.AreaManager);
+            Gui.CloseWindow(player, GuiWindowType.AreaManager, player);
+            Console.WriteLine("Area Manager window closed.");                     
+        }
+
+        [NWNEventHandler("mod_load")]
+        public static void OnModuleLoad()
+        {
+            LoadTemplateAreas();
+            LoadTemplateAreaObjects();
+        }
+
+        public static Dictionary<int, string> GetPlaceableAppearances(int pageNumber)
+        {
+            return PlaceableAppearanceByPage[pageNumber];
+        }
+        public static Dictionary<int, string> GetCreatureAppearances(int pageNumber)
+        {
+            return CreatureAppearanceByPage[pageNumber];
+        }
+        public static bool GetIsTemplateArea(uint area)
+        {
+            return GetLocalBool(area, "IS_TEMPLATE_AREA");
+        }
+
+        /// <summary>
+        /// Retrieves an area by its resref. If the area does not exist, OBJECT_INVALID will be returned.
+        /// </summary>
+        /// <param name="resref">The resref to use for the search.</param>
+        /// <returns>The area ID or OBJECT_INVALID if area does not exist.</returns>
+        public static uint GetTemplateAreaByResref(string resref)
+        {
+            if (!TemplateAreaByResRef.ContainsKey(resref))
+                return OBJECT_INVALID;
+
+            return TemplateAreaByResRef[resref];
+        }
+
+        public static void LoadTemplateAreas()
+        {
+            Console.WriteLine("Loading Area Templates, please wait...");
+
+            var areaDataQuery = new DBQuery<TemplateArea>();
+            var areaDataCount = DB.SearchCount(areaDataQuery);
+            var areaDatas = DB.Search(areaDataQuery
+                .AddPaging((int)areaDataCount, 0))
+                .ToList();
+
+            foreach (var templateArea in areaDatas)
+            {
+                Console.WriteLine($"Loaded Template Area Name: {templateArea.TemplateAreaName}.");
+                Console.WriteLine($"Loaded Template Area Data: {templateArea.TemplateAreaData}.");
+                Console.WriteLine($"Loaded Template Area ResRef: {templateArea.TemplateAreaResRef}.");
+                Console.WriteLine($"Loaded Template Area Tag: {templateArea.TemplateAreaTag}.");
+
+                var createdArea = CreateArea(templateArea.TemplateAreaResRef, templateArea.TemplateAreaTag, templateArea.TemplateAreaName);
+                SetLocalBool(createdArea, "IS_TEMPLATE_AREA", true);
+
+                // This deletes all of the creatures, waypoints, and transitions. Since many of our transitions are
+                // placeables with the DESTINATION tag, the GetObjectType(x) == ObjectType.Placeable && GetLocalBool(x, "DESTINATION")) line
+                // deletes placeables that serve as transitions, which would solve bugs like the placeable teleport
+                // in Jim's Cantina surviving to the template area and teleporting people to weird places. 
+                for (var x = GetFirstObjectInArea(createdArea); GetIsObjectValid(x); x = GetNextObjectInArea(createdArea))
+                {
+                    var isTeleportPlaceable = GetLocalString(x, "DESTINATION");
+
+                    if (GetObjectType(x) == ObjectType.Creature ||
+                        GetObjectType(x) == ObjectType.Waypoint ||
+                        GetObjectType(x) == ObjectType.Trigger ||
+                        (GetObjectType(x) == ObjectType.Placeable && (isTeleportPlaceable != "")))
+                    {
+                        DestroyObject(x);
+                    }
+                }
+            }
+            Console.WriteLine($"Loaded {areaDataCount} template areas.");
+        }
+
+        /// <summary>
+        /// This loads objects for the Template Areas upon module load.
+        /// </summary>
+        public static void LoadTemplateAreaObjects()
+        {
+            for (var area = GetFirstArea(); GetIsObjectValid(area); area = GetNextArea())
+            {
+                if (GetIsTemplateArea(area))
+                {
+                    var query = new DBQuery<AreaTemplateObject>()
+                        .AddFieldSearch(nameof(AreaTemplateObject.AreaTag), GetTag(area), false)
+                        .OrderBy(nameof(AreaTemplateObject.ObjectName));
+                    var areaTemplates = DB.Search(query)
+                        .ToList();
+
+                    foreach (var x in areaTemplates)
+                    {
+                        var deserialized = ObjectPlugin.Deserialize(x.ObjectData);
+                        var position = Vector3(x.LocationX, x.LocationY, x.LocationZ);
+                        var location = Location(area, position, x.LocationOrientation);
+                        var newObject = CopyObject(deserialized, location);
+
+                        if (!TemplateAreaCustomObjectsByArea.ContainsKey(area))
+                            TemplateAreaCustomObjectsByArea[area] = new List<uint>();
+
+                        if (!TemplateAreaCustomObjectsByArea[area].Contains(newObject))
+                        {
+                            TemplateAreaCustomObjectsByArea[area].Add(newObject);
+                        }
+
+                        SetLocalString(newObject, "DBID", x.Id);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Retrieves list of template areas only.
+        /// </summary>
+        /// <param> </param>
+        /// <returns>TemplateAreasByResref cache.</returns>
+        public static Dictionary<string, uint> GetTemplateAreas()
+        {
+            return TemplateAreaByResRef;
+        }
+
+        /// <summary>
+        /// Retrieves all of the objects created by DM's in the currently in the specified template area.
+        /// If no objects are in the area, an empty list will returned.
+        /// </summary>
+        /// <param name="area">The area to search by.</param>
+        /// <returns>A list of player objects</returns>
+        public static List<uint> GetTemplateAreaCustomObjectsByArea(uint area)
+        {
+            if (!TemplateAreaCustomObjectsByArea.ContainsKey(area))
+                return new List<uint>();
+
+            return TemplateAreaCustomObjectsByArea[area].ToList();
+        }
+
+        public static void RemoveTemplateAreaCustomObjectByArea(uint area, uint customObject)
+        {
+            if (!TemplateAreaCustomObjectsByArea.ContainsKey(area))
+                    TemplateAreaCustomObjectsByArea[area] = new List<uint>();
+
+            if (TemplateAreaCustomObjectsByArea[area].Contains(customObject))
+                TemplateAreaCustomObjectsByArea[area].Remove(customObject);
+        }
+
+        /// <summary>
+        /// When a DM spawns an object in the template area, add it to the cache.
+        /// </summary>
+        [NWNEventHandler("dm_spwnobj_aft")]
+        public static void DmSpawnObjectAfter()
+        {
+            var area = StringToObject(EventsPlugin.GetEventData("AREA"));
+            var spawn = StringToObject(EventsPlugin.GetEventData("OBJECT"));
+            if (GetIsTemplateArea(area))
+            {
+                if (!TemplateAreaCustomObjectsByArea.ContainsKey(area))
+                    TemplateAreaCustomObjectsByArea[area] = new List<uint>();
+
+                if (!TemplateAreaCustomObjectsByArea[area].Contains(spawn))
+                {
+                    TemplateAreaCustomObjectsByArea[area].Add(spawn);
+
+                    var areaTemplate = new AreaTemplateObject
+                    {
+                        AreaResref = GetResRef(area),
+                        AreaTag = GetTag(area),
+                        ObjectName = GetName(spawn),
+                        ObjectData = ObjectPlugin.Serialize(spawn),
+                        LocationX = GetPosition(spawn).X,
+                        LocationY = GetPosition(spawn).Y,
+                        LocationZ = GetPosition(spawn).Z,
+                        LocationOrientation = GetFacing(spawn)
+                    };
+                    
+                    var areaName = GetName(area);
+                    var objectName = GetName(spawn);
+
+                    DB.Set<AreaTemplateObject>(areaTemplate);
+                    SetLocalString(spawn, "DBID", areaTemplate.Id);
+                };                   
+            }
+        }
+
+        // this is in case DM's adjust objects positions or other attributes and want to resave the changes.
+        public static void ResaveAllAreaTemplateObjectsByArea(uint area)
+        {
+            if (!GetIsTemplateArea(area))
+                return;
+
+            foreach(var _customObject in TemplateAreaCustomObjectsByArea[area])
+            {                
+                var customObject = _customObject;
+                var dbId = GetLocalString(customObject, "DBID");
+
+                var dbObject = DB.Get<AreaTemplateObject>(dbId);
+
+                dbObject.ObjectName = GetName(customObject);
+                dbObject.ObjectData = ObjectPlugin.Serialize(customObject);
+                dbObject.LocationX = GetPosition(customObject).X;
+                dbObject.LocationY = GetPosition(customObject).Y;
+                dbObject.LocationZ = GetPosition(customObject).Z;
+                dbObject.LocationOrientation = GetFacing(customObject);
+
+                DB.Set<AreaTemplateObject>(dbObject);
+            }
+        }
+    }
+}

--- a/SWLOR.Game.Server/Service/GuiService/GuiWindowType.cs
+++ b/SWLOR.Game.Server/Service/GuiService/GuiWindowType.cs
@@ -52,6 +52,7 @@
         StatRebuild = 47,
         AssociateCharacterSheet = 48,
         HoloNet = 49,
+        AreaManagerNaming = 50,
         DebugEnmity = 900,
     }
 }


### PR DESCRIPTION
This adds an area manager that DMs can use. They create a template out of an existing module area, and may edit the template as they wish. Objects spawned in that template will be saved and both the template area and the objects would persist from reset to reset. This was based off of Givemedeath's Area Manager in PR1510, though fairly extensive changes have been made.