### PR TITLE
Fix non-Windows solution build post-build step

### DIFF
--- a/SWLOR.Game.Server/SWLOR.Game.Server.csproj
+++ b/SWLOR.Game.Server/SWLOR.Game.Server.csproj
@@ -43,7 +43,7 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(OS)' == 'Windows_NT'">
     <Exec Command="SWLOR.CLI.exe -o" WorkingDirectory="$(MSBuildProjectDirectory)\..\Build" />
   </Target>
 </Project>


### PR DESCRIPTION
### Motivation
- Prevent Linux/macOS solution builds from failing when the project attempts to execute the Windows-only `SWLOR.CLI.exe` during the post-build step in `SWLOR.Game.Server.csproj`.

### Description
- Add `Condition="'$(OS)' == 'Windows_NT'"` to the `PostBuild` target in `SWLOR.Game.Server.csproj` so the `Exec` (`SWLOR.CLI.exe -o`) runs only on Windows while preserving existing Windows behavior.

### Testing
- Ran `dotnet build SWLOR.Game.Server.sln -v minimal` in this environment and the build completed successfully with warnings only and no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbc5faf4208321a6b7a0a364141e29)