### PR TITLE
Nautolan Language FIx

### DIFF
--- a/SWLOR.Game.Server/Service/Language.cs
+++ b/SWLOR.Game.Server/Service/Language.cs
@@ -279,6 +279,7 @@ namespace SWLOR.Game.Server.Service
                         new LanguageCommand("Mando'a", SkillType.Mandoa, new []{"mandoa"}),
                         new LanguageCommand("Mirialan", SkillType.Mirialan, new []{"mirialan"}),
                         new LanguageCommand("Mon Calamarian", SkillType.MonCalamarian, new []{"moncalamarian", "moncal"}),
+                        new LanguageCommand("Nautila", SkillType.Nautila, new []{ "nautilan" }),
                         new LanguageCommand("Rodese", SkillType.Rodese, new []{"rodese", "rodian"}),
                         new LanguageCommand("Shyriiwook", SkillType.Shyriiwook, new []{"shyriiwook", "wookieespeak"}),
                         new LanguageCommand("Togruti", SkillType.Togruti, new []{"togruti"}),


### PR DESCRIPTION
Adds Nautila as a language you can switch to and speak with, as it was not included in language.cs.