### PR TITLE
Clamp starport transportation tax when calculating flight fees

### DIFF
--- a/SWLOR.Game.Server/Feature/DialogDefinition/StarportFlightsDialog.cs
+++ b/SWLOR.Game.Server/Feature/DialogDefinition/StarportFlightsDialog.cs
@@ -1,4 +1,5 @@
-﻿using SWLOR.Game.Server.Entity;
+﻿using System;
+using SWLOR.Game.Server.Entity;
 using SWLOR.Game.Server.Enumeration;
 using SWLOR.Game.Server.Service;
 using SWLOR.Game.Server.Service.DialogService;
@@ -46,7 +47,10 @@ namespace SWLOR.Game.Server.Feature.DialogDefinition
             var dbBuilding = DB.Get<WorldProperty>(dbProperty.ParentPropertyId);
             var dbCity = DB.Get<WorldProperty>(dbBuilding.ParentPropertyId);
 
-            model.Tax = 0.01f * dbCity.Taxes[PropertyTaxType.Transportation];
+            var transportationTaxRate = dbCity.Taxes[PropertyTaxType.Transportation];
+            transportationTaxRate = Math.Clamp(transportationTaxRate, 0, 25);
+
+            model.Tax = 0.01f * transportationTaxRate;
             model.CityPropertyId = dbCity.Id;
         }
 


### PR DESCRIPTION
### Motivation
- Prevent out-of-range city transportation tax values from producing unexpectedly large starport fares and charging players far more credits than intended when purchasing a flight.

### Description
- Added `using System;` and updated `SWLOR.Game.Server/Feature/DialogDefinition/StarportFlightsDialog.cs` to clamp the city transportation tax with `Math.Clamp(transportationTaxRate, 0, 25)` before converting it to the multiplier used for flight fees.

### Testing
- Built the server project with `dotnet build SWLOR.Game.Server/SWLOR.Game.Server.csproj -v minimal` and the build succeeded (warnings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd495dcaa48321bd1eefe089ab49c0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Transportation tax in starport flights is now capped at a maximum rate of 25%.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->