### PR TITLE
Remove GrantPermissions instead of regular Permissions during refresh.

### DIFF
--- a/SWLOR.Game.Server/Service/Property.cs
+++ b/SWLOR.Game.Server/Service/Property.cs
@@ -1001,7 +1001,7 @@ namespace SWLOR.Game.Server.Service
                 var grantPermission = dbPermission.GrantPermissions.ElementAt(index).Key;
                 if (!masterList.Contains(grantPermission))
                 {
-                    dbPermission.Permissions.Remove(grantPermission);
+                    dbPermission.GrantPermissions.Remove(grantPermission);
                     Log.Write(LogGroup.Property, $"Removing grant permission {grantPermission} from property {dbPermission.PropertyId} for player Id {dbPermission.PlayerId}.");
                     hasChanges = true;
                 }


### PR DESCRIPTION
Fixes #1979 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a permission management issue where grant-role permissions were not being properly removed from the system when they were no longer included in the master permission list. This ensures that role-based permissions are now consistently updated and maintained with greater accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->