### PR TITLE
Add calculations to ensure player doesn't try to overdistribute RP XP…

### DIFF
--- a/SWLOR.Game.Server/Feature/GuiDefinition/DistributeRPXPDefinition.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/DistributeRPXPDefinition.cs
@@ -13,7 +13,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
             _builder.CreateWindow(GuiWindowType.DistributeRPXP)
                 .SetIsResizable(true)
                 .SetIsCollapsible(false)
-                .SetInitialGeometry(0, 0, 327f, 224f)
+                .SetInitialGeometry(0, 0, 327f, 250f)
                 .SetTitle("Distribute RP XP")
 
                 .AddColumn(col =>
@@ -29,6 +29,13 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                     {
                         row.AddLabel()
                             .BindText(model => model.AvailableRPXP)
+                            .SetHeight(26f);
+                    });
+
+                    col.AddRow(row =>
+                    {
+                        row.AddLabel()
+                            .BindText(model => model.MaxDistributableInfo)
                             .SetHeight(26f);
                     });
 

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/DistributeRPXPViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/DistributeRPXPViewModel.cs
@@ -75,15 +75,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             SkillName = initialPayload.SkillName;
             AvailableRPXP = $"Available RP XP: {initialPayload.MaxRPXP}";
             
-            if (_maxDistributableXP == 0)
-            {
-                MaxDistributableInfo = "Skill at max rank - no XP accepted";
-            }
-            else
-            {
-                var maxUsable = Math.Min(_availableRPXP, _maxDistributableXP);
-                MaxDistributableInfo = $"Max distributable to this skill: {maxUsable} XP";
-            }
+            UpdateMaxDistributableInfo();
 
             WatchOnClient(model => model.Distribution);
         }
@@ -137,15 +129,8 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             Gui.TogglePlayerWindow(Player, GuiWindowType.DistributeRPXP);
         };
 
-        public void Refresh(RPXPRefreshEvent payload)
+        private void UpdateMaxDistributableInfo()
         {
-            var playerId = GetObjectUUID(Player);
-            var dbPlayer = DB.Get<Player>(playerId);
-
-            _availableRPXP = dbPlayer.UnallocatedXP;
-            _maxDistributableXP = Skill.GetMaxDistributableXP(Player, _skillType);
-            AvailableRPXP = $"Available RP XP: {dbPlayer.UnallocatedXP}";
-            
             if (_maxDistributableXP == 0)
             {
                 MaxDistributableInfo = "Skill at max rank - no XP accepted";
@@ -155,6 +140,18 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
                 var maxUsable = Math.Min(_availableRPXP, _maxDistributableXP);
                 MaxDistributableInfo = $"Max distributable to this skill: {maxUsable} XP";
             }
+        }
+
+        public void Refresh(RPXPRefreshEvent payload)
+        {
+            var playerId = GetObjectUUID(Player);
+            var dbPlayer = DB.Get<Player>(playerId);
+
+            _availableRPXP = dbPlayer.UnallocatedXP;
+            _maxDistributableXP = Skill.GetMaxDistributableXP(Player, _skillType);
+            AvailableRPXP = $"Available RP XP: {dbPlayer.UnallocatedXP}";
+            
+            UpdateMaxDistributableInfo();
         }
     }
 }

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/DistributeRPXPViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/DistributeRPXPViewModel.cs
@@ -15,6 +15,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
     {
         private SkillType _skillType;
         private int _availableRPXP;
+        private int _maxDistributableXP;
 
         public string SkillName
         {
@@ -23,6 +24,12 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
         }
 
         public string AvailableRPXP
+        {
+            get => Get<string>();
+            set => Set(value);
+        }
+
+        public string MaxDistributableInfo
         {
             get => Get<string>();
             set => Set(value);
@@ -50,9 +57,10 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
                 if (result < 0)
                     rpXP = "0";
 
-                // Handle max
-                if (result > _availableRPXP)
-                    rpXP = _availableRPXP.ToString();
+                // Handle max - limit to the minimum of available RPXP and max distributable XP to prevent loss
+                var maxAllowed = Math.Min(_availableRPXP, _maxDistributableXP);
+                if (result > maxAllowed)
+                    rpXP = maxAllowed.ToString();
 
                 Set(rpXP);
             }
@@ -63,8 +71,19 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             Distribution = "0";
             _availableRPXP = initialPayload.MaxRPXP;
             _skillType = initialPayload.Skill;
+            _maxDistributableXP = Skill.GetMaxDistributableXP(Player, _skillType);
             SkillName = initialPayload.SkillName;
             AvailableRPXP = $"Available RP XP: {initialPayload.MaxRPXP}";
+            
+            if (_maxDistributableXP == 0)
+            {
+                MaxDistributableInfo = "Skill at max rank - no XP accepted";
+            }
+            else
+            {
+                var maxUsable = Math.Min(_availableRPXP, _maxDistributableXP);
+                MaxDistributableInfo = $"Max distributable to this skill: {maxUsable} XP";
+            }
 
             WatchOnClient(model => model.Distribution);
         }
@@ -124,7 +143,18 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             var dbPlayer = DB.Get<Player>(playerId);
 
             _availableRPXP = dbPlayer.UnallocatedXP;
+            _maxDistributableXP = Skill.GetMaxDistributableXP(Player, _skillType);
             AvailableRPXP = $"Available RP XP: {dbPlayer.UnallocatedXP}";
+            
+            if (_maxDistributableXP == 0)
+            {
+                MaxDistributableInfo = "Skill at max rank - no XP accepted";
+            }
+            else
+            {
+                var maxUsable = Math.Min(_availableRPXP, _maxDistributableXP);
+                MaxDistributableInfo = $"Max distributable to this skill: {maxUsable} XP";
+            }
         }
     }
 }


### PR DESCRIPTION
… into a skill.

Fixes #1375

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The XP distribution window now displays the maximum amount of XP that can be safely distributed to a skill, helping users avoid XP loss when allocating points.
  * A new message is shown if a skill is already at its maximum rank.
* **Improvements**
  * The maximum distributable XP is now calculated more accurately, ensuring users cannot allocate more XP than allowed for each skill.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->