### PR TITLE
Increase player skill cap to 400

### DIFF
--- a/SWLOR.Game.Server/Service/Skill.cs
+++ b/SWLOR.Game.Server/Service/Skill.cs
@@ -16,7 +16,7 @@ namespace SWLOR.Game.Server.Service
         /// <summary>
         /// This is the maximum number of skill points a single character can have at any time.
         /// </summary>
-        public const int SkillCap = 350;
+        public const int SkillCap = 400;
 
         /// <summary>
         /// This is the maximum number of AP a single character can earn in total. This must be evenly divisible into SkillCap.
@@ -233,7 +233,7 @@ namespace SWLOR.Game.Server.Service
         /// <param name="dbPlayer">The database entity.</param>
         private static void ApplyAbilityPoint(uint player, Player dbPlayer)
         {
-            // Total AP have been earned (350SP = 35AP)
+            // Total AP have been earned (400SP = 40AP)
             if (dbPlayer.TotalAPAcquired >= SkillCap / 10) return;
 
             if (dbPlayer.TotalSPAcquired % 10 == 0)


### PR DESCRIPTION
### Motivation
- Raise the total skill point cap so max ability points (AP) available at top level becomes 40 (previously 35). 

### Description
- Change `Skill.SkillCap` from `350` to `400` and update the inline AP comment to reflect `400SP = 40AP`, with `APCap` remaining derived as `SkillCap / 10`.

### Testing
- Ran `git diff -- SWLOR.Game.Server/Service/Skill.cs` to inspect the change and `rg -n "SkillCap =|400SP|35AP|350SP" SWLOR.Game.Server/Service/Skill.cs` to verify updated occurrences, and committed the change with `git commit -m "Increase player skill cap to 400"`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffc3ace844832182811b0b81dec3c4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Balance Changes**
  * Increased the maximum skill points cap from 350 to 400.
  * Updated ability point distribution calculations to align with the new skill cap (400 skill points now equals 40 ability points).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zunath/SWLOR_NWN/pull/2014)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->