### PR TITLE
Update ForceDrainStatusEffectDefinition.cs

### DIFF
--- a/SWLOR.Game.Server/Feature/StatusEffectDefinition/ForceDrainStatusEffectDefinition.cs
+++ b/SWLOR.Game.Server/Feature/StatusEffectDefinition/ForceDrainStatusEffectDefinition.cs
@@ -152,8 +152,7 @@ namespace SWLOR.Game.Server.Feature.StatusEffectDefinition
 
         private void ProcessForceDrainTick(VisualEffect vfx, int damage, int heal, uint target, uint source)
         {
-<<<<<<< Updated upstream
-=======
+
             // Check if caster and target are within 20.0f range limit
             var distance = GetDistanceBetween(source, target);
             if (distance > 20.0f)
@@ -164,7 +163,7 @@ namespace SWLOR.Game.Server.Feature.StatusEffectDefinition
                 return;
             }
 
->>>>>>> Stashed changes
+
             var dc = Combat.CalculateSavingThrowDC(source, SavingThrow.Will, 14);
             var checkResult = WillSave(target, dc, SavingThrowType.None, source);
 


### PR DESCRIPTION
Add a range limit to Force Drain. No more wall-cheesing chiro mobs, sorry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Force Drain now enforces a 20m range: if the target moves beyond 20m the connection is immediately broken and concentration ends.
  * When broken by range, no further saving throws or effects are applied.
  * Players now receive a clear message when the Force Drain connection is lost due to exceeding 20m.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->