### PR TITLE
Add possession-safe pattern

### DIFF
--- a/SWLOR.Game.Server/Feature/ChatCommandDefinition/DiceChatCommand.cs
+++ b/SWLOR.Game.Server/Feature/ChatCommandDefinition/DiceChatCommand.cs
@@ -3,6 +3,7 @@ using SWLOR.Game.Server.Enumeration;
 using SWLOR.Game.Server.Service;
 using SWLOR.Game.Server.Service.ChatCommandService;
 using SWLOR.Game.Server.Service.GuiService;
+using static SWLOR.NWN.API.NWScript.NWScript;
 
 namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
 {
@@ -17,7 +18,15 @@ namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
                 .Permissions(AuthorizationLevel.All)
                 .Action((user, target, location, args) =>
                 {
-                    Gui.TogglePlayerWindow(user, GuiWindowType.Dice);
+                    var player = user;
+                    var uiTarget = OBJECT_INVALID;
+                    if (GetIsDMPossessed(player))
+                    {
+                        uiTarget = player;
+                        player = GetMaster(player);
+                    }
+
+                    Gui.TogglePlayerWindow(player, GuiWindowType.Dice, null, OBJECT_INVALID, uiTarget);
                 });
 
             return builder.Build();

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/DiceViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/DiceViewModel.cs
@@ -54,7 +54,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
 
         protected override void Initialize(GuiPayloadBase initialPayload)
         {
-            IsSkillSelectionVisible = !GetIsDM(Player);
+            IsSkillSelectionVisible = !GetIsDM(Player) && !GetIsDMPossessed(Player);
             LoadSkills();
             DiceCount = MinDiceCount;
             SelectedSkillId = (int)SkillType.Invalid;
@@ -112,7 +112,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             var dieRoll = number + "d" + sides;
             var message = ColorToken.SkillCheck("Dice Roll: ") + dieRoll + ": " + value;
 
-            if (!GetIsDM(Player))
+            if (!GetIsDM(Player) && !GetIsDMPossessed(Player))
             {
                 var skillType = (SkillType)SelectedSkillId;
                 if (skillType != SkillType.Invalid)


### PR DESCRIPTION
Fix to let DMs possess creatures and use the NUI dicebag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dice rolling for possessed Game Masters to properly display base roll values and streamline the skill selection interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->