### PR TITLE
Remove howl-style area VFX from Force Push

### DIFF
--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Force/ForcePushAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Force/ForcePushAbilityDefinition.cs
@@ -131,7 +131,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 centerOnActivator: !GetIsObjectValid(target),
                 damageType: CombatDamageType.Force,
                 targetVisualEffect: VisualEffect.Vfx_Imp_Pulse_Negative,
-                areaVisualEffect: VisualEffect.Vfx_Fnf_Howl_Mind,
+                areaVisualEffect: VisualEffect.None,
                 maxTargets: 2,
                 afterSuccessfulHit: hitTarget => ApplyHobble(activator, hitTarget, ForcePush2HobbleDurationSeconds),
                 playImpactAnimation: false);
@@ -155,7 +155,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 centerOnActivator: !GetIsObjectValid(target),
                 damageType: CombatDamageType.Force,
                 targetVisualEffect: VisualEffect.Vfx_Imp_Pulse_Negative,
-                areaVisualEffect: VisualEffect.Vfx_Fnf_Howl_Mind,
+                areaVisualEffect: VisualEffect.None,
                 maxTargets: 3,
                 afterSuccessfulHit: hitTarget => ApplyHobble(activator, hitTarget, ForcePush3HobbleDurationSeconds),
                 playImpactAnimation: false);


### PR DESCRIPTION
### Motivation
- Force Push II/III used a howl-style area visual (`Vfx_Fnf_Howl_Mind`) that looked out of place, so remove the area howl while keeping existing hit visuals and gameplay intact.

### Description
- Updated `SWLOR.Game.Server/Feature/AbilityDefinition/Force/ForcePushAbilityDefinition.cs` to set `areaVisualEffect` from `Vfx_Fnf_Howl_Mind` to `VisualEffect.None` for `ForcePush2` and `ForcePush3`, leaving the impact pulse `Vfx_Imp_Pulse_Negative` and all effect logic unchanged.

### Testing
- Ran `dotnet test SWLOR.Game.Server.Tests --filter ForceLightGuardianTests --nologo` and the filtered tests passed (5/5).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ea73e414c8321b8a0fed27b3abec6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated visual effects for Force Push II and Force Push III abilities to remove area visual effect telegraphing, resulting in a cleaner ability presentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zunath/SWLOR_NWN/pull/2024?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->