### PR TITLE
Add an optionally overrideable OnWindowClosed event to the GUI system…

### DIFF
--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/RefineryViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/RefineryViewModel.cs
@@ -355,7 +355,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             InputItemToggles[index] = !InputItemToggles[index];
         };
 
-        public Action OnWindowClosed() => () =>
+        public override Action OnWindowClosed() => () =>
         {
             foreach (var serialized in _inputItems)
             {

--- a/SWLOR.Game.Server/Service/Gui.cs
+++ b/SWLOR.Game.Server/Service/Gui.cs
@@ -346,6 +346,9 @@ namespace SWLOR.Game.Server.Service
             {
                 SaveWindowGeometry(playerId, type, playerWindow.ViewModel.Geometry);
                 NuiDestroy(player, playerWindow.WindowToken);
+                
+                // Call OnWindowClosed to ensure proper cleanup (like returning items to player)
+                playerWindow.ViewModel.OnWindowClosed()?.Invoke();
             }
         }
 

--- a/SWLOR.Game.Server/Service/GuiService/GuiViewModelBase.cs
+++ b/SWLOR.Game.Server/Service/GuiService/GuiViewModelBase.cs
@@ -378,6 +378,12 @@ namespace SWLOR.Game.Server.Service.GuiService
                 _callerCancelAction();
         };
 
+        /// <summary>
+        /// Default implementation for OnWindowClosed.
+        /// Override in derived classes to provide custom cleanup logic.
+        /// </summary>
+        public virtual Action OnWindowClosed() => () => { };
+
         // The following method works around a NUI issue where the new partial view won't display on screen until the window resizes.
         // We force a change to the geometry of the window to ensure it redraws appropriately.
         // If/when a fix is implemented by Beamdog, this can be removed.

--- a/SWLOR.Game.Server/Service/GuiService/IGuiViewModel.cs
+++ b/SWLOR.Game.Server/Service/GuiService/IGuiViewModel.cs
@@ -78,5 +78,10 @@ namespace SWLOR.Game.Server.Service.GuiService
         /// </summary>
         Action OnModalCancelClick();
 
+        /// <summary>
+        /// Runs when the window is closed.
+        /// </summary>
+        Action OnWindowClosed();
+
     }
 }


### PR DESCRIPTION
…. Fix an issue where refinery items would be destroyed if you moved away from the refinery.