### PR TITLE
Player Aura Fix

### DIFF
--- a/SWLOR.Game.Server/Feature/ChatCommandDefinition/CharacterChatCommand.cs
+++ b/SWLOR.Game.Server/Feature/ChatCommandDefinition/CharacterChatCommand.cs
@@ -451,7 +451,7 @@ namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
         private void ReapplyAuras()
         {
             _builder.Create("reapplyauras", "reaura")
-                .Description("Removes then reapplies your auras to resolve any errors.")
+                .Description("Removes all your auras, allowing you to reactivate the skills and reapply them without relogging.")
                 .Permissions(AuthorizationLevel.All)
                 .Action((user, target, location, args) =>
                 {

--- a/SWLOR.Game.Server/Feature/ChatCommandDefinition/CharacterChatCommand.cs
+++ b/SWLOR.Game.Server/Feature/ChatCommandDefinition/CharacterChatCommand.cs
@@ -453,7 +453,6 @@ namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
             _builder.Create("reapplyauras", "reaura")
                 .Description("Removes then reapplies your auras to resolve any errors.")
                 .Permissions(AuthorizationLevel.All)
-                .RequiresTarget()
                 .Action((user, target, location, args) =>
                 {
                     Ability.ReapplyPlayerAuraAOE(user);

--- a/SWLOR.Game.Server/Feature/ChatCommandDefinition/CharacterChatCommand.cs
+++ b/SWLOR.Game.Server/Feature/ChatCommandDefinition/CharacterChatCommand.cs
@@ -40,6 +40,7 @@ namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
             AlwaysWalk();
             AssociateCommands();
             Follow();
+            ReapplyAuras();
 
             return _builder.Build();
         }
@@ -444,6 +445,18 @@ namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
                     {
                         ActionMoveToObject(target, true);
                     });
+                });
+        }
+
+        private void ReapplyAuras()
+        {
+            _builder.Create("reapplyauras", "reaura")
+                .Description("Removes then reapplies your auras to resolve any errors.")
+                .Permissions(AuthorizationLevel.All)
+                .RequiresTarget()
+                .Action((user, target, location, args) =>
+                {
+                    Ability.ReapplyPlayerAuraAOE(user);
                 });
         }
     }


### PR DESCRIPTION
Creates a chat command performing the same function as a respawn for players with regards to removing and reapplying auras. Allows for players to reapply leadership buffs after dying and being revived, going to space, or any other issues that may emerge down the line with regard to auras.