### PR TITLE
Republic Base Bug Fixes

### DIFF
--- a/Module/are/v_repubbase_1.are.json
+++ b/Module/are/v_repubbase_1.are.json
@@ -3945,7 +3945,7 @@
   },
   "Version": {
     "type": "dword",
-    "value": 46
+    "value": 50
   },
   "Width": {
     "type": "int",

--- a/Module/are/v_repubbase_2.are.json
+++ b/Module/are/v_repubbase_2.are.json
@@ -740,19 +740,19 @@
         },
         "Tile_MainLight2": {
           "type": "byte",
-          "value": 13
+          "value": 14
         },
         "Tile_Orientation": {
           "type": "int",
-          "value": 0
+          "value": 2
         },
         "Tile_SrcLight1": {
           "type": "byte",
-          "value": 0
+          "value": 2
         },
         "Tile_SrcLight2": {
           "type": "byte",
-          "value": 0
+          "value": 2
         }
       },
       {
@@ -779,7 +779,7 @@
         },
         "Tile_MainLight1": {
           "type": "byte",
-          "value": 4
+          "value": 30
         },
         "Tile_MainLight2": {
           "type": "byte",
@@ -787,15 +787,15 @@
         },
         "Tile_Orientation": {
           "type": "int",
-          "value": 0
+          "value": 2
         },
         "Tile_SrcLight1": {
           "type": "byte",
-          "value": 3
+          "value": 2
         },
         "Tile_SrcLight2": {
           "type": "byte",
-          "value": 3
+          "value": 2
         }
       },
       {
@@ -1080,11 +1080,54 @@
         },
         "Tile_MainLight1": {
           "type": "byte",
+          "value": 30
+        },
+        "Tile_MainLight2": {
+          "type": "byte",
+          "value": 13
+        },
+        "Tile_Orientation": {
+          "type": "int",
+          "value": 1
+        },
+        "Tile_SrcLight1": {
+          "type": "byte",
+          "value": 2
+        },
+        "Tile_SrcLight2": {
+          "type": "byte",
+          "value": 2
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Tile_AnimLoop1": {
+          "type": "byte",
+          "value": 1
+        },
+        "Tile_AnimLoop2": {
+          "type": "byte",
+          "value": 1
+        },
+        "Tile_AnimLoop3": {
+          "type": "byte",
+          "value": 1
+        },
+        "Tile_Height": {
+          "type": "int",
+          "value": 0
+        },
+        "Tile_ID": {
+          "type": "int",
+          "value": 5
+        },
+        "Tile_MainLight1": {
+          "type": "byte",
           "value": 4
         },
         "Tile_MainLight2": {
           "type": "byte",
-          "value": 13
+          "value": 0
         },
         "Tile_Orientation": {
           "type": "int",
@@ -1123,50 +1166,7 @@
         },
         "Tile_MainLight1": {
           "type": "byte",
-          "value": 0
-        },
-        "Tile_MainLight2": {
-          "type": "byte",
-          "value": 13
-        },
-        "Tile_Orientation": {
-          "type": "int",
-          "value": 1
-        },
-        "Tile_SrcLight1": {
-          "type": "byte",
-          "value": 0
-        },
-        "Tile_SrcLight2": {
-          "type": "byte",
-          "value": 0
-        }
-      },
-      {
-        "__struct_id": 1,
-        "Tile_AnimLoop1": {
-          "type": "byte",
-          "value": 1
-        },
-        "Tile_AnimLoop2": {
-          "type": "byte",
-          "value": 1
-        },
-        "Tile_AnimLoop3": {
-          "type": "byte",
-          "value": 1
-        },
-        "Tile_Height": {
-          "type": "int",
-          "value": 0
-        },
-        "Tile_ID": {
-          "type": "int",
-          "value": 5
-        },
-        "Tile_MainLight1": {
-          "type": "byte",
-          "value": 0
+          "value": 30
         },
         "Tile_MainLight2": {
           "type": "byte",
@@ -1174,7 +1174,7 @@
         },
         "Tile_Orientation": {
           "type": "int",
-          "value": 0
+          "value": 1
         },
         "Tile_SrcLight1": {
           "type": "byte",
@@ -1424,50 +1424,7 @@
         },
         "Tile_MainLight1": {
           "type": "byte",
-          "value": 0
-        },
-        "Tile_MainLight2": {
-          "type": "byte",
-          "value": 0
-        },
-        "Tile_Orientation": {
-          "type": "int",
-          "value": 3
-        },
-        "Tile_SrcLight1": {
-          "type": "byte",
-          "value": 3
-        },
-        "Tile_SrcLight2": {
-          "type": "byte",
-          "value": 3
-        }
-      },
-      {
-        "__struct_id": 1,
-        "Tile_AnimLoop1": {
-          "type": "byte",
-          "value": 1
-        },
-        "Tile_AnimLoop2": {
-          "type": "byte",
-          "value": 1
-        },
-        "Tile_AnimLoop3": {
-          "type": "byte",
-          "value": 1
-        },
-        "Tile_Height": {
-          "type": "int",
-          "value": 0
-        },
-        "Tile_ID": {
-          "type": "int",
-          "value": 5
-        },
-        "Tile_MainLight1": {
-          "type": "byte",
-          "value": 0
+          "value": 30
         },
         "Tile_MainLight2": {
           "type": "byte",
@@ -1479,6 +1436,49 @@
         },
         "Tile_SrcLight1": {
           "type": "byte",
+          "value": 3
+        },
+        "Tile_SrcLight2": {
+          "type": "byte",
+          "value": 3
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Tile_AnimLoop1": {
+          "type": "byte",
+          "value": 1
+        },
+        "Tile_AnimLoop2": {
+          "type": "byte",
+          "value": 1
+        },
+        "Tile_AnimLoop3": {
+          "type": "byte",
+          "value": 1
+        },
+        "Tile_Height": {
+          "type": "int",
+          "value": 0
+        },
+        "Tile_ID": {
+          "type": "int",
+          "value": 5
+        },
+        "Tile_MainLight1": {
+          "type": "byte",
+          "value": 0
+        },
+        "Tile_MainLight2": {
+          "type": "byte",
+          "value": 0
+        },
+        "Tile_Orientation": {
+          "type": "int",
+          "value": 3
+        },
+        "Tile_SrcLight1": {
+          "type": "byte",
           "value": 0
         },
         "Tile_SrcLight2": {
@@ -1510,7 +1510,7 @@
         },
         "Tile_MainLight1": {
           "type": "byte",
-          "value": 0
+          "value": 30
         },
         "Tile_MainLight2": {
           "type": "byte",
@@ -1518,15 +1518,15 @@
         },
         "Tile_Orientation": {
           "type": "int",
-          "value": 3
+          "value": 2
         },
         "Tile_SrcLight1": {
           "type": "byte",
-          "value": 3
+          "value": 2
         },
         "Tile_SrcLight2": {
           "type": "byte",
-          "value": 3
+          "value": 2
         }
       },
       {
@@ -1768,50 +1768,7 @@
         },
         "Tile_MainLight1": {
           "type": "byte",
-          "value": 0
-        },
-        "Tile_MainLight2": {
-          "type": "byte",
-          "value": 14
-        },
-        "Tile_Orientation": {
-          "type": "int",
-          "value": 3
-        },
-        "Tile_SrcLight1": {
-          "type": "byte",
-          "value": 3
-        },
-        "Tile_SrcLight2": {
-          "type": "byte",
-          "value": 3
-        }
-      },
-      {
-        "__struct_id": 1,
-        "Tile_AnimLoop1": {
-          "type": "byte",
-          "value": 1
-        },
-        "Tile_AnimLoop2": {
-          "type": "byte",
-          "value": 1
-        },
-        "Tile_AnimLoop3": {
-          "type": "byte",
-          "value": 1
-        },
-        "Tile_Height": {
-          "type": "int",
-          "value": 0
-        },
-        "Tile_ID": {
-          "type": "int",
-          "value": 5
-        },
-        "Tile_MainLight1": {
-          "type": "byte",
-          "value": 0
+          "value": 4
         },
         "Tile_MainLight2": {
           "type": "byte",
@@ -1819,15 +1776,15 @@
         },
         "Tile_Orientation": {
           "type": "int",
-          "value": 2
+          "value": 3
         },
         "Tile_SrcLight1": {
           "type": "byte",
-          "value": 0
+          "value": 2
         },
         "Tile_SrcLight2": {
           "type": "byte",
-          "value": 0
+          "value": 2
         }
       },
       {
@@ -1862,7 +1819,50 @@
         },
         "Tile_Orientation": {
           "type": "int",
-          "value": 2
+          "value": 3
+        },
+        "Tile_SrcLight1": {
+          "type": "byte",
+          "value": 3
+        },
+        "Tile_SrcLight2": {
+          "type": "byte",
+          "value": 3
+        }
+      },
+      {
+        "__struct_id": 1,
+        "Tile_AnimLoop1": {
+          "type": "byte",
+          "value": 1
+        },
+        "Tile_AnimLoop2": {
+          "type": "byte",
+          "value": 1
+        },
+        "Tile_AnimLoop3": {
+          "type": "byte",
+          "value": 1
+        },
+        "Tile_Height": {
+          "type": "int",
+          "value": 0
+        },
+        "Tile_ID": {
+          "type": "int",
+          "value": 5
+        },
+        "Tile_MainLight1": {
+          "type": "byte",
+          "value": 4
+        },
+        "Tile_MainLight2": {
+          "type": "byte",
+          "value": 0
+        },
+        "Tile_Orientation": {
+          "type": "int",
+          "value": 1
         },
         "Tile_SrcLight1": {
           "type": "byte",
@@ -3601,7 +3601,7 @@
   },
   "Version": {
     "type": "dword",
-    "value": 26
+    "value": 29
   },
   "Width": {
     "type": "int",

--- a/Module/are/v_repubbase_cd.are.json
+++ b/Module/are/v_repubbase_cd.are.json
@@ -4633,7 +4633,7 @@
   },
   "Version": {
     "type": "dword",
-    "value": 16
+    "value": 17
   },
   "Width": {
     "type": "int",

--- a/Module/are/v_repubbase_ext.are.json
+++ b/Module/are/v_repubbase_ext.are.json
@@ -12588,7 +12588,7 @@
   },
   "Version": {
     "type": "dword",
-    "value": 24
+    "value": 26
   },
   "Width": {
     "type": "int",

--- a/Module/are/v_repubbase_hang.are.json
+++ b/Module/are/v_repubbase_hang.are.json
@@ -5364,7 +5364,7 @@
   },
   "Version": {
     "type": "dword",
-    "value": 15
+    "value": 16
   },
   "Width": {
     "type": "int",

--- a/Module/are/v_repubbase_jnrm.are.json
+++ b/Module/are/v_repubbase_jnrm.are.json
@@ -548,7 +548,7 @@
   },
   "Version": {
     "type": "dword",
-    "value": 10
+    "value": 11
   },
   "Width": {
     "type": "int",

--- a/Module/are/v_repubbase_off.are.json
+++ b/Module/are/v_repubbase_off.are.json
@@ -2913,7 +2913,7 @@
   },
   "Version": {
     "type": "dword",
-    "value": 14
+    "value": 15
   },
   "Width": {
     "type": "int",

--- a/Module/dlg/rep_armory.dlg.json
+++ b/Module/dlg/rep_armory.dlg.json
@@ -60,7 +60,7 @@
               },
               "Index": {
                 "type": "dword",
-                "value": 0
+                "value": 1
               },
               "IsChild": {
                 "type": "byte",
@@ -79,7 +79,7 @@
               },
               "Index": {
                 "type": "dword",
-                "value": 1
+                "value": 0
               },
               "IsChild": {
                 "type": "byte",
@@ -103,7 +103,95 @@
         "Text": {
           "type": "cexolocstring",
           "value": {
-            "0": "Welcome to my shop. Would you like to see my wares?"
+            "0": "Corporal Thremsi stands here, packing shelves, cataloguing ammunition, and checking them against a datapad. There is an expression of faint anxiety upon her, with regular glances towards the Quartermaster, as if she is expecting a reprimand at any time..."
+          }
+        }
+      },
+      {
+        "__struct_id": 1,
+        "ActionParams": {
+          "type": "list",
+          "value": []
+        },
+        "Animation": {
+          "type": "dword",
+          "value": 0
+        },
+        "AnimLoop": {
+          "type": "byte",
+          "value": 1
+        },
+        "Comment": {
+          "type": "cexostring",
+          "value": ""
+        },
+        "Delay": {
+          "type": "dword",
+          "value": 4294967295
+        },
+        "Quest": {
+          "type": "cexostring",
+          "value": ""
+        },
+        "RepliesList": {
+          "type": "list",
+          "value": [
+            {
+              "__struct_id": 0,
+              "Active": {
+                "type": "resref",
+                "value": ""
+              },
+              "ConditionParams": {
+                "type": "list",
+                "value": []
+              },
+              "Index": {
+                "type": "dword",
+                "value": 3
+              },
+              "IsChild": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 1,
+              "Active": {
+                "type": "resref",
+                "value": ""
+              },
+              "ConditionParams": {
+                "type": "list",
+                "value": []
+              },
+              "Index": {
+                "type": "dword",
+                "value": 2
+              },
+              "IsChild": {
+                "type": "byte",
+                "value": 0
+              }
+            }
+          ]
+        },
+        "Script": {
+          "type": "resref",
+          "value": ""
+        },
+        "Sound": {
+          "type": "resref",
+          "value": ""
+        },
+        "Speaker": {
+          "type": "cexostring",
+          "value": ""
+        },
+        "Text": {
+          "type": "cexolocstring",
+          "value": {
+            "0": "\"WHAT!?\" She snaps, looking harried. \"The armory? You need to make an indent? A requisition?\"\n"
           }
         }
       }
@@ -111,7 +199,7 @@
   },
   "NumWords": {
     "type": "dword",
-    "value": 23
+    "value": 74
   },
   "PreventZoomIn": {
     "type": "byte",
@@ -152,7 +240,7 @@
         },
         "Script": {
           "type": "resref",
-          "value": "rep_armory001"
+          "value": ""
         },
         "Sound": {
           "type": "resref",
@@ -161,12 +249,77 @@
         "Text": {
           "type": "cexolocstring",
           "value": {
-            "0": "Yes. I'd like to see what you have for sale."
+            "0": "Leave the Corporal alone..."
           }
         }
       },
       {
         "__struct_id": 1,
+        "ActionParams": {
+          "type": "list",
+          "value": []
+        },
+        "Animation": {
+          "type": "dword",
+          "value": 0
+        },
+        "AnimLoop": {
+          "type": "byte",
+          "value": 1
+        },
+        "Comment": {
+          "type": "cexostring",
+          "value": ""
+        },
+        "Delay": {
+          "type": "dword",
+          "value": 4294967295
+        },
+        "EntriesList": {
+          "type": "list",
+          "value": [
+            {
+              "__struct_id": 0,
+              "Active": {
+                "type": "resref",
+                "value": ""
+              },
+              "ConditionParams": {
+                "type": "list",
+                "value": []
+              },
+              "Index": {
+                "type": "dword",
+                "value": 1
+              },
+              "IsChild": {
+                "type": "byte",
+                "value": 0
+              }
+            }
+          ]
+        },
+        "Quest": {
+          "type": "cexostring",
+          "value": ""
+        },
+        "Script": {
+          "type": "resref",
+          "value": ""
+        },
+        "Sound": {
+          "type": "resref",
+          "value": ""
+        },
+        "Text": {
+          "type": "cexolocstring",
+          "value": {
+            "0": "\"Er, pardon me, Corporal?\""
+          }
+        }
+      },
+      {
+        "__struct_id": 2,
         "ActionParams": {
           "type": "list",
           "value": []
@@ -206,7 +359,64 @@
         "Text": {
           "type": "cexolocstring",
           "value": {
-            "0": "No, thanks."
+            "0": "\"Er, no...\" Leave the Corporal alone..."
+          }
+        }
+      },
+      {
+        "__struct_id": 3,
+        "ActionParams": {
+          "type": "list",
+          "value": [
+            {
+              "__struct_id": 0,
+              "Key": {
+                "type": "cexostring",
+                "value": "action-open-store"
+              },
+              "Value": {
+                "type": "cexostring",
+                "value": ""
+              }
+            }
+          ]
+        },
+        "Animation": {
+          "type": "dword",
+          "value": 0
+        },
+        "AnimLoop": {
+          "type": "byte",
+          "value": 1
+        },
+        "Comment": {
+          "type": "cexostring",
+          "value": ""
+        },
+        "Delay": {
+          "type": "dword",
+          "value": 4294967295
+        },
+        "EntriesList": {
+          "type": "list",
+          "value": []
+        },
+        "Quest": {
+          "type": "cexostring",
+          "value": ""
+        },
+        "Script": {
+          "type": "resref",
+          "value": "action"
+        },
+        "Sound": {
+          "type": "resref",
+          "value": ""
+        },
+        "Text": {
+          "type": "cexolocstring",
+          "value": {
+            "0": "\"I need to make a requisition.\""
           }
         }
       }

--- a/Module/dlg/rep_medicalbay.dlg.json
+++ b/Module/dlg/rep_medicalbay.dlg.json
@@ -60,7 +60,7 @@
               },
               "Index": {
                 "type": "dword",
-                "value": 0
+                "value": 1
               },
               "IsChild": {
                 "type": "byte",
@@ -79,7 +79,7 @@
               },
               "Index": {
                 "type": "dword",
-                "value": 1
+                "value": 0
               },
               "IsChild": {
                 "type": "byte",
@@ -152,7 +152,7 @@
         },
         "Script": {
           "type": "resref",
-          "value": "rep_medicalbay"
+          "value": ""
         },
         "Sound": {
           "type": "resref",
@@ -161,7 +161,7 @@
         "Text": {
           "type": "cexolocstring",
           "value": {
-            "0": "\"Yes.\""
+            "0": "\"No.\""
           }
         }
       },
@@ -169,7 +169,19 @@
         "__struct_id": 1,
         "ActionParams": {
           "type": "list",
-          "value": []
+          "value": [
+            {
+              "__struct_id": 0,
+              "Key": {
+                "type": "cexostring",
+                "value": "action-open-store"
+              },
+              "Value": {
+                "type": "cexostring",
+                "value": ""
+              }
+            }
+          ]
         },
         "Animation": {
           "type": "dword",
@@ -197,7 +209,7 @@
         },
         "Script": {
           "type": "resref",
-          "value": ""
+          "value": "action"
         },
         "Sound": {
           "type": "resref",
@@ -206,7 +218,7 @@
         "Text": {
           "type": "cexolocstring",
           "value": {
-            "0": "\"No.\""
+            "0": "\"Yes.\""
           }
         }
       }

--- a/Module/dlg/rep_messhall001.dlg.json
+++ b/Module/dlg/rep_messhall001.dlg.json
@@ -60,7 +60,7 @@
               },
               "Index": {
                 "type": "dword",
-                "value": 0
+                "value": 1
               },
               "IsChild": {
                 "type": "byte",
@@ -79,7 +79,7 @@
               },
               "Index": {
                 "type": "dword",
-                "value": 1
+                "value": 0
               },
               "IsChild": {
                 "type": "byte",
@@ -152,7 +152,7 @@
         },
         "Script": {
           "type": "resref",
-          "value": "rep_messhall001"
+          "value": ""
         },
         "Sound": {
           "type": "resref",
@@ -161,7 +161,7 @@
         "Text": {
           "type": "cexolocstring",
           "value": {
-            "0": "\"Any good deliveries of late from Veles, ma'am?\""
+            "0": "\"Opps, sorry for disturbing, ma'am.\""
           }
         }
       },
@@ -169,7 +169,19 @@
         "__struct_id": 1,
         "ActionParams": {
           "type": "list",
-          "value": []
+          "value": [
+            {
+              "__struct_id": 0,
+              "Key": {
+                "type": "cexostring",
+                "value": "action-open-store"
+              },
+              "Value": {
+                "type": "cexostring",
+                "value": ""
+              }
+            }
+          ]
         },
         "Animation": {
           "type": "dword",
@@ -197,7 +209,7 @@
         },
         "Script": {
           "type": "resref",
-          "value": ""
+          "value": "action"
         },
         "Sound": {
           "type": "resref",
@@ -206,7 +218,7 @@
         "Text": {
           "type": "cexolocstring",
           "value": {
-            "0": "\"Opps, sorry for disturbing, ma'am.\""
+            "0": "\"Any good deliveries of late from Veles, ma'am?\""
           }
         }
       }

--- a/Module/gic/v_repubbase_1.gic.json
+++ b/Module/gic/v_repubbase_1.gic.json
@@ -3233,6 +3233,13 @@
           "type": "cexostring",
           "value": "Invisible Object"
         }
+      },
+      {
+        "__struct_id": 9,
+        "Comment": {
+          "type": "cexostring",
+          "value": "Source: DK Furniture Plus by Nethy"
+        }
       }
     ]
   },

--- a/Module/gic/v_repubbase_2.gic.json
+++ b/Module/gic/v_repubbase_2.gic.json
@@ -133,6 +133,41 @@
           "type": "cexostring",
           "value": ""
         }
+      },
+      {
+        "__struct_id": 8,
+        "Comment": {
+          "type": "cexostring",
+          "value": ""
+        }
+      },
+      {
+        "__struct_id": 8,
+        "Comment": {
+          "type": "cexostring",
+          "value": ""
+        }
+      },
+      {
+        "__struct_id": 8,
+        "Comment": {
+          "type": "cexostring",
+          "value": ""
+        }
+      },
+      {
+        "__struct_id": 8,
+        "Comment": {
+          "type": "cexostring",
+          "value": ""
+        }
+      },
+      {
+        "__struct_id": 8,
+        "Comment": {
+          "type": "cexostring",
+          "value": ""
+        }
       }
     ]
   },
@@ -901,13 +936,6 @@
         "Comment": {
           "type": "cexostring",
           "value": "Source: DK Furniture Plus by Nethy"
-        }
-      },
-      {
-        "__struct_id": 9,
-        "Comment": {
-          "type": "cexostring",
-          "value": ""
         }
       },
       {

--- a/Module/gic/v_repubbase_ext.gic.json
+++ b/Module/gic/v_repubbase_ext.gic.json
@@ -154,7 +154,15 @@
   },
   "Door List": {
     "type": "list",
-    "value": []
+    "value": [
+      {
+        "__struct_id": 8,
+        "Comment": {
+          "type": "cexostring",
+          "value": ""
+        }
+      }
+    ]
   },
   "Encounter List": {
     "type": "list",
@@ -1074,13 +1082,6 @@
         "__struct_id": 9,
         "Comment": {
           "type": "cexostring",
-          "value": ""
-        }
-      },
-      {
-        "__struct_id": 9,
-        "Comment": {
-          "type": "cexostring",
           "value": "Source: Tir Na Og Tree Pack 1 v2.01 By Martin E"
         }
       },
@@ -1103,6 +1104,20 @@
         "Comment": {
           "type": "cexostring",
           "value": "Invisible Object"
+        }
+      },
+      {
+        "__struct_id": 9,
+        "Comment": {
+          "type": "cexostring",
+          "value": ""
+        }
+      },
+      {
+        "__struct_id": 9,
+        "Comment": {
+          "type": "cexostring",
+          "value": ""
         }
       },
       {
@@ -1263,13 +1278,6 @@
         "Comment": {
           "type": "cexostring",
           "value": ""
-        }
-      },
-      {
-        "__struct_id": 5,
-        "Comment": {
-          "type": "cexostring",
-          "value": "This is the default waypoint you may place to set a patrol path for a creature or NPC.\r\n1. Create the creature and either use its current Tag or fill in a new one.\r\n2. Place or make sure the WalkWayPoints() is within the body of the On Spawn script for the creature.\r\n3. Place a series of waypoints along the route you wish the creature to walk.\r\n4. Select all of the newly created waypoints and right click. Choose the Create Set option.\r\n5. The waypoint set will have a set name of \"WP_\" + NPC Tag. Thus if an NPC with the Tag \"Guard\" will have a waypoint set called \"WP_Guard\". Note that Tags are case sensitive."
         }
       }
     ]

--- a/Module/gic/v_repubbase_off.gic.json
+++ b/Module/gic/v_repubbase_off.gic.json
@@ -2356,13 +2356,6 @@
         "__struct_id": 9,
         "Comment": {
           "type": "cexostring",
-          "value": ""
-        }
-      },
-      {
-        "__struct_id": 9,
-        "Comment": {
-          "type": "cexostring",
           "value": "Source: DK Furniture Plus by Nethy"
         }
       },

--- a/Module/git/v_repubbase_1.git.json
+++ b/Module/git/v_repubbase_1.git.json
@@ -4823,7 +4823,7 @@
         },
         "Conversation": {
           "type": "resref",
-          "value": ""
+          "value": "rep_idleguard"
         },
         "CRAdjust": {
           "type": "int",
@@ -4952,7 +4952,7 @@
               },
               "XOrientation": {
                 "type": "float",
-                "value": 4.428103147266422e-043
+                "value": 0.0
               },
               "XPosition": {
                 "type": "float",
@@ -5427,7 +5427,7 @@
               },
               "XOrientation": {
                 "type": "float",
-                "value": 0.0
+                "value": 4.428103147266422e-043
               },
               "XPosition": {
                 "type": "float",
@@ -6087,7 +6087,7 @@
         },
         "Conversation": {
           "type": "resref",
-          "value": ""
+          "value": "rep_idleguard"
         },
         "CRAdjust": {
           "type": "int",
@@ -6216,7 +6216,7 @@
               },
               "XOrientation": {
                 "type": "float",
-                "value": 4.428103147266422e-043
+                "value": 0.0
               },
               "XPosition": {
                 "type": "float",
@@ -6691,7 +6691,7 @@
               },
               "XOrientation": {
                 "type": "float",
-                "value": 0.0
+                "value": 4.428103147266422e-043
               },
               "XPosition": {
                 "type": "float",
@@ -7351,7 +7351,7 @@
         },
         "Conversation": {
           "type": "resref",
-          "value": ""
+          "value": "rep_idleguard"
         },
         "CRAdjust": {
           "type": "int",
@@ -7480,7 +7480,7 @@
               },
               "XOrientation": {
                 "type": "float",
-                "value": 4.428103147266422e-043
+                "value": 0.0
               },
               "XPosition": {
                 "type": "float",
@@ -7955,7 +7955,7 @@
               },
               "XOrientation": {
                 "type": "float",
-                "value": 0.0
+                "value": 4.428103147266422e-043
               },
               "XPosition": {
                 "type": "float",
@@ -8615,7 +8615,7 @@
         },
         "Conversation": {
           "type": "resref",
-          "value": ""
+          "value": "rep_idleguard"
         },
         "CRAdjust": {
           "type": "int",
@@ -8744,7 +8744,7 @@
               },
               "XOrientation": {
                 "type": "float",
-                "value": 4.428103147266422e-043
+                "value": 0.0
               },
               "XPosition": {
                 "type": "float",
@@ -9219,7 +9219,7 @@
               },
               "XOrientation": {
                 "type": "float",
-                "value": 0.0
+                "value": 4.428103147266422e-043
               },
               "XPosition": {
                 "type": "float",
@@ -9879,7 +9879,7 @@
         },
         "Conversation": {
           "type": "resref",
-          "value": ""
+          "value": "rep_idleguard"
         },
         "CRAdjust": {
           "type": "int",
@@ -10008,7 +10008,7 @@
               },
               "XOrientation": {
                 "type": "float",
-                "value": 4.428103147266422e-043
+                "value": 0.0
               },
               "XPosition": {
                 "type": "float",
@@ -10483,7 +10483,7 @@
               },
               "XOrientation": {
                 "type": "float",
-                "value": 0.0
+                "value": 4.428103147266422e-043
               },
               "XPosition": {
                 "type": "float",
@@ -11143,7 +11143,7 @@
         },
         "Conversation": {
           "type": "resref",
-          "value": ""
+          "value": "rep_idleguard"
         },
         "CRAdjust": {
           "type": "int",
@@ -11270,7 +11270,7 @@
               },
               "XOrientation": {
                 "type": "float",
-                "value": 0.0
+                "value": 4.428103147266422e-043
               },
               "XPosition": {
                 "type": "float",
@@ -11745,7 +11745,7 @@
               },
               "XOrientation": {
                 "type": "float",
-                "value": 4.428103147266422e-043
+                "value": 0.0
               },
               "XPosition": {
                 "type": "float",
@@ -12405,7 +12405,7 @@
         },
         "Conversation": {
           "type": "resref",
-          "value": ""
+          "value": "rep_idleguard"
         },
         "CRAdjust": {
           "type": "int",
@@ -12607,7 +12607,7 @@
               },
               "XOrientation": {
                 "type": "float",
-                "value": 0.0
+                "value": 4.428103147266422e-043
               },
               "XPosition": {
                 "type": "float",
@@ -12894,7 +12894,7 @@
               },
               "XOrientation": {
                 "type": "float",
-                "value": 4.428103147266422e-043
+                "value": 0.0
               },
               "XPosition": {
                 "type": "float",
@@ -19558,7 +19558,7 @@
         },
         "Conversation": {
           "type": "resref",
-          "value": ""
+          "value": "rep_idleguard"
         },
         "CRAdjust": {
           "type": "int",
@@ -19687,7 +19687,7 @@
               },
               "XOrientation": {
                 "type": "float",
-                "value": 2.928713790438868e-043
+                "value": 0.0
               },
               "XPosition": {
                 "type": "float",
@@ -20162,7 +20162,7 @@
               },
               "XOrientation": {
                 "type": "float",
-                "value": 0.0
+                "value": 2.928713790438868e-043
               },
               "XPosition": {
                 "type": "float",
@@ -20822,7 +20822,7 @@
         },
         "Conversation": {
           "type": "resref",
-          "value": "untitled000"
+          "value": "rep_idleguard"
         },
         "CRAdjust": {
           "type": "int",
@@ -21024,7 +21024,7 @@
               },
               "XOrientation": {
                 "type": "float",
-                "value": 0.0
+                "value": 2.858648867222627e-043
               },
               "XPosition": {
                 "type": "float",
@@ -21311,7 +21311,7 @@
               },
               "XOrientation": {
                 "type": "float",
-                "value": 2.858648867222627e-043
+                "value": 0.0
               },
               "XPosition": {
                 "type": "float",
@@ -21971,7 +21971,7 @@
         },
         "Conversation": {
           "type": "resref",
-          "value": ""
+          "value": "rep_idleguard"
         },
         "CRAdjust": {
           "type": "int",
@@ -22173,7 +22173,7 @@
               },
               "XOrientation": {
                 "type": "float",
-                "value": 0.0
+                "value": 2.858648867222627e-043
               },
               "XPosition": {
                 "type": "float",
@@ -22460,7 +22460,7 @@
               },
               "XOrientation": {
                 "type": "float",
-                "value": 2.858648867222627e-043
+                "value": 0.0
               },
               "XPosition": {
                 "type": "float",
@@ -32117,7 +32117,7 @@
         "LocName": {
           "type": "cexolocstring",
           "value": {
-            "0": "Plaque, Carved Glyphs"
+            "0": "Mess Hall"
           }
         },
         "OnClick": {
@@ -32186,7 +32186,7 @@
         },
         "Plot": {
           "type": "byte",
-          "value": 0
+          "value": 1
         },
         "PortraitId": {
           "type": "word",
@@ -32198,7 +32198,7 @@
         },
         "Static": {
           "type": "byte",
-          "value": 1
+          "value": 0
         },
         "Tag": {
           "type": "cexostring",
@@ -32238,7 +32238,7 @@
         },
         "Useable": {
           "type": "byte",
-          "value": 0
+          "value": 1
         },
         "Will": {
           "type": "byte",
@@ -104930,7 +104930,7 @@
               },
               "Cursed": {
                 "type": "byte",
-                "value": 0
+                "value": 1
               },
               "DescIdentified": {
                 "type": "cexolocstring",
@@ -104960,7 +104960,7 @@
               },
               "Plot": {
                 "type": "byte",
-                "value": 0
+                "value": 1
               },
               "PropertiesList": {
                 "type": "list",
@@ -104992,7 +104992,7 @@
               },
               "XOrientation": {
                 "type": "float",
-                "value": 1.105624488352281e-042
+                "value": 7.062544260197078e-043
               },
               "XPosition": {
                 "type": "float",
@@ -105031,7 +105031,7 @@
               },
               "Cursed": {
                 "type": "byte",
-                "value": 0
+                "value": 1
               },
               "DescIdentified": {
                 "type": "cexolocstring",
@@ -105061,7 +105061,7 @@
               },
               "Plot": {
                 "type": "byte",
-                "value": 0
+                "value": 1
               },
               "PropertiesList": {
                 "type": "list",
@@ -105093,7 +105093,7 @@
               },
               "XOrientation": {
                 "type": "float",
-                "value": 0.0
+                "value": 7.062544260197078e-043
               },
               "XPosition": {
                 "type": "float",
@@ -105132,7 +105132,7 @@
               },
               "Cursed": {
                 "type": "byte",
-                "value": 0
+                "value": 1
               },
               "DescIdentified": {
                 "type": "cexolocstring",
@@ -105162,7 +105162,7 @@
               },
               "Plot": {
                 "type": "byte",
-                "value": 0
+                "value": 1
               },
               "PropertiesList": {
                 "type": "list",
@@ -105194,7 +105194,7 @@
               },
               "XOrientation": {
                 "type": "float",
-                "value": 7.062544260197078e-043
+                "value": 0.0
               },
               "XPosition": {
                 "type": "float",
@@ -105233,7 +105233,7 @@
               },
               "Cursed": {
                 "type": "byte",
-                "value": 0
+                "value": 1
               },
               "DescIdentified": {
                 "type": "cexolocstring",
@@ -105263,7 +105263,7 @@
               },
               "Plot": {
                 "type": "byte",
-                "value": 0
+                "value": 1
               },
               "PropertiesList": {
                 "type": "list",
@@ -105295,7 +105295,7 @@
               },
               "XOrientation": {
                 "type": "float",
-                "value": 7.062544260197078e-043
+                "value": 1.105624488352281e-042
               },
               "XPosition": {
                 "type": "float",
@@ -126880,7 +126880,7 @@
         },
         "HasInventory": {
           "type": "byte",
-          "value": 1
+          "value": 0
         },
         "HP": {
           "type": "short",
@@ -127044,6 +127044,235 @@
         "Y": {
           "type": "float",
           "value": 41.08989334106445
+        },
+        "Z": {
+          "type": "float",
+          "value": -5.7220458984375e-006
+        }
+      },
+      {
+        "__struct_id": 9,
+        "AnimationState": {
+          "type": "byte",
+          "value": 0
+        },
+        "Appearance": {
+          "type": "dword",
+          "value": 1604
+        },
+        "AutoRemoveKey": {
+          "type": "byte",
+          "value": 0
+        },
+        "Bearing": {
+          "type": "float",
+          "value": 1.570796370506287
+        },
+        "BodyBag": {
+          "type": "byte",
+          "value": 0
+        },
+        "CloseLockDC": {
+          "type": "byte",
+          "value": 0
+        },
+        "Conversation": {
+          "type": "resref",
+          "value": ""
+        },
+        "CurrentHP": {
+          "type": "short",
+          "value": 15
+        },
+        "Description": {
+          "id": 16810880,
+          "type": "cexolocstring",
+          "value": {
+            "0": "Click to Sit"
+          }
+        },
+        "DisarmDC": {
+          "type": "byte",
+          "value": 15
+        },
+        "Faction": {
+          "type": "dword",
+          "value": 1
+        },
+        "Fort": {
+          "type": "byte",
+          "value": 16
+        },
+        "Hardness": {
+          "type": "byte",
+          "value": 5
+        },
+        "HasInventory": {
+          "type": "byte",
+          "value": 0
+        },
+        "HP": {
+          "type": "short",
+          "value": 15
+        },
+        "Interruptable": {
+          "type": "byte",
+          "value": 1
+        },
+        "KeyName": {
+          "type": "cexostring",
+          "value": ""
+        },
+        "KeyRequired": {
+          "type": "byte",
+          "value": 0
+        },
+        "Lockable": {
+          "type": "byte",
+          "value": 0
+        },
+        "Locked": {
+          "type": "byte",
+          "value": 0
+        },
+        "LocName": {
+          "id": 16812066,
+          "type": "cexolocstring",
+          "value": {
+            "0": "*Sit*"
+          }
+        },
+        "OnClick": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnClosed": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnDamaged": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnDeath": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnDisarm": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnHeartbeat": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnInvDisturbed": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnLock": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnMeleeAttacked": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnOpen": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnSpellCastAt": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnTrapTriggered": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnUnlock": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnUsed": {
+          "type": "resref",
+          "value": "zep_use_chair"
+        },
+        "OnUserDefined": {
+          "type": "resref",
+          "value": ""
+        },
+        "OpenLockDC": {
+          "type": "byte",
+          "value": 18
+        },
+        "Plot": {
+          "type": "byte",
+          "value": 0
+        },
+        "PortraitId": {
+          "type": "word",
+          "value": 0
+        },
+        "Ref": {
+          "type": "byte",
+          "value": 0
+        },
+        "Static": {
+          "type": "byte",
+          "value": 0
+        },
+        "Tag": {
+          "type": "cexostring",
+          "value": "Night_InvisbileSit"
+        },
+        "TemplateResRef": {
+          "type": "resref",
+          "value": "night_invissit"
+        },
+        "TrapDetectable": {
+          "type": "byte",
+          "value": 1
+        },
+        "TrapDetectDC": {
+          "type": "byte",
+          "value": 0
+        },
+        "TrapDisarmable": {
+          "type": "byte",
+          "value": 1
+        },
+        "TrapFlag": {
+          "type": "byte",
+          "value": 0
+        },
+        "TrapOneShot": {
+          "type": "byte",
+          "value": 1
+        },
+        "TrapType": {
+          "type": "byte",
+          "value": 0
+        },
+        "Type": {
+          "type": "byte",
+          "value": 0
+        },
+        "Useable": {
+          "type": "byte",
+          "value": 1
+        },
+        "Will": {
+          "type": "byte",
+          "value": 0
+        },
+        "X": {
+          "type": "float",
+          "value": 47.628662109375
+        },
+        "Y": {
+          "type": "float",
+          "value": 101.6470336914063
         },
         "Z": {
           "type": "float",

--- a/Module/git/v_repubbase_2.git.json
+++ b/Module/git/v_repubbase_2.git.json
@@ -3099,7 +3099,7 @@
         },
         "XPosition": {
           "type": "float",
-          "value": 29.50647354125977
+          "value": 24.88226699829102
         },
         "YOrientation": {
           "type": "float",
@@ -3107,11 +3107,11 @@
         },
         "YPosition": {
           "type": "float",
-          "value": 22.04148101806641
+          "value": 17.78001594543457
         },
         "ZPosition": {
           "type": "float",
-          "value": 7.62939453125e-006
+          "value": -5.7220458984375e-006
         }
       },
       {
@@ -15554,19 +15554,19 @@
         },
         "XOrientation": {
           "type": "float",
-          "value": 7.876607657395732e-015
+          "value": -0.5956992506980896
         },
         "XPosition": {
           "type": "float",
-          "value": 42.07584381103516
+          "value": 43.65153121948242
         },
         "YOrientation": {
           "type": "float",
-          "value": -1.0
+          "value": 0.8032075762748718
         },
         "YPosition": {
           "type": "float",
-          "value": 18.70992279052734
+          "value": 19.19316101074219
         },
         "ZPosition": {
           "type": "float",
@@ -16471,19 +16471,19 @@
         },
         "KeyName": {
           "type": "cexostring",
-          "value": ""
+          "value": "Key_R_1"
         },
         "KeyRequired": {
           "type": "byte",
-          "value": 0
+          "value": 1
         },
         "LinkedTo": {
           "type": "cexostring",
-          "value": ""
+          "value": "RepBase_HangarToMedical"
         },
         "LinkedToFlags": {
           "type": "byte",
-          "value": 0
+          "value": 1
         },
         "LoadScreenID": {
           "type": "word",
@@ -16495,12 +16495,12 @@
         },
         "Locked": {
           "type": "byte",
-          "value": 0
+          "value": 1
         },
         "LocName": {
           "type": "cexolocstring",
           "value": {
-            "0": "Elevator Door"
+            "0": "Hangar Door"
           }
         },
         "OnClick": {
@@ -16577,7 +16577,7 @@
         },
         "Tag": {
           "type": "cexostring",
-          "value": "_mdrn_dt_elev"
+          "value": "RepBase_MedicalToHangar"
         },
         "TemplateResRef": {
           "type": "resref",
@@ -17052,6 +17052,1091 @@
         "Y": {
           "type": "float",
           "value": 40.0
+        },
+        "Z": {
+          "type": "float",
+          "value": 0.0
+        }
+      },
+      {
+        "__struct_id": 8,
+        "AnimationState": {
+          "type": "byte",
+          "value": 0
+        },
+        "Appearance": {
+          "type": "dword",
+          "value": 0
+        },
+        "AutoRemoveKey": {
+          "type": "byte",
+          "value": 0
+        },
+        "Bearing": {
+          "type": "float",
+          "value": -1.570796251296997
+        },
+        "CloseLockDC": {
+          "type": "byte",
+          "value": 30
+        },
+        "Conversation": {
+          "type": "resref",
+          "value": ""
+        },
+        "CurrentHP": {
+          "type": "short",
+          "value": 200
+        },
+        "Description": {
+          "type": "cexolocstring",
+          "value": {}
+        },
+        "DisarmDC": {
+          "type": "byte",
+          "value": 0
+        },
+        "Faction": {
+          "type": "dword",
+          "value": 1
+        },
+        "Fort": {
+          "type": "byte",
+          "value": 25
+        },
+        "GenericType_New": {
+          "type": "dword",
+          "value": 46
+        },
+        "Hardness": {
+          "type": "byte",
+          "value": 20
+        },
+        "HP": {
+          "type": "short",
+          "value": 200
+        },
+        "Interruptable": {
+          "type": "byte",
+          "value": 1
+        },
+        "KeyName": {
+          "type": "cexostring",
+          "value": "Key_R_1"
+        },
+        "KeyRequired": {
+          "type": "byte",
+          "value": 1
+        },
+        "LinkedTo": {
+          "type": "cexostring",
+          "value": ""
+        },
+        "LinkedToFlags": {
+          "type": "byte",
+          "value": 0
+        },
+        "LoadScreenID": {
+          "type": "word",
+          "value": 0
+        },
+        "Lockable": {
+          "type": "byte",
+          "value": 1
+        },
+        "Locked": {
+          "type": "byte",
+          "value": 1
+        },
+        "LocName": {
+          "type": "cexolocstring",
+          "value": {
+            "0": "Brig Door"
+          }
+        },
+        "OnClick": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnClosed": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnDamaged": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnDeath": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnDisarm": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnFailToOpen": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnHeartbeat": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnLock": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnMeleeAttacked": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnOpen": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnSpellCastAt": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnTrapTriggered": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnUnlock": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnUserDefined": {
+          "type": "resref",
+          "value": ""
+        },
+        "OpenLockDC": {
+          "type": "byte",
+          "value": 30
+        },
+        "Plot": {
+          "type": "byte",
+          "value": 1
+        },
+        "PortraitId": {
+          "type": "word",
+          "value": 558
+        },
+        "Ref": {
+          "type": "byte",
+          "value": 0
+        },
+        "Tag": {
+          "type": "cexostring",
+          "value": "rep_brig_doorA"
+        },
+        "TemplateResRef": {
+          "type": "resref",
+          "value": "_mdrn_dt_slid015"
+        },
+        "TrapDetectable": {
+          "type": "byte",
+          "value": 1
+        },
+        "TrapDetectDC": {
+          "type": "byte",
+          "value": 0
+        },
+        "TrapDisarmable": {
+          "type": "byte",
+          "value": 1
+        },
+        "TrapFlag": {
+          "type": "byte",
+          "value": 0
+        },
+        "TrapOneShot": {
+          "type": "byte",
+          "value": 1
+        },
+        "TrapType": {
+          "type": "byte",
+          "value": 0
+        },
+        "Will": {
+          "type": "byte",
+          "value": 0
+        },
+        "X": {
+          "type": "float",
+          "value": 38.5
+        },
+        "Y": {
+          "type": "float",
+          "value": 25.89999961853027
+        },
+        "Z": {
+          "type": "float",
+          "value": 0.0
+        }
+      },
+      {
+        "__struct_id": 8,
+        "AnimationState": {
+          "type": "byte",
+          "value": 0
+        },
+        "Appearance": {
+          "type": "dword",
+          "value": 0
+        },
+        "AutoRemoveKey": {
+          "type": "byte",
+          "value": 0
+        },
+        "Bearing": {
+          "type": "float",
+          "value": -1.570796251296997
+        },
+        "CloseLockDC": {
+          "type": "byte",
+          "value": 30
+        },
+        "Conversation": {
+          "type": "resref",
+          "value": ""
+        },
+        "CurrentHP": {
+          "type": "short",
+          "value": 200
+        },
+        "Description": {
+          "type": "cexolocstring",
+          "value": {}
+        },
+        "DisarmDC": {
+          "type": "byte",
+          "value": 0
+        },
+        "Faction": {
+          "type": "dword",
+          "value": 1
+        },
+        "Fort": {
+          "type": "byte",
+          "value": 25
+        },
+        "GenericType_New": {
+          "type": "dword",
+          "value": 46
+        },
+        "Hardness": {
+          "type": "byte",
+          "value": 15
+        },
+        "HP": {
+          "type": "short",
+          "value": 200
+        },
+        "Interruptable": {
+          "type": "byte",
+          "value": 1
+        },
+        "KeyName": {
+          "type": "cexostring",
+          "value": "Key_R_1"
+        },
+        "KeyRequired": {
+          "type": "byte",
+          "value": 1
+        },
+        "LinkedTo": {
+          "type": "cexostring",
+          "value": ""
+        },
+        "LinkedToFlags": {
+          "type": "byte",
+          "value": 0
+        },
+        "LoadScreenID": {
+          "type": "word",
+          "value": 0
+        },
+        "Lockable": {
+          "type": "byte",
+          "value": 1
+        },
+        "Locked": {
+          "type": "byte",
+          "value": 1
+        },
+        "LocName": {
+          "type": "cexolocstring",
+          "value": {
+            "0": "Brig Door"
+          }
+        },
+        "OnClick": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnClosed": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnDamaged": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnDeath": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnDisarm": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnFailToOpen": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnHeartbeat": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnLock": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnMeleeAttacked": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnOpen": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnSpellCastAt": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnTrapTriggered": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnUnlock": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnUserDefined": {
+          "type": "resref",
+          "value": ""
+        },
+        "OpenLockDC": {
+          "type": "byte",
+          "value": 30
+        },
+        "Plot": {
+          "type": "byte",
+          "value": 1
+        },
+        "PortraitId": {
+          "type": "word",
+          "value": 558
+        },
+        "Ref": {
+          "type": "byte",
+          "value": 0
+        },
+        "Tag": {
+          "type": "cexostring",
+          "value": "rep_brig_doorB"
+        },
+        "TemplateResRef": {
+          "type": "resref",
+          "value": "_mdrn_dt_slid007"
+        },
+        "TrapDetectable": {
+          "type": "byte",
+          "value": 1
+        },
+        "TrapDetectDC": {
+          "type": "byte",
+          "value": 0
+        },
+        "TrapDisarmable": {
+          "type": "byte",
+          "value": 1
+        },
+        "TrapFlag": {
+          "type": "byte",
+          "value": 0
+        },
+        "TrapOneShot": {
+          "type": "byte",
+          "value": 1
+        },
+        "TrapType": {
+          "type": "byte",
+          "value": 0
+        },
+        "Will": {
+          "type": "byte",
+          "value": 0
+        },
+        "X": {
+          "type": "float",
+          "value": 38.0
+        },
+        "Y": {
+          "type": "float",
+          "value": 35.79999923706055
+        },
+        "Z": {
+          "type": "float",
+          "value": 0.0
+        }
+      },
+      {
+        "__struct_id": 8,
+        "AnimationState": {
+          "type": "byte",
+          "value": 0
+        },
+        "Appearance": {
+          "type": "dword",
+          "value": 0
+        },
+        "AutoRemoveKey": {
+          "type": "byte",
+          "value": 0
+        },
+        "Bearing": {
+          "type": "float",
+          "value": -3.141592264175415
+        },
+        "CloseLockDC": {
+          "type": "byte",
+          "value": 30
+        },
+        "Conversation": {
+          "type": "resref",
+          "value": ""
+        },
+        "CurrentHP": {
+          "type": "short",
+          "value": 200
+        },
+        "Description": {
+          "type": "cexolocstring",
+          "value": {}
+        },
+        "DisarmDC": {
+          "type": "byte",
+          "value": 0
+        },
+        "Faction": {
+          "type": "dword",
+          "value": 1
+        },
+        "Fort": {
+          "type": "byte",
+          "value": 25
+        },
+        "GenericType_New": {
+          "type": "dword",
+          "value": 46
+        },
+        "Hardness": {
+          "type": "byte",
+          "value": 15
+        },
+        "HP": {
+          "type": "short",
+          "value": 200
+        },
+        "Interruptable": {
+          "type": "byte",
+          "value": 1
+        },
+        "KeyName": {
+          "type": "cexostring",
+          "value": "Key_R_1"
+        },
+        "KeyRequired": {
+          "type": "byte",
+          "value": 1
+        },
+        "LinkedTo": {
+          "type": "cexostring",
+          "value": ""
+        },
+        "LinkedToFlags": {
+          "type": "byte",
+          "value": 0
+        },
+        "LoadScreenID": {
+          "type": "word",
+          "value": 0
+        },
+        "Lockable": {
+          "type": "byte",
+          "value": 1
+        },
+        "Locked": {
+          "type": "byte",
+          "value": 1
+        },
+        "LocName": {
+          "type": "cexolocstring",
+          "value": {
+            "0": "Brig Door"
+          }
+        },
+        "OnClick": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnClosed": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnDamaged": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnDeath": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnDisarm": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnFailToOpen": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnHeartbeat": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnLock": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnMeleeAttacked": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnOpen": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnSpellCastAt": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnTrapTriggered": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnUnlock": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnUserDefined": {
+          "type": "resref",
+          "value": ""
+        },
+        "OpenLockDC": {
+          "type": "byte",
+          "value": 30
+        },
+        "Plot": {
+          "type": "byte",
+          "value": 1
+        },
+        "PortraitId": {
+          "type": "word",
+          "value": 558
+        },
+        "Ref": {
+          "type": "byte",
+          "value": 0
+        },
+        "Tag": {
+          "type": "cexostring",
+          "value": "rep_brig_doorC"
+        },
+        "TemplateResRef": {
+          "type": "resref",
+          "value": "_mdrn_dt_slid007"
+        },
+        "TrapDetectable": {
+          "type": "byte",
+          "value": 1
+        },
+        "TrapDetectDC": {
+          "type": "byte",
+          "value": 0
+        },
+        "TrapDisarmable": {
+          "type": "byte",
+          "value": 1
+        },
+        "TrapFlag": {
+          "type": "byte",
+          "value": 0
+        },
+        "TrapOneShot": {
+          "type": "byte",
+          "value": 1
+        },
+        "TrapType": {
+          "type": "byte",
+          "value": 0
+        },
+        "Will": {
+          "type": "byte",
+          "value": 0
+        },
+        "X": {
+          "type": "float",
+          "value": 33.75
+        },
+        "Y": {
+          "type": "float",
+          "value": 21.29999923706055
+        },
+        "Z": {
+          "type": "float",
+          "value": 0.0
+        }
+      },
+      {
+        "__struct_id": 8,
+        "AnimationState": {
+          "type": "byte",
+          "value": 0
+        },
+        "Appearance": {
+          "type": "dword",
+          "value": 0
+        },
+        "AutoRemoveKey": {
+          "type": "byte",
+          "value": 0
+        },
+        "Bearing": {
+          "type": "float",
+          "value": 1.570796251296997
+        },
+        "CloseLockDC": {
+          "type": "byte",
+          "value": 30
+        },
+        "Conversation": {
+          "type": "resref",
+          "value": ""
+        },
+        "CurrentHP": {
+          "type": "short",
+          "value": 200
+        },
+        "Description": {
+          "type": "cexolocstring",
+          "value": {}
+        },
+        "DisarmDC": {
+          "type": "byte",
+          "value": 0
+        },
+        "Faction": {
+          "type": "dword",
+          "value": 1
+        },
+        "Fort": {
+          "type": "byte",
+          "value": 25
+        },
+        "GenericType_New": {
+          "type": "dword",
+          "value": 46
+        },
+        "Hardness": {
+          "type": "byte",
+          "value": 15
+        },
+        "HP": {
+          "type": "short",
+          "value": 200
+        },
+        "Interruptable": {
+          "type": "byte",
+          "value": 1
+        },
+        "KeyName": {
+          "type": "cexostring",
+          "value": "Key_R_1"
+        },
+        "KeyRequired": {
+          "type": "byte",
+          "value": 1
+        },
+        "LinkedTo": {
+          "type": "cexostring",
+          "value": ""
+        },
+        "LinkedToFlags": {
+          "type": "byte",
+          "value": 0
+        },
+        "LoadScreenID": {
+          "type": "word",
+          "value": 0
+        },
+        "Lockable": {
+          "type": "byte",
+          "value": 1
+        },
+        "Locked": {
+          "type": "byte",
+          "value": 1
+        },
+        "LocName": {
+          "type": "cexolocstring",
+          "value": {
+            "0": "Brig Door"
+          }
+        },
+        "OnClick": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnClosed": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnDamaged": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnDeath": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnDisarm": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnFailToOpen": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnHeartbeat": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnLock": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnMeleeAttacked": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnOpen": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnSpellCastAt": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnTrapTriggered": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnUnlock": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnUserDefined": {
+          "type": "resref",
+          "value": ""
+        },
+        "OpenLockDC": {
+          "type": "byte",
+          "value": 30
+        },
+        "Plot": {
+          "type": "byte",
+          "value": 1
+        },
+        "PortraitId": {
+          "type": "word",
+          "value": 558
+        },
+        "Ref": {
+          "type": "byte",
+          "value": 0
+        },
+        "Tag": {
+          "type": "cexostring",
+          "value": "rep_brig_doorD"
+        },
+        "TemplateResRef": {
+          "type": "resref",
+          "value": "_mdrn_dt_slid007"
+        },
+        "TrapDetectable": {
+          "type": "byte",
+          "value": 1
+        },
+        "TrapDetectDC": {
+          "type": "byte",
+          "value": 0
+        },
+        "TrapDisarmable": {
+          "type": "byte",
+          "value": 1
+        },
+        "TrapFlag": {
+          "type": "byte",
+          "value": 0
+        },
+        "TrapOneShot": {
+          "type": "byte",
+          "value": 1
+        },
+        "TrapType": {
+          "type": "byte",
+          "value": 0
+        },
+        "Will": {
+          "type": "byte",
+          "value": 0
+        },
+        "X": {
+          "type": "float",
+          "value": 28.5
+        },
+        "Y": {
+          "type": "float",
+          "value": 26.0
+        },
+        "Z": {
+          "type": "float",
+          "value": 0.0
+        }
+      },
+      {
+        "__struct_id": 8,
+        "AnimationState": {
+          "type": "byte",
+          "value": 0
+        },
+        "Appearance": {
+          "type": "dword",
+          "value": 0
+        },
+        "AutoRemoveKey": {
+          "type": "byte",
+          "value": 0
+        },
+        "Bearing": {
+          "type": "float",
+          "value": -3.141592264175415
+        },
+        "CloseLockDC": {
+          "type": "byte",
+          "value": 30
+        },
+        "Conversation": {
+          "type": "resref",
+          "value": ""
+        },
+        "CurrentHP": {
+          "type": "short",
+          "value": 200
+        },
+        "Description": {
+          "type": "cexolocstring",
+          "value": {}
+        },
+        "DisarmDC": {
+          "type": "byte",
+          "value": 0
+        },
+        "Faction": {
+          "type": "dword",
+          "value": 1
+        },
+        "Fort": {
+          "type": "byte",
+          "value": 25
+        },
+        "GenericType_New": {
+          "type": "dword",
+          "value": 46
+        },
+        "Hardness": {
+          "type": "byte",
+          "value": 15
+        },
+        "HP": {
+          "type": "short",
+          "value": 200
+        },
+        "Interruptable": {
+          "type": "byte",
+          "value": 1
+        },
+        "KeyName": {
+          "type": "cexostring",
+          "value": "Key_R_1"
+        },
+        "KeyRequired": {
+          "type": "byte",
+          "value": 1
+        },
+        "LinkedTo": {
+          "type": "cexostring",
+          "value": ""
+        },
+        "LinkedToFlags": {
+          "type": "byte",
+          "value": 0
+        },
+        "LoadScreenID": {
+          "type": "word",
+          "value": 0
+        },
+        "Lockable": {
+          "type": "byte",
+          "value": 1
+        },
+        "Locked": {
+          "type": "byte",
+          "value": 1
+        },
+        "LocName": {
+          "type": "cexolocstring",
+          "value": {
+            "0": "Brig Door"
+          }
+        },
+        "OnClick": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnClosed": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnDamaged": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnDeath": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnDisarm": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnFailToOpen": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnHeartbeat": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnLock": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnMeleeAttacked": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnOpen": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnSpellCastAt": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnTrapTriggered": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnUnlock": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnUserDefined": {
+          "type": "resref",
+          "value": ""
+        },
+        "OpenLockDC": {
+          "type": "byte",
+          "value": 30
+        },
+        "Plot": {
+          "type": "byte",
+          "value": 1
+        },
+        "PortraitId": {
+          "type": "word",
+          "value": 558
+        },
+        "Ref": {
+          "type": "byte",
+          "value": 0
+        },
+        "Tag": {
+          "type": "cexostring",
+          "value": "rep_brig_doorE"
+        },
+        "TemplateResRef": {
+          "type": "resref",
+          "value": "_mdrn_dt_slid007"
+        },
+        "TrapDetectable": {
+          "type": "byte",
+          "value": 1
+        },
+        "TrapDetectDC": {
+          "type": "byte",
+          "value": 0
+        },
+        "TrapDisarmable": {
+          "type": "byte",
+          "value": 1
+        },
+        "TrapFlag": {
+          "type": "byte",
+          "value": 0
+        },
+        "TrapOneShot": {
+          "type": "byte",
+          "value": 1
+        },
+        "TrapType": {
+          "type": "byte",
+          "value": 0
+        },
+        "Will": {
+          "type": "byte",
+          "value": 0
+        },
+        "X": {
+          "type": "float",
+          "value": 33.90000152587891
+        },
+        "Y": {
+          "type": "float",
+          "value": 30.79999923706055
         },
         "Z": {
           "type": "float",
@@ -51508,231 +52593,6 @@
           "type": "float",
           "value": 7.62939453125e-006
         }
-      },
-      {
-        "__struct_id": 9,
-        "AnimationState": {
-          "type": "byte",
-          "value": 0
-        },
-        "Appearance": {
-          "type": "dword",
-          "value": 30092
-        },
-        "AutoRemoveKey": {
-          "type": "byte",
-          "value": 0
-        },
-        "Bearing": {
-          "type": "float",
-          "value": -0.0
-        },
-        "BodyBag": {
-          "type": "byte",
-          "value": 0
-        },
-        "CloseLockDC": {
-          "type": "byte",
-          "value": 0
-        },
-        "Conversation": {
-          "type": "resref",
-          "value": ""
-        },
-        "CurrentHP": {
-          "type": "short",
-          "value": 10
-        },
-        "Description": {
-          "type": "cexolocstring",
-          "value": {}
-        },
-        "DisarmDC": {
-          "type": "byte",
-          "value": 0
-        },
-        "Faction": {
-          "type": "dword",
-          "value": 1
-        },
-        "Fort": {
-          "type": "byte",
-          "value": 5
-        },
-        "Hardness": {
-          "type": "byte",
-          "value": 5
-        },
-        "HasInventory": {
-          "type": "byte",
-          "value": 0
-        },
-        "HP": {
-          "type": "short",
-          "value": 10
-        },
-        "Interruptable": {
-          "type": "byte",
-          "value": 1
-        },
-        "KeyName": {
-          "type": "cexostring",
-          "value": ""
-        },
-        "KeyRequired": {
-          "type": "byte",
-          "value": 0
-        },
-        "Lockable": {
-          "type": "byte",
-          "value": 1
-        },
-        "Locked": {
-          "type": "byte",
-          "value": 0
-        },
-        "LocName": {
-          "type": "cexolocstring",
-          "value": {
-            "0": "[SWLOR] Base, Bunker Door                                                            "
-          }
-        },
-        "OnClick": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnClosed": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnDamaged": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnDeath": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnDisarm": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnHeartbeat": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnInvDisturbed": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnLock": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnMeleeAttacked": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnOpen": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnSpellCastAt": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnTrapTriggered": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnUnlock": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnUsed": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnUserDefined": {
-          "type": "resref",
-          "value": ""
-        },
-        "OpenLockDC": {
-          "type": "byte",
-          "value": 0
-        },
-        "Plot": {
-          "type": "byte",
-          "value": 1
-        },
-        "PortraitId": {
-          "type": "word",
-          "value": 0
-        },
-        "Ref": {
-          "type": "byte",
-          "value": 0
-        },
-        "Static": {
-          "type": "byte",
-          "value": 0
-        },
-        "Tag": {
-          "type": "cexostring",
-          "value": "swlor_0001"
-        },
-        "TemplateResRef": {
-          "type": "resref",
-          "value": "swlor_0093"
-        },
-        "TrapDetectable": {
-          "type": "byte",
-          "value": 1
-        },
-        "TrapDetectDC": {
-          "type": "byte",
-          "value": 0
-        },
-        "TrapDisarmable": {
-          "type": "byte",
-          "value": 1
-        },
-        "TrapFlag": {
-          "type": "byte",
-          "value": 0
-        },
-        "TrapOneShot": {
-          "type": "byte",
-          "value": 1
-        },
-        "TrapType": {
-          "type": "byte",
-          "value": 0
-        },
-        "Type": {
-          "type": "byte",
-          "value": 0
-        },
-        "Useable": {
-          "type": "byte",
-          "value": 0
-        },
-        "Will": {
-          "type": "byte",
-          "value": 0
-        },
-        "X": {
-          "type": "float",
-          "value": 30.75708770751953
-        },
-        "Y": {
-          "type": "float",
-          "value": 27.68589019775391
-        },
-        "Z": {
-          "type": "float",
-          "value": -5.7220458984375e-006
-        }
       }
     ]
   },
@@ -51755,21 +52615,21 @@
         },
         "IdentifyPrice": {
           "type": "int",
-          "value": 100
+          "value": -1
         },
         "LocName": {
           "type": "cexolocstring",
           "value": {
-            "0": "Republic Armory"
+            "0": "Medical Supplies"
           }
         },
         "MarkDown": {
           "type": "int",
-          "value": 65
+          "value": 40
         },
         "MarkUp": {
           "type": "int",
-          "value": 100
+          "value": 150
         },
         "MaxBuyPrice": {
           "type": "int",
@@ -51785,7 +52645,7 @@
         },
         "ResRef": {
           "type": "resref",
-          "value": "republicarmory"
+          "value": "street_food001"
         },
         "StoreGold": {
           "type": "int",
@@ -51795,7 +52655,19 @@
           "type": "list",
           "value": [
             {
-              "__struct_id": 0,
+              "__struct_id": 0
+            },
+            {
+              "__struct_id": 4
+            },
+            {
+              "__struct_id": 2
+            },
+            {
+              "__struct_id": 3
+            },
+            {
+              "__struct_id": 1,
               "ItemList": {
                 "type": "list",
                 "value": [
@@ -51803,103 +52675,19 @@
                     "__struct_id": 0,
                     "AddCost": {
                       "type": "dword",
-                      "value": 0
-                    },
-                    "ArmorPart_Belt": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "ArmorPart_LBicep": {
-                      "type": "byte",
-                      "value": 75
-                    },
-                    "ArmorPart_LFArm": {
-                      "type": "byte",
-                      "value": 75
-                    },
-                    "ArmorPart_LFoot": {
-                      "type": "byte",
-                      "value": 200
-                    },
-                    "ArmorPart_LHand": {
-                      "type": "byte",
-                      "value": 198
-                    },
-                    "ArmorPart_LShin": {
-                      "type": "byte",
-                      "value": 75
-                    },
-                    "ArmorPart_LShoul": {
-                      "type": "byte",
-                      "value": 186
-                    },
-                    "ArmorPart_LThigh": {
-                      "type": "byte",
-                      "value": 75
-                    },
-                    "ArmorPart_Neck": {
-                      "type": "byte",
                       "value": 2
-                    },
-                    "ArmorPart_Pelvis": {
-                      "type": "byte",
-                      "value": 75
-                    },
-                    "ArmorPart_RBicep": {
-                      "type": "byte",
-                      "value": 75
-                    },
-                    "ArmorPart_RFArm": {
-                      "type": "byte",
-                      "value": 75
-                    },
-                    "ArmorPart_RFoot": {
-                      "type": "byte",
-                      "value": 200
-                    },
-                    "ArmorPart_RHand": {
-                      "type": "byte",
-                      "value": 198
-                    },
-                    "ArmorPart_Robe": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "ArmorPart_RShin": {
-                      "type": "byte",
-                      "value": 75
-                    },
-                    "ArmorPart_RShoul": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "ArmorPart_RThigh": {
-                      "type": "byte",
-                      "value": 75
-                    },
-                    "ArmorPart_Torso": {
-                      "type": "byte",
-                      "value": 193
                     },
                     "BaseItem": {
                       "type": "int",
-                      "value": 16
+                      "value": 39
                     },
                     "Charges": {
                       "type": "byte",
                       "value": 0
                     },
-                    "Cloth1Color": {
-                      "type": "byte",
-                      "value": 22
-                    },
-                    "Cloth2Color": {
-                      "type": "byte",
-                      "value": 93
-                    },
                     "Cost": {
                       "type": "dword",
-                      "value": 1
+                      "value": 2
                     },
                     "Cursed": {
                       "type": "byte",
@@ -51907,7 +52695,9 @@
                     },
                     "DescIdentified": {
                       "type": "cexolocstring",
-                      "value": {}
+                      "value": {
+                        "0": "Medical Supplies are required to use many of the First Aid perks."
+                      }
                     },
                     "Description": {
                       "type": "cexolocstring",
@@ -51917,27 +52707,16 @@
                       "type": "byte",
                       "value": 1
                     },
-                    "Leather1Color": {
-                      "type": "byte",
-                      "value": 23
-                    },
-                    "Leather2Color": {
-                      "type": "byte",
-                      "value": 92
-                    },
                     "LocalizedName": {
+                      "id": 13362,
                       "type": "cexolocstring",
                       "value": {
-                        "0": "Republic Heavy Gunner Armor"
+                        "0": "Medical Supplies"
                       }
                     },
-                    "Metal1Color": {
+                    "ModelPart1": {
                       "type": "byte",
-                      "value": 90
-                    },
-                    "Metal2Color": {
-                      "type": "byte",
-                      "value": 92
+                      "value": 1
                     },
                     "Plot": {
                       "type": "byte",
@@ -51954,228 +52733,11 @@
                           },
                           "CostTable": {
                             "type": "byte",
-                            "value": 2
-                          },
-                          "CostValue": {
-                            "type": "word",
-                            "value": 5
-                          },
-                          "Param1": {
-                            "type": "byte",
-                            "value": 255
-                          },
-                          "Param1Value": {
-                            "type": "byte",
-                            "value": 0
-                          },
-                          "PropertyName": {
-                            "type": "word",
-                            "value": 1
-                          },
-                          "Subtype": {
-                            "type": "word",
-                            "value": 0
-                          }
-                        },
-                        {
-                          "__struct_id": 0,
-                          "ChanceAppear": {
-                            "type": "byte",
-                            "value": 100
-                          },
-                          "CostTable": {
-                            "type": "byte",
-                            "value": 6
-                          },
-                          "CostValue": {
-                            "type": "word",
-                            "value": 2
-                          },
-                          "Param1": {
-                            "type": "byte",
-                            "value": 255
-                          },
-                          "Param1Value": {
-                            "type": "byte",
-                            "value": 0
-                          },
-                          "PropertyName": {
-                            "type": "word",
-                            "value": 22
-                          },
-                          "Subtype": {
-                            "type": "word",
-                            "value": 6
-                          }
-                        },
-                        {
-                          "__struct_id": 0,
-                          "ChanceAppear": {
-                            "type": "byte",
-                            "value": 100
-                          },
-                          "CostTable": {
-                            "type": "byte",
-                            "value": 22
-                          },
-                          "CostValue": {
-                            "type": "word",
-                            "value": 3
-                          },
-                          "Param1": {
-                            "type": "byte",
-                            "value": 255
-                          },
-                          "Param1Value": {
-                            "type": "byte",
-                            "value": 0
-                          },
-                          "PropertyName": {
-                            "type": "word",
-                            "value": 24
-                          },
-                          "Subtype": {
-                            "type": "word",
-                            "value": 9
-                          }
-                        },
-                        {
-                          "__struct_id": 0,
-                          "ChanceAppear": {
-                            "type": "byte",
-                            "value": 100
-                          },
-                          "CostTable": {
-                            "type": "byte",
-                            "value": 5
-                          },
-                          "CostValue": {
-                            "type": "word",
-                            "value": 1
-                          },
-                          "Param1": {
-                            "type": "byte",
-                            "value": 255
-                          },
-                          "Param1Value": {
-                            "type": "byte",
-                            "value": 0
-                          },
-                          "PropertyName": {
-                            "type": "word",
-                            "value": 20
-                          },
-                          "Subtype": {
-                            "type": "word",
-                            "value": 6
-                          }
-                        },
-                        {
-                          "__struct_id": 0,
-                          "ChanceAppear": {
-                            "type": "byte",
-                            "value": 100
-                          },
-                          "CostTable": {
-                            "type": "byte",
-                            "value": 5
-                          },
-                          "CostValue": {
-                            "type": "word",
-                            "value": 65
-                          },
-                          "Param1": {
-                            "type": "byte",
-                            "value": 255
-                          },
-                          "Param1Value": {
-                            "type": "byte",
-                            "value": 0
-                          },
-                          "PropertyName": {
-                            "type": "word",
-                            "value": 20
-                          },
-                          "Subtype": {
-                            "type": "word",
-                            "value": 0
-                          }
-                        },
-                        {
-                          "__struct_id": 0,
-                          "ChanceAppear": {
-                            "type": "byte",
-                            "value": 100
-                          },
-                          "CostTable": {
-                            "type": "byte",
-                            "value": 5
-                          },
-                          "CostValue": {
-                            "type": "word",
-                            "value": 1
-                          },
-                          "Param1": {
-                            "type": "byte",
-                            "value": 255
-                          },
-                          "Param1Value": {
-                            "type": "byte",
-                            "value": 0
-                          },
-                          "PropertyName": {
-                            "type": "word",
-                            "value": 20
-                          },
-                          "Subtype": {
-                            "type": "word",
-                            "value": 7
-                          }
-                        },
-                        {
-                          "__struct_id": 0,
-                          "ChanceAppear": {
-                            "type": "byte",
-                            "value": 100
-                          },
-                          "CostTable": {
-                            "type": "byte",
-                            "value": 5
-                          },
-                          "CostValue": {
-                            "type": "word",
-                            "value": 1
-                          },
-                          "Param1": {
-                            "type": "byte",
-                            "value": 255
-                          },
-                          "Param1Value": {
-                            "type": "byte",
-                            "value": 0
-                          },
-                          "PropertyName": {
-                            "type": "word",
-                            "value": 20
-                          },
-                          "Subtype": {
-                            "type": "word",
                             "value": 10
-                          }
-                        },
-                        {
-                          "__struct_id": 0,
-                          "ChanceAppear": {
-                            "type": "byte",
-                            "value": 100
-                          },
-                          "CostTable": {
-                            "type": "byte",
-                            "value": 5
                           },
                           "CostValue": {
                             "type": "word",
-                            "value": 75
+                            "value": 5
                           },
                           "Param1": {
                             "type": "byte",
@@ -52187,73 +52749,11 @@
                           },
                           "PropertyName": {
                             "type": "word",
-                            "value": 20
+                            "value": 11
                           },
                           "Subtype": {
                             "type": "word",
-                            "value": 1
-                          }
-                        },
-                        {
-                          "__struct_id": 0,
-                          "ChanceAppear": {
-                            "type": "byte",
-                            "value": 100
-                          },
-                          "CostTable": {
-                            "type": "byte",
-                            "value": 5
-                          },
-                          "CostValue": {
-                            "type": "word",
-                            "value": 65
-                          },
-                          "Param1": {
-                            "type": "byte",
-                            "value": 255
-                          },
-                          "Param1Value": {
-                            "type": "byte",
                             "value": 0
-                          },
-                          "PropertyName": {
-                            "type": "word",
-                            "value": 20
-                          },
-                          "Subtype": {
-                            "type": "word",
-                            "value": 2
-                          }
-                        },
-                        {
-                          "__struct_id": 0,
-                          "ChanceAppear": {
-                            "type": "byte",
-                            "value": 100
-                          },
-                          "CostTable": {
-                            "type": "byte",
-                            "value": 5
-                          },
-                          "CostValue": {
-                            "type": "word",
-                            "value": 1
-                          },
-                          "Param1": {
-                            "type": "byte",
-                            "value": 255
-                          },
-                          "Param1Value": {
-                            "type": "byte",
-                            "value": 0
-                          },
-                          "PropertyName": {
-                            "type": "word",
-                            "value": 20
-                          },
-                          "Subtype": {
-                            "type": "word",
-                            "value": 13
                           }
                         }
                       ]
@@ -52276,11 +52776,11 @@
                     },
                     "Tag": {
                       "type": "cexostring",
-                      "value": "RepublicHeavyGunnerArmor"
+                      "value": "med_supplies"
                     },
                     "TemplateResRef": {
                       "type": "resref",
-                      "value": "republicheavygun"
+                      "value": "med_supplies"
                     },
                     "XOrientation": {
                       "type": "float",
@@ -52307,103 +52807,19 @@
                     "__struct_id": 1,
                     "AddCost": {
                       "type": "dword",
-                      "value": 0
-                    },
-                    "ArmorPart_Belt": {
-                      "type": "byte",
-                      "value": 107
-                    },
-                    "ArmorPart_LBicep": {
-                      "type": "byte",
-                      "value": 4
-                    },
-                    "ArmorPart_LFArm": {
-                      "type": "byte",
-                      "value": 4
-                    },
-                    "ArmorPart_LFoot": {
-                      "type": "byte",
-                      "value": 243
-                    },
-                    "ArmorPart_LHand": {
-                      "type": "byte",
-                      "value": 1
-                    },
-                    "ArmorPart_LShin": {
-                      "type": "byte",
-                      "value": 249
-                    },
-                    "ArmorPart_LShoul": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "ArmorPart_LThigh": {
-                      "type": "byte",
-                      "value": 4
-                    },
-                    "ArmorPart_Neck": {
-                      "type": "byte",
-                      "value": 1
-                    },
-                    "ArmorPart_Pelvis": {
-                      "type": "byte",
-                      "value": 3
-                    },
-                    "ArmorPart_RBicep": {
-                      "type": "byte",
-                      "value": 4
-                    },
-                    "ArmorPart_RFArm": {
-                      "type": "byte",
-                      "value": 4
-                    },
-                    "ArmorPart_RFoot": {
-                      "type": "byte",
-                      "value": 243
-                    },
-                    "ArmorPart_RHand": {
-                      "type": "byte",
-                      "value": 1
-                    },
-                    "ArmorPart_Robe": {
-                      "type": "byte",
-                      "value": 235
-                    },
-                    "ArmorPart_RShin": {
-                      "type": "byte",
-                      "value": 249
-                    },
-                    "ArmorPart_RShoul": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "ArmorPart_RThigh": {
-                      "type": "byte",
-                      "value": 4
-                    },
-                    "ArmorPart_Torso": {
-                      "type": "byte",
-                      "value": 3
+                      "value": 2
                     },
                     "BaseItem": {
                       "type": "int",
-                      "value": 16
+                      "value": 39
                     },
                     "Charges": {
                       "type": "byte",
                       "value": 0
                     },
-                    "Cloth1Color": {
-                      "type": "byte",
-                      "value": 92
-                    },
-                    "Cloth2Color": {
-                      "type": "byte",
-                      "value": 22
-                    },
                     "Cost": {
                       "type": "dword",
-                      "value": 1
+                      "value": 2
                     },
                     "Cursed": {
                       "type": "byte",
@@ -52411,7 +52827,9 @@
                     },
                     "DescIdentified": {
                       "type": "cexolocstring",
-                      "value": {}
+                      "value": {
+                        "0": "Medical Supplies are required to use many of the First Aid perks."
+                      }
                     },
                     "Description": {
                       "type": "cexolocstring",
@@ -52421,27 +52839,16 @@
                       "type": "byte",
                       "value": 1
                     },
-                    "Leather1Color": {
-                      "type": "byte",
-                      "value": 102
-                    },
-                    "Leather2Color": {
-                      "type": "byte",
-                      "value": 22
-                    },
                     "LocalizedName": {
+                      "id": 13362,
                       "type": "cexolocstring",
                       "value": {
-                        "0": "Republic Officer Uniform"
+                        "0": "Medical Supplies"
                       }
                     },
-                    "Metal1Color": {
+                    "ModelPart1": {
                       "type": "byte",
-                      "value": 0
-                    },
-                    "Metal2Color": {
-                      "type": "byte",
-                      "value": 58
+                      "value": 1
                     },
                     "Plot": {
                       "type": "byte",
@@ -52449,7 +52856,39 @@
                     },
                     "PropertiesList": {
                       "type": "list",
-                      "value": []
+                      "value": [
+                        {
+                          "__struct_id": 0,
+                          "ChanceAppear": {
+                            "type": "byte",
+                            "value": 100
+                          },
+                          "CostTable": {
+                            "type": "byte",
+                            "value": 10
+                          },
+                          "CostValue": {
+                            "type": "word",
+                            "value": 5
+                          },
+                          "Param1": {
+                            "type": "byte",
+                            "value": 255
+                          },
+                          "Param1Value": {
+                            "type": "byte",
+                            "value": 0
+                          },
+                          "PropertyName": {
+                            "type": "word",
+                            "value": 11
+                          },
+                          "Subtype": {
+                            "type": "word",
+                            "value": 0
+                          }
+                        }
+                      ]
                     },
                     "Repos_PosX": {
                       "type": "word",
@@ -52461,7 +52900,7 @@
                     },
                     "StackSize": {
                       "type": "word",
-                      "value": 1
+                      "value": 50
                     },
                     "Stolen": {
                       "type": "byte",
@@ -52469,11 +52908,11 @@
                     },
                     "Tag": {
                       "type": "cexostring",
-                      "value": "RepublicOfficerUniform"
+                      "value": "med_supplies"
                     },
                     "TemplateResRef": {
                       "type": "resref",
-                      "value": "republicofficeru"
+                      "value": "med_supplies_50"
                     },
                     "XOrientation": {
                       "type": "float",
@@ -52500,27 +52939,19 @@
                     "__struct_id": 2,
                     "AddCost": {
                       "type": "dword",
-                      "value": 0
+                      "value": 2
                     },
                     "BaseItem": {
                       "type": "int",
-                      "value": 17
+                      "value": 39
                     },
                     "Charges": {
                       "type": "byte",
                       "value": 0
                     },
-                    "Cloth1Color": {
-                      "type": "byte",
-                      "value": 94
-                    },
-                    "Cloth2Color": {
-                      "type": "byte",
-                      "value": 3
-                    },
                     "Cost": {
                       "type": "dword",
-                      "value": 1
+                      "value": 2
                     },
                     "Cursed": {
                       "type": "byte",
@@ -52528,41 +52959,30 @@
                     },
                     "DescIdentified": {
                       "type": "cexolocstring",
-                      "value": {}
+                      "value": {
+                        "0": "Stim Packs are required for many of the First Aid perks."
+                      }
                     },
                     "Description": {
                       "type": "cexolocstring",
-                      "value": {}
+                      "value": {
+                        "0": ""
+                      }
                     },
                     "Identified": {
                       "type": "byte",
                       "value": 1
                     },
-                    "Leather1Color": {
-                      "type": "byte",
-                      "value": 101
-                    },
-                    "Leather2Color": {
-                      "type": "byte",
-                      "value": 135
-                    },
                     "LocalizedName": {
+                      "id": 13362,
                       "type": "cexolocstring",
                       "value": {
-                        "0": "Republic Officer Hat"
+                        "0": "Stim Pack"
                       }
-                    },
-                    "Metal1Color": {
-                      "type": "byte",
-                      "value": 3
-                    },
-                    "Metal2Color": {
-                      "type": "byte",
-                      "value": 3
                     },
                     "ModelPart1": {
                       "type": "byte",
-                      "value": 108
+                      "value": 2
                     },
                     "Plot": {
                       "type": "byte",
@@ -52570,7 +52990,39 @@
                     },
                     "PropertiesList": {
                       "type": "list",
-                      "value": []
+                      "value": [
+                        {
+                          "__struct_id": 0,
+                          "ChanceAppear": {
+                            "type": "byte",
+                            "value": 100
+                          },
+                          "CostTable": {
+                            "type": "byte",
+                            "value": 10
+                          },
+                          "CostValue": {
+                            "type": "word",
+                            "value": 5
+                          },
+                          "Param1": {
+                            "type": "byte",
+                            "value": 255
+                          },
+                          "Param1Value": {
+                            "type": "byte",
+                            "value": 0
+                          },
+                          "PropertyName": {
+                            "type": "word",
+                            "value": 11
+                          },
+                          "Subtype": {
+                            "type": "word",
+                            "value": 0
+                          }
+                        }
+                      ]
                     },
                     "Repos_PosX": {
                       "type": "word",
@@ -52590,15 +53042,15 @@
                     },
                     "Tag": {
                       "type": "cexostring",
-                      "value": "RepublicOfficerHat"
+                      "value": "stim_pack"
                     },
                     "TemplateResRef": {
                       "type": "resref",
-                      "value": "republicofficerh"
+                      "value": "stim_pack"
                     },
                     "XOrientation": {
                       "type": "float",
-                      "value": 0.0
+                      "value": 2.802596928649634e-045
                     },
                     "XPosition": {
                       "type": "float",
@@ -52621,103 +53073,19 @@
                     "__struct_id": 3,
                     "AddCost": {
                       "type": "dword",
-                      "value": 50
-                    },
-                    "ArmorPart_Belt": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "ArmorPart_LBicep": {
-                      "type": "byte",
-                      "value": 249
-                    },
-                    "ArmorPart_LFArm": {
-                      "type": "byte",
-                      "value": 246
-                    },
-                    "ArmorPart_LFoot": {
-                      "type": "byte",
-                      "value": 242
-                    },
-                    "ArmorPart_LHand": {
-                      "type": "byte",
-                      "value": 246
-                    },
-                    "ArmorPart_LShin": {
-                      "type": "byte",
-                      "value": 222
-                    },
-                    "ArmorPart_LShoul": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "ArmorPart_LThigh": {
-                      "type": "byte",
-                      "value": 235
-                    },
-                    "ArmorPart_Neck": {
-                      "type": "byte",
-                      "value": 1
-                    },
-                    "ArmorPart_Pelvis": {
-                      "type": "byte",
-                      "value": 234
-                    },
-                    "ArmorPart_RBicep": {
-                      "type": "byte",
-                      "value": 249
-                    },
-                    "ArmorPart_RFArm": {
-                      "type": "byte",
-                      "value": 246
-                    },
-                    "ArmorPart_RFoot": {
-                      "type": "byte",
-                      "value": 242
-                    },
-                    "ArmorPart_RHand": {
-                      "type": "byte",
-                      "value": 246
-                    },
-                    "ArmorPart_Robe": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "ArmorPart_RShin": {
-                      "type": "byte",
-                      "value": 222
-                    },
-                    "ArmorPart_RShoul": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "ArmorPart_RThigh": {
-                      "type": "byte",
-                      "value": 235
-                    },
-                    "ArmorPart_Torso": {
-                      "type": "byte",
-                      "value": 249
+                      "value": 2
                     },
                     "BaseItem": {
                       "type": "int",
-                      "value": 16
+                      "value": 39
                     },
                     "Charges": {
                       "type": "byte",
                       "value": 0
                     },
-                    "Cloth1Color": {
-                      "type": "byte",
-                      "value": 101
-                    },
-                    "Cloth2Color": {
-                      "type": "byte",
-                      "value": 22
-                    },
                     "Cost": {
                       "type": "dword",
-                      "value": 51
+                      "value": 2
                     },
                     "Cursed": {
                       "type": "byte",
@@ -52726,240 +53094,29 @@
                     "DescIdentified": {
                       "type": "cexolocstring",
                       "value": {
-                        "0": "A basic uniform given out to all Republic Troopers enlisted in the military."
+                        "0": "Stim Packs are required for many of the First Aid perks."
                       }
                     },
                     "Description": {
                       "type": "cexolocstring",
-                      "value": {}
+                      "value": {
+                        "0": ""
+                      }
                     },
                     "Identified": {
                       "type": "byte",
                       "value": 1
                     },
-                    "Infinite": {
-                      "type": "byte",
-                      "value": 1
-                    },
-                    "Leather1Color": {
-                      "type": "byte",
-                      "value": 22
-                    },
-                    "Leather2Color": {
-                      "type": "byte",
-                      "value": 118
-                    },
                     "LocalizedName": {
-                      "id": 12835,
+                      "id": 13362,
                       "type": "cexolocstring",
                       "value": {
-                        "0": "[NPC] Republic Trooper Uniform"
+                        "0": "Stim Pack"
                       }
                     },
-                    "Metal1Color": {
+                    "ModelPart1": {
                       "type": "byte",
-                      "value": 94
-                    },
-                    "Metal2Color": {
-                      "type": "byte",
-                      "value": 91
-                    },
-                    "Plot": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "PropertiesList": {
-                      "type": "list",
-                      "value": []
-                    },
-                    "Repos_PosX": {
-                      "type": "word",
-                      "value": 6
-                    },
-                    "Repos_Posy": {
-                      "type": "word",
-                      "value": 0
-                    },
-                    "StackSize": {
-                      "type": "word",
-                      "value": 1
-                    },
-                    "Stolen": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "Tag": {
-                      "type": "cexostring",
-                      "value": "RepublicTrooperUniform"
-                    },
-                    "TemplateResRef": {
-                      "type": "resref",
-                      "value": "republictrooper"
-                    },
-                    "XOrientation": {
-                      "type": "float",
-                      "value": 0.0
-                    },
-                    "XPosition": {
-                      "type": "float",
-                      "value": -1.0
-                    },
-                    "YOrientation": {
-                      "type": "float",
-                      "value": 1.0
-                    },
-                    "YPosition": {
-                      "type": "float",
-                      "value": -1.0
-                    },
-                    "ZPosition": {
-                      "type": "float",
-                      "value": -1.0
-                    }
-                  },
-                  {
-                    "__struct_id": 4,
-                    "AddCost": {
-                      "type": "dword",
-                      "value": 0
-                    },
-                    "ArmorPart_Belt": {
-                      "type": "byte",
-                      "value": 106
-                    },
-                    "ArmorPart_LBicep": {
-                      "type": "byte",
-                      "value": 249
-                    },
-                    "ArmorPart_LFArm": {
-                      "type": "byte",
-                      "value": 246
-                    },
-                    "ArmorPart_LFoot": {
-                      "type": "byte",
-                      "value": 242
-                    },
-                    "ArmorPart_LHand": {
-                      "type": "byte",
-                      "value": 246
-                    },
-                    "ArmorPart_LShin": {
-                      "type": "byte",
-                      "value": 23
-                    },
-                    "ArmorPart_LShoul": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "ArmorPart_LThigh": {
-                      "type": "byte",
-                      "value": 102
-                    },
-                    "ArmorPart_Neck": {
-                      "type": "byte",
-                      "value": 7
-                    },
-                    "ArmorPart_Pelvis": {
-                      "type": "byte",
-                      "value": 106
-                    },
-                    "ArmorPart_RBicep": {
-                      "type": "byte",
-                      "value": 249
-                    },
-                    "ArmorPart_RFArm": {
-                      "type": "byte",
-                      "value": 246
-                    },
-                    "ArmorPart_RFoot": {
-                      "type": "byte",
-                      "value": 242
-                    },
-                    "ArmorPart_RHand": {
-                      "type": "byte",
-                      "value": 246
-                    },
-                    "ArmorPart_Robe": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "ArmorPart_RShin": {
-                      "type": "byte",
-                      "value": 23
-                    },
-                    "ArmorPart_RShoul": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "ArmorPart_RThigh": {
-                      "type": "byte",
-                      "value": 102
-                    },
-                    "ArmorPart_Torso": {
-                      "type": "byte",
-                      "value": 100
-                    },
-                    "BaseItem": {
-                      "type": "int",
-                      "value": 16
-                    },
-                    "Charges": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "Cloth1Color": {
-                      "type": "byte",
-                      "value": 172
-                    },
-                    "Cloth2Color": {
-                      "type": "byte",
-                      "value": 22
-                    },
-                    "Cost": {
-                      "type": "dword",
-                      "value": 1
-                    },
-                    "Cursed": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "DescIdentified": {
-                      "type": "cexolocstring",
-                      "value": {}
-                    },
-                    "Description": {
-                      "type": "cexolocstring",
-                      "value": {}
-                    },
-                    "Identified": {
-                      "type": "byte",
-                      "value": 1
-                    },
-                    "Infinite": {
-                      "type": "byte",
-                      "value": 1
-                    },
-                    "Leather1Color": {
-                      "type": "byte",
-                      "value": 115
-                    },
-                    "Leather2Color": {
-                      "type": "byte",
-                      "value": 69
-                    },
-                    "LocalizedName": {
-                      "type": "cexolocstring",
-                      "value": {
-                        "0": "Republic Sniper Outfit"
-                      }
-                    },
-                    "Metal1Color": {
-                      "type": "byte",
-                      "value": 7
-                    },
-                    "Metal2Color": {
-                      "type": "byte",
-                      "value": 6
+                      "value": 2
                     },
                     "Plot": {
                       "type": "byte",
@@ -52976,1003 +53133,7 @@
                           },
                           "CostTable": {
                             "type": "byte",
-                            "value": 2
-                          },
-                          "CostValue": {
-                            "type": "word",
                             "value": 10
-                          },
-                          "Param1": {
-                            "type": "byte",
-                            "value": 255
-                          },
-                          "Param1Value": {
-                            "type": "byte",
-                            "value": 0
-                          },
-                          "PropertyName": {
-                            "type": "word",
-                            "value": 1
-                          },
-                          "Subtype": {
-                            "type": "word",
-                            "value": 0
-                          }
-                        }
-                      ]
-                    },
-                    "Repos_PosX": {
-                      "type": "word",
-                      "value": 8
-                    },
-                    "Repos_Posy": {
-                      "type": "word",
-                      "value": 0
-                    },
-                    "StackSize": {
-                      "type": "word",
-                      "value": 1
-                    },
-                    "Stolen": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "Tag": {
-                      "type": "cexostring",
-                      "value": "RepublicSniperOutfit"
-                    },
-                    "TemplateResRef": {
-                      "type": "resref",
-                      "value": "republicsniperou"
-                    },
-                    "XOrientation": {
-                      "type": "float",
-                      "value": 0.0
-                    },
-                    "XPosition": {
-                      "type": "float",
-                      "value": -1.0
-                    },
-                    "YOrientation": {
-                      "type": "float",
-                      "value": 1.0
-                    },
-                    "YPosition": {
-                      "type": "float",
-                      "value": -1.0
-                    },
-                    "ZPosition": {
-                      "type": "float",
-                      "value": -1.0
-                    }
-                  },
-                  {
-                    "__struct_id": 5,
-                    "AddCost": {
-                      "type": "dword",
-                      "value": 29
-                    },
-                    "BaseItem": {
-                      "type": "int",
-                      "value": 17
-                    },
-                    "Charges": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "Cloth1Color": {
-                      "type": "byte",
-                      "value": 35
-                    },
-                    "Cloth2Color": {
-                      "type": "byte",
-                      "value": 7
-                    },
-                    "Cost": {
-                      "type": "dword",
-                      "value": 30
-                    },
-                    "Cursed": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "DescIdentified": {
-                      "type": "cexolocstring",
-                      "value": {}
-                    },
-                    "Description": {
-                      "type": "cexolocstring",
-                      "value": {
-                        "0": ""
-                      }
-                    },
-                    "Identified": {
-                      "type": "byte",
-                      "value": 1
-                    },
-                    "Infinite": {
-                      "type": "byte",
-                      "value": 1
-                    },
-                    "Leather1Color": {
-                      "type": "byte",
-                      "value": 23
-                    },
-                    "Leather2Color": {
-                      "type": "byte",
-                      "value": 23
-                    },
-                    "LocalizedName": {
-                      "id": 90531,
-                      "type": "cexolocstring",
-                      "value": {
-                        "0": "Republic Trooper Helm"
-                      }
-                    },
-                    "Metal1Color": {
-                      "type": "byte",
-                      "value": 25
-                    },
-                    "Metal2Color": {
-                      "type": "byte",
-                      "value": 58
-                    },
-                    "ModelPart1": {
-                      "type": "byte",
-                      "value": 107
-                    },
-                    "Plot": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "PropertiesList": {
-                      "type": "list",
-                      "value": []
-                    },
-                    "Repos_PosX": {
-                      "type": "word",
-                      "value": 4
-                    },
-                    "Repos_Posy": {
-                      "type": "word",
-                      "value": 2
-                    },
-                    "StackSize": {
-                      "type": "word",
-                      "value": 1
-                    },
-                    "Stolen": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "Tag": {
-                      "type": "cexostring",
-                      "value": "RepublicTrooperHelm"
-                    },
-                    "TemplateResRef": {
-                      "type": "resref",
-                      "value": "trooperhelmet"
-                    },
-                    "XOrientation": {
-                      "type": "float",
-                      "value": 0.0
-                    },
-                    "XPosition": {
-                      "type": "float",
-                      "value": -1.0
-                    },
-                    "YOrientation": {
-                      "type": "float",
-                      "value": 1.0
-                    },
-                    "YPosition": {
-                      "type": "float",
-                      "value": -1.0
-                    },
-                    "ZPosition": {
-                      "type": "float",
-                      "value": -1.0
-                    }
-                  },
-                  {
-                    "__struct_id": 6,
-                    "AddCost": {
-                      "type": "dword",
-                      "value": 0
-                    },
-                    "BaseItem": {
-                      "type": "int",
-                      "value": 17
-                    },
-                    "Charges": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "Cloth1Color": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "Cloth2Color": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "Cost": {
-                      "type": "dword",
-                      "value": 1
-                    },
-                    "Cursed": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "DescIdentified": {
-                      "type": "cexolocstring",
-                      "value": {}
-                    },
-                    "Description": {
-                      "type": "cexolocstring",
-                      "value": {}
-                    },
-                    "Identified": {
-                      "type": "byte",
-                      "value": 1
-                    },
-                    "Infinite": {
-                      "type": "byte",
-                      "value": 1
-                    },
-                    "Leather1Color": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "Leather2Color": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "LocalizedName": {
-                      "type": "cexolocstring",
-                      "value": {
-                        "0": "Republic Trooper Helmet"
-                      }
-                    },
-                    "Metal1Color": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "Metal2Color": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "ModelPart1": {
-                      "type": "byte",
-                      "value": 107
-                    },
-                    "Plot": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "PropertiesList": {
-                      "type": "list",
-                      "value": []
-                    },
-                    "Repos_PosX": {
-                      "type": "word",
-                      "value": 0
-                    },
-                    "Repos_Posy": {
-                      "type": "word",
-                      "value": 3
-                    },
-                    "StackSize": {
-                      "type": "word",
-                      "value": 1
-                    },
-                    "Stolen": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "Tag": {
-                      "type": "cexostring",
-                      "value": "RepublicTrooperHelmet"
-                    },
-                    "TemplateResRef": {
-                      "type": "resref",
-                      "value": "republictrooperh"
-                    },
-                    "XOrientation": {
-                      "type": "float",
-                      "value": 0.0
-                    },
-                    "XPosition": {
-                      "type": "float",
-                      "value": -1.0
-                    },
-                    "YOrientation": {
-                      "type": "float",
-                      "value": 1.0
-                    },
-                    "YPosition": {
-                      "type": "float",
-                      "value": -1.0
-                    },
-                    "ZPosition": {
-                      "type": "float",
-                      "value": -1.0
-                    }
-                  },
-                  {
-                    "__struct_id": 7,
-                    "AddCost": {
-                      "type": "dword",
-                      "value": 0
-                    },
-                    "BaseItem": {
-                      "type": "int",
-                      "value": 17
-                    },
-                    "Charges": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "Cloth1Color": {
-                      "type": "byte",
-                      "value": 22
-                    },
-                    "Cloth2Color": {
-                      "type": "byte",
-                      "value": 23
-                    },
-                    "Cost": {
-                      "type": "dword",
-                      "value": 1
-                    },
-                    "Cursed": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "DescIdentified": {
-                      "type": "cexolocstring",
-                      "value": {}
-                    },
-                    "Description": {
-                      "type": "cexolocstring",
-                      "value": {}
-                    },
-                    "Identified": {
-                      "type": "byte",
-                      "value": 1
-                    },
-                    "Infinite": {
-                      "type": "byte",
-                      "value": 1
-                    },
-                    "Leather1Color": {
-                      "type": "byte",
-                      "value": 22
-                    },
-                    "Leather2Color": {
-                      "type": "byte",
-                      "value": 22
-                    },
-                    "LocalizedName": {
-                      "type": "cexolocstring",
-                      "value": {
-                        "0": "Republic Heavy Gunner Helmet"
-                      }
-                    },
-                    "Metal1Color": {
-                      "type": "byte",
-                      "value": 90
-                    },
-                    "Metal2Color": {
-                      "type": "byte",
-                      "value": 92
-                    },
-                    "ModelPart1": {
-                      "type": "byte",
-                      "value": 45
-                    },
-                    "Plot": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "PropertiesList": {
-                      "type": "list",
-                      "value": []
-                    },
-                    "Repos_PosX": {
-                      "type": "word",
-                      "value": 2
-                    },
-                    "Repos_Posy": {
-                      "type": "word",
-                      "value": 3
-                    },
-                    "StackSize": {
-                      "type": "word",
-                      "value": 1
-                    },
-                    "Stolen": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "Tag": {
-                      "type": "cexostring",
-                      "value": "RepublicHeavyGunnerHelmet"
-                    },
-                    "TemplateResRef": {
-                      "type": "resref",
-                      "value": "republicheavy001"
-                    },
-                    "XOrientation": {
-                      "type": "float",
-                      "value": 8.851416371776291e-015
-                    },
-                    "XPosition": {
-                      "type": "float",
-                      "value": -1.0
-                    },
-                    "YOrientation": {
-                      "type": "float",
-                      "value": 1.0
-                    },
-                    "YPosition": {
-                      "type": "float",
-                      "value": -1.0
-                    },
-                    "ZPosition": {
-                      "type": "float",
-                      "value": -1.0
-                    }
-                  },
-                  {
-                    "__struct_id": 8,
-                    "AddCost": {
-                      "type": "dword",
-                      "value": 0
-                    },
-                    "BaseItem": {
-                      "type": "int",
-                      "value": 17
-                    },
-                    "Charges": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "Cloth1Color": {
-                      "type": "byte",
-                      "value": 115
-                    },
-                    "Cloth2Color": {
-                      "type": "byte",
-                      "value": 127
-                    },
-                    "Cost": {
-                      "type": "dword",
-                      "value": 1
-                    },
-                    "Cursed": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "DescIdentified": {
-                      "type": "cexolocstring",
-                      "value": {}
-                    },
-                    "Description": {
-                      "type": "cexolocstring",
-                      "value": {}
-                    },
-                    "Identified": {
-                      "type": "byte",
-                      "value": 1
-                    },
-                    "Infinite": {
-                      "type": "byte",
-                      "value": 1
-                    },
-                    "Leather1Color": {
-                      "type": "byte",
-                      "value": 22
-                    },
-                    "Leather2Color": {
-                      "type": "byte",
-                      "value": 22
-                    },
-                    "LocalizedName": {
-                      "type": "cexolocstring",
-                      "value": {
-                        "0": "Republic Sniper Visor"
-                      }
-                    },
-                    "Metal1Color": {
-                      "type": "byte",
-                      "value": 115
-                    },
-                    "Metal2Color": {
-                      "type": "byte",
-                      "value": 3
-                    },
-                    "ModelPart1": {
-                      "type": "byte",
-                      "value": 46
-                    },
-                    "Plot": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "PropertiesList": {
-                      "type": "list",
-                      "value": []
-                    },
-                    "Repos_PosX": {
-                      "type": "word",
-                      "value": 6
-                    },
-                    "Repos_Posy": {
-                      "type": "word",
-                      "value": 3
-                    },
-                    "StackSize": {
-                      "type": "word",
-                      "value": 1
-                    },
-                    "Stolen": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "Tag": {
-                      "type": "cexostring",
-                      "value": "RepublicSniperVisor"
-                    },
-                    "TemplateResRef": {
-                      "type": "resref",
-                      "value": "republicsnipervi"
-                    },
-                    "XOrientation": {
-                      "type": "float",
-                      "value": 1.003162295256949e-017
-                    },
-                    "XPosition": {
-                      "type": "float",
-                      "value": -1.0
-                    },
-                    "YOrientation": {
-                      "type": "float",
-                      "value": 1.0
-                    },
-                    "YPosition": {
-                      "type": "float",
-                      "value": -1.0
-                    },
-                    "ZPosition": {
-                      "type": "float",
-                      "value": -1.0
-                    }
-                  },
-                  {
-                    "__struct_id": 9,
-                    "AddCost": {
-                      "type": "dword",
-                      "value": 0
-                    },
-                    "ArmorPart_Belt": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "ArmorPart_LBicep": {
-                      "type": "byte",
-                      "value": 4
-                    },
-                    "ArmorPart_LFArm": {
-                      "type": "byte",
-                      "value": 22
-                    },
-                    "ArmorPart_LFoot": {
-                      "type": "byte",
-                      "value": 4
-                    },
-                    "ArmorPart_LHand": {
-                      "type": "byte",
-                      "value": 1
-                    },
-                    "ArmorPart_LShin": {
-                      "type": "byte",
-                      "value": 4
-                    },
-                    "ArmorPart_LShoul": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "ArmorPart_LThigh": {
-                      "type": "byte",
-                      "value": 16
-                    },
-                    "ArmorPart_Neck": {
-                      "type": "byte",
-                      "value": 1
-                    },
-                    "ArmorPart_Pelvis": {
-                      "type": "byte",
-                      "value": 3
-                    },
-                    "ArmorPart_RBicep": {
-                      "type": "byte",
-                      "value": 4
-                    },
-                    "ArmorPart_RFArm": {
-                      "type": "byte",
-                      "value": 22
-                    },
-                    "ArmorPart_RFoot": {
-                      "type": "byte",
-                      "value": 4
-                    },
-                    "ArmorPart_RHand": {
-                      "type": "byte",
-                      "value": 1
-                    },
-                    "ArmorPart_Robe": {
-                      "type": "byte",
-                      "value": 10
-                    },
-                    "ArmorPart_RShin": {
-                      "type": "byte",
-                      "value": 4
-                    },
-                    "ArmorPart_RShoul": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "ArmorPart_RThigh": {
-                      "type": "byte",
-                      "value": 16
-                    },
-                    "ArmorPart_Torso": {
-                      "type": "byte",
-                      "value": 104
-                    },
-                    "BaseItem": {
-                      "type": "int",
-                      "value": 16
-                    },
-                    "Charges": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "Cloth1Color": {
-                      "type": "byte",
-                      "value": 22
-                    },
-                    "Cloth2Color": {
-                      "type": "byte",
-                      "value": 37
-                    },
-                    "Cost": {
-                      "type": "dword",
-                      "value": 1
-                    },
-                    "Cursed": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "DescIdentified": {
-                      "type": "cexolocstring",
-                      "value": {}
-                    },
-                    "Description": {
-                      "type": "cexolocstring",
-                      "value": {
-                        "0": ""
-                      }
-                    },
-                    "Identified": {
-                      "type": "byte",
-                      "value": 1
-                    },
-                    "Infinite": {
-                      "type": "byte",
-                      "value": 1
-                    },
-                    "Leather1Color": {
-                      "type": "byte",
-                      "value": 22
-                    },
-                    "Leather2Color": {
-                      "type": "byte",
-                      "value": 22
-                    },
-                    "LocalizedName": {
-                      "type": "cexolocstring",
-                      "value": {
-                        "0": "Republic Desk Worker Uniform"
-                      }
-                    },
-                    "Metal1Color": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "Metal2Color": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "Plot": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "PropertiesList": {
-                      "type": "list",
-                      "value": []
-                    },
-                    "Repos_PosX": {
-                      "type": "word",
-                      "value": 8
-                    },
-                    "Repos_Posy": {
-                      "type": "word",
-                      "value": 3
-                    },
-                    "StackSize": {
-                      "type": "word",
-                      "value": 1
-                    },
-                    "Stolen": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "Tag": {
-                      "type": "cexostring",
-                      "value": "RepublicDeskWorkerUniform"
-                    },
-                    "TemplateResRef": {
-                      "type": "resref",
-                      "value": "republicdeskwork"
-                    },
-                    "XOrientation": {
-                      "type": "float",
-                      "value": 0.0
-                    },
-                    "XPosition": {
-                      "type": "float",
-                      "value": -1.0
-                    },
-                    "YOrientation": {
-                      "type": "float",
-                      "value": 1.0
-                    },
-                    "YPosition": {
-                      "type": "float",
-                      "value": -1.0
-                    },
-                    "ZPosition": {
-                      "type": "float",
-                      "value": -1.0
-                    }
-                  },
-                  {
-                    "__struct_id": 10,
-                    "AddCost": {
-                      "type": "dword",
-                      "value": 0
-                    },
-                    "ArmorPart_Belt": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "ArmorPart_LBicep": {
-                      "type": "byte",
-                      "value": 105
-                    },
-                    "ArmorPart_LFArm": {
-                      "type": "byte",
-                      "value": 75
-                    },
-                    "ArmorPart_LFoot": {
-                      "type": "byte",
-                      "value": 75
-                    },
-                    "ArmorPart_LHand": {
-                      "type": "byte",
-                      "value": 75
-                    },
-                    "ArmorPart_LShin": {
-                      "type": "byte",
-                      "value": 75
-                    },
-                    "ArmorPart_LShoul": {
-                      "type": "byte",
-                      "value": 9
-                    },
-                    "ArmorPart_LThigh": {
-                      "type": "byte",
-                      "value": 75
-                    },
-                    "ArmorPart_Neck": {
-                      "type": "byte",
-                      "value": 1
-                    },
-                    "ArmorPart_Pelvis": {
-                      "type": "byte",
-                      "value": 75
-                    },
-                    "ArmorPart_RBicep": {
-                      "type": "byte",
-                      "value": 105
-                    },
-                    "ArmorPart_RFArm": {
-                      "type": "byte",
-                      "value": 75
-                    },
-                    "ArmorPart_RFoot": {
-                      "type": "byte",
-                      "value": 75
-                    },
-                    "ArmorPart_RHand": {
-                      "type": "byte",
-                      "value": 75
-                    },
-                    "ArmorPart_Robe": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "ArmorPart_RShin": {
-                      "type": "byte",
-                      "value": 75
-                    },
-                    "ArmorPart_RShoul": {
-                      "type": "byte",
-                      "value": 9
-                    },
-                    "ArmorPart_RThigh": {
-                      "type": "byte",
-                      "value": 75
-                    },
-                    "ArmorPart_Torso": {
-                      "type": "byte",
-                      "value": 75
-                    },
-                    "BaseItem": {
-                      "type": "int",
-                      "value": 16
-                    },
-                    "Charges": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "Cloth1Color": {
-                      "type": "byte",
-                      "value": 23
-                    },
-                    "Cloth2Color": {
-                      "type": "byte",
-                      "value": 50
-                    },
-                    "Cost": {
-                      "type": "dword",
-                      "value": 1
-                    },
-                    "Cursed": {
-                      "type": "byte",
-                      "value": 1
-                    },
-                    "DescIdentified": {
-                      "type": "cexolocstring",
-                      "value": {}
-                    },
-                    "Description": {
-                      "type": "cexolocstring",
-                      "value": {
-                        "0": ""
-                      }
-                    },
-                    "Identified": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "Infinite": {
-                      "type": "byte",
-                      "value": 1
-                    },
-                    "Leather1Color": {
-                      "type": "byte",
-                      "value": 23
-                    },
-                    "Leather2Color": {
-                      "type": "byte",
-                      "value": 89
-                    },
-                    "LocalizedName": {
-                      "id": 12835,
-                      "type": "cexolocstring",
-                      "value": {
-                        "0": "Republic Trooper Uniform"
-                      }
-                    },
-                    "Metal1Color": {
-                      "type": "byte",
-                      "value": 66
-                    },
-                    "Metal2Color": {
-                      "type": "byte",
-                      "value": 66
-                    },
-                    "Plot": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "PropertiesList": {
-                      "type": "list",
-                      "value": [
-                        {
-                          "__struct_id": 0,
-                          "ChanceAppear": {
-                            "type": "byte",
-                            "value": 100
-                          },
-                          "CostTable": {
-                            "type": "byte",
-                            "value": 50
-                          },
-                          "CostValue": {
-                            "type": "word",
-                            "value": 10
-                          },
-                          "Param1": {
-                            "type": "byte",
-                            "value": 255
-                          },
-                          "Param1Value": {
-                            "type": "byte",
-                            "value": 0
-                          },
-                          "PropertyName": {
-                            "type": "word",
-                            "value": 117
-                          },
-                          "Subtype": {
-                            "type": "word",
-                            "value": 0
-                          }
-                        },
-                        {
-                          "__struct_id": 0,
-                          "ChanceAppear": {
-                            "type": "byte",
-                            "value": 100
-                          },
-                          "CostTable": {
-                            "type": "byte",
-                            "value": 46
-                          },
-                          "CostValue": {
-                            "type": "word",
-                            "value": 20
-                          },
-                          "Param1": {
-                            "type": "byte",
-                            "value": 255
-                          },
-                          "Param1Value": {
-                            "type": "byte",
-                            "value": 0
-                          },
-                          "PropertyName": {
-                            "type": "word",
-                            "value": 113
-                          },
-                          "Subtype": {
-                            "type": "word",
-                            "value": 0
-                          }
-                        },
-                        {
-                          "__struct_id": 0,
-                          "ChanceAppear": {
-                            "type": "byte",
-                            "value": 100
-                          },
-                          "CostTable": {
-                            "type": "byte",
-                            "value": 57
                           },
                           "CostValue": {
                             "type": "word",
@@ -53988,69 +53149,7 @@
                           },
                           "PropertyName": {
                             "type": "word",
-                            "value": 124
-                          },
-                          "Subtype": {
-                            "type": "word",
-                            "value": 0
-                          }
-                        },
-                        {
-                          "__struct_id": 0,
-                          "ChanceAppear": {
-                            "type": "byte",
-                            "value": 100
-                          },
-                          "CostTable": {
-                            "type": "byte",
-                            "value": 49
-                          },
-                          "CostValue": {
-                            "type": "word",
-                            "value": 1
-                          },
-                          "Param1": {
-                            "type": "byte",
-                            "value": 255
-                          },
-                          "Param1Value": {
-                            "type": "byte",
-                            "value": 0
-                          },
-                          "PropertyName": {
-                            "type": "word",
-                            "value": 116
-                          },
-                          "Subtype": {
-                            "type": "word",
-                            "value": 0
-                          }
-                        },
-                        {
-                          "__struct_id": 0,
-                          "ChanceAppear": {
-                            "type": "byte",
-                            "value": 100
-                          },
-                          "CostTable": {
-                            "type": "byte",
-                            "value": 42
-                          },
-                          "CostValue": {
-                            "type": "word",
-                            "value": 40
-                          },
-                          "Param1": {
-                            "type": "byte",
-                            "value": 255
-                          },
-                          "Param1Value": {
-                            "type": "byte",
-                            "value": 0
-                          },
-                          "PropertyName": {
-                            "type": "word",
-                            "value": 109
+                            "value": 11
                           },
                           "Subtype": {
                             "type": "word",
@@ -54061,15 +53160,15 @@
                     },
                     "Repos_PosX": {
                       "type": "word",
-                      "value": 4
+                      "value": 6
                     },
                     "Repos_Posy": {
                       "type": "word",
-                      "value": 4
+                      "value": 0
                     },
                     "StackSize": {
                       "type": "word",
-                      "value": 1
+                      "value": 50
                     },
                     "Stolen": {
                       "type": "byte",
@@ -54077,247 +53176,15 @@
                     },
                     "Tag": {
                       "type": "cexostring",
-                      "value": "Republic_outfit"
+                      "value": "stim_pack"
                     },
                     "TemplateResRef": {
                       "type": "resref",
-                      "value": "republic_outfit"
+                      "value": "stim_pack_50"
                     },
                     "XOrientation": {
                       "type": "float",
-                      "value": 0.0
-                    },
-                    "XPosition": {
-                      "type": "float",
-                      "value": -1.0
-                    },
-                    "YOrientation": {
-                      "type": "float",
-                      "value": 1.0
-                    },
-                    "YPosition": {
-                      "type": "float",
-                      "value": -1.0
-                    },
-                    "ZPosition": {
-                      "type": "float",
-                      "value": -1.0
-                    }
-                  },
-                  {
-                    "__struct_id": 11,
-                    "AddCost": {
-                      "type": "dword",
-                      "value": 0
-                    },
-                    "ArmorPart_Belt": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "ArmorPart_LBicep": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "ArmorPart_LFArm": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "ArmorPart_LFoot": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "ArmorPart_LHand": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "ArmorPart_LShin": {
-                      "type": "byte",
-                      "value": 1
-                    },
-                    "ArmorPart_LShoul": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "ArmorPart_LThigh": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "ArmorPart_Neck": {
-                      "type": "byte",
-                      "value": 1
-                    },
-                    "ArmorPart_Pelvis": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "ArmorPart_RBicep": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "ArmorPart_RFArm": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "ArmorPart_RFoot": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "ArmorPart_RHand": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "ArmorPart_Robe": {
-                      "type": "byte",
-                      "value": 201
-                    },
-                    "ArmorPart_RShin": {
-                      "type": "byte",
-                      "value": 1
-                    },
-                    "ArmorPart_RShoul": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "ArmorPart_RThigh": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "ArmorPart_Torso": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "BaseItem": {
-                      "type": "int",
-                      "value": 16
-                    },
-                    "Charges": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "Cloth1Color": {
-                      "type": "byte",
-                      "value": 23
-                    },
-                    "Cloth2Color": {
-                      "type": "byte",
-                      "value": 23
-                    },
-                    "Cost": {
-                      "type": "dword",
-                      "value": 1
-                    },
-                    "Cursed": {
-                      "type": "byte",
-                      "value": 1
-                    },
-                    "DescIdentified": {
-                      "type": "cexolocstring",
-                      "value": {}
-                    },
-                    "Description": {
-                      "type": "cexolocstring",
-                      "value": {
-                        "0": ""
-                      }
-                    },
-                    "Identified": {
-                      "type": "byte",
-                      "value": 1
-                    },
-                    "Infinite": {
-                      "type": "byte",
-                      "value": 1
-                    },
-                    "Leather1Color": {
-                      "type": "byte",
-                      "value": 23
-                    },
-                    "Leather2Color": {
-                      "type": "byte",
-                      "value": 3
-                    },
-                    "LocalizedName": {
-                      "id": 12835,
-                      "type": "cexolocstring",
-                      "value": {
-                        "0": "Republic Outfit (Reinforced)"
-                      }
-                    },
-                    "Metal1Color": {
-                      "type": "byte",
-                      "value": 66
-                    },
-                    "Metal2Color": {
-                      "type": "byte",
-                      "value": 66
-                    },
-                    "Plot": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "PropertiesList": {
-                      "type": "list",
-                      "value": [
-                        {
-                          "__struct_id": 0,
-                          "ChanceAppear": {
-                            "type": "byte",
-                            "value": 100
-                          },
-                          "CostTable": {
-                            "type": "byte",
-                            "value": 50
-                          },
-                          "CostValue": {
-                            "type": "word",
-                            "value": 10
-                          },
-                          "Param1": {
-                            "type": "byte",
-                            "value": 255
-                          },
-                          "Param1Value": {
-                            "type": "byte",
-                            "value": 0
-                          },
-                          "PropertyName": {
-                            "type": "word",
-                            "value": 117
-                          },
-                          "Subtype": {
-                            "type": "word",
-                            "value": 0
-                          }
-                        }
-                      ]
-                    },
-                    "Repos_PosX": {
-                      "type": "word",
-                      "value": 0
-                    },
-                    "Repos_Posy": {
-                      "type": "word",
-                      "value": 5
-                    },
-                    "StackSize": {
-                      "type": "word",
-                      "value": 1
-                    },
-                    "Stolen": {
-                      "type": "byte",
-                      "value": 0
-                    },
-                    "Tag": {
-                      "type": "cexostring",
-                      "value": "Republic_outfit"
-                    },
-                    "TemplateResRef": {
-                      "type": "resref",
-                      "value": "republic_outf001"
-                    },
-                    "XOrientation": {
-                      "type": "float",
-                      "value": 0.0
+                      "value": 9.4039548065783e-038
                     },
                     "XPosition": {
                       "type": "float",
@@ -54338,24 +53205,12 @@
                   }
                 ]
               }
-            },
-            {
-              "__struct_id": 4
-            },
-            {
-              "__struct_id": 2
-            },
-            {
-              "__struct_id": 3
-            },
-            {
-              "__struct_id": 1
             }
           ]
         },
         "Tag": {
           "type": "cexostring",
-          "value": "RepublicArmory"
+          "value": "medical_supplies"
         },
         "WillNotBuy": {
           "type": "list",
@@ -54367,23 +53222,23 @@
         },
         "XOrientation": {
           "type": "float",
-          "value": 0.89322429895401
+          "value": 0.9987954497337341
         },
         "XPosition": {
           "type": "float",
-          "value": 15.97737407684326
+          "value": 15.95930290222168
         },
         "YOrientation": {
           "type": "float",
-          "value": 0.4496113061904907
+          "value": 0.04906776919960976
         },
         "YPosition": {
           "type": "float",
-          "value": 58.83294296264648
+          "value": 58.70582962036133
         },
         "ZPosition": {
           "type": "float",
-          "value": -5.7220458984375e-006
+          "value": 2.384185791015625e-007
         }
       }
     ]

--- a/Module/git/v_repubbase_cd.git.json
+++ b/Module/git/v_repubbase_cd.git.json
@@ -8868,7 +8868,7 @@
               },
               "XOrientation": {
                 "type": "float",
-                "value": 0.0
+                "value": 4.273960316190692e-043
               },
               "XPosition": {
                 "type": "float",
@@ -9155,7 +9155,7 @@
               },
               "XOrientation": {
                 "type": "float",
-                "value": 4.273960316190692e-043
+                "value": 0.0
               },
               "XPosition": {
                 "type": "float",

--- a/Module/git/v_repubbase_ext.git.json
+++ b/Module/git/v_repubbase_ext.git.json
@@ -23721,7 +23721,7 @@
         },
         "Conversation": {
           "type": "resref",
-          "value": ""
+          "value": "rep_gardenguard"
         },
         "CRAdjust": {
           "type": "int",
@@ -23923,7 +23923,7 @@
               },
               "XOrientation": {
                 "type": "float",
-                "value": 2.858648867222627e-043
+                "value": 0.0
               },
               "XPosition": {
                 "type": "float",
@@ -24210,7 +24210,7 @@
               },
               "XOrientation": {
                 "type": "float",
-                "value": 0.0
+                "value": 2.858648867222627e-043
               },
               "XPosition": {
                 "type": "float",
@@ -24327,7 +24327,7 @@
         "FirstName": {
           "type": "cexolocstring",
           "value": {
-            "0": "Female Republic Soldier"
+            "0": "Corporal Nissara"
           }
         },
         "fortbonus": {
@@ -25865,23 +25865,23 @@
         },
         "XOrientation": {
           "type": "float",
-          "value": 0.4275550544261932
+          "value": 0.7409510612487793
         },
         "XPosition": {
           "type": "float",
-          "value": 99.45648193359375
+          "value": 118.0409622192383
         },
         "YOrientation": {
           "type": "float",
-          "value": 0.903989315032959
+          "value": 0.6715590357780457
         },
         "YPosition": {
           "type": "float",
-          "value": 65.14141845703125
+          "value": 60.28390121459961
         },
         "ZPosition": {
           "type": "float",
-          "value": 0.0
+          "value": -5.7220458984375e-006
         }
       },
       {
@@ -27162,7 +27162,7 @@
         },
         "Conversation": {
           "type": "resref",
-          "value": ""
+          "value": "rep_idleguard"
         },
         "CRAdjust": {
           "type": "int",
@@ -27364,7 +27364,7 @@
               },
               "XOrientation": {
                 "type": "float",
-                "value": 2.858648867222627e-043
+                "value": 0.0
               },
               "XPosition": {
                 "type": "float",
@@ -27651,7 +27651,7 @@
               },
               "XOrientation": {
                 "type": "float",
-                "value": 0.0
+                "value": 2.858648867222627e-043
               },
               "XPosition": {
                 "type": "float",
@@ -27768,7 +27768,7 @@
         "FirstName": {
           "type": "cexolocstring",
           "value": {
-            "0": "Male Weequay Republic Soldier"
+            "0": "Republic Soldier"
           }
         },
         "fortbonus": {
@@ -28311,7 +28311,7 @@
         },
         "Conversation": {
           "type": "resref",
-          "value": ""
+          "value": "rep_idleguard"
         },
         "CRAdjust": {
           "type": "int",
@@ -28513,7 +28513,7 @@
               },
               "XOrientation": {
                 "type": "float",
-                "value": 2.858648867222627e-043
+                "value": 0.0
               },
               "XPosition": {
                 "type": "float",
@@ -28800,7 +28800,7 @@
               },
               "XOrientation": {
                 "type": "float",
-                "value": 0.0
+                "value": 2.858648867222627e-043
               },
               "XPosition": {
                 "type": "float",
@@ -28917,7 +28917,7 @@
         "FirstName": {
           "type": "cexolocstring",
           "value": {
-            "0": "Male Trandoshan Republic Soldier"
+            "0": "Republic Soldier"
           }
         },
         "fortbonus": {
@@ -30483,7 +30483,225 @@
   },
   "Door List": {
     "type": "list",
-    "value": []
+    "value": [
+      {
+        "__struct_id": 8,
+        "AnimationState": {
+          "type": "byte",
+          "value": 0
+        },
+        "Appearance": {
+          "type": "dword",
+          "value": 0
+        },
+        "AutoRemoveKey": {
+          "type": "byte",
+          "value": 0
+        },
+        "Bearing": {
+          "type": "float",
+          "value": 8.982323156322077e-043
+        },
+        "CloseLockDC": {
+          "type": "byte",
+          "value": 0
+        },
+        "Conversation": {
+          "type": "resref",
+          "value": ""
+        },
+        "CurrentHP": {
+          "type": "short",
+          "value": 10
+        },
+        "Description": {
+          "type": "cexolocstring",
+          "value": {}
+        },
+        "DisarmDC": {
+          "type": "byte",
+          "value": 0
+        },
+        "Faction": {
+          "type": "dword",
+          "value": 1
+        },
+        "Fort": {
+          "type": "byte",
+          "value": 5
+        },
+        "GenericType_New": {
+          "type": "dword",
+          "value": 65
+        },
+        "Hardness": {
+          "type": "byte",
+          "value": 5
+        },
+        "HP": {
+          "type": "short",
+          "value": 10
+        },
+        "Interruptable": {
+          "type": "byte",
+          "value": 1
+        },
+        "KeyName": {
+          "type": "cexostring",
+          "value": "Key_R_1"
+        },
+        "KeyRequired": {
+          "type": "byte",
+          "value": 1
+        },
+        "LinkedTo": {
+          "type": "cexostring",
+          "value": "RepBase_JuniorMessExit"
+        },
+        "LinkedToFlags": {
+          "type": "byte",
+          "value": 1
+        },
+        "LoadScreenID": {
+          "type": "word",
+          "value": 0
+        },
+        "Lockable": {
+          "type": "byte",
+          "value": 1
+        },
+        "Locked": {
+          "type": "byte",
+          "value": 1
+        },
+        "LocName": {
+          "type": "cexolocstring",
+          "value": {
+            "0": "Junior Mess Door"
+          }
+        },
+        "OnClick": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnClosed": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnDamaged": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnDeath": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnDisarm": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnFailToOpen": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnHeartbeat": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnLock": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnMeleeAttacked": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnOpen": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnSpellCastAt": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnTrapTriggered": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnUnlock": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnUserDefined": {
+          "type": "resref",
+          "value": ""
+        },
+        "OpenLockDC": {
+          "type": "byte",
+          "value": 0
+        },
+        "Plot": {
+          "type": "byte",
+          "value": 1
+        },
+        "PortraitId": {
+          "type": "word",
+          "value": 558
+        },
+        "Ref": {
+          "type": "byte",
+          "value": 0
+        },
+        "Tag": {
+          "type": "cexostring",
+          "value": "ToJuniorMess"
+        },
+        "TemplateResRef": {
+          "type": "resref",
+          "value": "_mdrn_dt_glassp3"
+        },
+        "TrapDetectable": {
+          "type": "byte",
+          "value": 1
+        },
+        "TrapDetectDC": {
+          "type": "byte",
+          "value": 0
+        },
+        "TrapDisarmable": {
+          "type": "byte",
+          "value": 1
+        },
+        "TrapFlag": {
+          "type": "byte",
+          "value": 0
+        },
+        "TrapOneShot": {
+          "type": "byte",
+          "value": 1
+        },
+        "TrapType": {
+          "type": "byte",
+          "value": 0
+        },
+        "Will": {
+          "type": "byte",
+          "value": 0
+        },
+        "X": {
+          "type": "float",
+          "value": 96.94999694824219
+        },
+        "Y": {
+          "type": "float",
+          "value": 80.59999847412109
+        },
+        "Z": {
+          "type": "float",
+          "value": -0.009999999776482582
+        }
+      }
+    ]
   },
   "Encounter List": {
     "type": "list",
@@ -58506,7 +58724,7 @@
         },
         "Bearing": {
           "type": "float",
-          "value": 0.8587020039558411
+          "value": 1.398990392684937
         },
         "BodyBag": {
           "type": "byte",
@@ -58704,15 +58922,15 @@
         },
         "X": {
           "type": "float",
-          "value": 98.25
+          "value": 122.7406158447266
         },
         "Y": {
           "type": "float",
-          "value": 71.12000274658203
+          "value": 64.61853790283203
         },
         "Z": {
           "type": "float",
-          "value": 0.0
+          "value": -5.7220458984375e-006
         }
       },
       {
@@ -59631,233 +59849,6 @@
         },
         "Appearance": {
           "type": "dword",
-          "value": 6811
-        },
-        "AutoRemoveKey": {
-          "type": "byte",
-          "value": 0
-        },
-        "Bearing": {
-          "type": "float",
-          "value": 2.871611833572388
-        },
-        "BodyBag": {
-          "type": "byte",
-          "value": 0
-        },
-        "CloseLockDC": {
-          "type": "byte",
-          "value": 0
-        },
-        "Conversation": {
-          "type": "resref",
-          "value": ""
-        },
-        "CurrentHP": {
-          "type": "short",
-          "value": 10
-        },
-        "Description": {
-          "type": "cexolocstring",
-          "value": {
-            "0": ""
-          }
-        },
-        "DisarmDC": {
-          "type": "byte",
-          "value": 0
-        },
-        "Faction": {
-          "type": "dword",
-          "value": 3
-        },
-        "Fort": {
-          "type": "byte",
-          "value": 5
-        },
-        "Hardness": {
-          "type": "byte",
-          "value": 5
-        },
-        "HasInventory": {
-          "type": "byte",
-          "value": 0
-        },
-        "HP": {
-          "type": "short",
-          "value": 10
-        },
-        "Interruptable": {
-          "type": "byte",
-          "value": 1
-        },
-        "KeyName": {
-          "type": "cexostring",
-          "value": ""
-        },
-        "KeyRequired": {
-          "type": "byte",
-          "value": 0
-        },
-        "Lockable": {
-          "type": "byte",
-          "value": 1
-        },
-        "Locked": {
-          "type": "byte",
-          "value": 0
-        },
-        "LocName": {
-          "type": "cexolocstring",
-          "value": {
-            "0": "Hover Car, Armoured Personnel Carrier (Green)"
-          }
-        },
-        "OnClick": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnClosed": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnDamaged": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnDeath": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnDisarm": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnHeartbeat": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnInvDisturbed": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnLock": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnMeleeAttacked": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnOpen": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnSpellCastAt": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnTrapTriggered": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnUnlock": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnUsed": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnUserDefined": {
-          "type": "resref",
-          "value": ""
-        },
-        "OpenLockDC": {
-          "type": "byte",
-          "value": 0
-        },
-        "Plot": {
-          "type": "byte",
-          "value": 0
-        },
-        "PortraitId": {
-          "type": "word",
-          "value": 0
-        },
-        "Ref": {
-          "type": "byte",
-          "value": 0
-        },
-        "Static": {
-          "type": "byte",
-          "value": 1
-        },
-        "Tag": {
-          "type": "cexostring",
-          "value": "_mdrn_pl_hcar006"
-        },
-        "TemplateResRef": {
-          "type": "resref",
-          "value": "_mdrn_pl_hcar006"
-        },
-        "TrapDetectable": {
-          "type": "byte",
-          "value": 1
-        },
-        "TrapDetectDC": {
-          "type": "byte",
-          "value": 0
-        },
-        "TrapDisarmable": {
-          "type": "byte",
-          "value": 1
-        },
-        "TrapFlag": {
-          "type": "byte",
-          "value": 0
-        },
-        "TrapOneShot": {
-          "type": "byte",
-          "value": 1
-        },
-        "TrapType": {
-          "type": "byte",
-          "value": 0
-        },
-        "Type": {
-          "type": "byte",
-          "value": 0
-        },
-        "Useable": {
-          "type": "byte",
-          "value": 0
-        },
-        "Will": {
-          "type": "byte",
-          "value": 0
-        },
-        "X": {
-          "type": "float",
-          "value": 76.34326171875
-        },
-        "Y": {
-          "type": "float",
-          "value": 65.81467437744141
-        },
-        "Z": {
-          "type": "float",
-          "value": -0.1399974822998047
-        }
-      },
-      {
-        "__struct_id": 9,
-        "AnimationState": {
-          "type": "byte",
-          "value": 0
-        },
-        "Appearance": {
-          "type": "dword",
           "value": 1771
         },
         "AutoRemoveKey": {
@@ -60113,7 +60104,7 @@
           "id": 16813933,
           "type": "cexolocstring",
           "value": {
-            "0": "This worn and weathered stone sits within the memorial garden. Words have been painstakingly carved upon it, and it appears maintained with a surprising care, despite within a military base. Upon this stone are scribed these words:\n\n\"In this age of war, we burn our lives for a peace we may never see. From your failing hands to ours, we shall raise the torch of your hope, that your light may never be extinguished. We shall remember you and your final sacrifice.\n\n...\n\n... a list of names follow...\n\n... Rodi Lucce...\n\n...\""
+            "0": "This worn and weathered stone sits within the memorial garden. Words have been painstakingly carved upon it, and it appears maintained with a surprising care, despite within a military base. Upon this stone are scribed these words:\n\n\"In this age of war, we burn our lives for a peace we may never see. From your failing hands to ours, we shall raise the torch of your hope, that your light may never be extinguished. We shall remember you and your final sacrifice.\n\n...\n\n... a list of names follow...\n\n... Captain Thornton...\n\n... Rodi Lucce...\n\n...\""
           }
         },
         "DisarmDC": {
@@ -63133,6 +63124,458 @@
           "type": "float",
           "value": 0.0
         }
+      },
+      {
+        "__struct_id": 9,
+        "AnimationState": {
+          "type": "byte",
+          "value": 0
+        },
+        "Appearance": {
+          "type": "dword",
+          "value": 20806
+        },
+        "AutoRemoveKey": {
+          "type": "byte",
+          "value": 0
+        },
+        "Bearing": {
+          "type": "float",
+          "value": -0.2945242822170258
+        },
+        "BodyBag": {
+          "type": "byte",
+          "value": 0
+        },
+        "CloseLockDC": {
+          "type": "byte",
+          "value": 0
+        },
+        "Conversation": {
+          "type": "resref",
+          "value": ""
+        },
+        "CurrentHP": {
+          "type": "short",
+          "value": 10
+        },
+        "Description": {
+          "type": "cexolocstring",
+          "value": {
+            "0": ""
+          }
+        },
+        "DisarmDC": {
+          "type": "byte",
+          "value": 0
+        },
+        "Faction": {
+          "type": "dword",
+          "value": 3
+        },
+        "Fort": {
+          "type": "byte",
+          "value": 5
+        },
+        "Hardness": {
+          "type": "byte",
+          "value": 5
+        },
+        "HasInventory": {
+          "type": "byte",
+          "value": 0
+        },
+        "HP": {
+          "type": "short",
+          "value": 10
+        },
+        "Interruptable": {
+          "type": "byte",
+          "value": 1
+        },
+        "KeyName": {
+          "type": "cexostring",
+          "value": ""
+        },
+        "KeyRequired": {
+          "type": "byte",
+          "value": 0
+        },
+        "Lockable": {
+          "type": "byte",
+          "value": 1
+        },
+        "Locked": {
+          "type": "byte",
+          "value": 0
+        },
+        "LocName": {
+          "type": "cexolocstring",
+          "value": {
+            "0": "Armored Personnel Carrier 1"
+          }
+        },
+        "OnClick": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnClosed": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnDamaged": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnDeath": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnDisarm": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnHeartbeat": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnInvDisturbed": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnLock": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnMeleeAttacked": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnOpen": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnSpellCastAt": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnTrapTriggered": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnUnlock": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnUsed": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnUserDefined": {
+          "type": "resref",
+          "value": ""
+        },
+        "OpenLockDC": {
+          "type": "byte",
+          "value": 0
+        },
+        "Plot": {
+          "type": "byte",
+          "value": 0
+        },
+        "PortraitId": {
+          "type": "word",
+          "value": 0
+        },
+        "Ref": {
+          "type": "byte",
+          "value": 0
+        },
+        "Static": {
+          "type": "byte",
+          "value": 1
+        },
+        "Tag": {
+          "type": "cexostring",
+          "value": "_mdrn_pl_alnapc1"
+        },
+        "TemplateResRef": {
+          "type": "resref",
+          "value": "_mdrn_pl_alnapc1"
+        },
+        "TrapDetectable": {
+          "type": "byte",
+          "value": 1
+        },
+        "TrapDetectDC": {
+          "type": "byte",
+          "value": 0
+        },
+        "TrapDisarmable": {
+          "type": "byte",
+          "value": 1
+        },
+        "TrapFlag": {
+          "type": "byte",
+          "value": 0
+        },
+        "TrapOneShot": {
+          "type": "byte",
+          "value": 1
+        },
+        "TrapType": {
+          "type": "byte",
+          "value": 0
+        },
+        "Type": {
+          "type": "byte",
+          "value": 0
+        },
+        "Useable": {
+          "type": "byte",
+          "value": 0
+        },
+        "Will": {
+          "type": "byte",
+          "value": 0
+        },
+        "X": {
+          "type": "float",
+          "value": 75.05593109130859
+        },
+        "Y": {
+          "type": "float",
+          "value": 63.29540634155273
+        },
+        "Z": {
+          "type": "float",
+          "value": -0.0335237979888916
+        }
+      },
+      {
+        "__struct_id": 9,
+        "AnimationState": {
+          "type": "byte",
+          "value": 0
+        },
+        "Appearance": {
+          "type": "dword",
+          "value": 30280
+        },
+        "AutoRemoveKey": {
+          "type": "byte",
+          "value": 0
+        },
+        "Bearing": {
+          "type": "float",
+          "value": 0.0
+        },
+        "BodyBag": {
+          "type": "byte",
+          "value": 0
+        },
+        "CloseLockDC": {
+          "type": "byte",
+          "value": 0
+        },
+        "Conversation": {
+          "type": "resref",
+          "value": ""
+        },
+        "CurrentHP": {
+          "type": "short",
+          "value": 10
+        },
+        "Description": {
+          "type": "cexolocstring",
+          "value": {}
+        },
+        "DisarmDC": {
+          "type": "byte",
+          "value": 0
+        },
+        "Faction": {
+          "type": "dword",
+          "value": 1
+        },
+        "Fort": {
+          "type": "byte",
+          "value": 5
+        },
+        "Hardness": {
+          "type": "byte",
+          "value": 5
+        },
+        "HasInventory": {
+          "type": "byte",
+          "value": 0
+        },
+        "HP": {
+          "type": "short",
+          "value": 10
+        },
+        "Interruptable": {
+          "type": "byte",
+          "value": 1
+        },
+        "KeyName": {
+          "type": "cexostring",
+          "value": ""
+        },
+        "KeyRequired": {
+          "type": "byte",
+          "value": 0
+        },
+        "Lockable": {
+          "type": "byte",
+          "value": 1
+        },
+        "Locked": {
+          "type": "byte",
+          "value": 0
+        },
+        "LocName": {
+          "type": "cexolocstring",
+          "value": {
+            "0": "[SWLOR] House, Generic, Small 01                                                     "
+          }
+        },
+        "OnClick": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnClosed": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnDamaged": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnDeath": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnDisarm": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnHeartbeat": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnInvDisturbed": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnLock": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnMeleeAttacked": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnOpen": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnSpellCastAt": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnTrapTriggered": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnUnlock": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnUsed": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnUserDefined": {
+          "type": "resref",
+          "value": ""
+        },
+        "OpenLockDC": {
+          "type": "byte",
+          "value": 0
+        },
+        "Plot": {
+          "type": "byte",
+          "value": 1
+        },
+        "PortraitId": {
+          "type": "word",
+          "value": 0
+        },
+        "Ref": {
+          "type": "byte",
+          "value": 0
+        },
+        "Static": {
+          "type": "byte",
+          "value": 0
+        },
+        "Tag": {
+          "type": "cexostring",
+          "value": "swlor_0001"
+        },
+        "TemplateResRef": {
+          "type": "resref",
+          "value": "swlor_0281"
+        },
+        "TrapDetectable": {
+          "type": "byte",
+          "value": 1
+        },
+        "TrapDetectDC": {
+          "type": "byte",
+          "value": 0
+        },
+        "TrapDisarmable": {
+          "type": "byte",
+          "value": 1
+        },
+        "TrapFlag": {
+          "type": "byte",
+          "value": 0
+        },
+        "TrapOneShot": {
+          "type": "byte",
+          "value": 1
+        },
+        "TrapType": {
+          "type": "byte",
+          "value": 0
+        },
+        "Type": {
+          "type": "byte",
+          "value": 0
+        },
+        "Useable": {
+          "type": "byte",
+          "value": 0
+        },
+        "Will": {
+          "type": "byte",
+          "value": 0
+        },
+        "X": {
+          "type": "float",
+          "value": 103.5
+        },
+        "Y": {
+          "type": "float",
+          "value": 82.5
+        },
+        "Z": {
+          "type": "float",
+          "value": 0.0
+        }
       }
     ]
   },
@@ -63998,68 +64441,6 @@
         "ZPosition": {
           "type": "float",
           "value": -0.4999923706054688
-        }
-      },
-      {
-        "__struct_id": 5,
-        "Appearance": {
-          "type": "byte",
-          "value": 1
-        },
-        "Description": {
-          "type": "cexolocstring",
-          "value": {}
-        },
-        "HasMapNote": {
-          "type": "byte",
-          "value": 0
-        },
-        "LinkedTo": {
-          "type": "cexostring",
-          "value": ""
-        },
-        "LocalizedName": {
-          "id": 14817,
-          "type": "cexolocstring",
-          "value": {
-            "0": "Waypoint"
-          }
-        },
-        "MapNote": {
-          "type": "cexolocstring",
-          "value": {}
-        },
-        "MapNoteEnabled": {
-          "type": "byte",
-          "value": 1
-        },
-        "Tag": {
-          "type": "cexostring",
-          "value": "TAXI_VELES_OUTPOST"
-        },
-        "TemplateResRef": {
-          "type": "resref",
-          "value": "nw_waypoint001"
-        },
-        "XOrientation": {
-          "type": "float",
-          "value": 0.9637760519981384
-        },
-        "XPosition": {
-          "type": "float",
-          "value": 81.14646148681641
-        },
-        "YOrientation": {
-          "type": "float",
-          "value": -0.2667127251625061
-        },
-        "YPosition": {
-          "type": "float",
-          "value": 62.98861312866211
-        },
-        "ZPosition": {
-          "type": "float",
-          "value": -5.7220458984375e-006
         }
       }
     ]

--- a/Module/git/v_repubbase_hang.git.json
+++ b/Module/git/v_repubbase_hang.git.json
@@ -18209,19 +18209,19 @@
         },
         "KeyName": {
           "type": "cexostring",
-          "value": ""
+          "value": "Key_R_1"
         },
         "KeyRequired": {
           "type": "byte",
-          "value": 0
+          "value": 1
         },
         "LinkedTo": {
           "type": "cexostring",
-          "value": ""
+          "value": "RepBase_MedicalToHangar"
         },
         "LinkedToFlags": {
           "type": "byte",
-          "value": 0
+          "value": 1
         },
         "LoadScreenID": {
           "type": "word",
@@ -18233,12 +18233,12 @@
         },
         "Locked": {
           "type": "byte",
-          "value": 0
+          "value": 1
         },
         "LocName": {
           "type": "cexolocstring",
           "value": {
-            "0": "Elevator Door"
+            "0": "Medical Bay Door"
           }
         },
         "OnClick": {
@@ -18303,7 +18303,7 @@
         },
         "Plot": {
           "type": "byte",
-          "value": 0
+          "value": 1
         },
         "PortraitId": {
           "type": "word",
@@ -18315,7 +18315,7 @@
         },
         "Tag": {
           "type": "cexostring",
-          "value": "_mdrn_dt_elev"
+          "value": "RepBase_HangarToMedical"
         },
         "TemplateResRef": {
           "type": "resref",

--- a/Module/git/v_repubbase_jnrm.git.json
+++ b/Module/git/v_repubbase_jnrm.git.json
@@ -341,7 +341,7 @@
         },
         "LinkedTo": {
           "type": "cexostring",
-          "value": "RepBase_JuniorMessFrom"
+          "value": "ToJuniorMess"
         },
         "LinkedToFlags": {
           "type": "byte",

--- a/Module/git/v_repubbase_off.git.json
+++ b/Module/git/v_repubbase_off.git.json
@@ -5154,7 +5154,7 @@
         },
         "Locked": {
           "type": "byte",
-          "value": 0
+          "value": 1
         },
         "LocName": {
           "type": "cexolocstring",
@@ -5224,7 +5224,7 @@
         },
         "Plot": {
           "type": "byte",
-          "value": 0
+          "value": 1
         },
         "PortraitId": {
           "type": "word",
@@ -5371,7 +5371,7 @@
         },
         "Locked": {
           "type": "byte",
-          "value": 0
+          "value": 1
         },
         "LocName": {
           "type": "cexolocstring",
@@ -5441,7 +5441,7 @@
         },
         "Plot": {
           "type": "byte",
-          "value": 0
+          "value": 1
         },
         "PortraitId": {
           "type": "word",
@@ -6456,7 +6456,7 @@
         },
         "Locked": {
           "type": "byte",
-          "value": 0
+          "value": 1
         },
         "LocName": {
           "type": "cexolocstring",
@@ -6526,7 +6526,7 @@
         },
         "Plot": {
           "type": "byte",
-          "value": 0
+          "value": 1
         },
         "PortraitId": {
           "type": "word",
@@ -8337,223 +8337,6 @@
         },
         "Bearing": {
           "type": "float",
-          "value": -1.570796251296997
-        },
-        "CloseLockDC": {
-          "type": "byte",
-          "value": 0
-        },
-        "Conversation": {
-          "type": "resref",
-          "value": ""
-        },
-        "CurrentHP": {
-          "type": "short",
-          "value": 10
-        },
-        "Description": {
-          "type": "cexolocstring",
-          "value": {}
-        },
-        "DisarmDC": {
-          "type": "byte",
-          "value": 0
-        },
-        "Faction": {
-          "type": "dword",
-          "value": 1
-        },
-        "Fort": {
-          "type": "byte",
-          "value": 5
-        },
-        "GenericType_New": {
-          "type": "dword",
-          "value": 68
-        },
-        "Hardness": {
-          "type": "byte",
-          "value": 5
-        },
-        "HP": {
-          "type": "short",
-          "value": 10
-        },
-        "Interruptable": {
-          "type": "byte",
-          "value": 1
-        },
-        "KeyName": {
-          "type": "cexostring",
-          "value": ""
-        },
-        "KeyRequired": {
-          "type": "byte",
-          "value": 0
-        },
-        "LinkedTo": {
-          "type": "cexostring",
-          "value": "RepBase_JuniorMessExit"
-        },
-        "LinkedToFlags": {
-          "type": "byte",
-          "value": 1
-        },
-        "LoadScreenID": {
-          "type": "word",
-          "value": 0
-        },
-        "Lockable": {
-          "type": "byte",
-          "value": 1
-        },
-        "Locked": {
-          "type": "byte",
-          "value": 0
-        },
-        "LocName": {
-          "type": "cexolocstring",
-          "value": {
-            "0": "Glass Panelled Door - Double"
-          }
-        },
-        "OnClick": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnClosed": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnDamaged": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnDeath": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnDisarm": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnFailToOpen": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnHeartbeat": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnLock": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnMeleeAttacked": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnOpen": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnSpellCastAt": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnTrapTriggered": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnUnlock": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnUserDefined": {
-          "type": "resref",
-          "value": ""
-        },
-        "OpenLockDC": {
-          "type": "byte",
-          "value": 0
-        },
-        "Plot": {
-          "type": "byte",
-          "value": 0
-        },
-        "PortraitId": {
-          "type": "word",
-          "value": 558
-        },
-        "Ref": {
-          "type": "byte",
-          "value": 0
-        },
-        "Tag": {
-          "type": "cexostring",
-          "value": "RepBase_JuniorMessFrom"
-        },
-        "TemplateResRef": {
-          "type": "resref",
-          "value": "_mdrn_dt_glassp2"
-        },
-        "TrapDetectable": {
-          "type": "byte",
-          "value": 1
-        },
-        "TrapDetectDC": {
-          "type": "byte",
-          "value": 0
-        },
-        "TrapDisarmable": {
-          "type": "byte",
-          "value": 1
-        },
-        "TrapFlag": {
-          "type": "byte",
-          "value": 0
-        },
-        "TrapOneShot": {
-          "type": "byte",
-          "value": 1
-        },
-        "TrapType": {
-          "type": "byte",
-          "value": 0
-        },
-        "Will": {
-          "type": "byte",
-          "value": 0
-        },
-        "X": {
-          "type": "float",
-          "value": 80.0
-        },
-        "Y": {
-          "type": "float",
-          "value": 55.0
-        },
-        "Z": {
-          "type": "float",
-          "value": 0.0
-        }
-      },
-      {
-        "__struct_id": 8,
-        "AnimationState": {
-          "type": "byte",
-          "value": 0
-        },
-        "Appearance": {
-          "type": "dword",
-          "value": 0
-        },
-        "AutoRemoveKey": {
-          "type": "byte",
-          "value": 0
-        },
-        "Bearing": {
-          "type": "float",
           "value": 1.570796370506287
         },
         "CloseLockDC": {
@@ -8749,6 +8532,223 @@
         "Y": {
           "type": "float",
           "value": 15.0
+        },
+        "Z": {
+          "type": "float",
+          "value": 0.0
+        }
+      },
+      {
+        "__struct_id": 8,
+        "AnimationState": {
+          "type": "byte",
+          "value": 0
+        },
+        "Appearance": {
+          "type": "dword",
+          "value": 0
+        },
+        "AutoRemoveKey": {
+          "type": "byte",
+          "value": 0
+        },
+        "Bearing": {
+          "type": "float",
+          "value": -1.570796251296997
+        },
+        "CloseLockDC": {
+          "type": "byte",
+          "value": 0
+        },
+        "Conversation": {
+          "type": "resref",
+          "value": ""
+        },
+        "CurrentHP": {
+          "type": "short",
+          "value": 10
+        },
+        "Description": {
+          "type": "cexolocstring",
+          "value": {}
+        },
+        "DisarmDC": {
+          "type": "byte",
+          "value": 0
+        },
+        "Faction": {
+          "type": "dword",
+          "value": 1
+        },
+        "Fort": {
+          "type": "byte",
+          "value": 5
+        },
+        "GenericType_New": {
+          "type": "dword",
+          "value": 66
+        },
+        "Hardness": {
+          "type": "byte",
+          "value": 5
+        },
+        "HP": {
+          "type": "short",
+          "value": 10
+        },
+        "Interruptable": {
+          "type": "byte",
+          "value": 1
+        },
+        "KeyName": {
+          "type": "cexostring",
+          "value": ""
+        },
+        "KeyRequired": {
+          "type": "byte",
+          "value": 0
+        },
+        "LinkedTo": {
+          "type": "cexostring",
+          "value": ""
+        },
+        "LinkedToFlags": {
+          "type": "byte",
+          "value": 0
+        },
+        "LoadScreenID": {
+          "type": "word",
+          "value": 0
+        },
+        "Lockable": {
+          "type": "byte",
+          "value": 1
+        },
+        "Locked": {
+          "type": "byte",
+          "value": 0
+        },
+        "LocName": {
+          "type": "cexolocstring",
+          "value": {
+            "0": "Push Bar Door - Double"
+          }
+        },
+        "OnClick": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnClosed": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnDamaged": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnDeath": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnDisarm": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnFailToOpen": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnHeartbeat": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnLock": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnMeleeAttacked": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnOpen": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnSpellCastAt": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnTrapTriggered": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnUnlock": {
+          "type": "resref",
+          "value": ""
+        },
+        "OnUserDefined": {
+          "type": "resref",
+          "value": ""
+        },
+        "OpenLockDC": {
+          "type": "byte",
+          "value": 0
+        },
+        "Plot": {
+          "type": "byte",
+          "value": 0
+        },
+        "PortraitId": {
+          "type": "word",
+          "value": 558
+        },
+        "Ref": {
+          "type": "byte",
+          "value": 0
+        },
+        "Tag": {
+          "type": "cexostring",
+          "value": "_mdrn_dt_glassp4"
+        },
+        "TemplateResRef": {
+          "type": "resref",
+          "value": "_mdrn_dt_glassp4"
+        },
+        "TrapDetectable": {
+          "type": "byte",
+          "value": 1
+        },
+        "TrapDetectDC": {
+          "type": "byte",
+          "value": 0
+        },
+        "TrapDisarmable": {
+          "type": "byte",
+          "value": 1
+        },
+        "TrapFlag": {
+          "type": "byte",
+          "value": 0
+        },
+        "TrapOneShot": {
+          "type": "byte",
+          "value": 1
+        },
+        "TrapType": {
+          "type": "byte",
+          "value": 0
+        },
+        "Will": {
+          "type": "byte",
+          "value": 0
+        },
+        "X": {
+          "type": "float",
+          "value": 80.0
+        },
+        "Y": {
+          "type": "float",
+          "value": 55.0
         },
         "Z": {
           "type": "float",
@@ -9657,7 +9657,7 @@
         },
         "Useable": {
           "type": "byte",
-          "value": 1
+          "value": 0
         },
         "Will": {
           "type": "byte",
@@ -14680,7 +14680,7 @@
         },
         "Conversation": {
           "type": "resref",
-          "value": ""
+          "value": "untitled000"
         },
         "CurrentHP": {
           "type": "short",
@@ -43786,11 +43786,11 @@
         },
         "X": {
           "type": "float",
-          "value": 74.94712829589844
+          "value": 74.94766998291016
         },
         "Y": {
           "type": "float",
-          "value": 64.39272308349609
+          "value": 64.40312957763672
         },
         "Z": {
           "type": "float",
@@ -79458,233 +79458,6 @@
         "Z": {
           "type": "float",
           "value": -5.7220458984375e-006
-        }
-      },
-      {
-        "__struct_id": 9,
-        "AnimationState": {
-          "type": "byte",
-          "value": 0
-        },
-        "Appearance": {
-          "type": "dword",
-          "value": 20114
-        },
-        "AutoRemoveKey": {
-          "type": "byte",
-          "value": 0
-        },
-        "Bearing": {
-          "type": "float",
-          "value": -1.570796251296997
-        },
-        "BodyBag": {
-          "type": "byte",
-          "value": 0
-        },
-        "CloseLockDC": {
-          "type": "byte",
-          "value": 0
-        },
-        "Conversation": {
-          "type": "resref",
-          "value": ""
-        },
-        "CurrentHP": {
-          "type": "short",
-          "value": 10
-        },
-        "Description": {
-          "type": "cexolocstring",
-          "value": {
-            "0": ""
-          }
-        },
-        "DisarmDC": {
-          "type": "byte",
-          "value": 0
-        },
-        "Faction": {
-          "type": "dword",
-          "value": 3
-        },
-        "Fort": {
-          "type": "byte",
-          "value": 5
-        },
-        "Hardness": {
-          "type": "byte",
-          "value": 5
-        },
-        "HasInventory": {
-          "type": "byte",
-          "value": 0
-        },
-        "HP": {
-          "type": "short",
-          "value": 10
-        },
-        "Interruptable": {
-          "type": "byte",
-          "value": 1
-        },
-        "KeyName": {
-          "type": "cexostring",
-          "value": ""
-        },
-        "KeyRequired": {
-          "type": "byte",
-          "value": 0
-        },
-        "Lockable": {
-          "type": "byte",
-          "value": 1
-        },
-        "Locked": {
-          "type": "byte",
-          "value": 0
-        },
-        "LocName": {
-          "type": "cexolocstring",
-          "value": {
-            "0": "Officer Mess"
-          }
-        },
-        "OnClick": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnClosed": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnDamaged": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnDeath": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnDisarm": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnHeartbeat": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnInvDisturbed": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnLock": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnMeleeAttacked": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnOpen": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnSpellCastAt": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnTrapTriggered": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnUnlock": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnUsed": {
-          "type": "resref",
-          "value": ""
-        },
-        "OnUserDefined": {
-          "type": "resref",
-          "value": ""
-        },
-        "OpenLockDC": {
-          "type": "byte",
-          "value": 0
-        },
-        "Plot": {
-          "type": "byte",
-          "value": 0
-        },
-        "PortraitId": {
-          "type": "word",
-          "value": 0
-        },
-        "Ref": {
-          "type": "byte",
-          "value": 0
-        },
-        "Static": {
-          "type": "byte",
-          "value": 0
-        },
-        "Tag": {
-          "type": "cexostring",
-          "value": "_mdrn_pl_panel12"
-        },
-        "TemplateResRef": {
-          "type": "resref",
-          "value": "_mdrn_pl_panel12"
-        },
-        "TrapDetectable": {
-          "type": "byte",
-          "value": 1
-        },
-        "TrapDetectDC": {
-          "type": "byte",
-          "value": 0
-        },
-        "TrapDisarmable": {
-          "type": "byte",
-          "value": 1
-        },
-        "TrapFlag": {
-          "type": "byte",
-          "value": 0
-        },
-        "TrapOneShot": {
-          "type": "byte",
-          "value": 1
-        },
-        "TrapType": {
-          "type": "byte",
-          "value": 0
-        },
-        "Type": {
-          "type": "byte",
-          "value": 0
-        },
-        "Useable": {
-          "type": "byte",
-          "value": 1
-        },
-        "Will": {
-          "type": "byte",
-          "value": 0
-        },
-        "X": {
-          "type": "float",
-          "value": 79.83000183105469
-        },
-        "Y": {
-          "type": "float",
-          "value": 52.0
-        },
-        "Z": {
-          "type": "float",
-          "value": 0.0
         }
       },
       {

--- a/Module/ifo/module.ifo.json
+++ b/Module/ifo/module.ifo.json
@@ -2125,13 +2125,6 @@
         "__struct_id": 6,
         "Area_Name": {
           "type": "resref",
-          "value": "vis_cz_inte_ka1"
-        }
-      },
-      {
-        "__struct_id": 6,
-        "Area_Name": {
-          "type": "resref",
           "value": "viscara_cave_2ka"
         }
       }
@@ -2426,7 +2419,7 @@
   },
   "Mod_ID": {
     "type": "void",
-    "value": "ÿÿÿÿ\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+    "value": "Ã¿Ã¿Ã¿Ã¿\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
   },
   "Mod_IsSaveGame": {
     "type": "byte",

--- a/Module/ifo/module.ifo.json
+++ b/Module/ifo/module.ifo.json
@@ -2125,6 +2125,13 @@
         "__struct_id": 6,
         "Area_Name": {
           "type": "resref",
+          "value": "vis_cz_inte_ka1"
+        }
+      },
+      {
+        "__struct_id": 6,
+        "Area_Name": {
+          "type": "resref",
           "value": "viscara_cave_2ka"
         }
       }

--- a/Module/itp/storepalcus.itp.json
+++ b/Module/itp/storepalcus.itp.json
@@ -108,7 +108,7 @@
               },
               "RESREF": {
                 "type": "resref",
-                "value": "street_food001"
+                "value": "medical_supplies"
               }
             },
             {

--- a/Module/itp/storepalcus.itp.json
+++ b/Module/itp/storepalcus.itp.json
@@ -104,6 +104,17 @@
               "__struct_id": 0,
               "NAME": {
                 "type": "cexostring",
+                "value": "Medical Supplies"
+              },
+              "RESREF": {
+                "type": "resref",
+                "value": "street_food001"
+              }
+            },
+            {
+              "__struct_id": 0,
+              "NAME": {
+                "type": "cexostring",
                 "value": "Mon Cala General Store"
               },
               "RESREF": {

--- a/Module/utm/medical_supplies.utm.json
+++ b/Module/utm/medical_supplies.utm.json
@@ -1,0 +1,154 @@
+{
+  "__data_type": "UTM ",
+  "BlackMarket": {
+    "type": "byte",
+    "value": 0
+  },
+  "BM_MarkDown": {
+    "type": "int",
+    "value": 25
+  },
+  "Comment": {
+    "type": "cexostring",
+    "value": ""
+  },
+  "ID": {
+    "type": "byte",
+    "value": 5
+  },
+  "IdentifyPrice": {
+    "type": "int",
+    "value": -1
+  },
+  "LocName": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "Medical Supplies"
+    }
+  },
+  "MarkDown": {
+    "type": "int",
+    "value": 40
+  },
+  "MarkUp": {
+    "type": "int",
+    "value": 150
+  },
+  "MaxBuyPrice": {
+    "type": "int",
+    "value": -1
+  },
+  "OnOpenStore": {
+    "type": "resref",
+    "value": ""
+  },
+  "OnStoreClosed": {
+    "type": "resref",
+    "value": ""
+  },
+  "ResRef": {
+    "type": "resref",
+    "value": "street_food001"
+  },
+  "StoreGold": {
+    "type": "int",
+    "value": -1
+  },
+  "StoreList": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0
+      },
+      {
+        "__struct_id": 4
+      },
+      {
+        "__struct_id": 2
+      },
+      {
+        "__struct_id": 3
+      },
+      {
+        "__struct_id": 1,
+        "ItemList": {
+          "type": "list",
+          "value": [
+            {
+              "__struct_id": 0,
+              "InventoryRes": {
+                "type": "resref",
+                "value": "med_supplies"
+              },
+              "Repos_PosX": {
+                "type": "word",
+                "value": 0
+              },
+              "Repos_Posy": {
+                "type": "word",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 1,
+              "InventoryRes": {
+                "type": "resref",
+                "value": "med_supplies_50"
+              },
+              "Repos_PosX": {
+                "type": "word",
+                "value": 2
+              },
+              "Repos_Posy": {
+                "type": "word",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 2,
+              "InventoryRes": {
+                "type": "resref",
+                "value": "stim_pack"
+              },
+              "Repos_PosX": {
+                "type": "word",
+                "value": 4
+              },
+              "Repos_Posy": {
+                "type": "word",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 3,
+              "InventoryRes": {
+                "type": "resref",
+                "value": "stim_pack_50"
+              },
+              "Repos_PosX": {
+                "type": "word",
+                "value": 6
+              },
+              "Repos_Posy": {
+                "type": "word",
+                "value": 0
+              }
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "Tag": {
+    "type": "cexostring",
+    "value": "medical_supplies"
+  },
+  "WillNotBuy": {
+    "type": "list",
+    "value": []
+  },
+  "WillOnlyBuy": {
+    "type": "list",
+    "value": []
+  }
+}

--- a/Module/utm/medical_supplies.utm.json
+++ b/Module/utm/medical_supplies.utm.json
@@ -48,7 +48,7 @@
   },
   "ResRef": {
     "type": "resref",
-    "value": "street_food001"
+    "value": "medical_supplies"
   },
   "StoreGold": {
     "type": "int",


### PR DESCRIPTION
Changes:
+ More of the soldiers have dialogues.
+ Fixed the merchants.
+ Locked some of the office doors (such as to the Base Commander).
+ Gave the guard of the Memorial Garden dialogues. 
+ Added a new transition between the Hangar and the Medical Bay.
+ Added lockable doors to the Brig.
+ Moved the Junior Mess to the Republic Base Exterior.
+ Added a 'sit' to the chair of the Tribunal Chamber for where the witnesses should be sitting.
+ Made it so that the books can no longer be taken out of the library shelves.