### PR TITLE
Bugfix/stealth breaking

### DIFF
--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/ConcussionGrenadeAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/ConcussionGrenadeAbilityDefinition.cs
@@ -74,6 +74,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
                 .UsesAnimation(Animation.ThrowGrenade)
                 .IsCastedAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasMaxRange(15f)
                 .HasCustomValidation(ExplosiveValidation)
                 .HasImpactAction((activator, _, _, location) =>
@@ -99,6 +100,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
                 .UsesAnimation(Animation.ThrowGrenade)
                 .IsCastedAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasMaxRange(15f)
                 .HasCustomValidation(ExplosiveValidation)
                 .HasImpactAction((activator, _, _, location) =>
@@ -125,6 +127,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
                 .UsesAnimation(Animation.ThrowGrenade)
                 .IsCastedAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasMaxRange(15f)
                 .HasCustomValidation(ExplosiveValidation)
                 .HasImpactAction((activator, _, _, location) =>

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/FlamethrowerAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/FlamethrowerAbilityDefinition.cs
@@ -88,6 +88,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
                 .RequirementStamina(1)
                 .IsCastedAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasImpactAction((activator, _, _, targetLocation) =>
                 {
                     var perBonus = GetAbilityScore(activator, AbilityType.Perception);
@@ -105,6 +106,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
                 .RequirementStamina(2)
                 .IsCastedAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasImpactAction((activator, _, _, targetLocation) =>
                 {
                     var perBonus = GetAbilityScore(activator, AbilityType.Perception);
@@ -123,6 +125,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
                 .RequirementStamina(3)
                 .IsCastedAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasImpactAction((activator, _, _, targetLocation) =>
                 {
                     var perBonus = GetAbilityScore(activator, AbilityType.Perception);

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/FragGrenadeAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/FragGrenadeAbilityDefinition.cs
@@ -74,6 +74,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
                 .UsesAnimation(Animation.ThrowGrenade)
                 .IsCastedAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasMaxRange(15f)
                 .HasCustomValidation(ExplosiveValidation)
                 .HasImpactAction((activator, _, _, location) =>
@@ -97,6 +98,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
                 .UsesAnimation(Animation.ThrowGrenade)
                 .IsCastedAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasMaxRange(15f)
                 .HasCustomValidation(ExplosiveValidation)
                 .HasImpactAction((activator, _, _, location) =>
@@ -121,6 +123,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
                 .UsesAnimation(Animation.ThrowGrenade)
                 .IsCastedAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasMaxRange(15f)
                 .HasCustomValidation(ExplosiveValidation)
                 .HasImpactAction((activator, _, _, location) =>

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/GasBombAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/GasBombAbilityDefinition.cs
@@ -101,6 +101,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
                 .UsesAnimation(Animation.ThrowGrenade)
                 .IsCastedAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasMaxRange(15f)
                 .HasCustomValidation(ExplosiveValidation)
                 .HasImpactAction((activator, _, _, targetLocation) =>
@@ -129,6 +130,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
                 .UsesAnimation(Animation.ThrowGrenade)
                 .IsCastedAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasMaxRange(20f)
                 .HasCustomValidation(ExplosiveValidation)
                 .HasImpactAction((activator, _, _, targetLocation) =>
@@ -157,6 +159,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
                 .UsesAnimation(Animation.ThrowGrenade)
                 .IsCastedAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasMaxRange(25f)
                 .HasCustomValidation(ExplosiveValidation)
                 .HasImpactAction((activator, _, _, targetLocation) =>

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/IncendiaryBombAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/IncendiaryBombAbilityDefinition.cs
@@ -106,6 +106,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
                 .UsesAnimation(Animation.ThrowGrenade)
                 .IsCastedAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasMaxRange(15f)
                 .HasCustomValidation(ExplosiveValidation)
                 .HasImpactAction((activator, _, _, targetLocation) =>
@@ -134,6 +135,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
                 .UsesAnimation(Animation.ThrowGrenade)
                 .IsCastedAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasMaxRange(20f)
                 .HasCustomValidation(ExplosiveValidation)
                 .HasImpactAction((activator, _, _, targetLocation) =>
@@ -162,6 +164,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
                 .UsesAnimation(Animation.ThrowGrenade)
                 .IsCastedAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasMaxRange(25f)
                 .HasCustomValidation(ExplosiveValidation)
                 .HasImpactAction((activator, _, _, targetLocation) =>

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/IonGrenadeAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/IonGrenadeAbilityDefinition.cs
@@ -80,6 +80,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
                 .UsesAnimation(Animation.ThrowGrenade)
                 .IsCastedAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasMaxRange(15f)
                 .HasCustomValidation(ExplosiveValidation)
                 .HasImpactAction((activator, _, _, location) =>
@@ -108,6 +109,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
                 .UsesAnimation(Animation.ThrowGrenade)
                 .IsCastedAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasMaxRange(15f)
                 .HasCustomValidation(ExplosiveValidation)
                 .HasImpactAction((activator, _, _, location) =>
@@ -137,6 +139,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
                 .UsesAnimation(Animation.ThrowGrenade)
                 .IsCastedAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasMaxRange(15f)
                 .HasCustomValidation(ExplosiveValidation)
                 .HasImpactAction((activator, _, _, location) =>

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/WristRocketAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/WristRocketAbilityDefinition.cs
@@ -74,6 +74,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
                 .UsesAnimation(Animation.CastOutAnimation)
                 .IsCastedAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasMaxRange(15f)
                 .HasImpactAction((activator,target, _, targetLocation) =>
                 {
@@ -96,6 +97,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
                 .UsesAnimation(Animation.CastOutAnimation)
                 .IsCastedAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasMaxRange(15f)
                 .HasImpactAction((activator, target, _, targetLocation) =>
                 {
@@ -119,6 +121,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
                 .UsesAnimation(Animation.CastOutAnimation)
                 .IsCastedAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasMaxRange(15f)
                 .HasImpactAction((activator, target, _, targetLocation) =>
                 {

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Force/DisturbanceAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Force/DisturbanceAbilityDefinition.cs
@@ -74,6 +74,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 .IsCastedAbility()
                 .HasMaxRange(10f)
                 .IsHostileAbility()
+                .BreaksStealth()
                 .UsesAnimation(Animation.LoopingConjure1)
                 .DisplaysVisualEffectWhenActivating()
                 .HasImpactAction((activator, target, level, location) =>
@@ -93,6 +94,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 .IsCastedAbility()
                 .HasMaxRange(10f)
                 .IsHostileAbility()
+                .BreaksStealth()
                 .UsesAnimation(Animation.LoopingConjure1)
                 .DisplaysVisualEffectWhenActivating()
                 .HasImpactAction((activator, target, level, location) =>
@@ -114,6 +116,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 .IsCastedAbility()
                 .HasMaxRange(10f)
                 .IsHostileAbility()
+                .BreaksStealth()
                 .UsesAnimation(Animation.LoopingConjure1)
                 .DisplaysVisualEffectWhenActivating()
                 .HasImpactAction((activator, target, level, location) =>

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Force/ForceBurstAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Force/ForceBurstAbilityDefinition.cs
@@ -107,6 +107,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 .RequirementFP(1)
                 .IsCastedAbility()
                 .IsHostileAbility()
+                .BreaksStealth()
                 .DisplaysVisualEffectWhenActivating()
                 .UsesAnimation(Animation.LoopingConjure1)
                 .HasImpactAction(ImpactAction);
@@ -123,6 +124,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 .RequirementFP(3)
                 .IsCastedAbility()
                 .IsHostileAbility()
+                .BreaksStealth()
                 .DisplaysVisualEffectWhenActivating()
                 .UsesAnimation(Animation.LoopingConjure1)
                 .HasImpactAction(ImpactAction);
@@ -139,6 +141,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 .RequirementFP(5)
                 .IsCastedAbility()
                 .IsHostileAbility()
+                .BreaksStealth()
                 .DisplaysVisualEffectWhenActivating()
                 .UsesAnimation(Animation.LoopingConjure1)
                 .HasImpactAction(ImpactAction);
@@ -155,6 +158,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 .RequirementFP(7)
                 .IsCastedAbility()
                 .IsHostileAbility()
+                .BreaksStealth()
                 .DisplaysVisualEffectWhenActivating()
                 .UsesAnimation(Animation.LoopingConjure1)
                 .HasImpactAction(ImpactAction);

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Force/ForceLightningAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Force/ForceLightningAbilityDefinition.cs
@@ -101,6 +101,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 .HasMaxRange(30.0f)
                 .IsCastedAbility()
                 .IsHostileAbility()
+                .BreaksStealth()
                 .UsesAnimation(Animation.LoopingConjure1)
                 .HasImpactAction(ImpactAction);
         }
@@ -115,6 +116,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 .HasMaxRange(30.0f)
                 .IsCastedAbility()
                 .IsHostileAbility()
+                .BreaksStealth()
                 .UsesAnimation(Animation.LoopingConjure1)
                 .HasImpactAction(ImpactAction);
         }
@@ -129,6 +131,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 .HasMaxRange(30.0f)
                 .IsCastedAbility()
                 .IsHostileAbility()
+                .BreaksStealth()
                 .UsesAnimation(Animation.LoopingConjure1)
                 .HasImpactAction(ImpactAction);
         }
@@ -143,6 +146,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 .HasMaxRange(30.0f)
                 .IsCastedAbility()
                 .IsHostileAbility()
+                .BreaksStealth()
                 .UsesAnimation(Animation.LoopingConjure1)
                 .HasImpactAction(ImpactAction);
         }

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Force/ForceSparkAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Force/ForceSparkAbilityDefinition.cs
@@ -82,6 +82,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 .IsCastedAbility()
                 .HasMaxRange(10f)
                 .IsHostileAbility()
+                .BreaksStealth()
                 .UsesAnimation(Animation.LoopingConjure1)
                 .DisplaysVisualEffectWhenActivating()
                 .HasImpactAction((activator, target, level, location) =>
@@ -100,6 +101,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 .IsCastedAbility()
                 .HasMaxRange(10f)
                 .IsHostileAbility()
+                .BreaksStealth()
                 .UsesAnimation(Animation.LoopingConjure1)
                 .DisplaysVisualEffectWhenActivating()
                 .HasImpactAction((activator, target, level, location) =>
@@ -118,6 +120,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 .IsCastedAbility()
                 .HasMaxRange(10f)
                 .IsHostileAbility()
+                .BreaksStealth()
                 .UsesAnimation(Animation.LoopingConjure1)
                 .DisplaysVisualEffectWhenActivating()
                 .HasImpactAction((activator, target, level, location) =>

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Force/ThrowLightsaberAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Force/ThrowLightsaberAbilityDefinition.cs
@@ -50,9 +50,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
             var delay = GetDistanceBetween(activator, target) / 10.0f;
             var attackerStat = GetAbilityScore(activator, AbilityType.Willpower);
 
-            // If activator is in stealth mode, force them out of stealth mode.
-            if (GetActionMode(activator, ActionMode.Stealth) == true)
-                SetActionMode(activator, ActionMode.Stealth, false);
+
 
             // Make the activator face their target.
             ClearAllActions();
@@ -138,6 +136,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 .RequirementStamina(1)
                 .IsCastedAbility()
                 .IsHostileAbility()
+                .BreaksStealth()
                 .DisplaysVisualEffectWhenActivating()
                 .HasCustomValidation(Validation)
                 .UnaffectedByHeavyArmor()
@@ -155,6 +154,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 .RequirementStamina(1)
                 .IsCastedAbility()
                 .IsHostileAbility()
+                .BreaksStealth()
                 .DisplaysVisualEffectWhenActivating()
                 .HasCustomValidation(Validation)
                 .UnaffectedByHeavyArmor()
@@ -172,6 +172,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 .RequirementStamina(2)
                 .IsCastedAbility()
                 .IsHostileAbility()
+                .BreaksStealth()
                 .DisplaysVisualEffectWhenActivating()
                 .HasCustomValidation(Validation)
                 .UnaffectedByHeavyArmor()

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Force/ThrowRockAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Force/ThrowRockAbilityDefinition.cs
@@ -90,6 +90,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 .RequirementFP(1)
                 .IsCastedAbility()
                 .IsHostileAbility()
+                .BreaksStealth()
                 .DisplaysVisualEffectWhenActivating(VisualEffect.None)
                 .UsesAnimation(Animation.CastOutAnimation)
                 .HasImpactAction(ImpactAction);
@@ -106,6 +107,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 .RequirementFP(2)
                 .IsCastedAbility()
                 .IsHostileAbility()
+                .BreaksStealth()
                 .DisplaysVisualEffectWhenActivating(VisualEffect.None)
                 .UsesAnimation(Animation.CastOutAnimation)
                 .HasImpactAction(ImpactAction);
@@ -122,6 +124,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 .RequirementFP(3)
                 .IsCastedAbility()
                 .IsHostileAbility()
+                .BreaksStealth()
                 .DisplaysVisualEffectWhenActivating(VisualEffect.None)
                 .UsesAnimation(Animation.CastOutAnimation)
                 .HasImpactAction(ImpactAction);
@@ -138,6 +141,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 .RequirementFP(4)
                 .IsCastedAbility()
                 .IsHostileAbility()
+                .BreaksStealth()
                 .DisplaysVisualEffectWhenActivating(VisualEffect.None)
                 .UsesAnimation(Animation.CastOutAnimation)
                 .HasImpactAction(ImpactAction);
@@ -153,6 +157,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 .RequirementFP(5)
                 .IsCastedAbility()
                 .IsHostileAbility()
+                .BreaksStealth()
                 .DisplaysVisualEffectWhenActivating(VisualEffect.None)
                 .UsesAnimation(Animation.CastOutAnimation)
                 .HasImpactAction(ImpactAction);

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/MartialArts/ElectricFistAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/MartialArts/ElectricFistAbilityDefinition.cs
@@ -38,9 +38,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.MartialArts
 
         private static void ImpactAction(uint activator, uint target, int level, Location targetLocation)
         {
-            // If activator is in stealth mode, force them out of stealth mode.
-            if (GetActionMode(activator, ActionMode.Stealth) == true)
-                SetActionMode(activator, ActionMode.Stealth, false);
+
 
             int dmg;
             int dc;
@@ -101,6 +99,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.MartialArts
                 .HasRecastDelay(RecastGroup.ElectricFist, 30f)
                 .RequirementStamina(3)
                 .IsWeaponAbility()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }
@@ -112,6 +111,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.MartialArts
                 .HasRecastDelay(RecastGroup.ElectricFist, 30f)
                 .RequirementStamina(4)
                 .IsWeaponAbility()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }
@@ -123,6 +123,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.MartialArts
                 .HasRecastDelay(RecastGroup.ElectricFist, 30f)
                 .RequirementStamina(5)
                 .IsWeaponAbility()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/MartialArts/LegSweepAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/MartialArts/LegSweepAbilityDefinition.cs
@@ -35,9 +35,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.MartialArts
 
         private static void ImpactAction(uint activator, uint target, int level, Location targetLocation)
         {
-            // If activator is in stealth mode, force them out of stealth mode.
-            if (GetActionMode(activator, ActionMode.Stealth) == true)
-                SetActionMode(activator, ActionMode.Stealth, false);
+
             int dmg;
             int dc;
             const float Duration = 6f;
@@ -103,6 +101,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.MartialArts
                 .HasRecastDelay(RecastGroup.LegSweep, 30f)
                 .RequirementStamina(3)
                 .IsWeaponAbility()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }
@@ -114,6 +113,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.MartialArts
                 .HasRecastDelay(RecastGroup.LegSweep, 30f)
                 .RequirementStamina(4)
                 .IsWeaponAbility()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }
@@ -125,6 +125,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.MartialArts
                 .HasRecastDelay(RecastGroup.LegSweep, 30f)
                 .RequirementStamina(5)
                 .IsWeaponAbility()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/MartialArts/SlamAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/MartialArts/SlamAbilityDefinition.cs
@@ -37,9 +37,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.MartialArts
 
         private static void ImpactAction(uint activator, uint target, int level, Location targetLocation)
         {
-            // If activator is in stealth mode, force them out of stealth mode.
-            if (GetActionMode(activator, ActionMode.Stealth) == true)
-                SetActionMode(activator, ActionMode.Stealth, false);
+
             int dmg;
             int dc;
             const float Duration = 12f;
@@ -106,6 +104,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.MartialArts
                 .HasRecastDelay(RecastGroup.Slam, 30f)
                 .RequirementStamina(3)
                 .IsWeaponAbility()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }
@@ -117,6 +116,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.MartialArts
                 .HasRecastDelay(RecastGroup.Slam, 30f)
                 .RequirementStamina(4)
                 .IsWeaponAbility()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }
@@ -128,6 +128,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.MartialArts
                 .HasRecastDelay(RecastGroup.Slam, 30f)
                 .RequirementStamina(5)
                 .IsWeaponAbility()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/MartialArts/StrikingCobraAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/MartialArts/StrikingCobraAbilityDefinition.cs
@@ -38,9 +38,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.MartialArts
 
         private static void ImpactAction(uint activator, uint target, int level, Location targetLocation)
         {
-            // If activator is in stealth mode, force them out of stealth mode.
-            if (GetActionMode(activator, ActionMode.Stealth) == true)
-                SetActionMode(activator, ActionMode.Stealth, false);
+
 
             int dmg;
             int dc;
@@ -101,6 +99,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.MartialArts
                 .HasRecastDelay(RecastGroup.StrikingCobra, 60f)
                 .RequirementStamina(3)
                 .IsWeaponAbility()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }
@@ -112,6 +111,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.MartialArts
                 .HasRecastDelay(RecastGroup.StrikingCobra, 60f)
                 .RequirementStamina(5)
                 .IsWeaponAbility()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }
@@ -123,6 +123,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.MartialArts
                 .HasRecastDelay(RecastGroup.StrikingCobra, 60f)
                 .RequirementStamina(8)
                 .IsWeaponAbility()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/OneHanded/BackstabAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/OneHanded/BackstabAbilityDefinition.cs
@@ -38,9 +38,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.OneHanded
         {
             var dmg = 0;
 
-            // If activator is in stealth mode, force them out of stealth mode.
-            if (GetActionMode(activator, ActionMode.Stealth) == true)
-                SetActionMode(activator, ActionMode.Stealth, false);
+
 
             switch (level)
             {
@@ -96,6 +94,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.OneHanded
                 .IsCastedAbility()
                 .IsHostileAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }
@@ -110,6 +109,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.OneHanded
                 .IsCastedAbility()
                 .IsHostileAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }
@@ -124,6 +124,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.OneHanded
                 .IsCastedAbility()
                 .IsHostileAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/OneHanded/ForceLeapAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/OneHanded/ForceLeapAbilityDefinition.cs
@@ -42,9 +42,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.OneHanded
         private static void ImpactAction(uint activator, uint target, int level, Location targetLocation)
         {
             var dmg = 0;
-            // If activator is in stealth mode, force them out of stealth mode.
-            if (GetActionMode(activator, ActionMode.Stealth) == true)
-                SetActionMode(activator, ActionMode.Stealth, false);
+
 
             switch (level)
             {
@@ -129,6 +127,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.OneHanded
                 .IsCastedAbility()
                 .IsHostileAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }
@@ -144,6 +143,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.OneHanded
                 .IsCastedAbility()
                 .IsHostileAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }
@@ -159,6 +159,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.OneHanded
                 .IsCastedAbility()
                 .IsHostileAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/OneHanded/HackingBladeAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/OneHanded/HackingBladeAbilityDefinition.cs
@@ -38,9 +38,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.OneHanded
 
         private static void ImpactAction(uint activator, uint target, int level, Location targetLocation)
         {
-            // If activator is in stealth mode, force them out of stealth mode.
-            if (GetActionMode(activator, ActionMode.Stealth) == true)
-                SetActionMode(activator, ActionMode.Stealth, false);
+
 
             int dmg;
             int dc;
@@ -98,6 +96,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.OneHanded
                 .HasRecastDelay(RecastGroup.HackingBlade, 30f)
                 .RequirementStamina(3)
                 .IsWeaponAbility()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }
@@ -109,6 +108,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.OneHanded
                 .HasRecastDelay(RecastGroup.HackingBlade, 30f)
                 .RequirementStamina(4)
                 .IsWeaponAbility()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }
@@ -120,6 +120,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.OneHanded
                 .HasRecastDelay(RecastGroup.HackingBlade, 30f)
                 .RequirementStamina(5)
                 .IsWeaponAbility()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/OneHanded/PoisonStabAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/OneHanded/PoisonStabAbilityDefinition.cs
@@ -37,9 +37,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.OneHanded
 
         private static void ImpactAction(uint activator, uint target, int level, Location targetLocation)
         {
-            // If activator is in stealth mode, force them out of stealth mode.
-            if (GetActionMode(activator, ActionMode.Stealth) == true)
-                SetActionMode(activator, ActionMode.Stealth, false);
+
 
             int dmg;
             int dc;
@@ -97,6 +95,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.OneHanded
                 .HasRecastDelay(RecastGroup.PoisonStab, 30f)
                 .RequirementStamina(3)
                 .IsWeaponAbility()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }
@@ -108,6 +107,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.OneHanded
                 .HasRecastDelay(RecastGroup.PoisonStab, 30f)
                 .RequirementStamina(4)
                 .IsWeaponAbility()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }
@@ -119,6 +119,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.OneHanded
                 .HasRecastDelay(RecastGroup.PoisonStab, 30f)
                 .RequirementStamina(5)
                 .IsWeaponAbility()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/OneHanded/RiotBladeAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/OneHanded/RiotBladeAbilityDefinition.cs
@@ -40,9 +40,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.OneHanded
         {
             var dmg = 0;
 
-            // If activator is in stealth mode, force them out of stealth mode.
-            if (GetActionMode(activator, ActionMode.Stealth) == true)
-                SetActionMode(activator, ActionMode.Stealth, false);
+
 
             switch (level)
             {
@@ -86,6 +84,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.OneHanded
                 .IsCastedAbility()
                 .IsHostileAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }
@@ -100,6 +99,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.OneHanded
                 .IsCastedAbility()
                 .IsHostileAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }
@@ -114,6 +114,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.OneHanded
                 .IsCastedAbility()
                 .IsHostileAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/OneHanded/SaberStrikeAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/OneHanded/SaberStrikeAbilityDefinition.cs
@@ -36,9 +36,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.OneHanded
 
         private static void ImpactAction(uint activator, uint target, int level, Location targetLocation)
         {
-            // If activator is in stealth mode, force them out of stealth mode.
-            if (GetActionMode(activator, ActionMode.Stealth) == true)
-                SetActionMode(activator, ActionMode.Stealth, false);
+
 
             int dmg;
             int dc;
@@ -111,6 +109,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.OneHanded
                 .RequirementStamina(3)
                 .IsWeaponAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }
@@ -123,6 +122,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.OneHanded
                 .RequirementStamina(5)
                 .IsWeaponAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }
@@ -135,6 +135,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.OneHanded
                 .RequirementStamina(8)
                 .IsWeaponAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/OneHanded/ShieldBashAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/OneHanded/ShieldBashAbilityDefinition.cs
@@ -38,9 +38,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.OneHanded
 
         private static void ImpactAction(uint activator, uint target, int level, Location targetLocation)
         {
-            // If activator is in stealth mode, force them out of stealth mode.
-            if (GetActionMode(activator, ActionMode.Stealth) == true)
-                SetActionMode(activator, ActionMode.Stealth, false);
+
 
             int dmg;
             const float Duration = 3f;
@@ -99,6 +97,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.OneHanded
                 .IsCastedAbility()
                 .IsHostileAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }
@@ -112,6 +111,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.OneHanded
                 .IsCastedAbility()
                 .IsHostileAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }
@@ -125,6 +125,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.OneHanded
                 .IsCastedAbility()
                 .IsHostileAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Ranged/CripplingShotAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Ranged/CripplingShotAbilityDefinition.cs
@@ -37,9 +37,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Ranged
 
         private static void ImpactAction(uint activator, uint target, int level, Location targetLocation)
         {
-            // If activator is in stealth mode, force them out of stealth mode.
-            if (GetActionMode(activator, ActionMode.Stealth) == true)
-                SetActionMode(activator, ActionMode.Stealth, false);
+
 
             int dmg;
             const float Duration = 6f;
@@ -97,6 +95,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Ranged
                 .HasRecastDelay(RecastGroup.CripplingShot, 60f)
                 .RequirementStamina(3)
                 .IsWeaponAbility()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }
@@ -108,6 +107,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Ranged
                 .HasRecastDelay(RecastGroup.CripplingShot, 60f)
                 .RequirementStamina(5)
                 .IsWeaponAbility()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }
@@ -119,6 +119,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Ranged
                 .HasRecastDelay(RecastGroup.CripplingShot, 60f)
                 .RequirementStamina(8)
                 .IsWeaponAbility()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Ranged/DoubleShotAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Ranged/DoubleShotAbilityDefinition.cs
@@ -37,10 +37,6 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Ranged
         {
             var dmg = 0;
 
-            // If activator is in stealth mode, force them out of stealth mode.
-            if (GetActionMode(activator, ActionMode.Stealth) == true)
-                SetActionMode(activator, ActionMode.Stealth, false);
-
             switch (level)
             {
                 case 1:
@@ -92,6 +88,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Ranged
                 .RequirementStamina(3)
                 .IsWeaponAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction((activator, target, level, targetLocation) =>
                 {
@@ -107,6 +104,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Ranged
                 .RequirementStamina(5)
                 .IsWeaponAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction((activator, target, level, targetLocation) =>
                 {
@@ -122,6 +120,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Ranged
                 .RequirementStamina(8)
                 .IsWeaponAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction((activator, target, level, targetLocation) =>
                 {

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Ranged/ExplosiveTossAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Ranged/ExplosiveTossAbilityDefinition.cs
@@ -38,9 +38,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Ranged
         private static void ImpactAction(uint activator, uint target, int level, Location targetLocation)
         {
             var dmg = 0;
-            // If activator is in stealth mode, force them out of stealth mode.
-            if (GetActionMode(activator, ActionMode.Stealth) == true)
-                SetActionMode(activator, ActionMode.Stealth, false);
+
 
             switch (level)
             {
@@ -105,6 +103,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Ranged
                 .IsCastedAbility()
                 .IsHostileAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .UsesAnimation(Animation.ThrowGrenade)
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
@@ -121,6 +120,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Ranged
                 .IsCastedAbility()
                 .IsHostileAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .UsesAnimation(Animation.ThrowGrenade)
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
@@ -137,6 +137,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Ranged
                 .IsCastedAbility()
                 .IsHostileAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .UsesAnimation(Animation.ThrowGrenade)
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Ranged/PiercingTossAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Ranged/PiercingTossAbilityDefinition.cs
@@ -38,9 +38,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Ranged
 
         private static void ImpactAction(uint activator, uint target, int level, Location targetLocation)
         {
-            // If activator is in stealth mode, force them out of stealth mode.
-            if (GetActionMode(activator, ActionMode.Stealth) == true)
-                SetActionMode(activator, ActionMode.Stealth, false);
+
             int dmg;
             int dc;
             float duration;
@@ -103,6 +101,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Ranged
                 .IsCastedAbility()
                 .IsHostileAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .UsesAnimation(Animation.ThrowGrenade)
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
@@ -119,6 +118,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Ranged
                 .IsCastedAbility()
                 .IsHostileAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .UsesAnimation(Animation.ThrowGrenade)
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
@@ -135,6 +135,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Ranged
                 .IsCastedAbility()
                 .IsHostileAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .UsesAnimation(Animation.ThrowGrenade)
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Ranged/QuickDrawAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Ranged/QuickDrawAbilityDefinition.cs
@@ -39,9 +39,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Ranged
         {
             var dmg = 0;
 
-            // If activator is in stealth mode, force them out of stealth mode.
-            if (GetActionMode(activator, ActionMode.Stealth) == true)
-                SetActionMode(activator, ActionMode.Stealth, false);
+
 
             switch (level)
             {
@@ -90,6 +88,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Ranged
                 .IsCastedAbility()
                 .IsHostileAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }
@@ -104,6 +103,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Ranged
                 .IsCastedAbility()
                 .IsHostileAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }
@@ -118,6 +118,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Ranged
                 .IsCastedAbility()
                 .IsHostileAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Ranged/TranquilizerShotAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Ranged/TranquilizerShotAbilityDefinition.cs
@@ -53,9 +53,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Ranged
 
         private void ImpactAction(uint activator, uint target, int level, Location targetLocation)
         {
-            // If activator is in stealth mode, force them out of stealth mode.
-            if (GetActionMode(activator, ActionMode.Stealth) == true)
-                SetActionMode(activator, ActionMode.Stealth, false);
+
             
             switch (level)
             {
@@ -91,6 +89,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Ranged
                 .HasRecastDelay(RecastGroup.TranquilizerShot, 60f)
                 .RequirementStamina(3)
                 .IsWeaponAbility()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }
@@ -102,6 +101,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Ranged
                 .HasRecastDelay(RecastGroup.TranquilizerShot, 60f)
                 .RequirementStamina(4)
                 .IsWeaponAbility()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }
@@ -113,6 +113,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Ranged
                 .HasRecastDelay(RecastGroup.TranquilizerShot, 300f)
                 .RequirementStamina(5)
                 .IsWeaponAbility()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/TwoHanded/CircleSlashAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/TwoHanded/CircleSlashAbilityDefinition.cs
@@ -38,9 +38,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.TwoHanded
         private static void ImpactAction(uint activator, uint target, int level, Location targetLocation)
         {
             var dmg = 0;
-            // If activator is in stealth mode, force them out of stealth mode.
-            if (GetActionMode(activator, ActionMode.Stealth) == true)
-                SetActionMode(activator, ActionMode.Stealth, false);
+
 
             switch (level)
             {
@@ -109,6 +107,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.TwoHanded
                 .RequirementStamina(3)
                 .IsCastedAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }
@@ -122,6 +121,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.TwoHanded
                 .RequirementStamina(4)
                 .IsCastedAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }
@@ -135,6 +135,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.TwoHanded
                 .RequirementStamina(5)
                 .IsCastedAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/TwoHanded/CrescentMoonAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/TwoHanded/CrescentMoonAbilityDefinition.cs
@@ -37,9 +37,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.TwoHanded
 
         private static void ImpactAction(uint activator, uint target, int level, Location targetLocation)
         {
-            // If activator is in stealth mode, force them out of stealth mode.
-            if (GetActionMode(activator, ActionMode.Stealth) == true)
-                SetActionMode(activator, ActionMode.Stealth, false);
+
             int dmg;
             int dc;
             const float Duration = 3f;
@@ -97,6 +95,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.TwoHanded
                 .HasRecastDelay(RecastGroup.CrescentMoon, 30f)
                 .RequirementStamina(3)
                 .IsWeaponAbility()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }
@@ -108,6 +107,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.TwoHanded
                 .HasRecastDelay(RecastGroup.CrescentMoon, 30f)
                 .RequirementStamina(4)
                 .IsWeaponAbility()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }
@@ -119,6 +119,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.TwoHanded
                 .HasRecastDelay(RecastGroup.CrescentMoon, 30f)
                 .RequirementStamina(5)
                 .IsWeaponAbility()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/TwoHanded/CrossCutAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/TwoHanded/CrossCutAbilityDefinition.cs
@@ -37,9 +37,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.TwoHanded
 
         private static void ImpactAction(uint activator, uint target, int level, Location targetLocation)
         {
-            // If activator is in stealth mode, force them out of stealth mode.
-            if (GetActionMode(activator, ActionMode.Stealth) == true)
-                SetActionMode(activator, ActionMode.Stealth, false);
+
 
             int dmg;
             int dc;
@@ -111,6 +109,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.TwoHanded
                 .IsCastedAbility()
                 .IsHostileAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction((activator, target, level, targetLocation) =>
                 {
@@ -129,6 +128,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.TwoHanded
                 .IsCastedAbility()
                 .IsHostileAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction((activator, target, level, targetLocation) =>
                 {
@@ -147,6 +147,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.TwoHanded
                 .IsCastedAbility()
                 .IsHostileAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction((activator, target, level, targetLocation) =>
                 {

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/TwoHanded/DoubleStrikeAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/TwoHanded/DoubleStrikeAbilityDefinition.cs
@@ -38,9 +38,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.TwoHanded
         private static void ImpactAction(uint activator, uint target, int level, Location targetLocation)
         {
             var dmg = 0;
-            // If activator is in stealth mode, force them out of stealth mode.
-            if (GetActionMode(activator, ActionMode.Stealth) == true)
-                SetActionMode(activator, ActionMode.Stealth, false);
+
 
             switch (level)
             {
@@ -95,6 +93,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.TwoHanded
                 .IsCastedAbility()
                 .IsHostileAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction((activator, target, level, targetLocation) =>
                 {
@@ -113,6 +112,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.TwoHanded
                 .IsCastedAbility()
                 .IsHostileAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction((activator, target, level, targetLocation) =>
                 {
@@ -131,6 +131,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.TwoHanded
                 .IsCastedAbility()
                 .IsHostileAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction((activator, target, level, targetLocation) =>
                 {

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/TwoHanded/DoubleThrustAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/TwoHanded/DoubleThrustAbilityDefinition.cs
@@ -39,10 +39,6 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.TwoHanded
         {
             var dmg = 0;
 
-            // If activator is in stealth mode, force them out of stealth mode.
-            if (GetActionMode(activator, ActionMode.Stealth) == true)
-                SetActionMode(activator, ActionMode.Stealth, false);
-
             switch (level)
             {
                 case 1:
@@ -90,6 +86,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.TwoHanded
                 .IsCastedAbility()
                 .IsHostileAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction((activator, target, level, targetLocation) =>
                 {
@@ -108,6 +105,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.TwoHanded
                 .IsCastedAbility()
                 .IsHostileAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction((activator, target, level, targetLocation) =>
                 {
@@ -126,6 +124,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.TwoHanded
                 .IsCastedAbility()
                 .IsHostileAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction((activator, target, level, targetLocation) =>
                 {

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/TwoHanded/HardSlashAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/TwoHanded/HardSlashAbilityDefinition.cs
@@ -39,10 +39,6 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.TwoHanded
         {
             var dmg = 0;
 
-            // If activator is in stealth mode, force them out of stealth mode.
-            if (GetActionMode(activator, ActionMode.Stealth) == true)
-                SetActionMode(activator, ActionMode.Stealth, false);
-
             switch (level)
             {
                 case 1:
@@ -90,6 +86,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.TwoHanded
                 .IsCastedAbility()
                 .IsHostileAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }
@@ -104,6 +101,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.TwoHanded
                 .IsCastedAbility()
                 .IsHostileAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }
@@ -118,6 +116,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.TwoHanded
                 .IsCastedAbility()
                 .IsHostileAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/TwoHanded/SkewerAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/TwoHanded/SkewerAbilityDefinition.cs
@@ -37,9 +37,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.TwoHanded
 
         private static void ImpactAction(uint activator, uint target, int level, Location targetLocation)
         {
-            // If activator is in stealth mode, force them out of stealth mode.
-            if (GetActionMode(activator, ActionMode.Stealth) == true)
-                SetActionMode(activator, ActionMode.Stealth, false);
+
             int dmg;
             int dc;
 
@@ -97,6 +95,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.TwoHanded
                 .HasRecastDelay(RecastGroup.Skewer, 30f)
                 .RequirementStamina(3)
                 .IsWeaponAbility()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }
@@ -108,6 +107,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.TwoHanded
                 .HasRecastDelay(RecastGroup.Skewer, 30f)
                 .RequirementStamina(4)
                 .IsWeaponAbility()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }
@@ -119,6 +119,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.TwoHanded
                 .HasRecastDelay(RecastGroup.Skewer, 30f)
                 .RequirementStamina(5)
                 .IsWeaponAbility()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/TwoHanded/SpinningWhirlAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/TwoHanded/SpinningWhirlAbilityDefinition.cs
@@ -38,9 +38,6 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.TwoHanded
         private static void ImpactAction(uint activator, uint target, int level, Location targetLocation)
         {
             var dmg = 0;
-            // If activator is in stealth mode, force them out of stealth mode.
-            if (GetActionMode(activator, ActionMode.Stealth) == true)
-                SetActionMode(activator, ActionMode.Stealth, false);
 
             switch (level)
             {
@@ -102,6 +99,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.TwoHanded
                 .RequirementStamina(3)
                 .IsCastedAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }
@@ -115,6 +113,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.TwoHanded
                 .RequirementStamina(5)
                 .IsCastedAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }
@@ -128,6 +127,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.TwoHanded
                 .RequirementStamina(8)
                 .IsCastedAbility()
                 .UnaffectedByHeavyArmor()
+                .BreaksStealth()
                 .HasCustomValidation(Validation)
                 .HasImpactAction(ImpactAction);
         }

--- a/SWLOR.Game.Server/Service/AbilityService/AbilityBuilder.cs
+++ b/SWLOR.Game.Server/Service/AbilityService/AbilityBuilder.cs
@@ -289,6 +289,17 @@ namespace SWLOR.Game.Server.Service.AbilityService
         }
 
         /// <summary>
+        /// Indicates this ability breaks stealth and invisibility when used.
+        /// </summary>
+        /// <returns>An ability builder with the configured options</returns>
+        public AbilityBuilder BreaksStealth()
+        {
+            _activeAbility.BreaksStealth = true;
+
+            return this;
+        }
+
+        /// <summary>
         /// Saves the ability level of the ability to be pulled when used later.
         /// </summary>
         /// <param name="level">The level of the ability</param>

--- a/SWLOR.Game.Server/Service/AbilityService/AbilityDetail.cs
+++ b/SWLOR.Game.Server/Service/AbilityService/AbilityDetail.cs
@@ -33,6 +33,7 @@ namespace SWLOR.Game.Server.Service.AbilityService
         public float MaxRange { get; set; }
         public bool IsHostileAbility { get; set; }
         public bool DisplaysActivationMessage { get; set; }
+        public bool BreaksStealth { get; set; }
         public int AbilityLevel { get; set; }
 
         public AbilityDetail()
@@ -44,6 +45,7 @@ namespace SWLOR.Game.Server.Service.AbilityService
             MaxRange = 5.0f;
             IsHostileAbility = false;
             DisplaysActivationMessage = true;
+            BreaksStealth = false;
             AbilityLevel = 1;
         }
     }


### PR DESCRIPTION
Fixes #1529

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Many abilities now explicitly break stealth and invisibility when used. This affects a wide range of abilities across devices, force powers, martial arts, one-handed, ranged, and two-handed categories.

* **Bug Fixes**
  * Stealth and invisibility effects are now consistently removed when using abilities that are intended to break stealth, ensuring reliable gameplay behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->