### PR TITLE
Refresh and enforce party aura eligibility when party membership changes

### DIFF
--- a/SWLOR.Game.Server/Service/Ability.cs
+++ b/SWLOR.Game.Server/Service/Ability.cs
@@ -663,6 +663,33 @@ namespace SWLOR.Game.Server.Service
             }
         }
 
+
+        /// <summary>
+        /// Refreshes party-aura eligibility for a creature against all active aura leaders.
+        /// If the creature is still tracked in a party aura range but is no longer in the leader's party,
+        /// remove the cached range entry and strip relevant aura effects.
+        /// </summary>
+        /// <param name="target">The creature whose party aura eligibility should be refreshed.</param>
+        public static void RefreshPartyAuraEligibility(uint target)
+        {
+            foreach (var (leader, playerAura) in _playerAuras)
+            {
+                if (!playerAura.PartyMembersInRange.Contains(target))
+                    continue;
+
+                if (Party.IsInParty(leader, target))
+                    continue;
+
+                playerAura.PartyMembersInRange.Remove(target);
+
+                foreach (var aura in playerAura.Auras)
+                {
+                    if (aura.TargetsParty && !HasAlternativeAuraSource(target, aura.Type, leader))
+                        StatusEffect.Remove(target, aura.Type, false);
+                }
+            }
+        }
+
         /// <summary>
         /// Re-applies any aura effects that a creature should be receiving based on their current position
         /// in active aura range lists. Used after in-place resurrection (subdual, revive) where the
@@ -713,7 +740,9 @@ namespace SWLOR.Game.Server.Service
                 {
                     if (aura.Type != type) continue;
 
-                    if (aura.TargetsParty && playerAura.PartyMembersInRange.Contains(recipient))
+                    if (aura.TargetsParty &&
+                        playerAura.PartyMembersInRange.Contains(recipient) &&
+                        Party.IsInParty(leader, recipient))
                         return true;
 
                     if (aura.TargetsEnemies && playerAura.CreaturesInRange.Contains(recipient))

--- a/SWLOR.Game.Server/Service/Party.cs
+++ b/SWLOR.Game.Server/Service/Party.cs
@@ -113,12 +113,23 @@ namespace SWLOR.Game.Server.Service
         private static void RemoveCreatureFromParty(uint creature)
         {
             if (!_creatureToParty.ContainsKey(creature)) return;
-            
+
             var partyId = _creatureToParty[creature];
+            var wasLeader = _partyLeaders[partyId] == creature;
 
             // Remove this creature from the caches.
             _parties[partyId].Remove(creature);
             _creatureToParty.Remove(creature);
+
+            // Ensure any active aura effects that this creature was receiving from former party members are removed.
+            Ability.RefreshPartyAuraEligibility(creature);
+
+            // Party composition changed. Refresh aura recipients for remaining members too,
+            // so effects from the departing member are not retained.
+            foreach (var member in _parties[partyId])
+            {
+                Ability.RefreshPartyAuraEligibility(member);
+            }
 
             // If there is now only one party member (or fewer)
             // Party needs to be disbanded and caches updated.
@@ -136,10 +147,9 @@ namespace SWLOR.Game.Server.Service
 
             // The party is still valid but the creature who left was its leader. 
             // Swap leadership to the next person in the party list.
-            creature = _parties[partyId].First();
-            if (_partyLeaders[partyId] == creature)
+            if (wasLeader)
             {
-                _partyLeaders[partyId] = creature;
+                _partyLeaders[partyId] = _parties[partyId].First();
             }
         }
 


### PR DESCRIPTION
### Motivation
- Prevent recipients from retaining party-targeted aura effects when they are no longer in the leader's party but still remain tracked in cached range lists.
- Ensure aura recipients are validated when party composition changes so effects aren't incorrectly preserved.

### Description
- Added `RefreshPartyAuraEligibility(uint target)` in `Ability.cs` to iterate active aura leaders and remove party cached entries and corresponding effects when the target is no longer in the leader's party.
- Enhanced `HasAlternativeAuraSource` in `Ability.cs` to verify party membership with `Party.IsInParty(leader, recipient)` before treating a cached party entry as an alternative source.
- Updated `RemoveCreatureFromParty` in `Party.cs` to call `Ability.RefreshPartyAuraEligibility` for the departing creature and for remaining members to refresh aura recipients after composition changes.
- Minor refactor around leader reassignment and variable usage when a leader leaves.

### Testing
- Ran unit tests covering `Ability` and `Party` logic and existing aura-related test cases, and they passed.
- Ran integration/server tests exercising party leave/join and aura application/removal flows, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffd4ecd97483218057c1ab293a9d8d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Party auras now properly refresh and update when party members leave the group or party leadership changes.
  * Fixed instances where aura effects could persist incorrectly after party status changes.
  * Improved party leadership reassignment logic when the current leader departs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zunath/SWLOR_NWN/pull/2016)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->