### PR TITLE
Replace guild task dialog list with custom GUI window

### DIFF
--- a/SWLOR.Game.Server/Feature/DialogDefinition/GuildMasterDialog.cs
+++ b/SWLOR.Game.Server/Feature/DialogDefinition/GuildMasterDialog.cs
@@ -1,11 +1,9 @@
-﻿using System.Linq;
-using SWLOR.Game.Server.Entity;
+﻿using SWLOR.Game.Server.Entity;
 using SWLOR.Game.Server.Enumeration;
+using SWLOR.Game.Server.Feature.GuiDefinition.Payload;
 using SWLOR.Game.Server.Service;
 using SWLOR.Game.Server.Service.DialogService;
-using SWLOR.Game.Server.Feature.GuiDefinition.Payload;
 using SWLOR.Game.Server.Service.GuiService;
-using SWLOR.Game.Server.Service.QuestService;
 using SWLOR.NWN.API.NWScript;
 
 namespace SWLOR.Game.Server.Feature.DialogDefinition
@@ -15,14 +13,11 @@ namespace SWLOR.Game.Server.Feature.DialogDefinition
         private class Model
         {
             public GuildType Guild { get; set; }
-            public string QuestId { get; set; }
         }
 
         private const string MainPageId = "MAIN_PAGE";
         private const string TellMePageId = "TELL_ME_PAGE";
         private const string RankTooLowPageId = "RANK_TOO_LOW_PAGE";
-        private const string TaskListPageId = "TASK_LIST_PAGE";
-        private const string TaskDetailsPageId = "TASK_DETAILS_PAGE";
         private const string GuildStorePageId = "GUILD_STORE_PAGE";
 
         public override PlayerDialog SetUp(uint player)
@@ -33,8 +28,6 @@ namespace SWLOR.Game.Server.Feature.DialogDefinition
                 .AddPage(MainPageId, MainPageInit)
                 .AddPage(TellMePageId, TellMePageInit)
                 .AddPage(RankTooLowPageId, RankTooLowPageInit)
-                .AddPage(TaskListPageId, TaskListPageInit)
-                .AddPage(TaskDetailsPageId, TaskDetailsPageInit)
                 .AddPage(GuildStorePageId, GuildStorePageInit);
 
             return builder.Build();
@@ -110,144 +103,6 @@ namespace SWLOR.Game.Server.Feature.DialogDefinition
         private void RankTooLowPageInit(DialogPage page)
         {
             page.Header = "I'm sorry but your rank is too low to grant you access to that. Perform tasks for us and come back when you've increased your rank with our guild.";
-        }
-
-        private void TaskListPageInit(DialogPage page)
-        {
-            var model = GetDataModel<Model>();
-            var player = GetPC();
-            var playerId = GetObjectUUID(player);
-            var dbPlayer = DB.Get<Player>(playerId);
-            page.Header = "The following tasks are available for you.";
-
-            var currentTasks = Guild.GetAllActiveGuildTasks(model.Guild);
-            // Expired quests - Quests the player accepted but are no longer offered by the guild master.
-            foreach (var (questId, pcQuest) in dbPlayer.Quests)
-            {
-                var task = Quest.GetQuestById(questId);
-                if (task.GuildType != model.Guild) continue; // This quest isn't associated with this guild type.
-                if (pcQuest.DateLastCompleted != null) continue; // Has already been completed.
-                if (currentTasks.ContainsKey(questId)) continue; // This task is currently offered
-
-                var status = ColorToken.Green("{ACCEPTED}");
-                var text = $"{task.Name} [Rank {task.GuildRank + 1}] {status}";
-                page.AddResponse(text, () =>
-                {
-                    model.QuestId = questId;
-                    ChangePage(TaskDetailsPageId);
-                });
-            }
-
-            foreach (var (_, task)in currentTasks)
-            {
-                // If the player has completed the task during this task cycle, it will be excluded from this list.
-                // The reason for this is to prevent players from repeating the same tasks over and over without impunity.
-                if (dbPlayer.Quests.ContainsKey(task.QuestId) &&
-                    dbPlayer.Quests[task.QuestId].DateLastCompleted >= Guild.DateTasksLoaded)
-                    continue;
-
-                // Player doesn't have the requisite guild rank to accept this task. Skip over it.
-                var playerRank = 0;
-                if (dbPlayer.Guilds.ContainsKey(task.GuildType))
-                    playerRank = dbPlayer.Guilds[task.GuildType].Rank;
-
-                if (playerRank < task.GuildRank)
-                    continue;
-
-                var status = ColorToken.Green("{ACCEPTED}");
-                // Player has never accepted the quest, or they've already completed it at least once and can accept it again.
-                if (!dbPlayer.Quests.ContainsKey(task.QuestId) ||
-                    (dbPlayer.Quests[task.QuestId].DateLastCompleted != null && dbPlayer.Quests[task.QuestId].TimesCompleted > 0))
-                {
-                    status = ColorToken.Yellow("{Available}");
-                }
-
-                var text = $"{task.Name} [Rank {task.GuildRank + 1}] {status}";
-                page.AddResponse(text, () =>
-                {
-                    model.QuestId = task.QuestId;
-                    ChangePage(TaskDetailsPageId);
-                });
-            }
-        }
-
-        private void TaskDetailsPageInit(DialogPage page)
-        {
-            var model = GetDataModel<Model>();
-            var player = GetPC();
-            var playerId = GetObjectUUID(player);
-            var dbPlayer = DB.Get<Player>(playerId);
-            var pcQuest = dbPlayer.Quests.ContainsKey(model.QuestId)
-                ? dbPlayer.Quests[model.QuestId]
-                : null;
-
-            var task = Quest.GetQuestById(model.QuestId);
-
-            var gpRewards = task.Rewards.Where(x => x.GetType() == typeof(GPReward)).Cast<GPReward>();
-            var goldRewards = task.Rewards.Where(x => x.GetType() == typeof(GoldReward)).Cast<GoldReward>();
-            var gpAmount = 0;
-            var goldAmount = 0;
-
-            foreach (var gpReward in gpRewards)
-            {
-                gpAmount += Guild.CalculateGPReward(player, model.Guild, gpReward.Amount);
-            }
-
-            foreach (var goldReward in goldRewards)
-            {
-                goldAmount += Quest.CalculateQuestGoldReward(player, true, goldReward.Amount);
-            }
-
-            page.Header = ColorToken.Green("Task: ") + task.Name + "\n\n" +
-                          "Rewards:\n\n" +
-                          ColorToken.Green("Credits: ") + goldAmount + "\n" +
-                          ColorToken.Green("Guild Points: ") + gpAmount;
-
-            // Never accepted, or has already been completed once.
-            if (pcQuest == null || pcQuest.DateLastCompleted != null)
-            {
-                page.AddResponse("Accept Task", () =>
-                {
-                    Quest.AcceptQuest(player, model.QuestId);
-                });
-            }
-
-            // Accepted, but not completed.
-            if (pcQuest != null && pcQuest.DateLastCompleted == null)
-            {
-                page.AddResponse("Give Report", GiveReport);
-            }
-        }
-
-        private void GiveReport()
-        {
-            var model = GetDataModel<Model>();
-            var player = GetPC();
-            var playerId = GetObjectUUID(player);
-            var dbPlayer = DB.Get<Player>(playerId);
-            if (!dbPlayer.Quests.ContainsKey(model.QuestId)) return;
-
-            var pcStatus = dbPlayer.Quests[model.QuestId];
-            var quest = Quest.GetQuestById(model.QuestId);
-            var state = quest.States[pcStatus.CurrentState];
-            var hasItemObjective =
-                state.GetObjectives().FirstOrDefault(x => x.GetType() == typeof(CollectItemObjective)) != null;
-
-            // Quest has at least one "collect item" objective.
-            if (hasItemObjective)
-            {
-                Quest.RequestItemsFromPlayer(player, model.QuestId);
-            }
-            // All other quest types
-            else if (quest.CanComplete(player))
-            {
-                quest.Complete(player, GetDialogTarget(), null);
-                EndConversation();
-            }
-            else
-            {
-                SendMessageToPC(player, ColorToken.Red("One or more task is incomplete. Refer to your journal for more information."));
-            }
         }
 
         private void GuildStorePageInit(DialogPage page)

--- a/SWLOR.Game.Server/Feature/DialogDefinition/GuildMasterDialog.cs
+++ b/SWLOR.Game.Server/Feature/DialogDefinition/GuildMasterDialog.cs
@@ -3,6 +3,8 @@ using SWLOR.Game.Server.Entity;
 using SWLOR.Game.Server.Enumeration;
 using SWLOR.Game.Server.Service;
 using SWLOR.Game.Server.Service.DialogService;
+using SWLOR.Game.Server.Feature.GuiDefinition.Payload;
+using SWLOR.Game.Server.Service.GuiService;
 using SWLOR.Game.Server.Service.QuestService;
 using SWLOR.NWN.API.NWScript;
 
@@ -79,7 +81,9 @@ namespace SWLOR.Game.Server.Feature.DialogDefinition
 
             page.AddResponse("Show me the task list.", () =>
             {
-                ChangePage(TaskListPageId);
+                var payload = new GuildTasksPayload(model.Guild, GetDialogTarget());
+                Gui.TogglePlayerWindow(player, GuiWindowType.GuildTasks, payload, GetDialogTarget());
+                EndConversation();
             });
 
             page.AddResponse("Show me the guild shop.", () =>

--- a/SWLOR.Game.Server/Feature/GuiDefinition/GuildTasksDefinition.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/GuildTasksDefinition.cs
@@ -1,0 +1,62 @@
+using SWLOR.Game.Server.Core.Beamdog;
+using SWLOR.Game.Server.Feature.GuiDefinition.ViewModel;
+using SWLOR.Game.Server.Service.GuiService;
+
+namespace SWLOR.Game.Server.Feature.GuiDefinition
+{
+    public class GuildTasksDefinition: IGuiWindowDefinition
+    {
+        private readonly GuiWindowBuilder<GuildTasksViewModel> _builder = new();
+
+        public GuiConstructedWindow BuildWindow()
+        {
+            _builder.CreateWindow(GuiWindowType.GuildTasks)
+                .SetIsResizable(true)
+                .SetIsCollapsible(true)
+                .SetInitialGeometry(0, 0, 700, 420)
+                .SetTitle("Guild Tasks")
+                .AddRow(root =>
+                {
+                    root.AddColumn(left =>
+                    {
+                        left.AddRow(r =>
+                        {
+                            r.AddText().BindText(model => model.HeaderText);
+                        });
+
+                        left.AddRow(r =>
+                        {
+                            r.AddList(template =>
+                            {
+                                template.AddCell(cell =>
+                                {
+                                    cell.AddToggleButton()
+                                        .BindText(model => model.TaskNames)
+                                        .BindIsToggled(model => model.TaskToggles)
+                                        .BindOnClicked(model => model.OnClickTask());
+                                });
+                            }).BindRowCount(model => model.TaskNames);
+                        });
+                    });
+
+                    root.AddColumn(right =>
+                    {
+                        right.AddRow(r => r.AddText().BindText(model => model.TaskDetails));
+                        right.AddRow(r =>
+                        {
+                            r.AddSpacer();
+                            r.AddButton().SetText("Accept Task")
+                                .BindOnClicked(model => model.OnClickAcceptTask())
+                                .BindIsEnabled(model => model.IsAcceptEnabled);
+                            r.AddButton().SetText("Give Report")
+                                .BindOnClicked(model => model.OnClickGiveReport())
+                                .BindIsEnabled(model => model.IsGiveReportEnabled);
+                            r.AddSpacer();
+                        });
+                    });
+                });
+
+            return _builder.Build();
+        }
+    }
+}

--- a/SWLOR.Game.Server/Feature/GuiDefinition/GuildTasksDefinition.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/GuildTasksDefinition.cs
@@ -21,7 +21,8 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                     {
                         left.AddRow(r =>
                         {
-                            r.AddText().BindText(model => model.HeaderText);
+                            r.AddText()
+                                .BindText(model => model.HeaderText);
                         });
 
                         left.AddRow(r =>
@@ -41,7 +42,11 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
 
                     root.AddColumn(right =>
                     {
-                        right.AddRow(r => r.AddText().BindText(model => model.TaskDetails));
+                        right.AddRow(r =>
+                        {
+                            r.AddText()
+                                .BindText(model => model.TaskDetails);
+                        });
                         right.AddRow(r =>
                         {
                             r.AddSpacer();

--- a/SWLOR.Game.Server/Feature/GuiDefinition/Payload/GuildTasksPayload.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/Payload/GuildTasksPayload.cs
@@ -1,0 +1,17 @@
+using SWLOR.Game.Server.Enumeration;
+using SWLOR.Game.Server.Service.GuiService;
+
+namespace SWLOR.Game.Server.Feature.GuiDefinition.Payload
+{
+    public class GuildTasksPayload: GuiPayloadBase
+    {
+        public GuildType Guild { get; }
+        public uint GuildMaster { get; }
+
+        public GuildTasksPayload(GuildType guild, uint guildMaster)
+        {
+            Guild = guild;
+            GuildMaster = guildMaster;
+        }
+    }
+}

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/GuildTasksViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/GuildTasksViewModel.cs
@@ -59,6 +59,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             _guildMaster = initialPayload.GuildMaster;
             _selectedQuestIndex = -1;
 
+            _selectedQuestIndex = -1;
             RefreshTasks();
             LoadSelectedTask();
         }
@@ -162,6 +163,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
         {
             if (_selectedQuestIndex < 0) return;
             Quest.AcceptQuest(Player, _questIds[_selectedQuestIndex]);
+            _selectedQuestIndex = -1;
             RefreshTasks();
             LoadSelectedTask();
         };
@@ -193,6 +195,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
                 SendMessageToPC(Player, ColorToken.Red("One or more task is incomplete. Refer to your journal for more information."));
             }
 
+            _selectedQuestIndex = -1;
             RefreshTasks();
             LoadSelectedTask();
         };

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/GuildTasksViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/GuildTasksViewModel.cs
@@ -1,0 +1,200 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using SWLOR.Game.Server.Entity;
+using SWLOR.Game.Server.Enumeration;
+using SWLOR.Game.Server.Feature.GuiDefinition.Payload;
+using SWLOR.Game.Server.Service;
+using SWLOR.Game.Server.Service.GuiService;
+using SWLOR.Game.Server.Service.QuestService;
+
+namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
+{
+    public class GuildTasksViewModel: GuiViewModelBase<GuildTasksViewModel, GuildTasksPayload>
+    {
+        private readonly List<string> _questIds = new();
+        private GuildType _guildType;
+        private uint _guildMaster;
+        private int _selectedQuestIndex;
+
+        public string HeaderText
+        {
+            get => Get<string>();
+            set => Set(value);
+        }
+
+        public GuiBindingList<string> TaskNames
+        {
+            get => Get<GuiBindingList<string>>();
+            set => Set(value);
+        }
+
+        public GuiBindingList<bool> TaskToggles
+        {
+            get => Get<GuiBindingList<bool>>();
+            set => Set(value);
+        }
+
+        public string TaskDetails
+        {
+            get => Get<string>();
+            set => Set(value);
+        }
+
+        public bool IsAcceptEnabled
+        {
+            get => Get<bool>();
+            set => Set(value);
+        }
+
+        public bool IsGiveReportEnabled
+        {
+            get => Get<bool>();
+            set => Set(value);
+        }
+
+        protected override void Initialize(GuildTasksPayload initialPayload)
+        {
+            _guildType = initialPayload.Guild;
+            _guildMaster = initialPayload.GuildMaster;
+            _selectedQuestIndex = -1;
+
+            RefreshTasks();
+            LoadSelectedTask();
+        }
+
+        private void RefreshTasks()
+        {
+            var playerId = GetObjectUUID(Player);
+            var dbPlayer = DB.Get<Player>(playerId);
+            var guild = Guild.GetGuild(_guildType);
+            var playerGuild = dbPlayer.Guilds.ContainsKey(_guildType)
+                ? dbPlayer.Guilds[_guildType]
+                : new PlayerGuild();
+
+            HeaderText = $"{guild.Name} Tasks - Rank {playerGuild.Rank}";
+
+            _questIds.Clear();
+            var taskNames = new GuiBindingList<string>();
+            var taskToggles = new GuiBindingList<bool>();
+            var currentTasks = Guild.GetAllActiveGuildTasks(_guildType);
+
+            foreach (var (questId, pcQuest) in dbPlayer.Quests)
+            {
+                var task = Quest.GetQuestById(questId);
+                if (task.GuildType != _guildType || pcQuest.DateLastCompleted != null || currentTasks.ContainsKey(questId))
+                    continue;
+
+                _questIds.Add(questId);
+                taskNames.Add($"{task.Name} [Rank {task.GuildRank + 1}] {{ACCEPTED}}");
+                taskToggles.Add(false);
+            }
+
+            foreach (var (_, task) in currentTasks)
+            {
+                if (dbPlayer.Quests.ContainsKey(task.QuestId) &&
+                    dbPlayer.Quests[task.QuestId].DateLastCompleted >= Guild.DateTasksLoaded)
+                    continue;
+
+                var playerRank = dbPlayer.Guilds.ContainsKey(task.GuildType)
+                    ? dbPlayer.Guilds[task.GuildType].Rank
+                    : 0;
+
+                if (playerRank < task.GuildRank)
+                    continue;
+
+                var status = "{ACCEPTED}";
+                if (!dbPlayer.Quests.ContainsKey(task.QuestId) ||
+                    (dbPlayer.Quests[task.QuestId].DateLastCompleted != null && dbPlayer.Quests[task.QuestId].TimesCompleted > 0))
+                {
+                    status = "{AVAILABLE}";
+                }
+
+                _questIds.Add(task.QuestId);
+                taskNames.Add($"{task.Name} [Rank {task.GuildRank + 1}] {status}");
+                taskToggles.Add(false);
+            }
+
+            TaskNames = taskNames;
+            TaskToggles = taskToggles;
+        }
+
+        private void LoadSelectedTask()
+        {
+            IsAcceptEnabled = false;
+            IsGiveReportEnabled = false;
+
+            if (_selectedQuestIndex < 0 || _selectedQuestIndex >= _questIds.Count)
+            {
+                TaskDetails = "Select a task to view details.";
+                return;
+            }
+
+            var questId = _questIds[_selectedQuestIndex];
+            var playerId = GetObjectUUID(Player);
+            var dbPlayer = DB.Get<Player>(playerId);
+            var pcQuest = dbPlayer.Quests.ContainsKey(questId) ? dbPlayer.Quests[questId] : null;
+            var task = Quest.GetQuestById(questId);
+
+            var gpAmount = task.Rewards.OfType<GPReward>().Sum(x => Guild.CalculateGPReward(Player, _guildType, x.Amount));
+            var creditAmount = task.Rewards.OfType<GoldReward>().Sum(x => Quest.CalculateQuestGoldReward(Player, true, x.Amount));
+
+            TaskDetails = $"Task: {task.Name}\n\nRewards:\nCredits: {creditAmount}\nGuild Points: {gpAmount}";
+
+            if (pcQuest == null || pcQuest.DateLastCompleted != null)
+                IsAcceptEnabled = true;
+
+            if (pcQuest != null && pcQuest.DateLastCompleted == null)
+                IsGiveReportEnabled = true;
+        }
+
+        public Action OnClickTask() => () =>
+        {
+            if (_selectedQuestIndex > -1 && _selectedQuestIndex < TaskToggles.Count)
+                TaskToggles[_selectedQuestIndex] = false;
+
+            _selectedQuestIndex = NuiGetEventArrayIndex();
+            TaskToggles[_selectedQuestIndex] = true;
+            LoadSelectedTask();
+        };
+
+        public Action OnClickAcceptTask() => () =>
+        {
+            if (_selectedQuestIndex < 0) return;
+            Quest.AcceptQuest(Player, _questIds[_selectedQuestIndex]);
+            RefreshTasks();
+            LoadSelectedTask();
+        };
+
+        public Action OnClickGiveReport() => () =>
+        {
+            if (_selectedQuestIndex < 0) return;
+
+            var questId = _questIds[_selectedQuestIndex];
+            var playerId = GetObjectUUID(Player);
+            var dbPlayer = DB.Get<Player>(playerId);
+            if (!dbPlayer.Quests.ContainsKey(questId)) return;
+
+            var pcStatus = dbPlayer.Quests[questId];
+            var quest = Quest.GetQuestById(questId);
+            var state = quest.States[pcStatus.CurrentState];
+            var hasItemObjective = state.GetObjectives().Any(x => x.GetType() == typeof(CollectItemObjective));
+
+            if (hasItemObjective)
+            {
+                Quest.RequestItemsFromPlayer(Player, questId);
+            }
+            else if (quest.CanComplete(Player))
+            {
+                quest.Complete(Player, _guildMaster, null);
+            }
+            else
+            {
+                SendMessageToPC(Player, ColorToken.Red("One or more task is incomplete. Refer to your journal for more information."));
+            }
+
+            RefreshTasks();
+            LoadSelectedTask();
+        };
+    }
+}

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/GuildTasksViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/GuildTasksViewModel.cs
@@ -162,6 +162,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
         public Action OnClickAcceptTask() => () =>
         {
             if (_selectedQuestIndex < 0) return;
+            if (!GetIsObjectValid(_guildMaster)) return;
             Quest.AcceptQuest(Player, _questIds[_selectedQuestIndex]);
             _selectedQuestIndex = -1;
             RefreshTasks();
@@ -171,6 +172,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
         public Action OnClickGiveReport() => () =>
         {
             if (_selectedQuestIndex < 0) return;
+            if (!GetIsObjectValid(_guildMaster)) return;
 
             var questId = _questIds[_selectedQuestIndex];
             var playerId = GetObjectUUID(Player);

--- a/SWLOR.Game.Server/Service/GuiService/GuiWindowType.cs
+++ b/SWLOR.Game.Server/Service/GuiService/GuiWindowType.cs
@@ -59,6 +59,7 @@ namespace SWLOR.Game.Server.Service.GuiService
         TargetDescription = 54,
         MusicPicker = 55,
         Dice = 56,
+        GuildTasks = 57,
 
         DebugEnmity = 900,
         ChangePortrait = 9999


### PR DESCRIPTION
### Motivation
- The dialog-based guild task menu is difficult to use and should be replaced with a custom GUI that preserves all existing rules and logic while improving usability. 
- The new window should provide the same functionality as the dialog pages but present tasks in a clearer, interactive layout. 
- Players must only be able to see and interact with task tiers they have earned, and existing rank/availability rules must be retained.

### Description
- Replaced the Guild Master dialog response for "Show me the task list" so it opens a new `GuiWindowType.GuildTasks` window and ends the conversation instead of navigating dialog pages. 
- Added a `GuildTasks` GUI window definition (`GuildTasksDefinition.cs`) and a payload class (`GuildTasksPayload.cs`) to pass `GuildType` and the guild-master object into the GUI. 
- Implemented `GuildTasksViewModel.cs` which ports the dialog task-list/detail/accept/report logic to the GUI while preserving filtering by player guild rank, accepted/available/expired handling, and reward preview calculations. 
- Added `GuiWindowType.GuildTasks` enum entry and updated the guild dialog to use the new payload and window toggle.

### Testing
- Built the server project with `dotnet build SWLOR.Game.Server/SWLOR.Game.Server.csproj -v minimal`, which succeeded with pre-existing warnings and produced no new errors. 
- No additional automated tests were added; the change is functionally equivalent to the previous dialog flow and relies on existing quest/guild logic for correctness. 
- Files primarily changed/added: `GuildMasterDialog.cs` (invoke GUI), `GuiWindowType.cs` (enum), `GuildTasksDefinition.cs`, `Payload/GuildTasksPayload.cs`, and `ViewModel/GuildTasksViewModel.cs`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbd2220a5883218f49945339275ed1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New Guild Tasks window: resizable panel showing a guild task list, task details, and buttons to accept tasks or submit reports.
  * Guild Master interactions now open the Guild Tasks interface directly for quicker task management.
* **UI**
  * Task list supports toggling/selecting entries and updates detail/enable states based on progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->