### PR TITLE
Fix invalid Agriculture Guild sardine quest target

### DIFF
--- a/SWLOR.Game.Server/Feature/QuestDefinition/AgricultureGuildQuestDefinition.cs
+++ b/SWLOR.Game.Server/Feature/QuestDefinition/AgricultureGuildQuestDefinition.cs
@@ -109,7 +109,7 @@ namespace SWLOR.Game.Server.Feature.QuestDefinition
             BuildItemTask(builder, "agr_tsk_223", "muddy_siredon", 4, 1, AgricultureCollectActivity.Catch);
             BuildItemTask(builder, "agr_tsk_224", "istavrit", 4, 1, AgricultureCollectActivity.Catch);
             BuildItemTask(builder, "agr_tsk_225", "fish_broth", 1, 1);
-            BuildItemTask(builder, "agr_tsk_226", "cooked_sardine", 1, 1);
+            BuildItemTask(builder, "agr_tsk_226", "sliced_sardine", 1, 1);
             BuildItemTask(builder, "agr_tsk_227", "rakaz_special", 1, 1);
             BuildItemTask(builder, "agr_tsk_228", "maringna", 1, 1);
             BuildItemTask(builder, "agr_tsk_229", "cooked_mackerel", 1, 1);


### PR DESCRIPTION
### Motivation
- Users reported the Agriculture Guild task requested a non-existent `cooked_sardine` output and the Sardine Ball recipe produced no inventory item, so the quest objective needed to reference an existing craftable item.

### Description
- Replaced the quest objective `BuildItemTask(builder, "agr_tsk_226", "cooked_sardine", 1, 1);` with `BuildItemTask(builder, "agr_tsk_226", "sliced_sardine", 1, 1);` in `SWLOR.Game.Server/Feature/QuestDefinition/AgricultureGuildQuestDefinition.cs` so the task now targets the existing `sliced_sardine` recipe.

### Testing
- Confirmed the change with `rg -n "agr_tsk_226"` and `git diff` showing the updated line, and verified a corresponding recipe exists for `sliced_sardine` in `CookingRecipes.cs`; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe780d7f008321b1701054ffae9a28)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted an Agriculture Guild quest task to require the correct ingredient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->