### PR TITLE
Per-player outfit and market listing limits with migration and GUI updates

### DIFF
--- a/SWLOR.Game.Server/Entity/Player.cs
+++ b/SWLOR.Game.Server/Entity/Player.cs
@@ -21,6 +21,9 @@ namespace SWLOR.Game.Server.Entity
 {
     public class Player: EntityBase
     {
+        public const int DefaultOutfitSlotLimit = 25;
+        public const int DefaultMarketListingLimit = 25;
+
         public Player()
         {
             Init();
@@ -89,6 +92,8 @@ namespace SWLOR.Game.Server.Entity
             CPBonus = new Dictionary<SkillType, int>();
             AbilityToggles = new Dictionary<AbilityToggleType, bool>();
             Currencies = new Dictionary<CurrencyType, int>();
+            OutfitSlotLimit = DefaultOutfitSlotLimit;
+            MarketListingLimit = DefaultMarketListingLimit;
         }
 
 
@@ -141,6 +146,8 @@ namespace SWLOR.Game.Server.Entity
         public float MovementRate { get; set; }
         public int AbilityRecastReduction { get; set; }
         public int MarketTill { get; set; }
+        public int OutfitSlotLimit { get; set; }
+        public int MarketListingLimit { get; set; }
         [Indexed]
         public string CitizenPropertyId { get; set; }
         public int PropertyOwedTaxes { get; set; }

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/MarketListingViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/MarketListingViewModel.cs
@@ -147,7 +147,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
         {
             var maxListings = GetMarketListingLimit();
             ListCount = $"  {_itemCount} / {maxListings} Items Listed";
-            IsAddItemEnabled = _itemIds.Count < maxListings;
+            IsAddItemEnabled = _itemCount < maxListings;
         }
 
         protected override void Initialize(MarketPayload initialPayload)
@@ -186,7 +186,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
                 return;
             }
 
-            if (_itemIds.Count >= GetMarketListingLimit())
+            if (_itemCount >= GetMarketListingLimit())
             {
                 FloatingTextStringOnCreature("You cannot list any more items.", Player, false);
                 return;

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/MarketListingViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/MarketListingViewModel.cs
@@ -86,6 +86,12 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             set => Set(value);
         }
 
+        private int GetMarketListingLimit()
+        {
+            var dbPlayer = DB.Get<Player>(GetObjectUUID(Player));
+            return dbPlayer?.MarketListingLimit > 0 ? dbPlayer.MarketListingLimit : Entity.Player.DefaultMarketListingLimit;
+        }
+
         private void LoadData()
         {
             var itemIconResrefs = new GuiBindingList<string>();
@@ -139,8 +145,9 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
 
         private void UpdateItemCount()
         {
-            ListCount = $"  {_itemCount} / {PlayerMarket.MaxListingsPerMarket} Items Listed";
-            IsAddItemEnabled = _itemIds.Count < PlayerMarket.MaxListingsPerMarket;
+            var maxListings = GetMarketListingLimit();
+            ListCount = $"  {_itemCount} / {maxListings} Items Listed";
+            IsAddItemEnabled = _itemIds.Count < maxListings;
         }
 
         protected override void Initialize(MarketPayload initialPayload)
@@ -179,7 +186,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
                 return;
             }
 
-            if (_itemIds.Count >= PlayerMarket.MaxListingsPerMarket)
+            if (_itemIds.Count >= GetMarketListingLimit())
             {
                 FloatingTextStringOnCreature("You cannot list any more items.", Player, false);
                 return;

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/OutfitViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/OutfitViewModel.cs
@@ -13,8 +13,6 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
 {
     public class OutfitViewModel: GuiViewModelBase<OutfitViewModel, GuiPayloadBase>
     {
-        private const int MaxOutfits = 25;
-
         private List<string> _outfitIds = new();
 
         public GuiBindingList<string> SlotNames
@@ -73,6 +71,12 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
         {
             get => Get<string>();
             set => Set(value);
+        }
+
+        private int GetOutfitSlotLimit()
+        {
+            var dbPlayer = DB.Get<Player>(GetObjectUUID(Player));
+            return dbPlayer?.OutfitSlotLimit > 0 ? dbPlayer.OutfitSlotLimit : Entity.Player.DefaultOutfitSlotLimit;
         }
 
         private List<PlayerOutfit> GetOutfits()
@@ -322,9 +326,11 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             var outfitCount = DB.SearchCount(new DBQuery<PlayerOutfit>()
                 .AddFieldSearch(nameof(PlayerOutfit.PlayerId), playerId, false));
 
-            if (outfitCount >= MaxOutfits)
+            var maxOutfits = GetOutfitSlotLimit();
+
+            if (outfitCount >= maxOutfits)
             {
-                FloatingTextStringOnCreature($"You may only create {MaxOutfits} outfits.", Player, false);
+                FloatingTextStringOnCreature($"You may only create {maxOutfits} outfits.", Player, false);
                 return;
             }
 

--- a/SWLOR.Game.Server/Feature/MigrationDefinition/ServerMigration/_21_SetDefaultOutfitAndMarketLimits.cs
+++ b/SWLOR.Game.Server/Feature/MigrationDefinition/ServerMigration/_21_SetDefaultOutfitAndMarketLimits.cs
@@ -1,0 +1,43 @@
+using SWLOR.Game.Server.Entity;
+using SWLOR.Game.Server.Service;
+using SWLOR.Game.Server.Service.DBService;
+using SWLOR.Game.Server.Service.MigrationService;
+
+namespace SWLOR.Game.Server.Feature.MigrationDefinition.ServerMigration
+{
+    public class _21_SetDefaultOutfitAndMarketLimits : ServerMigrationBase, IServerMigration
+    {
+        public int Version => 21;
+        public MigrationExecutionType ExecutionType => MigrationExecutionType.PostDatabaseLoad;
+
+        public void Migrate()
+        {
+            var query = new DBQuery<Player>();
+            var count = (int)DB.SearchCount(query);
+            var dbPlayers = DB.Search(query
+                .AddPaging(count, 0));
+
+            foreach (var player in dbPlayers)
+            {
+                var isModified = false;
+
+                if (player.OutfitSlotLimit <= 0)
+                {
+                    player.OutfitSlotLimit = Entity.Player.DefaultOutfitSlotLimit;
+                    isModified = true;
+                }
+
+                if (player.MarketListingLimit <= 0)
+                {
+                    player.MarketListingLimit = Entity.Player.DefaultMarketListingLimit;
+                    isModified = true;
+                }
+
+                if (isModified)
+                {
+                    DB.Set(player);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Add configurable per-player limits for outfit slots and market listings instead of hardcoded caps to support individualized caps and future flexibility. 
- Ensure existing player records receive sensible defaults so older accounts behave consistently after deployment.

### Description
- Introduced `DefaultOutfitSlotLimit` and `DefaultMarketListingLimit` constants (both `25`) and added `OutfitSlotLimit` and `MarketListingLimit` properties to the `Player` entity with defaults set in `Init`. 
- Updated `OutfitViewModel` to use a `GetOutfitSlotLimit()` helper that fetches the player's `OutfitSlotLimit` (falling back to `Player.DefaultOutfitSlotLimit`) and removed the hardcoded `MaxOutfits` constant. 
- Updated `MarketListingViewModel` to use a `GetMarketListingLimit()` helper to enforce each player's `MarketListingLimit` (falling back to `Player.DefaultMarketListingLimit`) when displaying counts and preventing new listings. 
- Added a migration `ServerMigration/_21_SetDefaultOutfitAndMarketLimits.cs` (version `21`) that iterates all `Player` records and sets the new limit fields to the defaults when they are unset or non-positive.

### Testing
- Built the solution and ran the automated test suite and CI build, and the run completed successfully. 
- Confirmed migration code compiles and applies default values through the migration script `21_SetDefaultOutfitAndMarketLimits` in a development environment (no failures reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff54a3f4788321b486041d22375c1c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Players can now have individual limits for stored outfits and active market listings (system defaults remain 25). UI shows per-player limits, disables adding items/outfits when a player has reached their limit, and displays the current max to the user.
* **Chores**
  * Existing player records are updated to ensure valid default limits are applied.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zunath/SWLOR_NWN/pull/2012)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->