### PR TITLE
Dark Essence and Benevolence

### DIFF
--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Force/DarkEssenceAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Force/DarkEssenceAbilityDefinition.cs
@@ -55,7 +55,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
             _builder.Create(FeatType.DarkEssence1, PerkType.DarkEssence)
                 .Name("Dark Essence I")
                 .Level(1)
-                .HasRecastDelay(RecastGroup.Benevolence, 12f)
+                .HasRecastDelay(RecastGroup.DarkEssence, 12f)
                 .HasActivationDelay(2f)
                 .RequirementFP(6)
                 .IsCastedAbility()

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Force/DarkEssenceAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Force/DarkEssenceAbilityDefinition.cs
@@ -1,0 +1,107 @@
+﻿using SWLOR.Game.Server.Service;
+using SWLOR.Game.Server.Service.AbilityService;
+using SWLOR.Game.Server.Service.PerkService;
+using SWLOR.Game.Server.Service.SkillService;
+using SWLOR.NWN.API.Engine;
+using SWLOR.NWN.API.NWScript.Enum;
+using SWLOR.NWN.API.NWScript.Enum.VisualEffect;
+using System.Collections.Generic;
+using Random = SWLOR.Game.Server.Service.Random;
+
+namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
+{
+    public class DarkEssenceAbilityDefinition : IAbilityListDefinition
+    {
+        private readonly AbilityBuilder _builder = new();
+        private const string DEssRegen = "DARK_ESSENCE";
+        private const string DEssTempHP = "DARK_ESSENCE_TEMP";
+
+        public Dictionary<FeatType, AbilityDetail> BuildAbilities()
+        {
+            DarkEssence1();
+            DarkEssence2();
+            DarkEssence3();
+
+            return _builder.Build();
+        }
+
+        private void Impact(uint activator, uint target, int baseAmount)
+        {
+            var willBonus = GetAbilityModifier(AbilityType.Willpower, activator);
+            var duration = 24f + (willBonus * 6f);
+            if (activator == target)
+            {
+                RemoveEffectByTag(target, DEssRegen);
+                var willRegen = (baseAmount / 2) + willBonus;
+                var effect = EffectRegenerate(willRegen, duration);
+                var regen = TagEffect(effect, DEssRegen);
+
+                ApplyEffectToObject(DurationType.Temporary, regen, target, duration);
+            }
+
+            RemoveEffectByTag(activator, DEssTempHP);
+            var tempHP = EffectTemporaryHitpoints(baseAmount + (willBonus * 12) + Random.D10(willBonus));
+            var tempHPEffect = TagEffect(tempHP, DEssTempHP);
+
+            ApplyEffectToObject(DurationType.Temporary, tempHPEffect, target, duration);
+            ApplyEffectToObject(DurationType.Instant, EffectVisualEffect(VisualEffect.Vfx_Imp_Head_Evil), target);
+
+            Enmity.ModifyEnmityOnAll(activator, 150 + (baseAmount + willBonus / 4));
+            CombatPoint.AddCombatPointToAllTagged(activator, SkillType.Force, 3);
+        }
+
+        private void DarkEssence1()
+        {
+            _builder.Create(FeatType.DarkEssence1, PerkType.DarkEssence)
+                .Name("Dark Essence I")
+                .Level(1)
+                .HasRecastDelay(RecastGroup.Benevolence, 12f)
+                .HasActivationDelay(2f)
+                .RequirementFP(6)
+                .IsCastedAbility()
+                .HasMaxRange(10f)
+                .UsesAnimation(Animation.LoopingConjure1)
+                .DisplaysVisualEffectWhenActivating()
+                .HasImpactAction((activator, target, level, location) =>
+                {
+                    Impact(activator, target, 30);
+                });
+        }
+
+        private void DarkEssence2()
+        {
+            _builder.Create(FeatType.DarkEssence2, PerkType.DarkEssence)
+                .Name("Dark Essence II")
+                .Level(2)
+                .HasRecastDelay(RecastGroup.DarkEssence, 12f)
+                .HasActivationDelay(2f)
+                .RequirementFP(8)
+                .IsCastedAbility()
+                .HasMaxRange(10f)
+                .UsesAnimation(Animation.LoopingConjure1)
+                .DisplaysVisualEffectWhenActivating()
+                .HasImpactAction((activator, target, level, location) =>
+                {
+                    Impact(activator, target, 60);
+                });
+        }
+
+        private void DarkEssence3()
+        {
+            _builder.Create(FeatType.DarkEssence3, PerkType.DarkEssence)
+                .Name("Dark Essence III")
+                .Level(3)
+                .HasRecastDelay(RecastGroup.DarkEssence, 12f)
+                .HasActivationDelay(2f)
+                .RequirementFP(10)
+                .IsCastedAbility()
+                .HasMaxRange(10f)
+                .UsesAnimation(Animation.LoopingConjure1)
+                .DisplaysVisualEffectWhenActivating()
+                .HasImpactAction((activator, target, level, location) =>
+                {
+                    Impact(activator, target, 90);
+                });
+        }
+    }
+}

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Force/DarkEssenceAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Force/DarkEssenceAbilityDefinition.cs
@@ -39,7 +39,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 ApplyEffectToObject(DurationType.Temporary, regen, target, duration);
             }
 
-            RemoveEffectByTag(activator, DEssTempHP);
+            RemoveEffectByTag(target, DEssTempHP);
             var tempHP = EffectTemporaryHitpoints(baseAmount + (willBonus * 12) + Random.D10(willBonus));
             var tempHPEffect = TagEffect(tempHP, DEssTempHP);
 

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Force/DarkEssenceAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Force/DarkEssenceAbilityDefinition.cs
@@ -40,7 +40,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
             }
 
             RemoveEffectByTag(target, DEssTempHP);
-            var tempHP = EffectTemporaryHitpoints(baseAmount + (willBonus * 12) + Random.D10(willBonus));
+            var tempHP = EffectTemporaryHitpoints(baseAmount + (willBonus * 6) + Random.D10(willBonus));
             var tempHPEffect = TagEffect(tempHP, DEssTempHP);
 
             ApplyEffectToObject(DurationType.Temporary, tempHPEffect, target, duration);
@@ -55,7 +55,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
             _builder.Create(FeatType.DarkEssence1, PerkType.DarkEssence)
                 .Name("Dark Essence I")
                 .Level(1)
-                .HasRecastDelay(RecastGroup.DarkEssence, 12f)
+                .HasRecastDelay(RecastGroup.DarkEssence, 18f)
                 .HasActivationDelay(2f)
                 .RequirementFP(6)
                 .IsCastedAbility()
@@ -73,7 +73,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
             _builder.Create(FeatType.DarkEssence2, PerkType.DarkEssence)
                 .Name("Dark Essence II")
                 .Level(2)
-                .HasRecastDelay(RecastGroup.DarkEssence, 12f)
+                .HasRecastDelay(RecastGroup.DarkEssence, 18f)
                 .HasActivationDelay(2f)
                 .RequirementFP(8)
                 .IsCastedAbility()
@@ -91,7 +91,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
             _builder.Create(FeatType.DarkEssence3, PerkType.DarkEssence)
                 .Name("Dark Essence III")
                 .Level(3)
-                .HasRecastDelay(RecastGroup.DarkEssence, 12f)
+                .HasRecastDelay(RecastGroup.DarkEssence, 18f)
                 .HasActivationDelay(2f)
                 .RequirementFP(10)
                 .IsCastedAbility()

--- a/SWLOR.Game.Server/Feature/PerkDefinition/ForcePerkDefinition.cs
+++ b/SWLOR.Game.Server/Feature/PerkDefinition/ForcePerkDefinition.cs
@@ -34,6 +34,7 @@ namespace SWLOR.Game.Server.Feature.PerkDefinition
             ForceRage();
             ThrowRock();
             ForceInspiration();
+            DarkEssence();
 
             return _builder.Build();
         }
@@ -526,7 +527,7 @@ namespace SWLOR.Game.Server.Feature.PerkDefinition
                 .Price(2)
                 .RequirementSkill(SkillType.Force, 10)
                 .RequirementCharacterType(CharacterType.ForceSensitive)
-                .RequirementCannotHavePerk(PerkType.CreepingTerror)
+                .RequirementCannotHavePerk(PerkType.DarkEssence)
                 .GrantsFeat(FeatType.Benevolence1)
 
                 .AddPerkLevel()
@@ -534,7 +535,7 @@ namespace SWLOR.Game.Server.Feature.PerkDefinition
                 .Price(2)
                 .RequirementSkill(SkillType.Force, 20)
                 .RequirementCharacterType(CharacterType.ForceSensitive)
-                .RequirementCannotHavePerk(PerkType.CreepingTerror)
+                .RequirementCannotHavePerk(PerkType.DarkEssence)
                 .GrantsFeat(FeatType.Benevolence2)
 
                 .AddPerkLevel()
@@ -542,7 +543,7 @@ namespace SWLOR.Game.Server.Feature.PerkDefinition
                 .Price(3)
                 .RequirementSkill(SkillType.Force, 30)
                 .RequirementCharacterType(CharacterType.ForceSensitive)
-                .RequirementCannotHavePerk(PerkType.CreepingTerror)
+                .RequirementCannotHavePerk(PerkType.DarkEssence)
                 .GrantsFeat(FeatType.Benevolence3);
         }
 
@@ -675,6 +676,36 @@ namespace SWLOR.Game.Server.Feature.PerkDefinition
                 .RequirementSkill(SkillType.Force, 45)
                 .RequirementCharacterType(CharacterType.ForceSensitive)
                 .GrantsFeat(FeatType.ForceInspiration3);
+        }
+
+        private void DarkEssence()
+        {
+            _builder.Create(PerkCategoryType.ForceDark, PerkType.DarkEssence)
+                .Name("Dark Essence")
+
+                .AddPerkLevel()
+                .Description("Grant 30 temporary HP to a single target. If you are the target, you also gain regeneration over the duration. Healing, temporary HP and duration are improved with higher Willpower.")
+                .Price(2)
+                .RequirementSkill(SkillType.Force, 10)
+                .RequirementCharacterType(CharacterType.ForceSensitive)
+                .RequirementCannotHavePerk(PerkType.Benevolence)
+                .GrantsFeat(FeatType.DarkEssence1)
+
+                .AddPerkLevel()
+                .Description("Grant 60 temporary HP to a single target. If you are the target, you also gain regeneration over the duration. Healing, temporary HP and duration are improved with higher Willpower.")
+                .Price(2)
+                .RequirementSkill(SkillType.Force, 20)
+                .RequirementCharacterType(CharacterType.ForceSensitive)
+                .RequirementCannotHavePerk(PerkType.Benevolence)
+                .GrantsFeat(FeatType.DarkEssence2)
+
+                .AddPerkLevel()
+                .Description("Grant 90 temporary HP to a single target. If you are the target, you also gain regeneration over the duration. Healing, temporary HP and duration are improved with higher Willpower.")
+                .Price(3)
+                .RequirementSkill(SkillType.Force, 30)
+                .RequirementCharacterType(CharacterType.ForceSensitive)
+                .RequirementCannotHavePerk(PerkType.Benevolence)
+                .GrantsFeat(FeatType.DarkEssence3);
         }
     }
 }

--- a/SWLOR.Game.Server/Service/AbilityService/RecastGroup.cs
+++ b/SWLOR.Game.Server/Service/AbilityService/RecastGroup.cs
@@ -40,7 +40,7 @@ namespace SWLOR.Game.Server.Service.AbilityService
         [RecastGroup("Poison Stab", "Poison Stab", true)]
         PoisonStab = 16,
         [RecastGroup("Backstab", "Backstab", true)]
-        Backstab = 17,        
+        Backstab = 17,
         [RecastGroup("Force Leap", "Force Leap", true)]
         ForceLeap = 18,
         [RecastGroup("Saber Strike", "Saber Strike", true)]
@@ -257,6 +257,8 @@ namespace SWLOR.Game.Server.Service.AbilityService
         ForceRestore = 124,
         [RecastGroup("Adrenal Stim", "Adr. Stim", true)]
         AdrenalStim = 125,
+        [RecastGroup("Dark Essence", "Dark Ess.", true)]
+        DarkEssence = 126,
     }
 
     public class RecastGroupAttribute: Attribute

--- a/SWLOR.Game.Server/Service/PerkService/PerkType.cs
+++ b/SWLOR.Game.Server/Service/PerkService/PerkType.cs
@@ -300,7 +300,7 @@
         ForceTouch = 293,
         Innervate = 294,
         ForceLink = 295,
-        // 296 is free
+        DarkEssence = 296,
         Research = 297,
         AdrenalStim = 298,
         ResearchProjects = 299,

--- a/SWLOR.NWN.API/NWScript/Enum/FeatType.cs
+++ b/SWLOR.NWN.API/NWScript/Enum/FeatType.cs
@@ -1963,5 +1963,8 @@ namespace SWLOR.NWN.API.NWScript.Enum
         ForceLink3 = 1994,
         ZenMarksmanship = 1995,
         IntuitivePiloting = 1996,
+        DarkEssence1 = 1997,
+        DarkEssence2 = 1998,
+        DarkEssence3 = 1999,
     }
 }


### PR DESCRIPTION
New power, Dark Essence, counterpart to Benevolence. Provides Temp HP instead of healing, and grants regen if used on self. Benevolence changed to require you not have this perk, and vice versa, instead of conflicting with Creeping Terror. I intend to add Plant Surge as a counterpart to Creeping Terror.

Also if you want a different name for this let me know. I guess "Unnatural Endurance" could work? 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced Dark Essence Force ability (three progressive levels) that grants targeted regeneration, temporary HP boosts, and visual effects.
  * Added Dark Essence perk (three levels) with requirements; Benevolence perks are now mutually exclusive with Dark Essence.
  * Added a Dark Essence recast group and new feat entries to support the abilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->