### PR TITLE
Two Handed General Perks - Open to All

### DIFF
--- a/SWLOR.Game.Server/Feature/PerkDefinition/TwoHandedPerkDefinition.cs
+++ b/SWLOR.Game.Server/Feature/PerkDefinition/TwoHandedPerkDefinition.cs
@@ -78,7 +78,6 @@ namespace SWLOR.Game.Server.Feature.PerkDefinition
                 .Price(5)
                 .DroidAISlots(3)
                 .RequirementSkill(SkillType.TwoHanded, 35)
-                .RequirementCharacterType(CharacterType.Standard)
                 .GrantsFeat(FeatType.SuperiorWeaponFocus);
         }
 
@@ -91,7 +90,6 @@ namespace SWLOR.Game.Server.Feature.PerkDefinition
                 .Description("Increases the maximum critical damage of two-handed weapons by 50%.")
                 .Price(6)
                 .RequirementSkill(SkillType.TwoHanded, 45)
-                .RequirementCharacterType(CharacterType.Standard)
                 .GrantsFeat(FeatType.IncreaseMultiplier);
         }
 


### PR DESCRIPTION
Removed Standard-Only requirement to Superior Weapon Focus and Increased Multiplier. Reasoning: None of the general perks for one handed weapons are restricted to Standards only, and have very similar effects. This opens up two handed weapons more to force users to invest more heavily in.

Improved Power Attack remains Standard only, I think its effects are significant enough to keep restricted.