### PR TITLE
Calculate and set vendor gold value for beast eggs based on incubation quality

### DIFF
--- a/SWLOR.Game.Server/Service/BeastMastery.cs
+++ b/SWLOR.Game.Server/Service/BeastMastery.cs
@@ -830,7 +830,41 @@ namespace SWLOR.Game.Server.Service
             var beastDetail = GetBeastDetail(beastType);
             SetName(egg, $"Beast Egg: {beastDetail.Name}");
 
+            var addGoldPiece = CalculateEggVendorBonus(job);
+            ItemPlugin.SetAddGoldPieceValue(egg, addGoldPiece);
+
             DB.Delete<IncubationJob>(job.Id);
+        }
+
+        private static int CalculateEggVendorBonus(IncubationJob job)
+        {
+            const float maxPurityValue = 1000f;
+            var purities = new List<int>
+            {
+                job.AttackPurity,
+                job.AccuracyPurity,
+                job.EvasionPurity,
+                job.LearningPurity,
+                job.DefensePurities[CombatDamageType.Physical],
+                job.DefensePurities[CombatDamageType.Force],
+                job.DefensePurities[CombatDamageType.Fire],
+                job.DefensePurities[CombatDamageType.Poison],
+                job.DefensePurities[CombatDamageType.Electrical],
+                job.DefensePurities[CombatDamageType.Ice],
+                job.SavingThrowPurities[SavingThrow.Fortitude],
+                job.SavingThrowPurities[SavingThrow.Reflex],
+                job.SavingThrowPurities[SavingThrow.Will],
+            };
+
+            var averagePurity = purities.Average();
+            var qualityPercent = averagePurity / maxPurityValue;
+            var xpPenaltyAdjustment = 1f - (job.XPPenalty / maxPurityValue);
+
+            const int baseVendorBonus = 180;
+            const int qualityVendorRange = 1170;
+            var addGoldPiece = (int)Math.Round(baseVendorBonus + (qualityVendorRange * qualityPercent * xpPenaltyAdjustment));
+
+            return Math.Max(baseVendorBonus, addGoldPiece);
         }
 
         /// <summary>


### PR DESCRIPTION
### Motivation
- Provide a meaningful vendor sell value for hatched beast eggs that scales with incubation quality and XP penalty so egg value reflects player effort.

### Description
- Set the egg's vendor add-gold value by calling `ItemPlugin.SetAddGoldPieceValue(egg, addGoldPiece)` when hatching completes.
- Add a new helper `CalculateEggVendorBonus(IncubationJob job)` that computes a vendor bonus from the average of all purity stats and the `XPPenalty`, using constants `maxPurityValue = 1000f`, `baseVendorBonus = 180`, and `qualityVendorRange = 1170` to produce a rounded bonus and enforce a minimum of `baseVendorBonus`.
- The calculation aggregates attack, accuracy, evasion, learning, all defense purities, and saving throw purities to determine egg quality.

### Testing
- Built the solution to verify compilation succeeded. 
- Ran the existing automated unit test suite and observed all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff4a2e83ac8321b4a1ac4a2605b437)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Beast eggs now generate a vendor gold bonus when sold, calculated based on the egg's quality metrics and attribute levels, rewarding players for successfully raising higher-quality creatures.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zunath/SWLOR_NWN/pull/2011)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->