### PR TITLE
Add check for possessed NPCs when sending translated messages

### DIFF
--- a/SWLOR.Game.Server/Service/Language.cs
+++ b/SWLOR.Game.Server/Service/Language.cs
@@ -76,9 +76,9 @@ namespace SWLOR.Game.Server.Service
                 }
             }
 
-            if (!GetIsPC(listener) || GetIsDM(listener))
+            if (!GetIsPC(listener) || GetIsDM(listener) || GetIsDMPossessed(listener))
             {
-                // Short circuit for a DM or NPC - they will always understand the text.
+                // Short circuit for a DM, NPC, or DM-possessed creature - they will always understand the text.
                 return snippet;
             }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved language translation handling so that DM-possessed creatures always understand text, ensuring consistent behavior for DMs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->