### PR TITLE
Due to item stacking issues, rely on a true/false flag instead of the…

### DIFF
--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/CraftViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/CraftViewModel.cs
@@ -1431,7 +1431,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             var dbPlayer = DB.Get<Player>(playerId);
             var recipe = Craft.GetRecipe(_recipe);
             var item = CreateItemOnObject(recipe.Resref, Player, recipe.Quantity);
-            SetLocalString(item, Item.ProducedByPlayerIdVariable, playerId);
+            SetLocalBool(item, Item.PlayerProducedItemVariable, true);
             var firstTime = !dbPlayer.CraftedRecipes.ContainsKey(_recipe);
             var propertyTransferChance = (int)(((float)_quality / (float)_maxQuality) * 100);
             var qualityPercent = (float)_quality / (float)_maxQuality;

--- a/SWLOR.Game.Server/Feature/QuestDefinition/AgricultureGuildQuestDefinition.cs
+++ b/SWLOR.Game.Server/Feature/QuestDefinition/AgricultureGuildQuestDefinition.cs
@@ -246,8 +246,8 @@ namespace SWLOR.Game.Server.Feature.QuestDefinition
         /// </summary>
         /// <param name="activity">Drives quest title and journal wording ("Craft" vs "Catch" for raw fish).</param>
         /// <param name="collectItemProducerRequirement">
-        /// Use <see cref="CollectItemProducerRequirementType.None"/> when the item is never player-produced (e.g. pure vendor goods).
-        /// Raw fish and crafted dishes use the default so caught or crafted items count.
+        /// For <see cref="AgricultureCollectActivity.Catch"/> tasks this is ignored; raw fish are not required to be player-produced.
+        /// For <see cref="AgricultureCollectActivity.Craft"/> tasks, use <see cref="CollectItemProducerRequirementType.None"/> when any matching resref is acceptable (e.g. vendor goods).
         /// </param>
         private void BuildItemTask(
             QuestBuilder builder,
@@ -256,28 +256,31 @@ namespace SWLOR.Game.Server.Feature.QuestDefinition
             int amount,
             int guildRank,
             AgricultureCollectActivity activity = AgricultureCollectActivity.Craft,
-            CollectItemProducerRequirementType collectItemProducerRequirement = CollectItemProducerRequirementType.ProducedByTurnInPlayer)
+            CollectItemProducerRequirementType collectItemProducerRequirement = CollectItemProducerRequirementType.PlayerProduced)
         {
             var itemName = Cache.GetItemNameByResref(resref);
             var rewardDetails = _rewardDetails[guildRank];
 
+            var producerForObjective = activity == AgricultureCollectActivity.Catch
+                ? CollectItemProducerRequirementType.None
+                : collectItemProducerRequirement;
+
             string questTitle;
             string journalText;
-            if (collectItemProducerRequirement == CollectItemProducerRequirementType.None)
+            if (activity == AgricultureCollectActivity.Catch)
+            {
+                questTitle = $"Catch {amount}x {itemName}";
+                journalText = $"Catch {amount}x {itemName} and return to the Agriculture Guildmaster";
+            }
+            else if (producerForObjective == CollectItemProducerRequirementType.None)
             {
                 questTitle = $"{amount}x {itemName}";
                 journalText = $"Collect {amount}x {itemName} and return to the Agriculture Guildmaster";
             }
             else
             {
-                var verb = activity switch
-                {
-                    AgricultureCollectActivity.Craft => "Craft",
-                    AgricultureCollectActivity.Catch => "Catch",
-                    _ => "Craft",
-                };
-                questTitle = $"{verb} {amount}x {itemName}";
-                journalText = $"{verb} {amount}x {itemName} and return to the Agriculture Guildmaster";
+                questTitle = $"Craft {amount}x {itemName}";
+                journalText = $"Craft {amount}x {itemName} and return to the Agriculture Guildmaster";
             }
 
             builder.Create(questId, questTitle)
@@ -286,7 +289,7 @@ namespace SWLOR.Game.Server.Feature.QuestDefinition
 
                 .AddState()
                 .SetStateJournalText(journalText)
-                .AddCollectItemObjective(resref, amount, collectItemProducerRequirement)
+                .AddCollectItemObjective(resref, amount, producerForObjective)
 
                 .AddGoldReward(rewardDetails.Gold)
                 .AddGPReward(GuildType.AgricultureGuild, rewardDetails.GP);

--- a/SWLOR.Game.Server/Feature/QuestDefinition/EngineeringGuildQuestDefinition.cs
+++ b/SWLOR.Game.Server/Feature/QuestDefinition/EngineeringGuildQuestDefinition.cs
@@ -142,7 +142,7 @@ namespace SWLOR.Game.Server.Feature.QuestDefinition
 
                 .AddState()
                 .SetStateJournalText($"Craft {amount}x {itemName} and return to the Engineering Guildmaster")
-                .AddCollectItemObjective(resref, amount, CollectItemProducerRequirementType.ProducedByTurnInPlayer)
+                .AddCollectItemObjective(resref, amount, CollectItemProducerRequirementType.PlayerProduced)
 
                 .AddGoldReward(rewardDetails.Gold)
                 .AddGPReward(GuildType.EngineeringGuild, rewardDetails.GP);

--- a/SWLOR.Game.Server/Feature/QuestDefinition/FabricationGuildQuestDefinition.cs
+++ b/SWLOR.Game.Server/Feature/QuestDefinition/FabricationGuildQuestDefinition.cs
@@ -272,7 +272,7 @@ namespace SWLOR.Game.Server.Feature.QuestDefinition
 
                 .AddState()
                 .SetStateJournalText($"Craft {amount}x {itemName} and return to the Fabrication Guildmaster")
-                .AddCollectItemObjective(resref, amount, CollectItemProducerRequirementType.ProducedByTurnInPlayer)
+                .AddCollectItemObjective(resref, amount, CollectItemProducerRequirementType.PlayerProduced)
 
                 .AddGoldReward(rewardDetails.Gold)
                 .AddGPReward(GuildType.FabricationGuild, rewardDetails.GP);

--- a/SWLOR.Game.Server/Feature/QuestDefinition/SmitheryGuildQuestDefinition.cs
+++ b/SWLOR.Game.Server/Feature/QuestDefinition/SmitheryGuildQuestDefinition.cs
@@ -237,7 +237,7 @@ namespace SWLOR.Game.Server.Feature.QuestDefinition
 
                 .AddState()
                 .SetStateJournalText($"Craft {amount}x {itemName} and return to the Smithery Guildmaster")
-                .AddCollectItemObjective(resref, amount, CollectItemProducerRequirementType.ProducedByTurnInPlayer)
+                .AddCollectItemObjective(resref, amount, CollectItemProducerRequirementType.PlayerProduced)
 
                 .AddGoldReward(rewardDetails.Gold)
                 .AddGPReward(GuildType.SmitheryGuild, rewardDetails.GP);

--- a/SWLOR.Game.Server/Service/Fishing.cs
+++ b/SWLOR.Game.Server/Service/Fishing.cs
@@ -420,9 +420,7 @@ namespace SWLOR.Game.Server.Service
             }
             else
             {
-                var caughtFish = CreateItemOnObject(fish.Resref, player);
-                if (GetIsObjectValid(caughtFish))
-                    SetLocalString(caughtFish, Item.ProducedByPlayerIdVariable, playerId);
+                CreateItemOnObject(fish.Resref, player);
 
                 SendMessageToPC(player, $"You landed a {fish.Name}!");
             }

--- a/SWLOR.Game.Server/Service/Item.cs
+++ b/SWLOR.Game.Server/Service/Item.cs
@@ -21,10 +21,9 @@ namespace SWLOR.Game.Server.Service
     public static class Item
     {
         /// <summary>
-        /// NWN local string key: object UUID of the player who produced this item (crafting, fishing, etc.).
-        /// Value is the legacy key <c>CRAFTED_BY_PLAYER_ID</c> for save and inventory compatibility.
+        /// NWN local bool: set to true on crafted output so collect objectives can require player-made items.
         /// </summary>
-        public const string ProducedByPlayerIdVariable = "CRAFTED_BY_PLAYER_ID";
+        public const string PlayerProducedItemVariable = "PLAYER_PRODUCED_ITEM";
 
         private static readonly Dictionary<string, ItemDetail> _items = new();
         private static readonly Dictionary<int, int[]> _2daCache = new();
@@ -1080,6 +1079,14 @@ namespace SWLOR.Game.Server.Service
                 SetItemStackSize(item, remaining);
                 return true;
             }
+        }
+
+        /// <summary>
+        /// Returns true if <see cref="PlayerProducedItemVariable"/> is set (e.g. crafting stamped the item).
+        /// </summary>
+        public static bool IsPlayerProducedItem(uint item)
+        {
+            return GetLocalBool(item, PlayerProducedItemVariable);
         }
 
         /// <summary>

--- a/SWLOR.Game.Server/Service/QuestService/CollectItemProducerRequirementType.cs
+++ b/SWLOR.Game.Server/Service/QuestService/CollectItemProducerRequirementType.cs
@@ -1,7 +1,7 @@
 namespace SWLOR.Game.Server.Service.QuestService
 {
     /// <summary>
-    /// Rules for whether a collect-item objective must be produced by a player (crafting, fishing, etc.).
+    /// Whether collect-item turn-ins must be crafted (or carry <see cref="Item.PlayerProducedItemVariable"/>), or any matching resref is accepted.
     /// </summary>
     public enum CollectItemProducerRequirementType
     {
@@ -11,13 +11,8 @@ namespace SWLOR.Game.Server.Service.QuestService
         None = 0,
 
         /// <summary>
-        /// Item must carry a player producer UUID and it must match the PC turning the item in.
+        /// The item must have been crafted (or otherwise stamped with <see cref="Item.PlayerProducedItemVariable"/>).
         /// </summary>
-        ProducedByTurnInPlayer = 1,
-
-        /// <summary>
-        /// Item must carry a player producer UUID (any player); vendor or unassigned items fail.
-        /// </summary>
-        ProducedByAnyPlayer = 2,
+        PlayerProduced = 1,
     }
 }

--- a/SWLOR.Game.Server/Service/QuestService/QuestBuilder.cs
+++ b/SWLOR.Game.Server/Service/QuestService/QuestBuilder.cs
@@ -295,7 +295,7 @@ namespace SWLOR.Game.Server.Service.QuestService
         /// </summary>
         /// <param name="resref">The resref of the required item.</param>
         /// <param name="amount">The number of items needed to complete the objective.</param>
-        /// <param name="producerRequirement">Whether items must be produced by a player and how producer identity is validated.</param>
+        /// <param name="producerRequirement">If <see cref="CollectItemProducerRequirementType.PlayerProduced"/>, the item must be crafted (stamped with <see cref="Item.PlayerProducedItemVariable"/>). See <see cref="CollectItemProducerRequirementType"/>.</param>
         /// <returns>A QuestBuilder with the configured options.</returns>
         public QuestBuilder AddCollectItemObjective(
             string resref,

--- a/SWLOR.Game.Server/Service/QuestService/QuestObjectives.cs
+++ b/SWLOR.Game.Server/Service/QuestService/QuestObjectives.cs
@@ -26,7 +26,7 @@ namespace SWLOR.Game.Server.Service.QuestService
         /// </summary>
         /// <param name="resref">The resref of the required item.</param>
         /// <param name="quantity">The number of items needed to complete the objective.</param>
-        /// <param name="producerRequirement">Whether turn-in items must be produced by a player and how producer identity is validated.</param>
+        /// <param name="producerRequirement">If <see cref="CollectItemProducerRequirementType.PlayerProduced"/>, the item must be crafted (stamped with <see cref="Item.PlayerProducedItemVariable"/>). See <see cref="CollectItemProducerRequirementType"/>.</param>
         public CollectItemObjective(
             string resref,
             int quantity,
@@ -50,22 +50,10 @@ namespace SWLOR.Game.Server.Service.QuestService
                 case CollectItemProducerRequirementType.None:
                     return string.Empty;
 
-                case CollectItemProducerRequirementType.ProducedByAnyPlayer:
-                case CollectItemProducerRequirementType.ProducedByTurnInPlayer:
-                    var producedByPlayerId = GetLocalString(item, Item.ProducedByPlayerIdVariable);
-                    if (string.IsNullOrWhiteSpace(producedByPlayerId))
+                case CollectItemProducerRequirementType.PlayerProduced:
+                    if (!Item.IsPlayerProducedItem(item))
                     {
-                        return ProducerRequirement switch
-                        {
-                            CollectItemProducerRequirementType.ProducedByTurnInPlayer =>
-                                "This quest only accepts items you obtained yourself (for example by crafting or fishing).",
-                            _ => "This quest only accepts items that were obtained by a player (not from vendors or similar sources)."
-                        };
-                    }
-                    if (ProducerRequirement == CollectItemProducerRequirementType.ProducedByTurnInPlayer &&
-                        producedByPlayerId != GetObjectUUID(player))
-                    {
-                        return "That item was obtained by another player and cannot be turned in for this quest.";
+                        return "This quest only accepts crafted items (not plain vendor purchases).";
                     }
                     return string.Empty;
 


### PR DESCRIPTION
… individual player's ID. Don't do this for fish due to stacking issues.