### PR TITLE
Add a way to sort by price to the market buy menu

### DIFF
--- a/SWLOR.Game.Server/Feature/GuiDefinition/MarketBuyDefinition.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/MarketBuyDefinition.cs
@@ -34,6 +34,13 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                             .SetText("Search")
                             .SetHeight(35f)
                             .BindOnClicked(model => model.OnClickSearch());
+
+                        // Text-based sort button (current implementation)
+                        row.AddButton()
+                            .BindText(model => model.SortByPriceText)
+                            .SetHeight(35f)
+                            .SetWidth(120f)
+                            .BindOnClicked(model => model.OnClickSortByPrice());
                     });
 
                     col.AddRow(row =>

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/MarketBuyViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/MarketBuyViewModel.cs
@@ -23,6 +23,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
         private bool _skipPaginationSearch;
         private readonly List<int> _activeCategoryIdFilters = new();
         private MarketRegionType _regionType;
+        private bool _sortByPriceAscending;
 
         /// <summary>
         /// When the module loads, set up the category lists so they don't need
@@ -113,6 +114,12 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             set => Set(value);
         }
 
+        public string SortByPriceText
+        {
+            get => Get<string>();
+            set => Set(value);
+        }
+
         private void LoadData()
         {
             var categoryToggles = new GuiBindingList<bool>();
@@ -135,6 +142,11 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             SelectedPageIndex = 0;
             SearchText = string.Empty;
             WindowTitle = $"{regionDetail.Name} Market";
+            
+            // Always default to lowest price first
+            _sortByPriceAscending = true;
+            SortByPriceText = "Price: Low-High";
+            
             LoadData();
             Search();
 
@@ -158,6 +170,9 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             {
                 query.AddFieldSearch(nameof(MarketItem.Category), _activeCategoryIdFilters);
             }
+
+            // Add sorting by price
+            query.OrderBy(nameof(MarketItem.Price), _sortByPriceAscending);
 
             query.AddPaging(ListingsPerPage, ListingsPerPage * SelectedPageIndex);
 
@@ -347,6 +362,17 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             else if (!CategoryToggles[index] && _activeCategoryIdFilters.Contains(categoryType))
                 _activeCategoryIdFilters.Remove(categoryType);
 
+            Search();
+        };
+
+        public Action OnClickSortByPrice() => () =>
+        {
+            _sortByPriceAscending = !_sortByPriceAscending;
+            SortByPriceText = _sortByPriceAscending ? "Price: Low-High" : "Price: High-Low";
+            
+            _skipPaginationSearch = true;
+            SelectedPageIndex = 0;
+            _skipPaginationSearch = false;
             Search();
         };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Sort by Price" button to the market buying window, allowing users to toggle between ascending and descending price order when viewing items.

* **Improvements**
  * The market search results now update automatically based on the selected price sort order, providing a clearer and more flexible browsing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->