### PR TITLE
Require explosives item for grenade abilities

### DIFF
--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/AdhesiveGrenadeAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/AdhesiveGrenadeAbilityDefinition.cs
@@ -48,7 +48,8 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
                 .IsCastedAbility()
                 .IsHostileAbility()
                 .BreaksStealth()
-                .RequirementStamina(4);
+                .RequirementStamina(4)
+                .RequirementItem("explosives");
         }
 
         private static void AdhesiveGrenade2(AbilityBuilder builder)
@@ -71,7 +72,8 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
                 .IsCastedAbility()
                 .IsHostileAbility()
                 .BreaksStealth()
-                .RequirementStamina(5);
+                .RequirementStamina(5)
+                .RequirementItem("explosives");
         }
 
         private static void AdhesiveGrenade1ImpactAction(uint activator, uint target, int level, Location targetLocation)

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/ClusterGrenadeAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/ClusterGrenadeAbilityDefinition.cs
@@ -50,7 +50,8 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
                 .IsCastedAbility()
                 .IsHostileAbility()
                 .BreaksStealth()
-                .RequirementStamina(5);
+                .RequirementStamina(5)
+                .RequirementItem("explosives");
         }
 
         private static void ClusterGrenade1ImpactAction(uint activator, uint target, int level, Location targetLocation)

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/FragGrenadeAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/FragGrenadeAbilityDefinition.cs
@@ -71,7 +71,8 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
                 .IsCastedAbility()
                 .IsHostileAbility()
                 .BreaksStealth()
-                .RequirementStamina(3);
+                .RequirementStamina(3)
+                .RequirementItem("explosives");
         }
 
         private static void FragGrenade3(AbilityBuilder builder)
@@ -94,7 +95,8 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
                 .IsCastedAbility()
                 .IsHostileAbility()
                 .BreaksStealth()
-                .RequirementStamina(5);
+                .RequirementStamina(5)
+                .RequirementItem("explosives");
         }
 
         private static void FragGrenade1ImpactAction(uint activator, uint target, int level, Location targetLocation)

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/IonGrenadeAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/IonGrenadeAbilityDefinition.cs
@@ -70,7 +70,8 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
                 .IsCastedAbility()
                 .IsHostileAbility()
                 .BreaksStealth()
-                .RequirementStamina(5);
+                .RequirementStamina(5)
+                .RequirementItem("explosives");
         }
 
         private static void IonGrenade1ImpactAction(uint activator, uint target, int level, Location targetLocation)


### PR DESCRIPTION
### Motivation
- Grenade abilities are documented and intended to consume an explosives item when used, but several ability ranks were missing that requirement. 
- Align runtime checks with the design/manifest so grenades behave consistently and cannot be used without explosives.

### Description
- Added `.RequirementItem("explosives")` to `Frag Grenade` ranks II and III in `SWLOR.Game.Server/Feature/AbilityDefinition/Devices/FragGrenadeAbilityDefinition.cs`.
- Added `.RequirementItem("explosives")` to `Ion Grenade` rank II in `SWLOR.Game.Server/Feature/AbilityDefinition/Devices/IonGrenadeAbilityDefinition.cs`.
- Added `.RequirementItem("explosives")` to both ranks of `Adhesive Grenade` in `SWLOR.Game.Server/Feature/AbilityDefinition/Devices/AdhesiveGrenadeAbilityDefinition.cs`.
- Added `.RequirementItem("explosives")` to `Cluster Grenade` in `SWLOR.Game.Server/Feature/AbilityDefinition/Devices/ClusterGrenadeAbilityDefinition.cs`.

### Testing
- Verified the new requirement lines exist by running `rg -n 'RequirementItem("explosives")'` against the modified ability definition files, which returned matches for each updated ability.
- No automated unit or integration tests were changed or run as part of this update; the search verification succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0eb10e1f348321a7fbdd7c5e7a31cc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adhesive Grenades (I & II): Now require stamina and explosives to activate.
  * Cluster Grenade: Now requires explosives to activate alongside stamina.
  * Frag Grenades (II & III): Updated stamina requirements and now require explosives to activate.
  * Ion Grenade (II): Now requires explosives to activate.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zunath/SWLOR_NWN/pull/2025?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->