### PR TITLE
Remove /bug cooldown in test environment

### DIFF
--- a/SWLOR.Game.Server/Feature/ChatCommandDefinition/SystemChatCommand.cs
+++ b/SWLOR.Game.Server/Feature/ChatCommandDefinition/SystemChatCommand.cs
@@ -32,6 +32,12 @@ namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
                 .Permissions(AuthorizationLevel.All)
                 .Validate((user, args) =>
                 {
+                    var appSettings = ApplicationSettings.Get();
+                    if (appSettings.ServerEnvironment == ServerEnvironmentType.Test)
+                    {
+                        return string.Empty;
+                    }
+
                     var lastSubmission = GetLocalString(user, "BUG_REPORT_LAST_SUBMISSION");
                     if (!string.IsNullOrWhiteSpace(lastSubmission))
                     {

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/BugReportViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/BugReportViewModel.cs
@@ -75,7 +75,10 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
                 return;
             }
 
-            SetLocalString(Player, "BUG_REPORT_LAST_SUBMISSION", nextReportAllowed.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture));
+            if (_appSettings.ServerEnvironment != ServerEnvironmentType.Test)
+            {
+                SetLocalString(Player, "BUG_REPORT_LAST_SUBMISSION", nextReportAllowed.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture));
+            }
             SendMessageToPC(Player, "Bug report submitted! Thank you for your report.");
             SendMessageToPC(Player, "Submitted Bug Report: " + BugReportText);
             Gui.TogglePlayerWindow(Player, GuiWindowType.BugReport);


### PR DESCRIPTION
### Motivation

- While running the server in test mode, developers need to submit multiple bug reports quickly without waiting for the one-minute cooldown, so the `/bug` command should not be rate-limited in that environment.

### Description

- Skip the cooldown validation when `ApplicationSettings.ServerEnvironment == ServerEnvironmentType.Test` by short-circuiting the `/bug` command validation in `SWLOR.Game.Server/Feature/ChatCommandDefinition/SystemChatCommand.cs`.
- Avoid persisting the `BUG_REPORT_LAST_SUBMISSION` local string when running in `Test` mode by gating the `SetLocalString` call in `SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/BugReportViewModel.cs` behind an environment check.
- The change keeps the one-minute restriction in non-test environments and preserves existing Discord submission logic and thread naming.

### Testing

- Built the server with `dotnet build SWLOR.Game.Server/SWLOR.Game.Server.csproj -v minimal` and the build succeeded with warnings but no errors.
- No automated unit tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0116e3f1e083219391d76ef2fc0850)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved bug report submission experience in test environments by removing cooldown restrictions on repeated submissions and refining timestamp tracking behavior to better support rapid testing and iteration during development cycles.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zunath/SWLOR_NWN/pull/2019)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->