### PR TITLE
Add per-player outfit and market listing limits with defaults and migration

### DIFF
--- a/SWLOR.Game.Server/Entity/Player.cs
+++ b/SWLOR.Game.Server/Entity/Player.cs
@@ -21,6 +21,9 @@ namespace SWLOR.Game.Server.Entity
 {
     public class Player: EntityBase
     {
+        public const int DefaultOutfitSlotLimit = 25;
+        public const int DefaultMarketListingLimit = 25;
+
         public Player()
         {
             Init();
@@ -89,6 +92,8 @@ namespace SWLOR.Game.Server.Entity
             CPBonus = new Dictionary<SkillType, int>();
             AbilityToggles = new Dictionary<AbilityToggleType, bool>();
             Currencies = new Dictionary<CurrencyType, int>();
+            OutfitSlotLimit = DefaultOutfitSlotLimit;
+            MarketListingLimit = DefaultMarketListingLimit;
         }
 
 
@@ -141,6 +146,8 @@ namespace SWLOR.Game.Server.Entity
         public float MovementRate { get; set; }
         public int AbilityRecastReduction { get; set; }
         public int MarketTill { get; set; }
+        public int OutfitSlotLimit { get; set; }
+        public int MarketListingLimit { get; set; }
         [Indexed]
         public string CitizenPropertyId { get; set; }
         public int PropertyOwedTaxes { get; set; }

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/MarketListingViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/MarketListingViewModel.cs
@@ -86,6 +86,12 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             set => Set(value);
         }
 
+        private int GetMarketListingLimit()
+        {
+            var dbPlayer = DB.Get<Player>(GetObjectUUID(Player));
+            return dbPlayer?.MarketListingLimit > 0 ? dbPlayer.MarketListingLimit : Entity.Player.DefaultMarketListingLimit;
+        }
+
         private void LoadData()
         {
             var itemIconResrefs = new GuiBindingList<string>();
@@ -139,8 +145,9 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
 
         private void UpdateItemCount()
         {
-            ListCount = $"  {_itemCount} / {PlayerMarket.MaxListingsPerMarket} Items Listed";
-            IsAddItemEnabled = _itemIds.Count < PlayerMarket.MaxListingsPerMarket;
+            var maxListings = GetMarketListingLimit();
+            ListCount = $"  {_itemCount} / {maxListings} Items Listed";
+            IsAddItemEnabled = _itemCount < maxListings;
         }
 
         protected override void Initialize(MarketPayload initialPayload)
@@ -179,7 +186,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
                 return;
             }
 
-            if (_itemIds.Count >= PlayerMarket.MaxListingsPerMarket)
+            if (_itemCount >= GetMarketListingLimit())
             {
                 FloatingTextStringOnCreature("You cannot list any more items.", Player, false);
                 return;

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/OutfitViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/OutfitViewModel.cs
@@ -13,8 +13,6 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
 {
     public class OutfitViewModel: GuiViewModelBase<OutfitViewModel, GuiPayloadBase>
     {
-        private const int MaxOutfits = 25;
-
         private List<string> _outfitIds = new();
 
         public GuiBindingList<string> SlotNames
@@ -73,6 +71,12 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
         {
             get => Get<string>();
             set => Set(value);
+        }
+
+        private int GetOutfitSlotLimit()
+        {
+            var dbPlayer = DB.Get<Player>(GetObjectUUID(Player));
+            return dbPlayer?.OutfitSlotLimit > 0 ? dbPlayer.OutfitSlotLimit : Entity.Player.DefaultOutfitSlotLimit;
         }
 
         private List<PlayerOutfit> GetOutfits()
@@ -322,9 +326,11 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             var outfitCount = DB.SearchCount(new DBQuery<PlayerOutfit>()
                 .AddFieldSearch(nameof(PlayerOutfit.PlayerId), playerId, false));
 
-            if (outfitCount >= MaxOutfits)
+            var maxOutfits = GetOutfitSlotLimit();
+
+            if (outfitCount >= maxOutfits)
             {
-                FloatingTextStringOnCreature($"You may only create {MaxOutfits} outfits.", Player, false);
+                FloatingTextStringOnCreature($"You may only create {maxOutfits} outfits.", Player, false);
                 return;
             }
 

--- a/SWLOR.Game.Server/Feature/MigrationDefinition/ServerMigration/_21_SetDefaultOutfitAndMarketLimits.cs
+++ b/SWLOR.Game.Server/Feature/MigrationDefinition/ServerMigration/_21_SetDefaultOutfitAndMarketLimits.cs
@@ -1,0 +1,60 @@
+using SWLOR.Game.Server.Entity;
+using SWLOR.Game.Server.Service;
+using SWLOR.Game.Server.Service.DBService;
+using System;
+using SWLOR.Game.Server.Service.LogService;
+using SWLOR.Game.Server.Service.MigrationService;
+
+namespace SWLOR.Game.Server.Feature.MigrationDefinition.ServerMigration
+{
+    public class _21_SetDefaultOutfitAndMarketLimits : ServerMigrationBase, IServerMigration
+    {
+        public int Version => 21;
+        public MigrationExecutionType ExecutionType => MigrationExecutionType.PostDatabaseLoad;
+
+        public void Migrate()
+        {
+            var query = new DBQuery<Player>();
+            var count = (int)DB.SearchCount(query);
+            Log.Write(LogGroup.Migration, $"Starting migration _21_SetDefaultOutfitAndMarketLimits: totalPlayers={count}");
+
+            var modifiedCount = 0;
+
+            try
+            {
+                var dbPlayers = DB.Search(query
+                    .AddPaging(count, 0));
+
+                foreach (var player in dbPlayers)
+                {
+                    var isModified = false;
+
+                    if (player.OutfitSlotLimit <= 0)
+                    {
+                        player.OutfitSlotLimit = Entity.Player.DefaultOutfitSlotLimit;
+                        isModified = true;
+                    }
+
+                    if (player.MarketListingLimit <= 0)
+                    {
+                        player.MarketListingLimit = Entity.Player.DefaultMarketListingLimit;
+                        isModified = true;
+                    }
+
+                    if (isModified)
+                    {
+                        modifiedCount++;
+                        DB.Set(player);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Write(LogGroup.Migration, $"Migration _21_SetDefaultOutfitAndMarketLimits failed unexpectedly. Exception: {ex}", true);
+                throw;
+            }
+
+            Log.Write(LogGroup.Migration, $"Completed migration _21_SetDefaultOutfitAndMarketLimits: modifiedPlayers={modifiedCount}, totalPlayers={count}");
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Introduce per-player limits for outfit slots and market listings so limits can be customized per account while retaining sensible defaults.
- Ensure existing player records receive the new defaults via a migration so behavior remains consistent after deployment.

### Description
- Added `Player.DefaultOutfitSlotLimit` and `Player.DefaultMarketListingLimit` constants and new `OutfitSlotLimit` and `MarketListingLimit` properties on `Player`, initialized in `Init()`.
- Updated `OutfitViewModel` and `MarketListingViewModel` to read per-player limits via `GetOutfitSlotLimit()` and `GetMarketListingLimit()` with fallbacks to the new defaults, and removed the hardcoded `MaxOutfits`/global checks.
- Adjusted market add/listing logic and item count display to use the per-player `MarketListingLimit` and the tracked `_itemCount` value.
- Added server migration `ServerMigration/_21_SetDefaultOutfitAndMarketLimits` to backfill existing `Player` records with default limits when values are non-positive.

### Testing
- Ran `dotnet build` and `dotnet test` for the `SWLOR.Game.Server` solution and associated test projects; all tests completed successfully.
- Executed the new migration against a local test database and confirmed players with non-positive limits were updated to the default values.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff54a3f4788321b486041d22375c1c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Outfit slot limits are now individually customizable per player instead of using a shared fixed limit, enabling more personalized inventory management.
  * Market listing limits are now individually customizable per player instead of enforcing a global maximum, providing greater flexibility in marketplace activities.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zunath/SWLOR_NWN/pull/2013)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->