### PR TITLE
Replace guild task dialog with GUI-based Guild Tasks window

### DIFF
--- a/SWLOR.Game.Server/Feature/DialogDefinition/GuildMasterDialog.cs
+++ b/SWLOR.Game.Server/Feature/DialogDefinition/GuildMasterDialog.cs
@@ -1,9 +1,9 @@
-﻿using System.Linq;
-using SWLOR.Game.Server.Entity;
+﻿using SWLOR.Game.Server.Entity;
 using SWLOR.Game.Server.Enumeration;
+using SWLOR.Game.Server.Feature.GuiDefinition.Payload;
 using SWLOR.Game.Server.Service;
 using SWLOR.Game.Server.Service.DialogService;
-using SWLOR.Game.Server.Service.QuestService;
+using SWLOR.Game.Server.Service.GuiService;
 using SWLOR.NWN.API.NWScript;
 
 namespace SWLOR.Game.Server.Feature.DialogDefinition
@@ -13,14 +13,11 @@ namespace SWLOR.Game.Server.Feature.DialogDefinition
         private class Model
         {
             public GuildType Guild { get; set; }
-            public string QuestId { get; set; }
         }
 
         private const string MainPageId = "MAIN_PAGE";
         private const string TellMePageId = "TELL_ME_PAGE";
         private const string RankTooLowPageId = "RANK_TOO_LOW_PAGE";
-        private const string TaskListPageId = "TASK_LIST_PAGE";
-        private const string TaskDetailsPageId = "TASK_DETAILS_PAGE";
         private const string GuildStorePageId = "GUILD_STORE_PAGE";
 
         public override PlayerDialog SetUp(uint player)
@@ -31,8 +28,6 @@ namespace SWLOR.Game.Server.Feature.DialogDefinition
                 .AddPage(MainPageId, MainPageInit)
                 .AddPage(TellMePageId, TellMePageInit)
                 .AddPage(RankTooLowPageId, RankTooLowPageInit)
-                .AddPage(TaskListPageId, TaskListPageInit)
-                .AddPage(TaskDetailsPageId, TaskDetailsPageInit)
                 .AddPage(GuildStorePageId, GuildStorePageInit);
 
             return builder.Build();
@@ -79,7 +74,9 @@ namespace SWLOR.Game.Server.Feature.DialogDefinition
 
             page.AddResponse("Show me the task list.", () =>
             {
-                ChangePage(TaskListPageId);
+                var payload = new GuildTasksPayload(model.Guild, GetDialogTarget());
+                Gui.TogglePlayerWindow(player, GuiWindowType.GuildTasks, payload, GetDialogTarget());
+                EndConversation();
             });
 
             page.AddResponse("Show me the guild shop.", () =>
@@ -106,144 +103,6 @@ namespace SWLOR.Game.Server.Feature.DialogDefinition
         private void RankTooLowPageInit(DialogPage page)
         {
             page.Header = "I'm sorry but your rank is too low to grant you access to that. Perform tasks for us and come back when you've increased your rank with our guild.";
-        }
-
-        private void TaskListPageInit(DialogPage page)
-        {
-            var model = GetDataModel<Model>();
-            var player = GetPC();
-            var playerId = GetObjectUUID(player);
-            var dbPlayer = DB.Get<Player>(playerId);
-            page.Header = "The following tasks are available for you.";
-
-            var currentTasks = Guild.GetAllActiveGuildTasks(model.Guild);
-            // Expired quests - Quests the player accepted but are no longer offered by the guild master.
-            foreach (var (questId, pcQuest) in dbPlayer.Quests)
-            {
-                var task = Quest.GetQuestById(questId);
-                if (task.GuildType != model.Guild) continue; // This quest isn't associated with this guild type.
-                if (pcQuest.DateLastCompleted != null) continue; // Has already been completed.
-                if (currentTasks.ContainsKey(questId)) continue; // This task is currently offered
-
-                var status = ColorToken.Green("{ACCEPTED}");
-                var text = $"{task.Name} [Rank {task.GuildRank + 1}] {status}";
-                page.AddResponse(text, () =>
-                {
-                    model.QuestId = questId;
-                    ChangePage(TaskDetailsPageId);
-                });
-            }
-
-            foreach (var (_, task)in currentTasks)
-            {
-                // If the player has completed the task during this task cycle, it will be excluded from this list.
-                // The reason for this is to prevent players from repeating the same tasks over and over without impunity.
-                if (dbPlayer.Quests.ContainsKey(task.QuestId) &&
-                    dbPlayer.Quests[task.QuestId].DateLastCompleted >= Guild.DateTasksLoaded)
-                    continue;
-
-                // Player doesn't have the requisite guild rank to accept this task. Skip over it.
-                var playerRank = 0;
-                if (dbPlayer.Guilds.ContainsKey(task.GuildType))
-                    playerRank = dbPlayer.Guilds[task.GuildType].Rank;
-
-                if (playerRank < task.GuildRank)
-                    continue;
-
-                var status = ColorToken.Green("{ACCEPTED}");
-                // Player has never accepted the quest, or they've already completed it at least once and can accept it again.
-                if (!dbPlayer.Quests.ContainsKey(task.QuestId) ||
-                    (dbPlayer.Quests[task.QuestId].DateLastCompleted != null && dbPlayer.Quests[task.QuestId].TimesCompleted > 0))
-                {
-                    status = ColorToken.Yellow("{Available}");
-                }
-
-                var text = $"{task.Name} [Rank {task.GuildRank + 1}] {status}";
-                page.AddResponse(text, () =>
-                {
-                    model.QuestId = task.QuestId;
-                    ChangePage(TaskDetailsPageId);
-                });
-            }
-        }
-
-        private void TaskDetailsPageInit(DialogPage page)
-        {
-            var model = GetDataModel<Model>();
-            var player = GetPC();
-            var playerId = GetObjectUUID(player);
-            var dbPlayer = DB.Get<Player>(playerId);
-            var pcQuest = dbPlayer.Quests.ContainsKey(model.QuestId)
-                ? dbPlayer.Quests[model.QuestId]
-                : null;
-
-            var task = Quest.GetQuestById(model.QuestId);
-
-            var gpRewards = task.Rewards.Where(x => x.GetType() == typeof(GPReward)).Cast<GPReward>();
-            var goldRewards = task.Rewards.Where(x => x.GetType() == typeof(GoldReward)).Cast<GoldReward>();
-            var gpAmount = 0;
-            var goldAmount = 0;
-
-            foreach (var gpReward in gpRewards)
-            {
-                gpAmount += Guild.CalculateGPReward(player, model.Guild, gpReward.Amount);
-            }
-
-            foreach (var goldReward in goldRewards)
-            {
-                goldAmount += Quest.CalculateQuestGoldReward(player, true, goldReward.Amount);
-            }
-
-            page.Header = ColorToken.Green("Task: ") + task.Name + "\n\n" +
-                          "Rewards:\n\n" +
-                          ColorToken.Green("Credits: ") + goldAmount + "\n" +
-                          ColorToken.Green("Guild Points: ") + gpAmount;
-
-            // Never accepted, or has already been completed once.
-            if (pcQuest == null || pcQuest.DateLastCompleted != null)
-            {
-                page.AddResponse("Accept Task", () =>
-                {
-                    Quest.AcceptQuest(player, model.QuestId);
-                });
-            }
-
-            // Accepted, but not completed.
-            if (pcQuest != null && pcQuest.DateLastCompleted == null)
-            {
-                page.AddResponse("Give Report", GiveReport);
-            }
-        }
-
-        private void GiveReport()
-        {
-            var model = GetDataModel<Model>();
-            var player = GetPC();
-            var playerId = GetObjectUUID(player);
-            var dbPlayer = DB.Get<Player>(playerId);
-            if (!dbPlayer.Quests.ContainsKey(model.QuestId)) return;
-
-            var pcStatus = dbPlayer.Quests[model.QuestId];
-            var quest = Quest.GetQuestById(model.QuestId);
-            var state = quest.States[pcStatus.CurrentState];
-            var hasItemObjective =
-                state.GetObjectives().FirstOrDefault(x => x.GetType() == typeof(CollectItemObjective)) != null;
-
-            // Quest has at least one "collect item" objective.
-            if (hasItemObjective)
-            {
-                Quest.RequestItemsFromPlayer(player, model.QuestId);
-            }
-            // All other quest types
-            else if (quest.CanComplete(player))
-            {
-                quest.Complete(player, GetDialogTarget(), null);
-                EndConversation();
-            }
-            else
-            {
-                SendMessageToPC(player, ColorToken.Red("One or more task is incomplete. Refer to your journal for more information."));
-            }
         }
 
         private void GuildStorePageInit(DialogPage page)

--- a/SWLOR.Game.Server/Feature/GuiDefinition/GuildTasksDefinition.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/GuildTasksDefinition.cs
@@ -83,7 +83,8 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                         left.AddRow(r =>
                         {
                             r.AddSpacer();
-                            r.AddButton().SetText("Accept All")
+                            r.AddButton()
+                                .SetText("Accept All")
                                 .BindOnClicked(model => model.OnClickAcceptAllTasks())
                                 .BindIsEnabled(model => model.IsAcceptAllEnabled)
                                 .SetHeight(32f)
@@ -99,12 +100,14 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                         right.AddRow(r =>
                         {
                             r.AddSpacer();
-                            r.AddButton().SetText("Accept Task")
+                            r.AddButton()
+                                .SetText("Accept Task")
                                 .BindOnClicked(model => model.OnClickAcceptTask())
                                 .BindIsEnabled(model => model.IsAcceptEnabled)
                                 .SetHeight(32f)
                                 .SetWidth(120f);
-                            r.AddButton().SetText("Give Report")
+                            r.AddButton()
+                                .SetText("Give Report")
                                 .BindOnClicked(model => model.OnClickGiveReport())
                                 .BindIsEnabled(model => model.IsGiveReportEnabled)
                                 .SetHeight(32f)

--- a/SWLOR.Game.Server/Feature/GuiDefinition/GuildTasksDefinition.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/GuildTasksDefinition.cs
@@ -28,35 +28,40 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                                 .BindColor(model => model.Rank1Color)
                                 .BindIsEnabled(model => model.IsRank1Enabled)
                                 .BindOnClicked(model => model.OnClickRankFilter(1))
-                                .SetHeight(32f);
+                                .SetHeight(32f)
+                                .SetWidth(80f);
                             r.AddToggleButton()
                                 .BindText(model => model.Rank2Text)
                                 .BindIsToggled(model => model.IsRank2Toggled)
                                 .BindColor(model => model.Rank2Color)
                                 .BindIsEnabled(model => model.IsRank2Enabled)
                                 .BindOnClicked(model => model.OnClickRankFilter(2))
-                                .SetHeight(32f);
+                                .SetHeight(32f)
+                                .SetWidth(80f);
                             r.AddToggleButton()
                                 .BindText(model => model.Rank3Text)
                                 .BindIsToggled(model => model.IsRank3Toggled)
                                 .BindColor(model => model.Rank3Color)
                                 .BindIsEnabled(model => model.IsRank3Enabled)
                                 .BindOnClicked(model => model.OnClickRankFilter(3))
-                                .SetHeight(32f);
+                                .SetHeight(32f)
+                                .SetWidth(80f);
                             r.AddToggleButton()
                                 .BindText(model => model.Rank4Text)
                                 .BindIsToggled(model => model.IsRank4Toggled)
                                 .BindColor(model => model.Rank4Color)
                                 .BindIsEnabled(model => model.IsRank4Enabled)
                                 .BindOnClicked(model => model.OnClickRankFilter(4))
-                                .SetHeight(32f);
+                                .SetHeight(32f)
+                                .SetWidth(80f);
                             r.AddToggleButton()
                                 .BindText(model => model.Rank5Text)
                                 .BindIsToggled(model => model.IsRank5Toggled)
                                 .BindColor(model => model.Rank5Color)
                                 .BindIsEnabled(model => model.IsRank5Enabled)
                                 .BindOnClicked(model => model.OnClickRankFilter(5))
-                                .SetHeight(32f);
+                                .SetHeight(32f)
+                                .SetWidth(80f);
                             r.AddSpacer();
                         });
 
@@ -74,20 +79,36 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                                 });
                             }).BindRowCount(model => model.TaskNames);
                         });
+
+                        left.AddRow(r =>
+                        {
+                            r.AddSpacer();
+                            r.AddButton().SetText("Accept All")
+                                .BindOnClicked(model => model.OnClickAcceptAllTasks())
+                                .BindIsEnabled(model => model.IsAcceptAllEnabled)
+                                .SetHeight(32f)
+                                .SetWidth(120f);
+                            r.AddSpacer();
+                        });
                     });
 
                     root.AddColumn(right =>
                     {
+                        right.SetWidth(300f);
                         right.AddRow(r => r.AddText().BindText(model => model.TaskDetails));
                         right.AddRow(r =>
                         {
                             r.AddSpacer();
                             r.AddButton().SetText("Accept Task")
                                 .BindOnClicked(model => model.OnClickAcceptTask())
-                                .BindIsEnabled(model => model.IsAcceptEnabled);
+                                .BindIsEnabled(model => model.IsAcceptEnabled)
+                                .SetHeight(32f)
+                                .SetWidth(120f);
                             r.AddButton().SetText("Give Report")
                                 .BindOnClicked(model => model.OnClickGiveReport())
-                                .BindIsEnabled(model => model.IsGiveReportEnabled);
+                                .BindIsEnabled(model => model.IsGiveReportEnabled)
+                                .SetHeight(32f)
+                                .SetWidth(120f);
                             r.AddSpacer();
                         });
                     });

--- a/SWLOR.Game.Server/Feature/GuiDefinition/GuildTasksDefinition.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/GuildTasksDefinition.cs
@@ -21,26 +21,43 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                     {
                         left.AddRow(r =>
                         {
-                            r.AddButton().BindText(model => model.Rank1Text)
+                            r.AddSpacer();
+                            r.AddToggleButton()
+                                .BindText(model => model.Rank1Text)
+                                .BindIsToggled(model => model.IsRank1Toggled)
                                 .BindColor(model => model.Rank1Color)
                                 .BindIsEnabled(model => model.IsRank1Enabled)
-                                .BindOnClicked(model => model.OnClickRankFilter(1));
-                            r.AddButton().BindText(model => model.Rank2Text)
+                                .BindOnClicked(model => model.OnClickRankFilter(1))
+                                .SetHeight(32f);
+                            r.AddToggleButton()
+                                .BindText(model => model.Rank2Text)
+                                .BindIsToggled(model => model.IsRank2Toggled)
                                 .BindColor(model => model.Rank2Color)
                                 .BindIsEnabled(model => model.IsRank2Enabled)
-                                .BindOnClicked(model => model.OnClickRankFilter(2));
-                            r.AddButton().BindText(model => model.Rank3Text)
+                                .BindOnClicked(model => model.OnClickRankFilter(2))
+                                .SetHeight(32f);
+                            r.AddToggleButton()
+                                .BindText(model => model.Rank3Text)
+                                .BindIsToggled(model => model.IsRank3Toggled)
                                 .BindColor(model => model.Rank3Color)
                                 .BindIsEnabled(model => model.IsRank3Enabled)
-                                .BindOnClicked(model => model.OnClickRankFilter(3));
-                            r.AddButton().BindText(model => model.Rank4Text)
+                                .BindOnClicked(model => model.OnClickRankFilter(3))
+                                .SetHeight(32f);
+                            r.AddToggleButton()
+                                .BindText(model => model.Rank4Text)
+                                .BindIsToggled(model => model.IsRank4Toggled)
                                 .BindColor(model => model.Rank4Color)
                                 .BindIsEnabled(model => model.IsRank4Enabled)
-                                .BindOnClicked(model => model.OnClickRankFilter(4));
-                            r.AddButton().BindText(model => model.Rank5Text)
+                                .BindOnClicked(model => model.OnClickRankFilter(4))
+                                .SetHeight(32f);
+                            r.AddToggleButton()
+                                .BindText(model => model.Rank5Text)
+                                .BindIsToggled(model => model.IsRank5Toggled)
                                 .BindColor(model => model.Rank5Color)
                                 .BindIsEnabled(model => model.IsRank5Enabled)
-                                .BindOnClicked(model => model.OnClickRankFilter(5));
+                                .BindOnClicked(model => model.OnClickRankFilter(5))
+                                .SetHeight(32f);
+                            r.AddSpacer();
                         });
 
                         left.AddRow(r =>

--- a/SWLOR.Game.Server/Feature/GuiDefinition/GuildTasksDefinition.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/GuildTasksDefinition.cs
@@ -1,0 +1,82 @@
+using SWLOR.Game.Server.Core.Beamdog;
+using SWLOR.Game.Server.Feature.GuiDefinition.ViewModel;
+using SWLOR.Game.Server.Service.GuiService;
+
+namespace SWLOR.Game.Server.Feature.GuiDefinition
+{
+    public class GuildTasksDefinition: IGuiWindowDefinition
+    {
+        private readonly GuiWindowBuilder<GuildTasksViewModel> _builder = new();
+
+        public GuiConstructedWindow BuildWindow()
+        {
+            _builder.CreateWindow(GuiWindowType.GuildTasks)
+                .SetIsResizable(true)
+                .SetIsCollapsible(true)
+                .SetInitialGeometry(0, 0, 700, 420)
+                .SetTitle("Guild Tasks")
+                .AddRow(root =>
+                {
+                    root.AddColumn(left =>
+                    {
+                        left.AddRow(r =>
+                        {
+                            r.AddButton().BindText(model => model.Rank1Text)
+                                .BindColor(model => model.Rank1Color)
+                                .BindIsEnabled(model => model.IsRank1Enabled)
+                                .BindOnClicked(model => model.OnClickRankFilter(1));
+                            r.AddButton().BindText(model => model.Rank2Text)
+                                .BindColor(model => model.Rank2Color)
+                                .BindIsEnabled(model => model.IsRank2Enabled)
+                                .BindOnClicked(model => model.OnClickRankFilter(2));
+                            r.AddButton().BindText(model => model.Rank3Text)
+                                .BindColor(model => model.Rank3Color)
+                                .BindIsEnabled(model => model.IsRank3Enabled)
+                                .BindOnClicked(model => model.OnClickRankFilter(3));
+                            r.AddButton().BindText(model => model.Rank4Text)
+                                .BindColor(model => model.Rank4Color)
+                                .BindIsEnabled(model => model.IsRank4Enabled)
+                                .BindOnClicked(model => model.OnClickRankFilter(4));
+                            r.AddButton().BindText(model => model.Rank5Text)
+                                .BindColor(model => model.Rank5Color)
+                                .BindIsEnabled(model => model.IsRank5Enabled)
+                                .BindOnClicked(model => model.OnClickRankFilter(5));
+                        });
+
+                        left.AddRow(r =>
+                        {
+                            r.AddList(template =>
+                            {
+                                template.AddCell(cell =>
+                                {
+                                    cell.AddToggleButton()
+                                        .BindText(model => model.TaskNames)
+                                        .BindIsToggled(model => model.TaskToggles)
+                                        .BindOnClicked(model => model.OnClickTask())
+                                        .BindColor(model => model.TaskColors);
+                                });
+                            }).BindRowCount(model => model.TaskNames);
+                        });
+                    });
+
+                    root.AddColumn(right =>
+                    {
+                        right.AddRow(r => r.AddText().BindText(model => model.TaskDetails));
+                        right.AddRow(r =>
+                        {
+                            r.AddSpacer();
+                            r.AddButton().SetText("Accept Task")
+                                .BindOnClicked(model => model.OnClickAcceptTask())
+                                .BindIsEnabled(model => model.IsAcceptEnabled);
+                            r.AddButton().SetText("Give Report")
+                                .BindOnClicked(model => model.OnClickGiveReport())
+                                .BindIsEnabled(model => model.IsGiveReportEnabled);
+                            r.AddSpacer();
+                        });
+                    });
+                });
+
+            return _builder.Build();
+        }
+    }
+}

--- a/SWLOR.Game.Server/Feature/GuiDefinition/Payload/GuildTasksPayload.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/Payload/GuildTasksPayload.cs
@@ -1,0 +1,17 @@
+using SWLOR.Game.Server.Enumeration;
+using SWLOR.Game.Server.Service.GuiService;
+
+namespace SWLOR.Game.Server.Feature.GuiDefinition.Payload
+{
+    public class GuildTasksPayload: GuiPayloadBase
+    {
+        public GuildType Guild { get; }
+        public uint GuildMaster { get; }
+
+        public GuildTasksPayload(GuildType guild, uint guildMaster)
+        {
+            Guild = guild;
+            GuildMaster = guildMaster;
+        }
+    }
+}

--- a/SWLOR.Game.Server/Feature/GuiDefinition/RefreshEvent/QuestAbandonedRefreshEvent.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/RefreshEvent/QuestAbandonedRefreshEvent.cs
@@ -1,0 +1,14 @@
+using SWLOR.Game.Server.Service.GuiService;
+
+namespace SWLOR.Game.Server.Feature.GuiDefinition.RefreshEvent
+{
+    public class QuestAbandonedRefreshEvent: IGuiRefreshEvent
+    {
+        public string QuestId { get; set; }
+
+        public QuestAbandonedRefreshEvent(string questId)
+        {
+            QuestId = questId;
+        }
+    }
+}

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/GuildTasksViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/GuildTasksViewModel.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using SWLOR.Game.Server.Entity;
 using SWLOR.Game.Server.Enumeration;
 using SWLOR.Game.Server.Feature.GuiDefinition.Payload;
+using SWLOR.Game.Server.Feature.GuiDefinition.RefreshEvent;
 using SWLOR.Game.Server.Service;
 using SWLOR.Game.Server.Service.GuiService;
 using SWLOR.Game.Server.Service.GuiService.Component;
@@ -11,7 +12,11 @@ using SWLOR.Game.Server.Service.QuestService;
 
 namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
 {
-    public class GuildTasksViewModel: GuiViewModelBase<GuildTasksViewModel, GuildTasksPayload>
+    public class GuildTasksViewModel: GuiViewModelBase<GuildTasksViewModel, GuildTasksPayload>,
+        IGuiRefreshable<QuestAcquiredRefreshEvent>,
+        IGuiRefreshable<QuestProgressedRefreshEvent>,
+        IGuiRefreshable<QuestCompletedRefreshEvent>,
+        IGuiRefreshable<QuestAbandonedRefreshEvent>
     {
         private readonly List<string> _questIds = new();
         private GuildType _guildType;
@@ -52,6 +57,11 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
         public bool IsRank3Enabled { get => Get<bool>(); set => Set(value); }
         public bool IsRank4Enabled { get => Get<bool>(); set => Set(value); }
         public bool IsRank5Enabled { get => Get<bool>(); set => Set(value); }
+        public bool IsRank1Toggled { get => Get<bool>(); set => Set(value); }
+        public bool IsRank2Toggled { get => Get<bool>(); set => Set(value); }
+        public bool IsRank3Toggled { get => Get<bool>(); set => Set(value); }
+        public bool IsRank4Toggled { get => Get<bool>(); set => Set(value); }
+        public bool IsRank5Toggled { get => Get<bool>(); set => Set(value); }
 
         public string TaskDetails
         {
@@ -160,6 +170,11 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             Rank3Color = _selectedRankFilter == 3 ? GuiColor.Cyan : GuiColor.White;
             Rank4Color = _selectedRankFilter == 4 ? GuiColor.Cyan : GuiColor.White;
             Rank5Color = _selectedRankFilter == 5 ? GuiColor.Cyan : GuiColor.White;
+            IsRank1Toggled = _selectedRankFilter == 1;
+            IsRank2Toggled = _selectedRankFilter == 2;
+            IsRank3Toggled = _selectedRankFilter == 3;
+            IsRank4Toggled = _selectedRankFilter == 4;
+            IsRank5Toggled = _selectedRankFilter == 5;
         }
 
         private void LoadSelectedTask()
@@ -167,7 +182,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             IsAcceptEnabled = false;
             IsGiveReportEnabled = false;
 
-            if (_selectedQuestIndex < 0 || _selectedQuestIndex >= _questIds.Count)
+            if (!HasSelectedQuest())
             {
                 TaskDetails = "Select a task to view details.";
                 return;
@@ -191,19 +206,32 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
                 IsGiveReportEnabled = true;
         }
 
+        private bool HasSelectedQuest()
+        {
+            return _selectedQuestIndex >= 0 && _selectedQuestIndex < _questIds.Count;
+        }
+
         public Action OnClickTask() => () =>
         {
             if (_selectedQuestIndex > -1 && _selectedQuestIndex < TaskToggles.Count)
                 TaskToggles[_selectedQuestIndex] = false;
 
-            _selectedQuestIndex = NuiGetEventArrayIndex();
+            var index = NuiGetEventArrayIndex();
+            if (index < 0 || index >= TaskToggles.Count || index >= _questIds.Count)
+            {
+                _selectedQuestIndex = -1;
+                LoadSelectedTask();
+                return;
+            }
+
+            _selectedQuestIndex = index;
             TaskToggles[_selectedQuestIndex] = true;
             LoadSelectedTask();
         };
 
         public Action OnClickAcceptTask() => () =>
         {
-            if (_selectedQuestIndex < 0) return;
+            if (!HasSelectedQuest()) return;
             Quest.AcceptQuest(Player, _questIds[_selectedQuestIndex]);
             _selectedQuestIndex = -1;
             RefreshTasks();
@@ -212,7 +240,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
 
         public Action OnClickGiveReport() => () =>
         {
-            if (_selectedQuestIndex < 0) return;
+            if (!HasSelectedQuest()) return;
 
             var questId = _questIds[_selectedQuestIndex];
             var playerId = GetObjectUUID(Player);
@@ -234,7 +262,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             }
             else
             {
-                SendMessageToPC(Player, ColorToken.Red("One or more task is incomplete. Refer to your journal for more information."));
+                SendMessageToPC(Player, ColorToken.Red("One or more tasks are incomplete. Refer to your journal for more information."));
             }
 
             _selectedQuestIndex = -1;
@@ -249,5 +277,34 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             RefreshTasks();
             LoadSelectedTask();
         };
+
+        private void ReloadFromQuestEvent(string questId)
+        {
+            if (_selectedQuestIndex >= 0 && _selectedQuestIndex < _questIds.Count && _questIds[_selectedQuestIndex] == questId)
+                _selectedQuestIndex = -1;
+
+            RefreshTasks();
+            LoadSelectedTask();
+        }
+
+        public void Refresh(QuestAcquiredRefreshEvent payload)
+        {
+            ReloadFromQuestEvent(payload.QuestId);
+        }
+
+        public void Refresh(QuestProgressedRefreshEvent payload)
+        {
+            ReloadFromQuestEvent(payload.QuestId);
+        }
+
+        public void Refresh(QuestCompletedRefreshEvent payload)
+        {
+            ReloadFromQuestEvent(payload.QuestId);
+        }
+
+        public void Refresh(QuestAbandonedRefreshEvent payload)
+        {
+            ReloadFromQuestEvent(payload.QuestId);
+        }
     }
 }

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/GuildTasksViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/GuildTasksViewModel.cs
@@ -1,0 +1,253 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using SWLOR.Game.Server.Entity;
+using SWLOR.Game.Server.Enumeration;
+using SWLOR.Game.Server.Feature.GuiDefinition.Payload;
+using SWLOR.Game.Server.Service;
+using SWLOR.Game.Server.Service.GuiService;
+using SWLOR.Game.Server.Service.GuiService.Component;
+using SWLOR.Game.Server.Service.QuestService;
+
+namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
+{
+    public class GuildTasksViewModel: GuiViewModelBase<GuildTasksViewModel, GuildTasksPayload>
+    {
+        private readonly List<string> _questIds = new();
+        private GuildType _guildType;
+        private uint _guildMaster;
+        private int _selectedQuestIndex;
+        private int _selectedRankFilter;
+
+        public GuiBindingList<string> TaskNames
+        {
+            get => Get<GuiBindingList<string>>();
+            set => Set(value);
+        }
+
+        public GuiBindingList<bool> TaskToggles
+        {
+            get => Get<GuiBindingList<bool>>();
+            set => Set(value);
+        }
+        
+        public GuiBindingList<GuiColor> TaskColors
+        {
+            get => Get<GuiBindingList<GuiColor>>();
+            set => Set(value);
+        }
+
+        public string Rank1Text { get => Get<string>(); set => Set(value); }
+        public string Rank2Text { get => Get<string>(); set => Set(value); }
+        public string Rank3Text { get => Get<string>(); set => Set(value); }
+        public string Rank4Text { get => Get<string>(); set => Set(value); }
+        public string Rank5Text { get => Get<string>(); set => Set(value); }
+        public GuiColor Rank1Color { get => Get<GuiColor>(); set => Set(value); }
+        public GuiColor Rank2Color { get => Get<GuiColor>(); set => Set(value); }
+        public GuiColor Rank3Color { get => Get<GuiColor>(); set => Set(value); }
+        public GuiColor Rank4Color { get => Get<GuiColor>(); set => Set(value); }
+        public GuiColor Rank5Color { get => Get<GuiColor>(); set => Set(value); }
+        public bool IsRank1Enabled { get => Get<bool>(); set => Set(value); }
+        public bool IsRank2Enabled { get => Get<bool>(); set => Set(value); }
+        public bool IsRank3Enabled { get => Get<bool>(); set => Set(value); }
+        public bool IsRank4Enabled { get => Get<bool>(); set => Set(value); }
+        public bool IsRank5Enabled { get => Get<bool>(); set => Set(value); }
+
+        public string TaskDetails
+        {
+            get => Get<string>();
+            set => Set(value);
+        }
+
+        public bool IsAcceptEnabled
+        {
+            get => Get<bool>();
+            set => Set(value);
+        }
+
+        public bool IsGiveReportEnabled
+        {
+            get => Get<bool>();
+            set => Set(value);
+        }
+
+        protected override void Initialize(GuildTasksPayload initialPayload)
+        {
+            _guildType = initialPayload.Guild;
+            _guildMaster = initialPayload.GuildMaster;
+            _selectedQuestIndex = -1;
+            _selectedRankFilter = 1;
+
+            Rank1Text = "Rank 1";
+            Rank2Text = "Rank 2";
+            Rank3Text = "Rank 3";
+            Rank4Text = "Rank 4";
+            Rank5Text = "Rank 5";
+
+            RefreshTasks();
+            LoadSelectedTask();
+        }
+
+        private void RefreshTasks()
+        {
+            var playerId = GetObjectUUID(Player);
+            var dbPlayer = DB.Get<Player>(playerId);
+            var playerGuild = dbPlayer.Guilds.ContainsKey(_guildType)
+                ? dbPlayer.Guilds[_guildType]
+                : new PlayerGuild();
+
+            _questIds.Clear();
+            var taskNames = new GuiBindingList<string>();
+            var taskToggles = new GuiBindingList<bool>();
+            var taskColors = new GuiBindingList<GuiColor>();
+            var currentTasks = Guild.GetAllActiveGuildTasks(_guildType);
+            var rankHasTasks = new Dictionary<int, bool> {{1,false}, {2,false}, {3,false}, {4,false}, {5,false}};
+
+            foreach (var (questId, pcQuest) in dbPlayer.Quests)
+            {
+                var task = Quest.GetQuestById(questId);
+                if (task.GuildType != _guildType || pcQuest.DateLastCompleted != null || currentTasks.ContainsKey(questId))
+                    continue;
+                if (task.GuildRank + 1 != _selectedRankFilter)
+                    continue;
+
+                _questIds.Add(questId);
+                taskNames.Add($"{task.Name} [Rank {task.GuildRank + 1}]");
+                taskToggles.Add(false);
+                taskColors.Add(GuiColor.Red);
+                rankHasTasks[task.GuildRank + 1] = true;
+            }
+
+            foreach (var (_, task) in currentTasks)
+            {
+                if (dbPlayer.Quests.ContainsKey(task.QuestId) &&
+                    dbPlayer.Quests[task.QuestId].DateLastCompleted >= Guild.DateTasksLoaded)
+                    continue;
+
+                var playerRank = dbPlayer.Guilds.ContainsKey(task.GuildType)
+                    ? dbPlayer.Guilds[task.GuildType].Rank
+                    : 0;
+
+                if (playerRank < task.GuildRank)
+                    continue;
+                rankHasTasks[task.GuildRank + 1] = true;
+                if (task.GuildRank + 1 != _selectedRankFilter)
+                    continue;
+
+                var statusColor = GuiColor.Green;
+                if (!dbPlayer.Quests.ContainsKey(task.QuestId) ||
+                    (dbPlayer.Quests[task.QuestId].DateLastCompleted != null && dbPlayer.Quests[task.QuestId].TimesCompleted > 0))
+                {
+                    statusColor = new GuiColor(255, 255, 0);
+                }
+
+                _questIds.Add(task.QuestId);
+                taskNames.Add($"{task.Name} [Rank {task.GuildRank + 1}]");
+                taskToggles.Add(false);
+                taskColors.Add(statusColor);
+            }
+
+            TaskNames = taskNames;
+            TaskToggles = taskToggles;
+            TaskColors = taskColors;
+            IsRank1Enabled = rankHasTasks[1] && playerGuild.Rank >= 0;
+            IsRank2Enabled = rankHasTasks[2] && playerGuild.Rank >= 1;
+            IsRank3Enabled = rankHasTasks[3] && playerGuild.Rank >= 2;
+            IsRank4Enabled = rankHasTasks[4] && playerGuild.Rank >= 3;
+            IsRank5Enabled = rankHasTasks[5] && playerGuild.Rank >= 4;
+            Rank1Color = _selectedRankFilter == 1 ? GuiColor.Cyan : GuiColor.White;
+            Rank2Color = _selectedRankFilter == 2 ? GuiColor.Cyan : GuiColor.White;
+            Rank3Color = _selectedRankFilter == 3 ? GuiColor.Cyan : GuiColor.White;
+            Rank4Color = _selectedRankFilter == 4 ? GuiColor.Cyan : GuiColor.White;
+            Rank5Color = _selectedRankFilter == 5 ? GuiColor.Cyan : GuiColor.White;
+        }
+
+        private void LoadSelectedTask()
+        {
+            IsAcceptEnabled = false;
+            IsGiveReportEnabled = false;
+
+            if (_selectedQuestIndex < 0 || _selectedQuestIndex >= _questIds.Count)
+            {
+                TaskDetails = "Select a task to view details.";
+                return;
+            }
+
+            var questId = _questIds[_selectedQuestIndex];
+            var playerId = GetObjectUUID(Player);
+            var dbPlayer = DB.Get<Player>(playerId);
+            var pcQuest = dbPlayer.Quests.ContainsKey(questId) ? dbPlayer.Quests[questId] : null;
+            var task = Quest.GetQuestById(questId);
+
+            var gpAmount = task.Rewards.OfType<GPReward>().Sum(x => Guild.CalculateGPReward(Player, _guildType, x.Amount));
+            var creditAmount = task.Rewards.OfType<GoldReward>().Sum(x => Quest.CalculateQuestGoldReward(Player, true, x.Amount));
+
+            TaskDetails = $"Task: {task.Name}\n\nRewards:\nCredits: {creditAmount}\nGuild Points: {gpAmount}";
+
+            if (pcQuest == null || pcQuest.DateLastCompleted != null)
+                IsAcceptEnabled = true;
+
+            if (pcQuest != null && pcQuest.DateLastCompleted == null)
+                IsGiveReportEnabled = true;
+        }
+
+        public Action OnClickTask() => () =>
+        {
+            if (_selectedQuestIndex > -1 && _selectedQuestIndex < TaskToggles.Count)
+                TaskToggles[_selectedQuestIndex] = false;
+
+            _selectedQuestIndex = NuiGetEventArrayIndex();
+            TaskToggles[_selectedQuestIndex] = true;
+            LoadSelectedTask();
+        };
+
+        public Action OnClickAcceptTask() => () =>
+        {
+            if (_selectedQuestIndex < 0) return;
+            Quest.AcceptQuest(Player, _questIds[_selectedQuestIndex]);
+            _selectedQuestIndex = -1;
+            RefreshTasks();
+            LoadSelectedTask();
+        };
+
+        public Action OnClickGiveReport() => () =>
+        {
+            if (_selectedQuestIndex < 0) return;
+
+            var questId = _questIds[_selectedQuestIndex];
+            var playerId = GetObjectUUID(Player);
+            var dbPlayer = DB.Get<Player>(playerId);
+            if (!dbPlayer.Quests.ContainsKey(questId)) return;
+
+            var pcStatus = dbPlayer.Quests[questId];
+            var quest = Quest.GetQuestById(questId);
+            var state = quest.States[pcStatus.CurrentState];
+            var hasItemObjective = state.GetObjectives().Any(x => x.GetType() == typeof(CollectItemObjective));
+
+            if (hasItemObjective)
+            {
+                Quest.RequestItemsFromPlayer(Player, questId);
+            }
+            else if (quest.CanComplete(Player))
+            {
+                quest.Complete(Player, _guildMaster, null);
+            }
+            else
+            {
+                SendMessageToPC(Player, ColorToken.Red("One or more task is incomplete. Refer to your journal for more information."));
+            }
+
+            _selectedQuestIndex = -1;
+            RefreshTasks();
+            LoadSelectedTask();
+        };
+
+        public Action OnClickRankFilter(int rank) => () =>
+        {
+            _selectedRankFilter = rank;
+            _selectedQuestIndex = -1;
+            RefreshTasks();
+            LoadSelectedTask();
+        };
+    }
+}

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/GuildTasksViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/GuildTasksViewModel.cs
@@ -81,6 +81,12 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             set => Set(value);
         }
 
+        public bool IsAcceptAllEnabled
+        {
+            get => Get<bool>();
+            set => Set(value);
+        }
+
         protected override void Initialize(GuildTasksPayload initialPayload)
         {
             _guildType = initialPayload.Guild;
@@ -122,7 +128,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
                     continue;
 
                 _questIds.Add(questId);
-                taskNames.Add($"{task.Name} [Rank {task.GuildRank + 1}]");
+                taskNames.Add($"{task.Name} [Rank {task.GuildRank + 1}] [Expired]");
                 taskToggles.Add(false);
                 taskColors.Add(GuiColor.Red);
                 rankHasTasks[task.GuildRank + 1] = true;
@@ -175,6 +181,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             IsRank3Toggled = _selectedRankFilter == 3;
             IsRank4Toggled = _selectedRankFilter == 4;
             IsRank5Toggled = _selectedRankFilter == 5;
+            IsAcceptAllEnabled = _questIds.Any(questId => IsQuestAcceptable(dbPlayer, questId));
         }
 
         private void LoadSelectedTask()
@@ -193,11 +200,20 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             var dbPlayer = DB.Get<Player>(playerId);
             var pcQuest = dbPlayer.Quests.ContainsKey(questId) ? dbPlayer.Quests[questId] : null;
             var task = Quest.GetQuestById(questId);
+            var currentTasks = Guild.GetAllActiveGuildTasks(_guildType);
+            var isExpired = pcQuest != null &&
+                            pcQuest.DateLastCompleted == null &&
+                            task.GuildType == _guildType &&
+                            !currentTasks.ContainsKey(questId);
 
             var gpAmount = task.Rewards.OfType<GPReward>().Sum(x => Guild.CalculateGPReward(Player, _guildType, x.Amount));
             var creditAmount = task.Rewards.OfType<GoldReward>().Sum(x => Quest.CalculateQuestGoldReward(Player, true, x.Amount));
 
             TaskDetails = $"Task: {task.Name}\n\nRewards:\nCredits: {creditAmount}\nGuild Points: {gpAmount}";
+            if (isExpired)
+            {
+                TaskDetails += "\n\nStatus: Expired task. This task is no longer in the current guild task rotation.";
+            }
 
             if (pcQuest == null || pcQuest.DateLastCompleted != null)
                 IsAcceptEnabled = true;
@@ -209,6 +225,11 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
         private bool HasSelectedQuest()
         {
             return _selectedQuestIndex >= 0 && _selectedQuestIndex < _questIds.Count;
+        }
+
+        private static bool IsQuestAcceptable(Player dbPlayer, string questId)
+        {
+            return !dbPlayer.Quests.ContainsKey(questId) || dbPlayer.Quests[questId].DateLastCompleted != null;
         }
 
         public Action OnClickTask() => () =>
@@ -236,6 +257,34 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             _selectedQuestIndex = -1;
             RefreshTasks();
             LoadSelectedTask();
+        };
+
+        public Action OnClickAcceptAllTasks() => () =>
+        {
+            var playerId = GetObjectUUID(Player);
+            var dbPlayer = DB.Get<Player>(playerId);
+            var questIds = _questIds
+                .Where(questId => IsQuestAcceptable(dbPlayer, questId))
+                .ToList();
+
+            if (questIds.Count <= 0)
+                return;
+
+            ShowModal($"Accept all {questIds.Count} available Rank {_selectedRankFilter} tasks?", () =>
+            {
+                var acceptedCount = 0;
+                foreach (var questId in questIds)
+                {
+                    Quest.AcceptQuest(Player, questId);
+                    acceptedCount++;
+                }
+
+                SendMessageToPC(Player, $"Accepted {acceptedCount} Rank {_selectedRankFilter} guild tasks.");
+
+                _selectedQuestIndex = -1;
+                RefreshTasks();
+                LoadSelectedTask();
+            });
         };
 
         public Action OnClickGiveReport() => () =>

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/QuestsViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/QuestsViewModel.cs
@@ -13,7 +13,8 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
     public class QuestsViewModel: GuiViewModelBase<QuestsViewModel, GuiPayloadBase>,
         IGuiRefreshable<QuestAcquiredRefreshEvent>,
         IGuiRefreshable<QuestProgressedRefreshEvent>,
-        IGuiRefreshable<QuestCompletedRefreshEvent>
+        IGuiRefreshable<QuestCompletedRefreshEvent>,
+        IGuiRefreshable<QuestAbandonedRefreshEvent>
     {
         public string SearchText
         {
@@ -177,15 +178,6 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
                 }
 
                 Quest.AbandonQuest(Player, questId);
-
-                _questIds.RemoveAt(SelectedQuestIndex);
-                QuestNames.RemoveAt(SelectedQuestIndex);
-                QuestToggles.RemoveAt(SelectedQuestIndex);
-                ActiveQuestName = "[Select a Quest]";
-                ActiveQuestDescription = "[Select a Quest]";
-                IsAbandonQuestEnabled = false;
-
-                SelectedQuestIndex = -1;
             });
         };
 
@@ -200,6 +192,11 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
         }
 
         public void Refresh(QuestCompletedRefreshEvent payload)
+        {
+            Search();
+        }
+
+        public void Refresh(QuestAbandonedRefreshEvent payload)
         {
             Search();
         }

--- a/SWLOR.Game.Server/Service/GuiService/GuiWindowType.cs
+++ b/SWLOR.Game.Server/Service/GuiService/GuiWindowType.cs
@@ -59,6 +59,7 @@ namespace SWLOR.Game.Server.Service.GuiService
         TargetDescription = 54,
         MusicPicker = 55,
         Dice = 56,
+        GuildTasks = 57,
 
         DebugEnmity = 900,
         ChangePortrait = 9999

--- a/SWLOR.Game.Server/Service/QuestService/QuestDetail.cs
+++ b/SWLOR.Game.Server/Service/QuestService/QuestDetail.cs
@@ -217,6 +217,8 @@ namespace SWLOR.Game.Server.Service.QuestService
             {
                 action.Invoke(player);
             }
+
+            Gui.PublishRefreshEvent(player, new QuestAbandonedRefreshEvent(QuestId));
         }
 
         /// <summary>


### PR DESCRIPTION
### Motivation
- Move guild task listing and management out of the old dialog pages and into a reusable GUI window for better UX and maintainability.
- Simplify the guild master dialog by delegating task browsing, acceptance, and reporting to a dedicated GUI view.

### Description
- Removed dialog-driven task pages and associated model state from `GuildMasterDialog.cs` and instead open a GUI window via `Gui.TogglePlayerWindow` with a `GuildTasksPayload` when the player requests the task list.
- Added a new GUI window definition `GuildTasksDefinition` that builds the Guild Tasks UI layout and a strongly-typed payload `GuildTasksPayload` for passing the guild and guild master reference.
- Implemented `GuildTasksViewModel` which drives task filtering by rank, task selection, detail display, task acceptance, and giving reports, and encapsulates quest/GP/gold calculations and state refresh logic.
- Added a new `GuiWindowType.GuildTasks` enum value and updated imports/usings accordingly.

### Testing
- Performed an automated project build with `dotnet build` which completed successfully.
- Ran the automated unit/integration test suite with `dotnet test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbd2220a5883218f49945339275ed1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Guild Tasks window for browsing, filtering (ranks 1–5), viewing details, accepting tasks, accepting all, and submitting reports with color-coded indicators.
  * Guild Master interaction now opens the Guild Tasks window directly.

* **Bug Fixes / Behavior**
  * UI now refreshes automatically after abandoning or completing quests so lists stay in sync.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->