### PR TITLE
Feature/combat upgrade personas

### DIFF
--- a/Module/are/dan_smugcaverns.are.json
+++ b/Module/are/dan_smugcaverns.are.json
@@ -4283,13 +4283,17 @@
       }
     ]
   },
+  "TileBrdrDisabled": {
+    "type": "byte",
+    "value": 0
+  },
   "Tileset": {
     "type": "resref",
     "value": "tdm01"
   },
   "Version": {
     "type": "dword",
-    "value": 17
+    "value": 18
   },
   "Width": {
     "type": "int",

--- a/Module/are/ooc_area.are.json
+++ b/Module/are/ooc_area.are.json
@@ -2229,7 +2229,7 @@
   },
   "Version": {
     "type": "dword",
-    "value": 102
+    "value": 103
   },
   "Width": {
     "type": "int",

--- a/Module/gic/dan_smugcaverns.gic.json
+++ b/Module/gic/dan_smugcaverns.gic.json
@@ -37,6 +37,13 @@
           "type": "cexostring",
           "value": ""
         }
+      },
+      {
+        "__struct_id": 4,
+        "Comment": {
+          "type": "cexostring",
+          "value": "Allows players to permanently wipe retired disguise identities for a fee."
+        }
       }
     ]
   },

--- a/Module/git/dan_smugcaverns.git.json
+++ b/Module/git/dan_smugcaverns.git.json
@@ -40,26 +40,6 @@
       "MusicNight": {
         "type": "int",
         "value": 349
-      },
-      "VarTable": {
-        "type": "list",
-        "value": [
-          {
-            "__struct_id": 0,
-            "Name": {
-              "type": "cexostring",
-              "value": "PLANET_TYPE_ID"
-            },
-            "Type": {
-              "type": "dword",
-              "value": 1
-            },
-            "Value": {
-              "type": "int",
-              "value": 128
-            }
-          }
-        ]
       }
     }
   },
@@ -4039,6 +4019,1033 @@
         "ZPosition": {
           "type": "float",
           "value": 3.576278686523438e-007
+        }
+      },
+      {
+        "__struct_id": 4,
+        "Appearance_Head": {
+          "type": "byte",
+          "value": 115
+        },
+        "Appearance_Type": {
+          "type": "word",
+          "value": 10004
+        },
+        "ArmorPart_RFoot": {
+          "type": "byte",
+          "value": 1
+        },
+        "BodyBag": {
+          "type": "byte",
+          "value": 0
+        },
+        "BodyPart_Belt": {
+          "type": "byte",
+          "value": 0
+        },
+        "BodyPart_LBicep": {
+          "type": "byte",
+          "value": 1
+        },
+        "BodyPart_LFArm": {
+          "type": "byte",
+          "value": 1
+        },
+        "BodyPart_LFoot": {
+          "type": "byte",
+          "value": 1
+        },
+        "BodyPart_LHand": {
+          "type": "byte",
+          "value": 1
+        },
+        "BodyPart_LShin": {
+          "type": "byte",
+          "value": 1
+        },
+        "BodyPart_LShoul": {
+          "type": "byte",
+          "value": 0
+        },
+        "BodyPart_LThigh": {
+          "type": "byte",
+          "value": 1
+        },
+        "BodyPart_Neck": {
+          "type": "byte",
+          "value": 1
+        },
+        "BodyPart_Pelvis": {
+          "type": "byte",
+          "value": 1
+        },
+        "BodyPart_RBicep": {
+          "type": "byte",
+          "value": 1
+        },
+        "BodyPart_RFArm": {
+          "type": "byte",
+          "value": 1
+        },
+        "BodyPart_RHand": {
+          "type": "byte",
+          "value": 1
+        },
+        "BodyPart_RShin": {
+          "type": "byte",
+          "value": 1
+        },
+        "BodyPart_RShoul": {
+          "type": "byte",
+          "value": 0
+        },
+        "BodyPart_RThigh": {
+          "type": "byte",
+          "value": 1
+        },
+        "BodyPart_Torso": {
+          "type": "byte",
+          "value": 1
+        },
+        "Cha": {
+          "type": "byte",
+          "value": 9
+        },
+        "ChallengeRating": {
+          "type": "float",
+          "value": 2.0
+        },
+        "ClassList": {
+          "type": "list",
+          "value": [
+            {
+              "__struct_id": 2,
+              "Class": {
+                "type": "int",
+                "value": 4
+              },
+              "ClassLevel": {
+                "type": "short",
+                "value": 1
+              }
+            }
+          ]
+        },
+        "Color_Hair": {
+          "type": "byte",
+          "value": 1
+        },
+        "Color_Skin": {
+          "type": "byte",
+          "value": 149
+        },
+        "Color_Tattoo1": {
+          "type": "byte",
+          "value": 1
+        },
+        "Color_Tattoo2": {
+          "type": "byte",
+          "value": 1
+        },
+        "Con": {
+          "type": "byte",
+          "value": 16
+        },
+        "Conversation": {
+          "type": "resref",
+          "value": ""
+        },
+        "CRAdjust": {
+          "type": "int",
+          "value": 0
+        },
+        "CurrentHitPoints": {
+          "type": "short",
+          "value": 45
+        },
+        "DecayTime": {
+          "type": "dword",
+          "value": 5000
+        },
+        "Deity": {
+          "type": "cexostring",
+          "value": ""
+        },
+        "Description": {
+          "type": "cexolocstring",
+          "value": {}
+        },
+        "Dex": {
+          "type": "byte",
+          "value": 13
+        },
+        "Disarmable": {
+          "type": "byte",
+          "value": 1
+        },
+        "Equip_ItemList": {
+          "type": "list",
+          "value": [
+            {
+              "__struct_id": 2,
+              "AddCost": {
+                "type": "dword",
+                "value": 49
+              },
+              "ArmorPart_Belt": {
+                "type": "byte",
+                "value": 0
+              },
+              "ArmorPart_LBicep": {
+                "type": "byte",
+                "value": 1
+              },
+              "ArmorPart_LFArm": {
+                "type": "byte",
+                "value": 1
+              },
+              "ArmorPart_LFoot": {
+                "type": "byte",
+                "value": 160
+              },
+              "ArmorPart_LHand": {
+                "type": "byte",
+                "value": 1
+              },
+              "ArmorPart_LShin": {
+                "type": "byte",
+                "value": 243
+              },
+              "ArmorPart_LShoul": {
+                "type": "byte",
+                "value": 0
+              },
+              "ArmorPart_LThigh": {
+                "type": "byte",
+                "value": 241
+              },
+              "ArmorPart_Neck": {
+                "type": "byte",
+                "value": 1
+              },
+              "ArmorPart_Pelvis": {
+                "type": "byte",
+                "value": 50
+              },
+              "ArmorPart_RBicep": {
+                "type": "byte",
+                "value": 1
+              },
+              "ArmorPart_RFArm": {
+                "type": "byte",
+                "value": 1
+              },
+              "ArmorPart_RFoot": {
+                "type": "byte",
+                "value": 160
+              },
+              "ArmorPart_RHand": {
+                "type": "byte",
+                "value": 1
+              },
+              "ArmorPart_Robe": {
+                "type": "byte",
+                "value": 10
+              },
+              "ArmorPart_RShin": {
+                "type": "byte",
+                "value": 243
+              },
+              "ArmorPart_RShoul": {
+                "type": "byte",
+                "value": 0
+              },
+              "ArmorPart_RThigh": {
+                "type": "byte",
+                "value": 241
+              },
+              "ArmorPart_Torso": {
+                "type": "byte",
+                "value": 1
+              },
+              "BaseItem": {
+                "type": "int",
+                "value": 16
+              },
+              "Charges": {
+                "type": "byte",
+                "value": 0
+              },
+              "Cloth1Color": {
+                "type": "byte",
+                "value": 23
+              },
+              "Cloth2Color": {
+                "type": "byte",
+                "value": 23
+              },
+              "Cost": {
+                "type": "dword",
+                "value": 50
+              },
+              "Cursed": {
+                "type": "byte",
+                "value": 1
+              },
+              "DescIdentified": {
+                "type": "cexolocstring",
+                "value": {}
+              },
+              "Description": {
+                "type": "cexolocstring",
+                "value": {
+                  "0": ""
+                }
+              },
+              "Identified": {
+                "type": "byte",
+                "value": 1
+              },
+              "Leather1Color": {
+                "type": "byte",
+                "value": 23
+              },
+              "Leather2Color": {
+                "type": "byte",
+                "value": 23
+              },
+              "LocalizedName": {
+                "id": 12835,
+                "type": "cexolocstring",
+                "value": {
+                  "0": "[NPC] Smuggler Outfit 2 Male"
+                }
+              },
+              "Metal1Color": {
+                "type": "byte",
+                "value": 6
+              },
+              "Metal2Color": {
+                "type": "byte",
+                "value": 6
+              },
+              "Plot": {
+                "type": "byte",
+                "value": 0
+              },
+              "PropertiesList": {
+                "type": "list",
+                "value": []
+              },
+              "StackSize": {
+                "type": "word",
+                "value": 1
+              },
+              "Stolen": {
+                "type": "byte",
+                "value": 0
+              },
+              "Tag": {
+                "type": "cexostring",
+                "value": "npc_smuggler2_m"
+              },
+              "TemplateResRef": {
+                "type": "resref",
+                "value": "npc_smuggler2_m"
+              },
+              "xArmorPart_Belt": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_LBice": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_LFArm": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_LFoot": {
+                "type": "word",
+                "value": 160
+              },
+              "xArmorPart_LHand": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_LShin": {
+                "type": "word",
+                "value": 243
+              },
+              "xArmorPart_LShou": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_LThig": {
+                "type": "word",
+                "value": 241
+              },
+              "xArmorPart_Neck": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_Pelvi": {
+                "type": "word",
+                "value": 50
+              },
+              "xArmorPart_RBice": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_RFArm": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_RFoot": {
+                "type": "word",
+                "value": 160
+              },
+              "xArmorPart_RHand": {
+                "type": "word",
+                "value": 1
+              },
+              "xArmorPart_Robe": {
+                "type": "word",
+                "value": 10
+              },
+              "xArmorPart_RShin": {
+                "type": "word",
+                "value": 243
+              },
+              "xArmorPart_RShou": {
+                "type": "word",
+                "value": 0
+              },
+              "xArmorPart_RThig": {
+                "type": "word",
+                "value": 241
+              },
+              "xArmorPart_Torso": {
+                "type": "word",
+                "value": 1
+              },
+              "XOrientation": {
+                "type": "float",
+                "value": 0.0
+              },
+              "XPosition": {
+                "type": "float",
+                "value": -1.0
+              },
+              "YOrientation": {
+                "type": "float",
+                "value": 1.0
+              },
+              "YPosition": {
+                "type": "float",
+                "value": -1.0
+              },
+              "ZPosition": {
+                "type": "float",
+                "value": -1.0
+              }
+            }
+          ]
+        },
+        "FactionID": {
+          "type": "word",
+          "value": 2
+        },
+        "FeatList": {
+          "type": "list",
+          "value": [
+            {
+              "__struct_id": 1,
+              "Feat": {
+                "type": "word",
+                "value": 2
+              }
+            },
+            {
+              "__struct_id": 1,
+              "Feat": {
+                "type": "word",
+                "value": 3
+              }
+            },
+            {
+              "__struct_id": 1,
+              "Feat": {
+                "type": "word",
+                "value": 4
+              }
+            },
+            {
+              "__struct_id": 1,
+              "Feat": {
+                "type": "word",
+                "value": 10
+              }
+            },
+            {
+              "__struct_id": 1,
+              "Feat": {
+                "type": "word",
+                "value": 1089
+              }
+            },
+            {
+              "__struct_id": 1,
+              "Feat": {
+                "type": "word",
+                "value": 28
+              }
+            },
+            {
+              "__struct_id": 1,
+              "Feat": {
+                "type": "word",
+                "value": 258
+              }
+            },
+            {
+              "__struct_id": 1,
+              "Feat": {
+                "type": "word",
+                "value": 32
+              }
+            },
+            {
+              "__struct_id": 1,
+              "Feat": {
+                "type": "word",
+                "value": 106
+              }
+            },
+            {
+              "__struct_id": 1,
+              "Feat": {
+                "type": "word",
+                "value": 45
+              }
+            },
+            {
+              "__struct_id": 1,
+              "Feat": {
+                "type": "word",
+                "value": 46
+              }
+            }
+          ]
+        },
+        "FirstName": {
+          "type": "cexolocstring",
+          "value": {
+            "0": "Identity Broker"
+          }
+        },
+        "fortbonus": {
+          "type": "short",
+          "value": 0
+        },
+        "Gender": {
+          "type": "byte",
+          "value": 0
+        },
+        "GoodEvil": {
+          "type": "byte",
+          "value": 50
+        },
+        "HitPoints": {
+          "type": "short",
+          "value": 45
+        },
+        "Int": {
+          "type": "byte",
+          "value": 10
+        },
+        "Interruptable": {
+          "type": "byte",
+          "value": 1
+        },
+        "IsImmortal": {
+          "type": "byte",
+          "value": 1
+        },
+        "IsPC": {
+          "type": "byte",
+          "value": 0
+        },
+        "LastName": {
+          "type": "cexolocstring",
+          "value": {
+            "0": ""
+          }
+        },
+        "LawfulChaotic": {
+          "type": "byte",
+          "value": 50
+        },
+        "Lootable": {
+          "type": "byte",
+          "value": 0
+        },
+        "MaxHitPoints": {
+          "type": "short",
+          "value": 48
+        },
+        "NaturalAC": {
+          "type": "byte",
+          "value": 0
+        },
+        "NoPermDeath": {
+          "type": "byte",
+          "value": 0
+        },
+        "PerceptionRange": {
+          "type": "byte",
+          "value": 11
+        },
+        "Phenotype": {
+          "type": "int",
+          "value": 0
+        },
+        "Plot": {
+          "type": "byte",
+          "value": 0
+        },
+        "PortraitId": {
+          "type": "word",
+          "value": 3638
+        },
+        "Race": {
+          "type": "byte",
+          "value": 6
+        },
+        "refbonus": {
+          "type": "short",
+          "value": 0
+        },
+        "ScriptAttacked": {
+          "type": "resref",
+          "value": "nw_c2_default5"
+        },
+        "ScriptDamaged": {
+          "type": "resref",
+          "value": "nw_c2_default6"
+        },
+        "ScriptDeath": {
+          "type": "resref",
+          "value": "nw_c2_default7"
+        },
+        "ScriptDialogue": {
+          "type": "resref",
+          "value": "nw_c2_default4"
+        },
+        "ScriptDisturbed": {
+          "type": "resref",
+          "value": "nw_c2_default8"
+        },
+        "ScriptEndRound": {
+          "type": "resref",
+          "value": "nw_c2_default3"
+        },
+        "ScriptHeartbeat": {
+          "type": "resref",
+          "value": "nw_c2_default1"
+        },
+        "ScriptOnBlocked": {
+          "type": "resref",
+          "value": "nw_c2_defaulte"
+        },
+        "ScriptOnNotice": {
+          "type": "resref",
+          "value": "nw_c2_default2"
+        },
+        "ScriptRested": {
+          "type": "resref",
+          "value": "nw_c2_defaulta"
+        },
+        "ScriptSpawn": {
+          "type": "resref",
+          "value": "nw_c2_default9"
+        },
+        "ScriptSpellAt": {
+          "type": "resref",
+          "value": "nw_c2_defaultb"
+        },
+        "ScriptUserDefine": {
+          "type": "resref",
+          "value": "nw_c2_defaultd"
+        },
+        "SkillList": {
+          "type": "list",
+          "value": [
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            },
+            {
+              "__struct_id": 0,
+              "Rank": {
+                "type": "byte",
+                "value": 0
+              }
+            }
+          ]
+        },
+        "SoundSetFile": {
+          "type": "word",
+          "value": 940
+        },
+        "SpecAbilityList": {
+          "type": "list",
+          "value": []
+        },
+        "StartingPackage": {
+          "type": "byte",
+          "value": 4
+        },
+        "Str": {
+          "type": "byte",
+          "value": 18
+        },
+        "Subrace": {
+          "type": "cexostring",
+          "value": ""
+        },
+        "Tag": {
+          "type": "cexostring",
+          "value": "identity_broker"
+        },
+        "Tail_New": {
+          "type": "dword",
+          "value": 0
+        },
+        "TemplateList": {
+          "type": "list",
+          "value": []
+        },
+        "TemplateResRef": {
+          "type": "resref",
+          "value": "identitybroker"
+        },
+        "VarTable": {
+          "type": "list",
+          "value": [
+            {
+              "__struct_id": 0,
+              "Name": {
+                "type": "cexostring",
+                "value": "CONVERSATION"
+              },
+              "Type": {
+                "type": "dword",
+                "value": 3
+              },
+              "Value": {
+                "type": "cexostring",
+                "value": "IdentityBrokerDialog"
+              }
+            }
+          ]
+        },
+        "WalkRate": {
+          "type": "int",
+          "value": 7
+        },
+        "willbonus": {
+          "type": "short",
+          "value": 0
+        },
+        "Wings_New": {
+          "type": "dword",
+          "value": 0
+        },
+        "Wis": {
+          "type": "byte",
+          "value": 10
+        },
+        "xAppearance_Head": {
+          "type": "word",
+          "value": 115
+        },
+        "xArmorPart_RFoot": {
+          "type": "word",
+          "value": 1
+        },
+        "xBodyPart_Belt": {
+          "type": "word",
+          "value": 0
+        },
+        "xBodyPart_LBicep": {
+          "type": "word",
+          "value": 1
+        },
+        "xBodyPart_LFArm": {
+          "type": "word",
+          "value": 1
+        },
+        "xBodyPart_LFoot": {
+          "type": "word",
+          "value": 1
+        },
+        "xBodyPart_LHand": {
+          "type": "word",
+          "value": 1
+        },
+        "xBodyPart_LShin": {
+          "type": "word",
+          "value": 1
+        },
+        "xBodyPart_LShoul": {
+          "type": "word",
+          "value": 0
+        },
+        "xBodyPart_LThigh": {
+          "type": "word",
+          "value": 1
+        },
+        "xBodyPart_Neck": {
+          "type": "word",
+          "value": 1
+        },
+        "xBodyPart_Pelvis": {
+          "type": "word",
+          "value": 1
+        },
+        "xBodyPart_RBicep": {
+          "type": "word",
+          "value": 1
+        },
+        "xBodyPart_RFArm": {
+          "type": "word",
+          "value": 1
+        },
+        "xBodyPart_RHand": {
+          "type": "word",
+          "value": 1
+        },
+        "xBodyPart_RShin": {
+          "type": "word",
+          "value": 1
+        },
+        "xBodyPart_RShoul": {
+          "type": "word",
+          "value": 0
+        },
+        "xBodyPart_RThigh": {
+          "type": "word",
+          "value": 1
+        },
+        "xBodyPart_Torso": {
+          "type": "word",
+          "value": 1
+        },
+        "XOrientation": {
+          "type": "float",
+          "value": 0.4928983449935913
+        },
+        "XPosition": {
+          "type": "float",
+          "value": 12.23215866088867
+        },
+        "YOrientation": {
+          "type": "float",
+          "value": -0.8700869083404541
+        },
+        "YPosition": {
+          "type": "float",
+          "value": 70.04020690917969
+        },
+        "ZPosition": {
+          "type": "float",
+          "value": 0.0
         }
       }
     ]

--- a/Module/git/ka_crnt_corellia.git.json
+++ b/Module/git/ka_crnt_corellia.git.json
@@ -117694,10 +117694,6 @@
     "type": "list",
     "value": []
   },
-  "WaypointList": {
-    "type": "list",
-    "value": []
-  },
   "VarTable": {
     "type": "list",
     "value": [
@@ -117717,5 +117713,9 @@
         }
       }
     ]
+  },
+  "WaypointList": {
+    "type": "list",
+    "value": []
   }
 }

--- a/Module/git/ka_dropsh_cr_sno.git.json
+++ b/Module/git/ka_dropsh_cr_sno.git.json
@@ -10680,10 +10680,6 @@
     "type": "list",
     "value": []
   },
-  "WaypointList": {
-    "type": "list",
-    "value": []
-  },
   "VarTable": {
     "type": "list",
     "value": [
@@ -10703,5 +10699,9 @@
         }
       }
     ]
+  },
+  "WaypointList": {
+    "type": "list",
+    "value": []
   }
 }

--- a/Module/git/ka_dropship_spac.git.json
+++ b/Module/git/ka_dropship_spac.git.json
@@ -18555,10 +18555,6 @@
     "type": "list",
     "value": []
   },
-  "WaypointList": {
-    "type": "list",
-    "value": []
-  },
   "VarTable": {
     "type": "list",
     "value": [
@@ -18578,5 +18574,9 @@
         }
       }
     ]
+  },
+  "WaypointList": {
+    "type": "list",
+    "value": []
   }
 }

--- a/Module/git/ka_drps_crsh_kor.git.json
+++ b/Module/git/ka_drps_crsh_kor.git.json
@@ -7084,10 +7084,6 @@
     "type": "list",
     "value": []
   },
-  "WaypointList": {
-    "type": "list",
-    "value": []
-  },
   "VarTable": {
     "type": "list",
     "value": [
@@ -7107,5 +7103,9 @@
         }
       }
     ]
+  },
+  "WaypointList": {
+    "type": "list",
+    "value": []
   }
 }

--- a/Module/git/ka_drps_crsh_vis.git.json
+++ b/Module/git/ka_drps_crsh_vis.git.json
@@ -15192,10 +15192,6 @@
     "type": "list",
     "value": []
   },
-  "WaypointList": {
-    "type": "list",
-    "value": []
-  },
   "VarTable": {
     "type": "list",
     "value": [
@@ -15215,5 +15211,9 @@
         }
       }
     ]
+  },
+  "WaypointList": {
+    "type": "list",
+    "value": []
   }
 }

--- a/Module/git/ka_trenchpr1.git.json
+++ b/Module/git/ka_trenchpr1.git.json
@@ -110673,10 +110673,6 @@
     "type": "list",
     "value": []
   },
-  "WaypointList": {
-    "type": "list",
-    "value": []
-  },
   "VarTable": {
     "type": "list",
     "value": [
@@ -110696,5 +110692,9 @@
         }
       }
     ]
+  },
+  "WaypointList": {
+    "type": "list",
+    "value": []
   }
 }

--- a/Module/git/ka_vis_mntscrapy.git.json
+++ b/Module/git/ka_vis_mntscrapy.git.json
@@ -82683,10 +82683,6 @@
     "type": "list",
     "value": []
   },
-  "WaypointList": {
-    "type": "list",
-    "value": []
-  },
   "VarTable": {
     "type": "list",
     "value": [
@@ -82706,5 +82702,9 @@
         }
       }
     ]
+  },
+  "WaypointList": {
+    "type": "list",
+    "value": []
   }
 }

--- a/Module/git/na_ka_pref_scene.git.json
+++ b/Module/git/na_ka_pref_scene.git.json
@@ -166395,10 +166395,6 @@
     "type": "list",
     "value": []
   },
-  "WaypointList": {
-    "type": "list",
-    "value": []
-  },
   "VarTable": {
     "type": "list",
     "value": [
@@ -166418,5 +166414,9 @@
         }
       }
     ]
+  },
+  "WaypointList": {
+    "type": "list",
+    "value": []
   }
 }

--- a/Module/git/republicshipevnt.git.json
+++ b/Module/git/republicshipevnt.git.json
@@ -751,10 +751,6 @@
     "type": "list",
     "value": []
   },
-  "WaypointList": {
-    "type": "list",
-    "value": []
-  },
   "VarTable": {
     "type": "list",
     "value": [
@@ -774,5 +770,9 @@
         }
       }
     ]
+  },
+  "WaypointList": {
+    "type": "list",
+    "value": []
   }
 }

--- a/Module/git/vrotranccsitharc.git.json
+++ b/Module/git/vrotranccsitharc.git.json
@@ -15789,10 +15789,6 @@
     "type": "list",
     "value": []
   },
-  "WaypointList": {
-    "type": "list",
-    "value": []
-  },
   "VarTable": {
     "type": "list",
     "value": [
@@ -15812,5 +15808,9 @@
         }
       }
     ]
+  },
+  "WaypointList": {
+    "type": "list",
+    "value": []
   }
 }

--- a/Module/git/vrotrbescloudext.git.json
+++ b/Module/git/vrotrbescloudext.git.json
@@ -30075,6 +30075,26 @@
       }
     ]
   },
+  "VarTable": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "COMMS_EVENT_AREA"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 1
+        },
+        "Value": {
+          "type": "int",
+          "value": 1
+        }
+      }
+    ]
+  },
   "WaypointList": {
     "type": "list",
     "value": [
@@ -30257,26 +30277,6 @@
         "ZPosition": {
           "type": "float",
           "value": -1.068786978721619
-        }
-      }
-    ]
-  },
-  "VarTable": {
-    "type": "list",
-    "value": [
-      {
-        "__struct_id": 0,
-        "Name": {
-          "type": "cexostring",
-          "value": "COMMS_EVENT_AREA"
-        },
-        "Type": {
-          "type": "dword",
-          "value": 1
-        },
-        "Value": {
-          "type": "int",
-          "value": 1
         }
       }
     ]

--- a/Module/git/vrotrbescloudint.git.json
+++ b/Module/git/vrotrbescloudint.git.json
@@ -31391,6 +31391,26 @@
       }
     ]
   },
+  "VarTable": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "COMMS_EVENT_AREA"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 1
+        },
+        "Value": {
+          "type": "int",
+          "value": 1
+        }
+      }
+    ]
+  },
   "WaypointList": {
     "type": "list",
     "value": [
@@ -31453,26 +31473,6 @@
         "ZPosition": {
           "type": "float",
           "value": -5.7220458984375e-006
-        }
-      }
-    ]
-  },
-  "VarTable": {
-    "type": "list",
-    "value": [
-      {
-        "__struct_id": 0,
-        "Name": {
-          "type": "cexostring",
-          "value": "COMMS_EVENT_AREA"
-        },
-        "Type": {
-          "type": "dword",
-          "value": 1
-        },
-        "Value": {
-          "type": "int",
-          "value": 1
         }
       }
     ]

--- a/Module/git/vrotrbescomshop.git.json
+++ b/Module/git/vrotrbescomshop.git.json
@@ -19119,10 +19119,6 @@
     "type": "list",
     "value": []
   },
-  "WaypointList": {
-    "type": "list",
-    "value": []
-  },
   "VarTable": {
     "type": "list",
     "value": [
@@ -19142,5 +19138,9 @@
         }
       }
     ]
+  },
+  "WaypointList": {
+    "type": "list",
+    "value": []
   }
 }

--- a/Module/git/vrotrbesgasmine.git.json
+++ b/Module/git/vrotrbesgasmine.git.json
@@ -39551,6 +39551,26 @@
       }
     ]
   },
+  "VarTable": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "COMMS_EVENT_AREA"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 1
+        },
+        "Value": {
+          "type": "int",
+          "value": 1
+        }
+      }
+    ]
+  },
   "WaypointList": {
     "type": "list",
     "value": [
@@ -39611,26 +39631,6 @@
         "ZPosition": {
           "type": "float",
           "value": 3.024999856948853
-        }
-      }
-    ]
-  },
-  "VarTable": {
-    "type": "list",
-    "value": [
-      {
-        "__struct_id": 0,
-        "Name": {
-          "type": "cexostring",
-          "value": "COMMS_EVENT_AREA"
-        },
-        "Type": {
-          "type": "dword",
-          "value": 1
-        },
-        "Value": {
-          "type": "int",
-          "value": 1
         }
       }
     ]

--- a/Module/git/vrotrbeslanding.git.json
+++ b/Module/git/vrotrbeslanding.git.json
@@ -7707,6 +7707,26 @@
       }
     ]
   },
+  "VarTable": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "COMMS_EVENT_AREA"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 1
+        },
+        "Value": {
+          "type": "int",
+          "value": 1
+        }
+      }
+    ]
+  },
   "WaypointList": {
     "type": "list",
     "value": [
@@ -7830,26 +7850,6 @@
         "ZPosition": {
           "type": "float",
           "value": 1.524999976158142
-        }
-      }
-    ]
-  },
-  "VarTable": {
-    "type": "list",
-    "value": [
-      {
-        "__struct_id": 0,
-        "Name": {
-          "type": "cexostring",
-          "value": "COMMS_EVENT_AREA"
-        },
-        "Type": {
-          "type": "dword",
-          "value": 1
-        },
-        "Value": {
-          "type": "int",
-          "value": 1
         }
       }
     ]

--- a/Module/git/vrotrbesporttown.git.json
+++ b/Module/git/vrotrbesporttown.git.json
@@ -14134,6 +14134,26 @@
       }
     ]
   },
+  "VarTable": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "COMMS_EVENT_AREA"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 1
+        },
+        "Value": {
+          "type": "int",
+          "value": 1
+        }
+      }
+    ]
+  },
   "WaypointList": {
     "type": "list",
     "value": [
@@ -14194,26 +14214,6 @@
         "ZPosition": {
           "type": "float",
           "value": -0.4827108681201935
-        }
-      }
-    ]
-  },
-  "VarTable": {
-    "type": "list",
-    "value": [
-      {
-        "__struct_id": 0,
-        "Name": {
-          "type": "cexostring",
-          "value": "COMMS_EVENT_AREA"
-        },
-        "Type": {
-          "type": "dword",
-          "value": 1
-        },
-        "Value": {
-          "type": "int",
-          "value": 1
         }
       }
     ]

--- a/Module/git/vrotrcapship1.git.json
+++ b/Module/git/vrotrcapship1.git.json
@@ -57360,10 +57360,6 @@
     "type": "list",
     "value": []
   },
-  "WaypointList": {
-    "type": "list",
-    "value": []
-  },
   "VarTable": {
     "type": "list",
     "value": [
@@ -57383,5 +57379,9 @@
         }
       }
     ]
+  },
+  "WaypointList": {
+    "type": "list",
+    "value": []
   }
 }

--- a/Module/git/vrotrcorelclouds.git.json
+++ b/Module/git/vrotrcorelclouds.git.json
@@ -4017,10 +4017,6 @@
     "type": "list",
     "value": []
   },
-  "WaypointList": {
-    "type": "list",
-    "value": []
-  },
   "VarTable": {
     "type": "list",
     "value": [
@@ -4040,5 +4036,9 @@
         }
       }
     ]
+  },
+  "WaypointList": {
+    "type": "list",
+    "value": []
   }
 }

--- a/Module/git/vrotrdantcourt.git.json
+++ b/Module/git/vrotrdantcourt.git.json
@@ -2025,6 +2025,26 @@
       }
     ]
   },
+  "VarTable": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "COMMS_EVENT_AREA"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 1
+        },
+        "Value": {
+          "type": "int",
+          "value": 1
+        }
+      }
+    ]
+  },
   "WaypointList": {
     "type": "list",
     "value": [
@@ -2209,26 +2229,6 @@
         "ZPosition": {
           "type": "float",
           "value": 0.07720759510993958
-        }
-      }
-    ]
-  },
-  "VarTable": {
-    "type": "list",
-    "value": [
-      {
-        "__struct_id": 0,
-        "Name": {
-          "type": "cexostring",
-          "value": "COMMS_EVENT_AREA"
-        },
-        "Type": {
-          "type": "dword",
-          "value": 1
-        },
-        "Value": {
-          "type": "int",
-          "value": 1
         }
       }
     ]

--- a/Module/git/vrotrdantcrystal.git.json
+++ b/Module/git/vrotrdantcrystal.git.json
@@ -295,6 +295,26 @@
     "type": "list",
     "value": []
   },
+  "VarTable": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "COMMS_EVENT_AREA"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 1
+        },
+        "Value": {
+          "type": "int",
+          "value": 1
+        }
+      }
+    ]
+  },
   "WaypointList": {
     "type": "list",
     "value": [
@@ -361,26 +381,6 @@
         "ZPosition": {
           "type": "float",
           "value": -5.7220458984375e-006
-        }
-      }
-    ]
-  },
-  "VarTable": {
-    "type": "list",
-    "value": [
-      {
-        "__struct_id": 0,
-        "Name": {
-          "type": "cexostring",
-          "value": "COMMS_EVENT_AREA"
-        },
-        "Type": {
-          "type": "dword",
-          "value": 1
-        },
-        "Value": {
-          "type": "int",
-          "value": 1
         }
       }
     ]

--- a/Module/git/vrotrdantfarms.git.json
+++ b/Module/git/vrotrdantfarms.git.json
@@ -919,6 +919,26 @@
       }
     ]
   },
+  "VarTable": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "COMMS_EVENT_AREA"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 1
+        },
+        "Value": {
+          "type": "int",
+          "value": 1
+        }
+      }
+    ]
+  },
   "WaypointList": {
     "type": "list",
     "value": [
@@ -1038,26 +1058,6 @@
         "ZPosition": {
           "type": "float",
           "value": -5.222045729169622e-006
-        }
-      }
-    ]
-  },
-  "VarTable": {
-    "type": "list",
-    "value": [
-      {
-        "__struct_id": 0,
-        "Name": {
-          "type": "cexostring",
-          "value": "COMMS_EVENT_AREA"
-        },
-        "Type": {
-          "type": "dword",
-          "value": 1
-        },
-        "Value": {
-          "type": "int",
-          "value": 1
         }
       }
     ]

--- a/Module/git/vrotrdantkhoonda.git.json
+++ b/Module/git/vrotrdantkhoonda.git.json
@@ -9971,6 +9971,26 @@
     "type": "list",
     "value": []
   },
+  "VarTable": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "COMMS_EVENT_AREA"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 1
+        },
+        "Value": {
+          "type": "int",
+          "value": 1
+        }
+      }
+    ]
+  },
   "WaypointList": {
     "type": "list",
     "value": [
@@ -10037,26 +10057,6 @@
         "ZPosition": {
           "type": "float",
           "value": 2.009999990463257
-        }
-      }
-    ]
-  },
-  "VarTable": {
-    "type": "list",
-    "value": [
-      {
-        "__struct_id": 0,
-        "Name": {
-          "type": "cexostring",
-          "value": "COMMS_EVENT_AREA"
-        },
-        "Type": {
-          "type": "dword",
-          "value": 1
-        },
-        "Value": {
-          "type": "int",
-          "value": 1
         }
       }
     ]

--- a/Module/git/vrotrdantplains.git.json
+++ b/Module/git/vrotrdantplains.git.json
@@ -712,6 +712,26 @@
       }
     ]
   },
+  "VarTable": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "COMMS_EVENT_AREA"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 1
+        },
+        "Value": {
+          "type": "int",
+          "value": 1
+        }
+      }
+    ]
+  },
   "WaypointList": {
     "type": "list",
     "value": [
@@ -896,26 +916,6 @@
         "ZPosition": {
           "type": "float",
           "value": -5.222045729169622e-006
-        }
-      }
-    ]
-  },
-  "VarTable": {
-    "type": "list",
-    "value": [
-      {
-        "__struct_id": 0,
-        "Name": {
-          "type": "cexostring",
-          "value": "COMMS_EVENT_AREA"
-        },
-        "Type": {
-          "type": "dword",
-          "value": 1
-        },
-        "Value": {
-          "type": "int",
-          "value": 1
         }
       }
     ]

--- a/Module/git/vrotrghostship.git.json
+++ b/Module/git/vrotrghostship.git.json
@@ -37682,10 +37682,6 @@
     "type": "list",
     "value": []
   },
-  "WaypointList": {
-    "type": "list",
-    "value": []
-  },
   "VarTable": {
     "type": "list",
     "value": [
@@ -37705,5 +37701,9 @@
         }
       }
     ]
+  },
+  "WaypointList": {
+    "type": "list",
+    "value": []
   }
 }

--- a/Module/git/vrotrhighoffice.git.json
+++ b/Module/git/vrotrhighoffice.git.json
@@ -2771,10 +2771,6 @@
     "type": "list",
     "value": []
   },
-  "WaypointList": {
-    "type": "list",
-    "value": []
-  },
   "VarTable": {
     "type": "list",
     "value": [
@@ -2794,5 +2790,9 @@
         }
       }
     ]
+  },
+  "WaypointList": {
+    "type": "list",
+    "value": []
   }
 }

--- a/Module/git/vrotrkorracadarc.git.json
+++ b/Module/git/vrotrkorracadarc.git.json
@@ -34512,10 +34512,6 @@
     "type": "list",
     "value": []
   },
-  "WaypointList": {
-    "type": "list",
-    "value": []
-  },
   "VarTable": {
     "type": "list",
     "value": [
@@ -34535,5 +34531,9 @@
         }
       }
     ]
+  },
+  "WaypointList": {
+    "type": "list",
+    "value": []
   }
 }

--- a/Module/git/vrotrkorracadrft.git.json
+++ b/Module/git/vrotrkorracadrft.git.json
@@ -11294,10 +11294,6 @@
     "type": "list",
     "value": []
   },
-  "WaypointList": {
-    "type": "list",
-    "value": []
-  },
   "VarTable": {
     "type": "list",
     "value": [
@@ -11317,5 +11313,9 @@
         }
       }
     ]
+  },
+  "WaypointList": {
+    "type": "list",
+    "value": []
   }
 }

--- a/Module/git/vrotrkorracsacad.git.json
+++ b/Module/git/vrotrkorracsacad.git.json
@@ -92303,6 +92303,26 @@
     "type": "list",
     "value": []
   },
+  "VarTable": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "COMMS_EVENT_AREA"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 1
+        },
+        "Value": {
+          "type": "int",
+          "value": 1
+        }
+      }
+    ]
+  },
   "WaypointList": {
     "type": "list",
     "value": [
@@ -92499,26 +92519,6 @@
         "ZPosition": {
           "type": "float",
           "value": 1.061502456665039
-        }
-      }
-    ]
-  },
-  "VarTable": {
-    "type": "list",
-    "value": [
-      {
-        "__struct_id": 0,
-        "Name": {
-          "type": "cexostring",
-          "value": "COMMS_EVENT_AREA"
-        },
-        "Type": {
-          "type": "dword",
-          "value": 1
-        },
-        "Value": {
-          "type": "int",
-          "value": 1
         }
       }
     ]

--- a/Module/git/vrotrkorrdnkside.git.json
+++ b/Module/git/vrotrkorrdnkside.git.json
@@ -14485,10 +14485,6 @@
     "type": "list",
     "value": []
   },
-  "WaypointList": {
-    "type": "list",
-    "value": []
-  },
   "VarTable": {
     "type": "list",
     "value": [
@@ -14508,5 +14504,9 @@
         }
       }
     ]
+  },
+  "WaypointList": {
+    "type": "list",
+    "value": []
   }
 }

--- a/Module/git/vrotrkorrdresh.git.json
+++ b/Module/git/vrotrkorrdresh.git.json
@@ -7237,6 +7237,26 @@
       }
     ]
   },
+  "VarTable": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "COMMS_EVENT_AREA"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 1
+        },
+        "Value": {
+          "type": "int",
+          "value": 1
+        }
+      }
+    ]
+  },
   "WaypointList": {
     "type": "list",
     "value": [
@@ -7364,26 +7384,6 @@
         "ZPosition": {
           "type": "float",
           "value": 0.01000607013702393
-        }
-      }
-    ]
-  },
-  "VarTable": {
-    "type": "list",
-    "value": [
-      {
-        "__struct_id": 0,
-        "Name": {
-          "type": "cexostring",
-          "value": "COMMS_EVENT_AREA"
-        },
-        "Type": {
-          "type": "dword",
-          "value": 1
-        },
-        "Value": {
-          "type": "int",
-          "value": 1
         }
       }
     ]

--- a/Module/git/vrotrkorretpyre.git.json
+++ b/Module/git/vrotrkorretpyre.git.json
@@ -927,6 +927,26 @@
       }
     ]
   },
+  "VarTable": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "COMMS_EVENT_AREA"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 1
+        },
+        "Value": {
+          "type": "int",
+          "value": 1
+        }
+      }
+    ]
+  },
   "WaypointList": {
     "type": "list",
     "value": [
@@ -1115,26 +1135,6 @@
         "ZPosition": {
           "type": "float",
           "value": 0.04887533187866211
-        }
-      }
-    ]
-  },
-  "VarTable": {
-    "type": "list",
-    "value": [
-      {
-        "__struct_id": 0,
-        "Name": {
-          "type": "cexostring",
-          "value": "COMMS_EVENT_AREA"
-        },
-        "Type": {
-          "type": "dword",
-          "value": 1
-        },
-        "Value": {
-          "type": "int",
-          "value": 1
         }
       }
     ]

--- a/Module/git/vrotrkorrforgcav.git.json
+++ b/Module/git/vrotrkorrforgcav.git.json
@@ -969,6 +969,26 @@
     "type": "list",
     "value": []
   },
+  "VarTable": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "COMMS_EVENT_AREA"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 1
+        },
+        "Value": {
+          "type": "int",
+          "value": 1
+        }
+      }
+    ]
+  },
   "WaypointList": {
     "type": "list",
     "value": [
@@ -1100,26 +1120,6 @@
         "ZPosition": {
           "type": "float",
           "value": 0.009999954141676426
-        }
-      }
-    ]
-  },
-  "VarTable": {
-    "type": "list",
-    "value": [
-      {
-        "__struct_id": 0,
-        "Name": {
-          "type": "cexostring",
-          "value": "COMMS_EVENT_AREA"
-        },
-        "Type": {
-          "type": "dword",
-          "value": 1
-        },
-        "Value": {
-          "type": "int",
-          "value": 1
         }
       }
     ]

--- a/Module/git/vrotrkorrmission.git.json
+++ b/Module/git/vrotrkorrmission.git.json
@@ -1832,10 +1832,6 @@
     "type": "list",
     "value": []
   },
-  "WaypointList": {
-    "type": "list",
-    "value": []
-  },
   "VarTable": {
     "type": "list",
     "value": [
@@ -1855,5 +1851,9 @@
         }
       }
     ]
+  },
+  "WaypointList": {
+    "type": "list",
+    "value": []
   }
 }

--- a/Module/git/vrotrkorrvalley.git.json
+++ b/Module/git/vrotrkorrvalley.git.json
@@ -6428,6 +6428,26 @@
       }
     ]
   },
+  "VarTable": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "COMMS_EVENT_AREA"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 1
+        },
+        "Value": {
+          "type": "int",
+          "value": 1
+        }
+      }
+    ]
+  },
   "WaypointList": {
     "type": "list",
     "value": [
@@ -6815,26 +6835,6 @@
         "ZPosition": {
           "type": "float",
           "value": -5.222045729169622e-006
-        }
-      }
-    ]
-  },
-  "VarTable": {
-    "type": "list",
-    "value": [
-      {
-        "__struct_id": 0,
-        "Name": {
-          "type": "cexostring",
-          "value": "COMMS_EVENT_AREA"
-        },
-        "Type": {
-          "type": "dword",
-          "value": 1
-        },
-        "Value": {
-          "type": "int",
-          "value": 1
         }
       }
     ]

--- a/Module/git/vrotrnabmission.git.json
+++ b/Module/git/vrotrnabmission.git.json
@@ -9376,10 +9376,6 @@
     "type": "list",
     "value": []
   },
-  "WaypointList": {
-    "type": "list",
-    "value": []
-  },
   "VarTable": {
     "type": "list",
     "value": [
@@ -9399,5 +9395,9 @@
         }
       }
     ]
+  },
+  "WaypointList": {
+    "type": "list",
+    "value": []
   }
 }

--- a/Module/git/vrotrnsdockbay.git.json
+++ b/Module/git/vrotrnsdockbay.git.json
@@ -7237,6 +7237,26 @@
       }
     ]
   },
+  "VarTable": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "COMMS_EVENT_AREA"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 1
+        },
+        "Value": {
+          "type": "int",
+          "value": 1
+        }
+      }
+    ]
+  },
   "WaypointList": {
     "type": "list",
     "value": [
@@ -7364,26 +7384,6 @@
         "ZPosition": {
           "type": "float",
           "value": -5.222045729169622e-006
-        }
-      }
-    ]
-  },
-  "VarTable": {
-    "type": "list",
-    "value": [
-      {
-        "__struct_id": 0,
-        "Name": {
-          "type": "cexostring",
-          "value": "COMMS_EVENT_AREA"
-        },
-        "Type": {
-          "type": "dword",
-          "value": 1
-        },
-        "Value": {
-          "type": "int",
-          "value": 1
         }
       }
     ]

--- a/Module/git/vrotrnsinterior.git.json
+++ b/Module/git/vrotrnsinterior.git.json
@@ -5879,6 +5879,26 @@
     "type": "list",
     "value": []
   },
+  "VarTable": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "COMMS_EVENT_AREA"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 1
+        },
+        "Value": {
+          "type": "int",
+          "value": 1
+        }
+      }
+    ]
+  },
   "WaypointList": {
     "type": "list",
     "value": [
@@ -6270,26 +6290,6 @@
         "ZPosition": {
           "type": "float",
           "value": 0.100006103515625
-        }
-      }
-    ]
-  },
-  "VarTable": {
-    "type": "list",
-    "value": [
-      {
-        "__struct_id": 0,
-        "Name": {
-          "type": "cexostring",
-          "value": "COMMS_EVENT_AREA"
-        },
-        "Type": {
-          "type": "dword",
-          "value": 1
-        },
-        "Value": {
-          "type": "int",
-          "value": 1
         }
       }
     ]

--- a/Module/git/vrotrnsroofconf.git.json
+++ b/Module/git/vrotrnsroofconf.git.json
@@ -278,6 +278,26 @@
       }
     ]
   },
+  "VarTable": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "COMMS_EVENT_AREA"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 1
+        },
+        "Value": {
+          "type": "int",
+          "value": 1
+        }
+      }
+    ]
+  },
   "WaypointList": {
     "type": "list",
     "value": [
@@ -344,26 +364,6 @@
         "ZPosition": {
           "type": "float",
           "value": -1.843866348266602
-        }
-      }
-    ]
-  },
-  "VarTable": {
-    "type": "list",
-    "value": [
-      {
-        "__struct_id": 0,
-        "Name": {
-          "type": "cexostring",
-          "value": "COMMS_EVENT_AREA"
-        },
-        "Type": {
-          "type": "dword",
-          "value": 1
-        },
-        "Value": {
-          "type": "int",
-          "value": 1
         }
       }
     ]

--- a/Module/git/vrotrnsrooftops.git.json
+++ b/Module/git/vrotrnsrooftops.git.json
@@ -278,6 +278,26 @@
       }
     ]
   },
+  "VarTable": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "COMMS_EVENT_AREA"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 1
+        },
+        "Value": {
+          "type": "int",
+          "value": 1
+        }
+      }
+    ]
+  },
   "WaypointList": {
     "type": "list",
     "value": [
@@ -344,26 +364,6 @@
         "ZPosition": {
           "type": "float",
           "value": -1.883283615112305
-        }
-      }
-    ]
-  },
-  "VarTable": {
-    "type": "list",
-    "value": [
-      {
-        "__struct_id": 0,
-        "Name": {
-          "type": "cexostring",
-          "value": "COMMS_EVENT_AREA"
-        },
-        "Type": {
-          "type": "dword",
-          "value": 1
-        },
-        "Value": {
-          "type": "int",
-          "value": 1
         }
       }
     ]

--- a/Module/git/vrotrnsrooftops2.git.json
+++ b/Module/git/vrotrnsrooftops2.git.json
@@ -301,10 +301,6 @@
     "type": "list",
     "value": []
   },
-  "WaypointList": {
-    "type": "list",
-    "value": []
-  },
   "VarTable": {
     "type": "list",
     "value": [
@@ -324,5 +320,9 @@
         }
       }
     ]
+  },
+  "WaypointList": {
+    "type": "list",
+    "value": []
   }
 }

--- a/Module/git/vrotrnsslums.git.json
+++ b/Module/git/vrotrnsslums.git.json
@@ -11132,6 +11132,26 @@
       }
     ]
   },
+  "VarTable": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "COMMS_EVENT_AREA"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 1
+        },
+        "Value": {
+          "type": "int",
+          "value": 1
+        }
+      }
+    ]
+  },
   "WaypointList": {
     "type": "list",
     "value": [
@@ -11389,26 +11409,6 @@
         "ZPosition": {
           "type": "float",
           "value": -5.222045729169622e-006
-        }
-      }
-    ]
-  },
-  "VarTable": {
-    "type": "list",
-    "value": [
-      {
-        "__struct_id": 0,
-        "Name": {
-          "type": "cexostring",
-          "value": "COMMS_EVENT_AREA"
-        },
-        "Type": {
-          "type": "dword",
-          "value": 1
-        },
-        "Value": {
-          "type": "int",
-          "value": 1
         }
       }
     ]

--- a/Module/git/vrotrsithlordext.git.json
+++ b/Module/git/vrotrsithlordext.git.json
@@ -2771,6 +2771,26 @@
     "type": "list",
     "value": []
   },
+  "VarTable": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "COMMS_EVENT_AREA"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 1
+        },
+        "Value": {
+          "type": "int",
+          "value": 1
+        }
+      }
+    ]
+  },
   "WaypointList": {
     "type": "list",
     "value": [
@@ -2831,26 +2851,6 @@
         "ZPosition": {
           "type": "float",
           "value": 0.5930728316307068
-        }
-      }
-    ]
-  },
-  "VarTable": {
-    "type": "list",
-    "value": [
-      {
-        "__struct_id": 0,
-        "Name": {
-          "type": "cexostring",
-          "value": "COMMS_EVENT_AREA"
-        },
-        "Type": {
-          "type": "dword",
-          "value": 1
-        },
-        "Value": {
-          "type": "int",
-          "value": 1
         }
       }
     ]

--- a/Module/git/vrotrsithlordint.git.json
+++ b/Module/git/vrotrsithlordint.git.json
@@ -63887,6 +63887,26 @@
       }
     ]
   },
+  "VarTable": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "COMMS_EVENT_AREA"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 1
+        },
+        "Value": {
+          "type": "int",
+          "value": 1
+        }
+      }
+    ]
+  },
   "WaypointList": {
     "type": "list",
     "value": [
@@ -64304,26 +64324,6 @@
         "ZPosition": {
           "type": "float",
           "value": 0.0
-        }
-      }
-    ]
-  },
-  "VarTable": {
-    "type": "list",
-    "value": [
-      {
-        "__struct_id": 0,
-        "Name": {
-          "type": "cexostring",
-          "value": "COMMS_EVENT_AREA"
-        },
-        "Type": {
-          "type": "dword",
-          "value": 1
-        },
-        "Value": {
-          "type": "int",
-          "value": 1
         }
       }
     ]

--- a/Module/git/vrotrtatdescamp.git.json
+++ b/Module/git/vrotrtatdescamp.git.json
@@ -1915,10 +1915,6 @@
     "type": "list",
     "value": []
   },
-  "WaypointList": {
-    "type": "list",
-    "value": []
-  },
   "VarTable": {
     "type": "list",
     "value": [
@@ -1938,5 +1934,9 @@
         }
       }
     ]
+  },
+  "WaypointList": {
+    "type": "list",
+    "value": []
   }
 }

--- a/Module/git/vrotrviscvokouts.git.json
+++ b/Module/git/vrotrviscvokouts.git.json
@@ -8990,10 +8990,6 @@
     "type": "list",
     "value": []
   },
-  "WaypointList": {
-    "type": "list",
-    "value": []
-  },
   "VarTable": {
     "type": "list",
     "value": [
@@ -9013,5 +9009,9 @@
         }
       }
     ]
+  },
+  "WaypointList": {
+    "type": "list",
+    "value": []
   }
 }

--- a/Module/itp/creaturepalcus.itp.json
+++ b/Module/itp/creaturepalcus.itp.json
@@ -4283,6 +4283,25 @@
                     "__struct_id": 0,
                     "CR": {
                       "type": "float",
+                      "value": 63.0
+                    },
+                    "FACTION": {
+                      "type": "cexostring",
+                      "value": "Hostile"
+                    },
+                    "NAME": {
+                      "type": "cexostring",
+                      "value": "Sith Marauder, Apprentice"
+                    },
+                    "RESREF": {
+                      "type": "resref",
+                      "value": "vnpcswar2"
+                    }
+                  },
+                  {
+                    "__struct_id": 0,
+                    "CR": {
+                      "type": "float",
                       "value": 41.0
                     },
                     "FACTION": {
@@ -4397,6 +4416,25 @@
                     "__struct_id": 0,
                     "CR": {
                       "type": "float",
+                      "value": 26.0
+                    },
+                    "FACTION": {
+                      "type": "cexostring",
+                      "value": "Hostile"
+                    },
+                    "NAME": {
+                      "type": "cexostring",
+                      "value": "Sith Soldier"
+                    },
+                    "RESREF": {
+                      "type": "resref",
+                      "value": "vnpcstroop2"
+                    }
+                  },
+                  {
+                    "__struct_id": 0,
+                    "CR": {
+                      "type": "float",
                       "value": 66.0
                     },
                     "FACTION": {
@@ -4429,6 +4467,25 @@
                     "RESREF": {
                       "type": "resref",
                       "value": "vnpcssorc4"
+                    }
+                  },
+                  {
+                    "__struct_id": 0,
+                    "CR": {
+                      "type": "float",
+                      "value": 42.0
+                    },
+                    "FACTION": {
+                      "type": "cexostring",
+                      "value": "Hostile"
+                    },
+                    "NAME": {
+                      "type": "cexostring",
+                      "value": "Sith Sorcerer, Apprentice"
+                    },
+                    "RESREF": {
+                      "type": "resref",
+                      "value": "vnpcssorc2"
                     }
                   },
                   {
@@ -6106,6 +6163,25 @@
                     "RESREF": {
                       "type": "resref",
                       "value": "hunter_guildmast"
+                    }
+                  },
+                  {
+                    "__struct_id": 0,
+                    "CR": {
+                      "type": "float",
+                      "value": 2.0
+                    },
+                    "FACTION": {
+                      "type": "cexostring",
+                      "value": "Commoner"
+                    },
+                    "NAME": {
+                      "type": "cexostring",
+                      "value": "Identity Broker"
+                    },
+                    "RESREF": {
+                      "type": "resref",
+                      "value": "identitybroker"
                     }
                   },
                   {

--- a/Module/utc/identitybroker.utc.json
+++ b/Module/utc/identitybroker.utc.json
@@ -2,11 +2,11 @@
   "__data_type": "UTC ",
   "Appearance_Head": {
     "type": "byte",
-    "value": 9
+    "value": 115
   },
   "Appearance_Type": {
     "type": "word",
-    "value": 3
+    "value": 10004
   },
   "ArmorPart_RFoot": {
     "type": "byte",
@@ -86,11 +86,11 @@
   },
   "Cha": {
     "type": "byte",
-    "value": 8
+    "value": 9
   },
   "ChallengeRating": {
     "type": "float",
-    "value": 5.0
+    "value": 2.0
   },
   "ClassList": {
     "type": "list",
@@ -105,28 +105,6 @@
           "type": "short",
           "value": 1
         }
-      },
-      {
-        "__struct_id": 2,
-        "Class": {
-          "type": "int",
-          "value": 64
-        },
-        "ClassLevel": {
-          "type": "short",
-          "value": 2
-        }
-      },
-      {
-        "__struct_id": 2,
-        "Class": {
-          "type": "int",
-          "value": 57
-        },
-        "ClassLevel": {
-          "type": "short",
-          "value": 2
-        }
       }
     ]
   },
@@ -136,11 +114,11 @@
   },
   "Color_Skin": {
     "type": "byte",
-    "value": 1
+    "value": 149
   },
   "Color_Tattoo1": {
     "type": "byte",
-    "value": 33
+    "value": 1
   },
   "Color_Tattoo2": {
     "type": "byte",
@@ -148,11 +126,11 @@
   },
   "Comment": {
     "type": "cexostring",
-    "value": ""
+    "value": "Allows players to permanently wipe retired disguise identities for a fee."
   },
   "Con": {
     "type": "byte",
-    "value": 11
+    "value": 16
   },
   "Conversation": {
     "type": "resref",
@@ -160,15 +138,15 @@
   },
   "CRAdjust": {
     "type": "int",
-    "value": -1
+    "value": 0
   },
   "CurrentHitPoints": {
     "type": "short",
-    "value": 65
+    "value": 45
   },
   "DecayTime": {
     "type": "dword",
-    "value": 15000
+    "value": 5000
   },
   "Deity": {
     "type": "cexostring",
@@ -176,13 +154,11 @@
   },
   "Description": {
     "type": "cexolocstring",
-    "value": {
-      "2": "Les ninjas Jawa sont aussi loufoques que leur crÃ©ateur. Prenez garde Ã  vous !"
-    }
+    "value": {}
   },
   "Dex": {
     "type": "byte",
-    "value": 14
+    "value": 13
   },
   "Disarmable": {
     "type": "byte",
@@ -195,28 +171,14 @@
         "__struct_id": 2,
         "EquippedRes": {
           "type": "resref",
-          "value": "vet_togejawa002"
-        }
-      },
-      {
-        "__struct_id": 16,
-        "EquippedRes": {
-          "type": "resref",
-          "value": "extjawa004_wp"
-        }
-      },
-      {
-        "__struct_id": 131072,
-        "EquippedRes": {
-          "type": "resref",
-          "value": "extjawa004_sk"
+          "value": "npc_smuggler2_m"
         }
       }
     ]
   },
   "FactionID": {
     "type": "word",
-    "value": 1
+    "value": 2
   },
   "FeatList": {
     "type": "list",
@@ -246,27 +208,6 @@
         "__struct_id": 1,
         "Feat": {
           "type": "word",
-          "value": 408
-        }
-      },
-      {
-        "__struct_id": 1,
-        "Feat": {
-          "type": "word",
-          "value": 5
-        }
-      },
-      {
-        "__struct_id": 1,
-        "Feat": {
-          "type": "word",
-          "value": 1075
-        }
-      },
-      {
-        "__struct_id": 1,
-        "Feat": {
-          "type": "word",
           "value": 10
         }
       },
@@ -274,56 +215,21 @@
         "__struct_id": 1,
         "Feat": {
           "type": "word",
-          "value": 1076
+          "value": 1089
         }
       },
       {
         "__struct_id": 1,
         "Feat": {
           "type": "word",
-          "value": 1077
+          "value": 28
         }
       },
       {
         "__struct_id": 1,
         "Feat": {
           "type": "word",
-          "value": 249
-        }
-      },
-      {
-        "__struct_id": 1,
-        "Feat": {
-          "type": "word",
-          "value": 250
-        }
-      },
-      {
-        "__struct_id": 1,
-        "Feat": {
-          "type": "word",
-          "value": 23
-        }
-      },
-      {
-        "__struct_id": 1,
-        "Feat": {
-          "type": "word",
-          "value": 248
-        }
-      },
-      {
-        "__struct_id": 1,
-        "Feat": {
-          "type": "word",
-          "value": 26
-        }
-      },
-      {
-        "__struct_id": 1,
-        "Feat": {
-          "type": "word",
-          "value": 27
+          "value": 258
         }
       },
       {
@@ -331,27 +237,6 @@
         "Feat": {
           "type": "word",
           "value": 32
-        }
-      },
-      {
-        "__struct_id": 1,
-        "Feat": {
-          "type": "word",
-          "value": 237
-        }
-      },
-      {
-        "__struct_id": 1,
-        "Feat": {
-          "type": "word",
-          "value": 247
-        }
-      },
-      {
-        "__struct_id": 1,
-        "Feat": {
-          "type": "word",
-          "value": 375
         }
       },
       {
@@ -374,28 +259,13 @@
           "type": "word",
           "value": 46
         }
-      },
-      {
-        "__struct_id": 2,
-        "Feat": {
-          "type": "word",
-          "value": 1850
-        }
-      },
-      {
-        "__struct_id": 3,
-        "Feat": {
-          "type": "word",
-          "value": 1851
-        }
       }
     ]
   },
   "FirstName": {
     "type": "cexolocstring",
     "value": {
-      "0": "Jawa",
-      "2": "Ninja Jawa"
+      "0": "Identity Broker"
     }
   },
   "fortbonus": {
@@ -412,47 +282,23 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 65
+    "value": 45
   },
   "Int": {
     "type": "byte",
-    "value": 11
+    "value": 10
   },
   "Interruptable": {
     "type": "byte",
-    "value": 0
+    "value": 1
   },
   "IsImmortal": {
     "type": "byte",
-    "value": 0
+    "value": 1
   },
   "IsPC": {
     "type": "byte",
     "value": 0
-  },
-  "ItemList": {
-    "type": "list",
-    "value": [
-      {
-        "__struct_id": 0,
-        "Dropable": {
-          "type": "byte",
-          "value": 1
-        },
-        "InventoryRes": {
-          "type": "resref",
-          "value": "equ_capsule_eau"
-        },
-        "Repos_PosX": {
-          "type": "word",
-          "value": 0
-        },
-        "Repos_Posy": {
-          "type": "word",
-          "value": 0
-        }
-      }
-    ]
   },
   "LastName": {
     "type": "cexolocstring",
@@ -466,11 +312,11 @@
   },
   "Lootable": {
     "type": "byte",
-    "value": 1
+    "value": 0
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 65
+    "value": 48
   },
   "NaturalAC": {
     "type": "byte",
@@ -478,15 +324,15 @@
   },
   "NoPermDeath": {
     "type": "byte",
-    "value": 1
+    "value": 0
   },
   "PaletteID": {
     "type": "byte",
-    "value": 154
+    "value": 44
   },
   "PerceptionRange": {
     "type": "byte",
-    "value": 9
+    "value": 11
   },
   "Phenotype": {
     "type": "int",
@@ -498,11 +344,11 @@
   },
   "PortraitId": {
     "type": "word",
-    "value": 129
+    "value": 3638
   },
   "Race": {
     "type": "byte",
-    "value": 3
+    "value": 6
   },
   "refbonus": {
     "type": "short",
@@ -510,55 +356,55 @@
   },
   "ScriptAttacked": {
     "type": "resref",
-    "value": "x2_def_attacked"
+    "value": "nw_c2_default5"
   },
   "ScriptDamaged": {
     "type": "resref",
-    "value": "x2_def_ondamage"
+    "value": "nw_c2_default6"
   },
   "ScriptDeath": {
     "type": "resref",
-    "value": "x2_def_ondeath"
+    "value": "nw_c2_default7"
   },
   "ScriptDialogue": {
     "type": "resref",
-    "value": "x2_def_onconv"
+    "value": "nw_c2_default4"
   },
   "ScriptDisturbed": {
     "type": "resref",
-    "value": "x2_def_ondisturb"
+    "value": "nw_c2_default8"
   },
   "ScriptEndRound": {
     "type": "resref",
-    "value": "x2_def_endcombat"
+    "value": "nw_c2_default3"
   },
   "ScriptHeartbeat": {
     "type": "resref",
-    "value": "x2_def_heartbeat"
+    "value": "nw_c2_default1"
   },
   "ScriptOnBlocked": {
     "type": "resref",
-    "value": "x2_def_onblocked"
+    "value": "nw_c2_defaulte"
   },
   "ScriptOnNotice": {
     "type": "resref",
-    "value": "x2_def_percept"
+    "value": "nw_c2_default2"
   },
   "ScriptRested": {
     "type": "resref",
-    "value": "x2_def_rested"
+    "value": "nw_c2_defaulta"
   },
   "ScriptSpawn": {
     "type": "resref",
-    "value": "x2_def_spawn"
+    "value": "nw_c2_default9"
   },
   "ScriptSpellAt": {
     "type": "resref",
-    "value": "x2_def_spellcast"
+    "value": "nw_c2_defaultb"
   },
   "ScriptUserDefine": {
     "type": "resref",
-    "value": "x2_def_userdef"
+    "value": "nw_c2_defaultd"
   },
   "SkillList": {
     "type": "list",
@@ -595,7 +441,28 @@
         "__struct_id": 0,
         "Rank": {
           "type": "byte",
-          "value": 2
+          "value": 0
+        }
+      },
+      {
+        "__struct_id": 0,
+        "Rank": {
+          "type": "byte",
+          "value": 0
+        }
+      },
+      {
+        "__struct_id": 0,
+        "Rank": {
+          "type": "byte",
+          "value": 0
+        }
+      },
+      {
+        "__struct_id": 0,
+        "Rank": {
+          "type": "byte",
+          "value": 0
         }
       },
       {
@@ -630,14 +497,21 @@
         "__struct_id": 0,
         "Rank": {
           "type": "byte",
-          "value": 2
+          "value": 0
         }
       },
       {
         "__struct_id": 0,
         "Rank": {
           "type": "byte",
-          "value": 2
+          "value": 0
+        }
+      },
+      {
+        "__struct_id": 0,
+        "Rank": {
+          "type": "byte",
+          "value": 0
         }
       },
       {
@@ -665,7 +539,21 @@
         "__struct_id": 0,
         "Rank": {
           "type": "byte",
-          "value": 2
+          "value": 0
+        }
+      },
+      {
+        "__struct_id": 0,
+        "Rank": {
+          "type": "byte",
+          "value": 0
+        }
+      },
+      {
+        "__struct_id": 0,
+        "Rank": {
+          "type": "byte",
+          "value": 0
         }
       },
       {
@@ -693,14 +581,7 @@
         "__struct_id": 0,
         "Rank": {
           "type": "byte",
-          "value": 2
-        }
-      },
-      {
-        "__struct_id": 0,
-        "Rank": {
-          "type": "byte",
-          "value": 2
+          "value": 0
         }
       },
       {
@@ -714,13 +595,6 @@
         "__struct_id": 0,
         "Rank": {
           "type": "byte",
-          "value": 4
-        }
-      },
-      {
-        "__struct_id": 0,
-        "Rank": {
-          "type": "byte",
           "value": 0
         }
       },
@@ -728,42 +602,14 @@
         "__struct_id": 0,
         "Rank": {
           "type": "byte",
-          "value": 2
-        }
-      },
-      {
-        "__struct_id": 0,
-        "Rank": {
-          "type": "byte",
-          "value": 2
-        }
-      },
-      {
-        "__struct_id": 0,
-        "Rank": {
-          "type": "byte",
-          "value": 2
-        }
-      },
-      {
-        "__struct_id": 0,
-        "Rank": {
-          "type": "byte",
-          "value": 2
-        }
-      },
-      {
-        "__struct_id": 0,
-        "Rank": {
-          "type": "byte",
-          "value": 2
+          "value": 0
         }
       }
     ]
   },
   "SoundSetFile": {
     "type": "word",
-    "value": 65535
+    "value": 940
   },
   "SpecAbilityList": {
     "type": "list",
@@ -775,7 +621,7 @@
   },
   "Str": {
     "type": "byte",
-    "value": 8
+    "value": 18
   },
   "Subrace": {
     "type": "cexostring",
@@ -783,7 +629,7 @@
   },
   "Tag": {
     "type": "cexostring",
-    "value": "ext_jawa004"
+    "value": "identity_broker"
   },
   "Tail_New": {
     "type": "dword",
@@ -795,11 +641,31 @@
   },
   "TemplateResRef": {
     "type": "resref",
-    "value": "ext_jawa004"
+    "value": "identitybroker"
+  },
+  "VarTable": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "CONVERSATION"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 3
+        },
+        "Value": {
+          "type": "cexostring",
+          "value": "IdentityBrokerDialog"
+        }
+      }
+    ]
   },
   "WalkRate": {
     "type": "int",
-    "value": 5
+    "value": 7
   },
   "willbonus": {
     "type": "short",
@@ -811,11 +677,11 @@
   },
   "Wis": {
     "type": "byte",
-    "value": 8
+    "value": 10
   },
   "xAppearance_Head": {
     "type": "word",
-    "value": 9
+    "value": 115
   },
   "xArmorPart_RFoot": {
     "type": "word",

--- a/SWLOR.Game.Server.Tests/Feature/PlayerFacingNameBroadcastTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/PlayerFacingNameBroadcastTests.cs
@@ -82,6 +82,12 @@ public class PlayerFacingNameBroadcastTests
         communicationSource.Should().NotContain("var inCharacterChat =");
         communicationSource.Should().Contain("if (channel == ChatChannel.PlayerShout && (GetIsDM(sender) || GetIsDMPossessed(sender)))");
         communicationSource.Should().Contain("SendMessageToPC(sender, ColorToken.Red(DisabledChannelMessage));");
+        communicationSource.Should().Contain("private static bool IsChatCommandMessage(string message)");
+        var chatCommandEarlyOutIndex = communicationSource.IndexOf("if (IsChatCommandMessage(message))", StringComparison.Ordinal);
+        var disabledChannelMessageIndex = communicationSource.IndexOf("SendMessageToPC(sender, ColorToken.Red(DisabledChannelMessage));", StringComparison.Ordinal);
+        chatCommandEarlyOutIndex.Should().BeGreaterThanOrEqualTo(0);
+        disabledChannelMessageIndex.Should().BeGreaterThanOrEqualTo(0);
+        chatCommandEarlyOutIndex.Should().BeLessThan(disabledChannelMessageIndex, "slash chat commands must bypass disabled-channel handling");
         communicationSource.Should().Contain("var recipients = new List<uint> { sender };");
         communicationSource.Should().NotContain("recipients.AddRange(allPlayers.Where(player => GetLocalBool(player, \"DISPLAY_HOLONET\")))");
         communicationSource.Should().NotContain("LoadHolonetSetting");
@@ -202,9 +208,7 @@ public class PlayerFacingNameBroadcastTests
             "SWLOR.Game.Server",
             "Service",
             "ChatCommand.cs"));
-        chatCommandSource.Should().Contain("ChatPlugin.GetChannel() == ChatChannel.PlayerShout");
-        chatCommandSource.Should().Contain("!GetIsDM(sender)");
-        chatCommandSource.Should().Contain("!GetIsDMPossessed(sender)");
+        chatCommandSource.Should().NotContain("ChatPlugin.GetChannel() == ChatChannel.PlayerShout");
 
         var eventAreaDirectory = Path.Combine(root.FullName, "Module", "are");
         var eventAreaFiles = Directory.GetFiles(eventAreaDirectory, "*.are.json")

--- a/SWLOR.Game.Server.Tests/Feature/PlayerNameRecognitionTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/PlayerNameRecognitionTests.cs
@@ -18,7 +18,7 @@ public class PlayerNameRecognitionTests
             "PlayerName.cs"));
         var method = ExtractMethod(source, "private static void ApplyNameOverridesForPlayer(uint player)");
 
-        method.Should().Contain("var shouldScrambleAccountName = ShouldScrambleAccountName(player);");
+        method.Should().Contain("var shouldScrambleAccountName = Disguise.ShouldScrambleAccountName(player);");
         method.Should().Contain("if (!shouldScrambleAccountName)");
         method.Should().Contain("RenamePlugin.ClearPCNameOverride(player);");
         method.Should().Contain("if (shouldScrambleAccountName)");
@@ -164,7 +164,7 @@ public class PlayerNameRecognitionTests
         var validationMethod = ExtractMethod(source, "private static string ValidateKnownNameTarget(uint observer, uint target)");
 
         var validationIndex = setMethod.IndexOf("ValidateKnownNameAssignment(observer, target, name);", StringComparison.Ordinal);
-        var targetIdIndex = setMethod.IndexOf("var targetId = GetObjectUUID(target);", StringComparison.Ordinal);
+        var targetIdIndex = setMethod.IndexOf("var targetId = Disguise.GetIdentityKey(target);", StringComparison.Ordinal);
 
         validationIndex.Should().BeGreaterThanOrEqualTo(0);
         targetIdIndex.Should().BeGreaterThanOrEqualTo(0);
@@ -195,6 +195,9 @@ public class PlayerNameRecognitionTests
         var setMethod = ExtractMethod(source, "public static void SetKnownName(uint observer, uint target, string name)");
         var unknownDisplayMethod = ExtractMethod(descriptorSource, "public static void SetUnknownDisplayName(uint player, string name)");
 
+        source.Should().Contain("public const int MaxKnownNameLength = 64;");
+        source.Should().Contain("if (name.Length > MaxKnownNameLength)");
+        source.Should().Contain("Names may be no longer than {MaxKnownNameLength} characters.");
         inputValidationMethod.Should().Contain("ContainsColorToken(name)");
         inputValidationMethod.Should().Contain("\"Names may not contain color codes.\"");
         inputValidationMethod.Should().Contain("ValidateKnownName(SanitizeKnownName(name))");
@@ -282,7 +285,7 @@ public class PlayerNameRecognitionTests
         var playerIdDisplayMethod = ExtractMethod(source, "public static string GetDisplayNameByPlayerId(uint observer, string targetPlayerId, string fallbackName)");
         coloredDisplayMethod.Should().Contain("ColorToken.Gray(displayName)");
         coloredDisplayMethod.Should().Contain("ShouldShowDescriptorForNamedPlayers(observer)");
-        coloredDisplayMethod.Should().Contain("BuildColoredDisplayNameWithDescriptor(knownName, PlayerDescriptor.GetUnknownDisplayName(target))");
+        coloredDisplayMethod.Should().Contain("BuildColoredDisplayNameWithDescriptor(knownName, Disguise.GetDisplayDescriptor(target))");
         coloredDisplayMethod.Should().Contain("ColorToken.GetPCColor(knownName)");
         coloredChatDisplayMethod.Should().Contain("ResolveChatDisplayName(observer, target, out var isUnknown)");
         coloredChatDisplayMethod.Should().NotContain("ShouldShowDescriptorForNamedPlayers(observer)");
@@ -299,7 +302,7 @@ public class PlayerNameRecognitionTests
         playerSource.Should().Contain("ShowOwnDescriptor = true;");
         playerSource.Should().Contain("ScrambleAccountName = true;");
         descriptorSource.Should().Contain("public static void SetUnknownDisplayName(uint player, string name)");
-        source.Should().Contain("PlayerDescriptor.GetUnknownDisplayName(target)");
+        source.Should().Contain("Disguise.GetDisplayDescriptor(target)");
         source.Should().Contain("public static void SendChatMessageWithChatNameOverride(uint observer, uint target, Action sendMessage)");
         source.Should().Contain("private static string BuildDisplayNameWithDescriptor(string primaryName, string descriptor)");
         source.Should().Contain("private static string BuildColoredDisplayNameWithDescriptor(string primaryName, string descriptor)");
@@ -325,20 +328,20 @@ public class PlayerNameRecognitionTests
 
         var resolveDisplayMethod = ExtractMethod(source, "private static string ResolveDisplayName(uint observer, uint target, out bool isUnknown)");
         resolveDisplayMethod.Should().Contain("ShouldShowDescriptorForNamedPlayers(observer)");
-        resolveDisplayMethod.Should().Contain("BuildDisplayNameWithDescriptor(knownName, PlayerDescriptor.GetUnknownDisplayName(target))");
+        resolveDisplayMethod.Should().Contain("BuildDisplayNameWithDescriptor(knownName, Disguise.GetDisplayDescriptor(target))");
         resolveDisplayMethod.Should().Contain(": knownName");
 
         var resolveChatDisplayMethod = ExtractMethod(source, "private static string ResolveChatDisplayName(uint observer, uint target, out bool isUnknown)");
         resolveChatDisplayMethod.Should().Contain("GetIsDM(observer)");
         resolveChatDisplayMethod.Should().Contain("TryGetKnownName(observer, target, out var knownName)");
         resolveChatDisplayMethod.Should().Contain("return knownName;");
-        resolveChatDisplayMethod.Should().Contain("return PlayerDescriptor.GetUnknownDisplayName(target);");
+        resolveChatDisplayMethod.Should().Contain("return Disguise.GetDisplayDescriptor(target);");
         resolveChatDisplayMethod.Should().NotContain("BuildDisplayNameWithDescriptor");
         resolveChatDisplayMethod.Should().NotContain("ShouldShowDescriptorForNamedPlayers(observer)");
 
         var staffDisplayMethod = ExtractMethod(source, "private static string BuildStaffDisplayName(uint target)");
         staffDisplayMethod.Should().Contain("GetName(target)");
-        staffDisplayMethod.Should().Contain("PlayerDescriptor.GetUnknownDisplayName(target)");
+        staffDisplayMethod.Should().Contain("Disguise.GetDisplayDescriptor(target)");
         staffDisplayMethod.Should().Contain("return $\"{trueName} [{ColorToken.Gray(unknownDisplayName)}]\";");
         staffDisplayMethod.Should().Contain("ColorToken.Gray(unknownDisplayName)");
 
@@ -502,9 +505,394 @@ public class PlayerNameRecognitionTests
         playerNameSource.Should().Contain("public static void RefreshNameOverridesForObserver(uint observer)");
         playerNameSource.Should().Contain("ShowDescriptorsForNamedPlayersByObserverId.Remove(observerId);");
         playerNameSource.Should().Contain("private static bool ShouldShowOwnDescriptor(uint player)");
-        playerNameSource.Should().Contain("private static bool ShouldScrambleAccountName(uint player)");
+        playerNameSource.Should().Contain("Disguise.ShouldScrambleAccountName(player)");
         playerNameSource.Should().Contain("GetIsDM(observer) ||");
         playerNameSource.Should().Contain("GetIsDMPossessed(observer)");
+    }
+
+    [Test]
+    public void Disguises_UseDisguiseIdentityKeysAndHardDeleteRetiredIdentities()
+    {
+        var root = FindRepositoryRoot();
+        var disguiseSource = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "SWLOR.Game.Server",
+            "Service",
+            "Disguise.cs"));
+        var activateResultSource = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "SWLOR.Game.Server",
+            "Service",
+            "DisguiseService",
+            "ActivateDisguiseResult.cs"));
+        var entitySource = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "SWLOR.Game.Server",
+            "Entity",
+            "PlayerDisguise.cs"));
+        var playerSource = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "SWLOR.Game.Server",
+            "Entity",
+            "Player.cs"));
+        var viewModelSource = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "SWLOR.Game.Server",
+            "Feature",
+            "GuiDefinition",
+            "ViewModel",
+            "DisguiseViewModel.cs"));
+        var cacheSource = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "SWLOR.Game.Server",
+            "Service",
+            "Cache.cs"));
+        var dialogSource = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "SWLOR.Game.Server",
+            "Feature",
+            "DialogDefinition",
+            "IdentityBrokerDialog.cs"));
+        var characterSheetDefinitionSource = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "SWLOR.Game.Server",
+            "Feature",
+            "GuiDefinition",
+            "CharacterSheetDefinition.cs"));
+        var characterSheetViewModelSource = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "SWLOR.Game.Server",
+            "Feature",
+            "GuiDefinition",
+            "ViewModel",
+            "CharacterSheetViewModel.cs"));
+        var dmChatCommandSource = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "SWLOR.Game.Server",
+            "Feature",
+            "ChatCommandDefinition",
+            "DMChatCommand.cs"));
+
+        disguiseSource.Should().Contain("public const string IdentityKeyPrefix = \"disguise:\";");
+        disguiseSource.Should().Contain("BuildIdentityKey(activeDisguise.Id)");
+        disguiseSource.Should().Contain("PlayerName.DeleteKnownNameReferences(identityKey)");
+        disguiseSource.Should().Contain("DB.Delete<PlayerDisguise>(disguise.Id)");
+        disguiseSource.Should().Contain("public const int ActivationDelayMinutes = 30;");
+        disguiseSource.Should().Contain("private static readonly TimeSpan ActivationDelay = TimeSpan.FromMinutes(ActivationDelayMinutes);");
+        disguiseSource.Should().Contain("public static ActivateDisguiseResult Activate");
+        disguiseSource.Should().Contain("ValidateActivationDelay(playerId)");
+        disguiseSource.Should().Contain("GetLatestActivationDate(playerId)");
+        disguiseSource.Should().Contain("There is a {ActivationDelayMinutes}-minute delay between disguise activations.");
+        disguiseSource.Should().Contain("Deactivation is available immediately.");
+        disguiseSource.Should().Contain("DateLastActivated = DateTime.UtcNow");
+        disguiseSource.Should().Contain("public static int ResetActivationCooldowns(uint player)");
+        disguiseSource.Should().Contain("disguise.DateLastActivated = null;");
+        disguiseSource.Should().Contain("public static bool Unretire");
+        disguiseSource.Should().Contain("disguise.DateRetired = null;");
+        disguiseSource.Should().Contain("TakeGoldFromCreature(amount, player, true)");
+        disguiseSource.Should().Contain("dbPlayer.UnallocatedXP -= amount");
+        disguiseSource.Should().Contain("new RPXPRefreshEvent()");
+        disguiseSource.Should().Contain("new DisguiseChangedRefreshEvent()");
+        dmChatCommandSource.Should().Contain(".Description(\"Resets a player's ability and disguise cooldowns.\")");
+        dmChatCommandSource.Should().Contain("AbilityCooldownVisual.ClearAllRecastDelays(target);");
+        dmChatCommandSource.Should().Contain("Disguise.ResetActivationCooldowns(target);");
+
+        activateResultSource.Should().Contain("public bool IsSuccessful");
+        activateResultSource.Should().Contain("public string ErrorMessage");
+        activateResultSource.Should().Contain("public static ActivateDisguiseResult Success()");
+        activateResultSource.Should().Contain("public static ActivateDisguiseResult Failure(string errorMessage)");
+
+        entitySource.Should().Contain("[Indexed]");
+        entitySource.Should().Contain("public string PlayerId { get; set; }");
+        entitySource.Should().Contain("public bool IsRetired { get; set; }");
+        entitySource.Should().Contain("public bool ScrambleAccountId { get; set; }");
+        playerSource.Should().Contain("public const int DefaultDisguiseSlotLimit = 1;");
+        playerSource.Should().Contain("DisguiseSlotLimit = DefaultDisguiseSlotLimit;");
+
+        viewModelSource.Should().Contain("public bool IsAvailableSelected");
+        viewModelSource.Should().Contain("public bool IsRetiredSelected");
+        viewModelSource.Should().Contain("public bool ShowEmptyState");
+        viewModelSource.Should().Contain("public string EmptyStateTitle");
+        viewModelSource.Should().Contain("public string EmptyStateText");
+        viewModelSource.Should().Contain("public bool ScrambleAccountId");
+        viewModelSource.Should().Contain("public bool ShowUnretireButton");
+        viewModelSource.Should().NotContain("public bool ShowDetailActionRow");
+        viewModelSource.Should().Contain("public const string DetailPartialElement");
+        viewModelSource.Should().Contain("public const string PortraitPartialElement");
+        viewModelSource.Should().Contain("public const string ActionPartialElement");
+        viewModelSource.Should().Contain("public const string ActionAvailablePartial");
+        viewModelSource.Should().Contain("public const string ActionRetiredPartial");
+        viewModelSource.Should().Contain("public const string ActionEditPartial");
+        viewModelSource.Should().Contain("public const string ActionEmptyPartial");
+        disguiseSource.Should().Contain("PrivateName = $\"Disguise #{usedSlots + 1}\"");
+        disguiseSource.Should().Contain("public const int MaxPrivateNameLength = 32;");
+        disguiseSource.Should().Contain("privateName.Length > MaxPrivateNameLength");
+        disguiseSource.Should().Contain("Private disguise names may be no longer than {MaxPrivateNameLength} characters.");
+        disguiseSource.Should().Contain("Unable to locate that disguise.");
+        disguiseSource.Should().Contain("Retired disguises cannot be edited.");
+        disguiseSource.Should().Contain("Unable to activate that disguise.");
+        disguiseSource.Should().Contain("before activating another disguise.");
+        viewModelSource.Should().Contain("Creating a new disguise will consume one of your disguise slots. Retired disguises also occupy disguise slots until they are wiped. Are you sure?");
+        viewModelSource.Should().Contain("ActivateButtonText = IsSelectedDisguiseActive() ? \"Deactivate\" : \"Activate\";");
+        viewModelSource.Should().Contain("Disguise.Deactivate(Player)");
+        viewModelSource.Should().Contain("Deactivating this disguise immediately restores your normal identity. Deactivation does not trigger the 30-minute delay between disguise activations. Are you sure?");
+        viewModelSource.Should().Contain("Activating this disguise starts a 30-minute delay before you can activate another disguise. Deactivation has no delay. Are you sure?");
+        viewModelSource.Should().Contain("var selectedDisguiseId = _selectedDisguiseId;");
+        viewModelSource.Should().Contain("var result = Disguise.Activate(Player, selectedDisguiseId);");
+        viewModelSource.Should().Contain("private void ReloadAvailableDisguise(string selectedDisguiseId)");
+        viewModelSource.Should().Contain("LoadList(selectedDisguiseId);");
+        viewModelSource.Should().Contain("if (!result.IsSuccessful)");
+        viewModelSource.Should().Contain("FloatingTextStringOnCreature(result.ErrorMessage, Player, false);");
+        viewModelSource.Should().Contain("Disguise.Unretire(Player, _selectedDisguiseId)");
+        viewModelSource.Should().Contain("Restoring this disguise will move it back to your available disguises. Are you sure?");
+        viewModelSource.Should().Contain("public Action OnClickPreviewSoundSet()");
+        viewModelSource.Should().Contain("Cache.GetSoundSetPreviewSoundResref(_selectedSoundSetId)");
+        viewModelSource.Should().Contain("PlayerPlugin.PlaySound(Player, previewSoundResref, OBJECT_INVALID)");
+        viewModelSource.Should().NotContain("PlayVoiceChat(VoiceChat.Hello, Player)");
+        viewModelSource.Should().Contain("public int SelectedSoundSetIndex");
+        viewModelSource.Should().Contain("private readonly Dictionary<int, int> _soundSetIndexesById");
+        viewModelSource.Should().Contain("private readonly List<GuiBindingList<GuiComboEntry>> _soundSetOptionPages");
+        viewModelSource.Should().Contain("currentPage.Add(new GuiComboEntry(label, optionIndex));");
+        viewModelSource.Should().Contain("private const int SoundSetPageSize");
+        viewModelSource.Should().Contain("public GuiBindingList<GuiComboEntry> SoundSetPageNumbers");
+        viewModelSource.Should().Contain("public int SelectedSoundSetPageIndex");
+        viewModelSource.Should().Contain("private bool _suppressSoundSetPageChange");
+        viewModelSource.Should().Contain("private int _selectedSoundSetId");
+        viewModelSource.Should().Contain("SelectSoundSet(disguise.SoundSetId);");
+        viewModelSource.Should().Contain("private void LoadSoundSetPageOptions");
+        viewModelSource.Should().Contain("private void LoadSoundSetPageNumbers");
+        viewModelSource.Should().Contain("private int GetSelectedSoundSetIndexOnCurrentPage");
+        viewModelSource.Should().Contain("_soundSetPageIndex = absoluteIndex / SoundSetPageSize;");
+        viewModelSource.Should().Contain("SoundSetOptions = _soundSetOptionPages[_soundSetPageIndex];");
+        viewModelSource.Should().Contain("SoundSetPageNumbers = pageNumbers;");
+        viewModelSource.Should().Contain("WatchOnClient(model => model.SelectedSoundSetPageIndex)");
+        viewModelSource.Should().Contain("_soundSetIndexesById.TryGetValue");
+        viewModelSource.Should().Contain("private void SetSelectedSoundSetFromPageIndex");
+        viewModelSource.Should().Contain("public Action OnClickPreviousSoundSetPage()");
+        viewModelSource.Should().Contain("public Action OnClickNextSoundSetPage()");
+        viewModelSource.Should().Contain("private int SanitizeSoundSetIndex");
+        viewModelSource.Should().Contain("if (index < 0)");
+        viewModelSource.Should().Contain("LoadSoundSetPageOptions(GetSelectedSoundSetIndexOnCurrentPage(), true);");
+        viewModelSource.Should().Contain("selectedPageIndex = GetCurrentSoundSetPageSize() > 0 ? 0 : -1;");
+        viewModelSource.Should().Contain("private void RefreshSoundSetBindings");
+        viewModelSource.Should().NotContain("SetSoundset(Player, _soundSetIds[SelectedSoundSetIndex])");
+        viewModelSource.Should().Contain("DelayCommand(0.0f, () => PortraitInternalId = sanitizedValue)");
+        viewModelSource.Should().Contain("PortraitInternalId = _activePortraitInternalId.ToString();");
+        viewModelSource.Should().Contain("Disguise.GetDisguises(playerId, IsRetiredSelected)");
+        viewModelSource.Should().Contain("ConfigureEmptyState(_disguiseIds.Count > 0);");
+        viewModelSource.Should().Contain("EmptyStateTitle = \"No Disguise Selected\";");
+        viewModelSource.Should().Contain("EmptyStateTitle = \"No Retired Disguises\";");
+        viewModelSource.Should().Contain("EmptyStateTitle = \"No Available Disguises\";");
+        viewModelSource.Should().Contain("SelectDisguiseAtIndex(0);");
+        viewModelSource.Should().Contain("ChangePartialView(DetailPartialElement, HasSelection ? DetailSelectedPartial : DetailEmptyPartial)");
+        viewModelSource.Should().Contain("ChangePartialView(PortraitPartialElement, HasSelection ? PortraitSelectedPartial : PortraitEmptyPartial)");
+        viewModelSource.Should().Contain("ChangePartialView(ActionPartialElement, GetActionPartialName())");
+        viewModelSource.Should().Contain("private Action WithLayoutRestore(Action action)");
+        viewModelSource.Should().Contain("private void RestoreLayoutPartials()");
+        viewModelSource.Should().Contain("ChangePartialView(\"_window_\", \"%%WINDOW_MAIN%%\");");
+        viewModelSource.Should().Contain("DelayCommand(0.0f, ApplyLayoutPartials);");
+        viewModelSource.Should().Contain("private string GetActionPartialName()");
+        viewModelSource.Should().Contain("return ActionEditPartial;");
+        viewModelSource.Should().Contain("return ActionRetiredPartial;");
+        viewModelSource.Should().Contain("return IsAvailableSelected ? ActionAvailablePartial : ActionEmptyPartial;");
+
+        cacheSource.Should().Contain("private static Dictionary<int, string> SoundSetPreviewSoundResrefs");
+        cacheSource.Should().Contain("private static string ResolveSoundSetPreviewSoundResref(string soundSetResref)");
+        cacheSource.Should().Contain("public static string GetSoundSetPreviewSoundResref(int soundSetId)");
+        cacheSource.Should().Contain("[\"wookie\"] = \"p_zaalbar_bat1\"");
+        cacheSource.Should().Contain("return trimmedResref.Length <= 11");
+
+        var disguiseInitializeMethod = ExtractMethod(viewModelSource, "protected override void Initialize(GuiPayloadBase initialPayload)");
+        var portraitDefaultIndex = disguiseInitializeMethod.IndexOf("PortraitInternalId = \"1\";", StringComparison.Ordinal);
+        var portraitWatchIndex = disguiseInitializeMethod.IndexOf("WatchOnClient(model => model.PortraitInternalId);", StringComparison.Ordinal);
+        portraitDefaultIndex.Should().BeGreaterThanOrEqualTo(0);
+        portraitWatchIndex.Should().BeGreaterThanOrEqualTo(0);
+        portraitDefaultIndex.Should().BeLessThan(portraitWatchIndex);
+        ExtractMethod(viewModelSource, "private void ClearSelection()")
+            .Should().Contain("PortraitInternalId = \"1\";");
+        var newMethod = ExtractMethod(viewModelSource, "public Action OnClickNew()");
+        newMethod.Should().Contain("ShowModal(\"Creating a new disguise will consume one of your disguise slots. Retired disguises also occupy disguise slots until they are wiped. Are you sure?\"");
+        newMethod.Should().Contain("WithLayoutRestore(() =>");
+        newMethod.Should().Contain("RestoreLayoutPartials");
+        var activateOrDeactivateMethod = ExtractMethod(viewModelSource, "public Action OnClickActivateOrDeactivate()");
+        activateOrDeactivateMethod.Should().Contain("ShowModal(\"Deactivating this disguise immediately restores your normal identity. Deactivation does not trigger the 30-minute delay between disguise activations. Are you sure?\"");
+        activateOrDeactivateMethod.Should().Contain("ShowModal(\"Activating this disguise starts a 30-minute delay before you can activate another disguise. Deactivation has no delay. Are you sure?\"");
+        activateOrDeactivateMethod.Should().Contain("WithLayoutRestore(() =>");
+        activateOrDeactivateMethod.Should().Contain("RestoreLayoutPartials");
+        activateOrDeactivateMethod.Should().Contain("var selectedDisguiseId = _selectedDisguiseId;");
+        activateOrDeactivateMethod.Should().Contain("var result = Disguise.Activate(Player, selectedDisguiseId);");
+        activateOrDeactivateMethod.Should().Contain("ReloadAvailableDisguise(selectedDisguiseId);");
+        activateOrDeactivateMethod.Should().NotContain("LoadList(_selectedDisguiseId);");
+        var retireMethod = ExtractMethod(viewModelSource, "public Action OnClickRetire()");
+        retireMethod.Should().Contain("WithLayoutRestore(() =>");
+        retireMethod.Should().Contain("RestoreLayoutPartials");
+        var unretireMethod = ExtractMethod(viewModelSource, "public Action OnClickUnretire()");
+        unretireMethod.Should().Contain("ShowModal(\"Restoring this disguise will move it back to your available disguises. Are you sure?\"");
+        unretireMethod.Should().Contain("WithLayoutRestore(() =>");
+        unretireMethod.Should().Contain("RestoreLayoutPartials");
+
+        dialogSource.Should().Contain("Disguise.WipeCreditCost");
+        dialogSource.Should().Contain("Disguise.WipeRoleplayXPCost");
+        dialogSource.Should().Contain("DisguisePaymentMethod.Credits");
+        dialogSource.Should().Contain("DisguisePaymentMethod.RoleplayXP");
+        dialogSource.Should().Contain("Disguise.DeleteRetiredDisguise");
+        dialogSource.Should().Contain("starport registries, transit manifests, broker ledgers, and public ID mirrors");
+        dialogSource.Should().Contain("Authorize the Scrub");
+        dialogSource.Should().Contain("The identity is gone. Anyone chasing that name will find static.");
+
+        characterSheetDefinitionSource.Should().Contain("AddActionButton(actions, \"Disguises\", model => model.OnClickDisguises());");
+        characterSheetViewModelSource.Should().Contain("public Action OnClickDisguises()");
+        characterSheetViewModelSource.Should().Contain("Gui.TogglePlayerWindow(Player, GuiWindowType.Disguises)");
+        characterSheetViewModelSource.Should().Contain("IGuiRefreshable<DisguiseChangedRefreshEvent>");
+        var disguiseChangedRefreshMethod = ExtractMethod(characterSheetViewModelSource, "public void Refresh(DisguiseChangedRefreshEvent payload)");
+        disguiseChangedRefreshMethod.Should().Contain("RefreshPortrait();");
+        disguiseChangedRefreshMethod.Should().Contain("RefreshStats();");
+
+        var disguiseDefinitionSource = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "SWLOR.Game.Server",
+            "Feature",
+            "GuiDefinition",
+            "DisguiseDefinition.cs"));
+        disguiseDefinitionSource.Should().Contain("private const float ListRailWidth");
+        disguiseDefinitionSource.Should().Contain("private const float PortraitRailWidth");
+        disguiseDefinitionSource.Should().Contain("private const float DetailRailWidth");
+        disguiseDefinitionSource.Should().Contain("private const float DisguiseListHeight");
+        disguiseDefinitionSource.Should().Contain(".SetWidth(ListRailWidth)");
+        disguiseDefinitionSource.Should().Contain(".SetWidth(PortraitRailWidth)");
+        disguiseDefinitionSource.Should().Contain(".SetWidth(DetailRailWidth)");
+        disguiseDefinitionSource.Should().Contain(".SetWidth(FormFieldWidth)");
+        disguiseDefinitionSource.Should().Contain(".SetWidth(PortraitWidth)");
+        disguiseDefinitionSource.Should().Contain(".SetWidth(ActionButtonWidth)");
+        disguiseDefinitionSource.Should().Contain("Private Disguise Name");
+        disguiseDefinitionSource.Should().Contain("AddTextField(col, \"Private Disguise Name\", model => model.PrivateName, Disguise.MaxPrivateNameLength);");
+        disguiseDefinitionSource.Should().Contain("AddTextField(col, \"Public Descriptor\", model => model.Descriptor, PlayerName.MaxKnownNameLength);");
+        disguiseDefinitionSource.Should().NotContain("AddTextField(col, \"Private Disguise Name\", model => model.PrivateName, 32)");
+        disguiseDefinitionSource.Should().NotContain("AddTextField(col, \"Public Descriptor\", model => model.Descriptor, 64)");
+        disguiseDefinitionSource.Should().Contain(".SetText(\"Unretire\")");
+        disguiseDefinitionSource.Should().Contain("private static void AddActionBand");
+        disguiseDefinitionSource.Should().Contain("private static void AddAvailableActionBand");
+        disguiseDefinitionSource.Should().Contain("private static void AddRetiredActionBand");
+        disguiseDefinitionSource.Should().Contain("private static void AddEditActionBand");
+        disguiseDefinitionSource.Should().Contain("private static void AddEmptyActionBand");
+        disguiseDefinitionSource.Should().Contain("private static void AddAvailableDetailActions");
+        disguiseDefinitionSource.Should().Contain("private static void AddRetiredDetailActions");
+        disguiseDefinitionSource.Should().Contain("private static void AddEditDetailActions");
+        disguiseDefinitionSource.Should().NotContain("private static void AddDetailActions");
+        disguiseDefinitionSource.Should().NotContain("BindIsVisible(model => model.ShowDetailActionRow)");
+        disguiseDefinitionSource.Should().NotContain("BindIsVisible(model => model.ShowActivateButton)");
+        disguiseDefinitionSource.Should().NotContain("BindIsVisible(model => model.ShowUnretireButton)");
+        disguiseDefinitionSource.Should().Contain(".SetWidth(SoundSetFieldWidth)");
+        disguiseDefinitionSource.Should().Contain(".SetWidth(SoundSetPageButtonWidth)");
+        disguiseDefinitionSource.Should().Contain(".SetWidth(SoundSetPageComboWidth)");
+        disguiseDefinitionSource.Should().Contain("BindOptions(model => model.SoundSetPageNumbers)");
+        disguiseDefinitionSource.Should().Contain("BindSelectedIndex(model => model.SelectedSoundSetPageIndex)");
+        disguiseDefinitionSource.Should().NotContain("BindText(model => model.SoundSetPageText)");
+        disguiseDefinitionSource.Should().NotContain("BindIsEnabled(model => model.CanPreviousSoundSetPage)");
+        disguiseDefinitionSource.Should().NotContain("BindIsEnabled(model => model.CanNextSoundSetPage)");
+        disguiseDefinitionSource.Should().Contain("BindOnClicked(model => model.OnClickPreviousSoundSetPage())");
+        disguiseDefinitionSource.Should().Contain("BindOnClicked(model => model.OnClickNextSoundSetPage())");
+        disguiseDefinitionSource.Should().Contain(".DefinePartialView(DisguiseViewModel.DetailSelectedPartial, AddSelectedDetailArea)");
+        disguiseDefinitionSource.Should().Contain(".DefinePartialView(DisguiseViewModel.DetailEmptyPartial, AddEmptyDetailArea)");
+        disguiseDefinitionSource.Should().Contain(".DefinePartialView(DisguiseViewModel.PortraitSelectedPartial, AddSelectedPortraitRail)");
+        disguiseDefinitionSource.Should().Contain(".DefinePartialView(DisguiseViewModel.PortraitEmptyPartial, AddEmptyPortraitRail)");
+        disguiseDefinitionSource.Should().Contain(".DefinePartialView(DisguiseViewModel.ActionAvailablePartial, AddAvailableActionBand)");
+        disguiseDefinitionSource.Should().Contain(".DefinePartialView(DisguiseViewModel.ActionRetiredPartial, AddRetiredActionBand)");
+        disguiseDefinitionSource.Should().Contain(".DefinePartialView(DisguiseViewModel.ActionEditPartial, AddEditActionBand)");
+        disguiseDefinitionSource.Should().Contain(".DefinePartialView(DisguiseViewModel.ActionEmptyPartial, AddEmptyActionBand)");
+        disguiseDefinitionSource.Should().Contain("private static void AddEmptyState");
+        disguiseDefinitionSource.Should().Contain("BindText(model => model.EmptyStateTitle)");
+        disguiseDefinitionSource.Should().Contain("BindText(model => model.EmptyStateText)");
+        disguiseDefinitionSource.Should().Contain("private static void AddEmptyPortraitRail");
+        disguiseDefinitionSource.Should().NotContain(".BindIsVisible(model => model.ShowEmptyState)");
+        disguiseDefinitionSource.Should().Contain("Hide Account Name");
+        disguiseDefinitionSource.Should().NotContain("Account ID");
+        disguiseDefinitionSource.Should().NotContain(".SetText(\"Portrait\")");
+        disguiseDefinitionSource.Should().NotContain("MaxPortraitsText");
+        disguiseDefinitionSource.Should().NotContain(".SetText(\"Previous\")");
+        disguiseDefinitionSource.Should().NotContain(".SetText(\"Next\")");
+        disguiseDefinitionSource.Should().NotContain(".SetRowHeight(");
+
+        var mainContentMethod = ExtractMethod(disguiseDefinitionSource, "private static void AddMainContent");
+        var listRailIndex = mainContentMethod.IndexOf("row.AddColumn(AddListRail)", StringComparison.Ordinal);
+        var detailAreaIndex = mainContentMethod.IndexOf("row.AddPartialView(DisguiseViewModel.DetailPartialElement)", StringComparison.Ordinal);
+        var portraitRailIndex = mainContentMethod.IndexOf("row.AddPartialView(DisguiseViewModel.PortraitPartialElement)", StringComparison.Ordinal);
+        listRailIndex.Should().BeGreaterThanOrEqualTo(0);
+        detailAreaIndex.Should().BeGreaterThan(listRailIndex);
+        portraitRailIndex.Should().BeGreaterThan(detailAreaIndex);
+
+        var buildWindowMethod = ExtractMethod(disguiseDefinitionSource, "public GuiConstructedWindow BuildWindow()");
+        var mainContentCallIndex = buildWindowMethod.IndexOf("AddMainContent(root);", StringComparison.Ordinal);
+        var actionBandCallIndex = buildWindowMethod.IndexOf("AddActionBand(root);", StringComparison.Ordinal);
+        mainContentCallIndex.Should().BeGreaterThanOrEqualTo(0);
+        actionBandCallIndex.Should().BeGreaterThan(mainContentCallIndex);
+
+        var detailAreaMethod = ExtractMethod(disguiseDefinitionSource, "private static void AddSelectedDetailArea");
+        detailAreaMethod.Should().NotContain("AddPortraitField");
+        detailAreaMethod.Should().NotContain("AddDetailActions");
+
+        var actionBandMethod = ExtractMethod(disguiseDefinitionSource, "private static void AddActionBand");
+        actionBandMethod.Should().Contain(".SetWidth(ListRailWidth)");
+        actionBandMethod.Should().Contain("row.AddPartialView(DisguiseViewModel.ActionPartialElement)");
+        actionBandMethod.Should().Contain(".SetWidth(DetailRailWidth)");
+        actionBandMethod.Should().Contain(".SetWidth(PortraitRailWidth)");
+
+        var availableActionBandMethod = ExtractMethod(disguiseDefinitionSource, "private static void AddAvailableActionBand");
+        availableActionBandMethod.Should().Contain("group.AddColumn(AddAvailableDetailActions);");
+
+        var retiredActionBandMethod = ExtractMethod(disguiseDefinitionSource, "private static void AddRetiredActionBand");
+        retiredActionBandMethod.Should().Contain("group.AddColumn(AddRetiredDetailActions);");
+
+        var editActionBandMethod = ExtractMethod(disguiseDefinitionSource, "private static void AddEditActionBand");
+        editActionBandMethod.Should().Contain("group.AddColumn(AddEditDetailActions);");
+
+        var emptyActionBandMethod = ExtractMethod(disguiseDefinitionSource, "private static void AddEmptyActionBand");
+        emptyActionBandMethod.Should().Contain(".SetHeight(ButtonHeight)");
+
+        var availableActionsMethod = ExtractMethod(disguiseDefinitionSource, "private static void AddAvailableDetailActions");
+        availableActionsMethod.Should().Contain("ActivateButtonText");
+        availableActionsMethod.Should().Contain(".SetText(\"Edit\")");
+        availableActionsMethod.Should().Contain(".SetText(\"Retire\")");
+        availableActionsMethod.Should().NotContain("BindIsVisible");
+        availableActionsMethod.Should().NotContain("BindIsVisible(model => model.ShowEditButton)");
+        availableActionsMethod.Should().NotContain("BindIsVisible(model => model.ShowRetireButton)");
+        availableActionsMethod.Should().NotContain(".SetText(\"Unretire\")");
+        availableActionsMethod.Should().NotContain(".SetText(\"Save\")");
+        availableActionsMethod.Should().NotContain(".SetText(\"Cancel\")");
+
+        var retiredActionsMethod = ExtractMethod(disguiseDefinitionSource, "private static void AddRetiredDetailActions");
+        retiredActionsMethod.Should().Contain(".SetText(\"Unretire\")");
+        retiredActionsMethod.Should().NotContain("BindIsVisible");
+        retiredActionsMethod.Should().NotContain("ActivateButtonText");
+        retiredActionsMethod.Should().NotContain(".SetText(\"Edit\")");
+        retiredActionsMethod.Should().NotContain(".SetText(\"Retire\")");
+        retiredActionsMethod.Should().NotContain(".SetText(\"Save\")");
+        retiredActionsMethod.Should().NotContain(".SetText(\"Cancel\")");
+
+        var editActionsMethod = ExtractMethod(disguiseDefinitionSource, "private static void AddEditDetailActions");
+        editActionsMethod.Should().Contain(".SetText(\"Save\")");
+        editActionsMethod.Should().Contain(".SetText(\"Cancel\")");
+        editActionsMethod.Should().NotContain("BindIsVisible");
+        editActionsMethod.Should().NotContain("ActivateButtonText");
+        editActionsMethod.Should().NotContain(".SetText(\"Edit\")");
+        editActionsMethod.Should().NotContain(".SetText(\"Retire\")");
+        editActionsMethod.Should().NotContain(".SetText(\"Unretire\")");
+
+        var portraitRailMethod = ExtractMethod(disguiseDefinitionSource, "private static void AddSelectedPortraitRail");
+        var portraitImageIndex = portraitRailMethod.IndexOf(".BindResref(model => model.PortraitResref)", StringComparison.Ordinal);
+        var portraitFieldIndex = portraitRailMethod.IndexOf("AddPortraitField(col);", StringComparison.Ordinal);
+        portraitImageIndex.Should().BeGreaterThanOrEqualTo(0);
+        portraitFieldIndex.Should().BeGreaterThan(portraitImageIndex);
+
+        var portraitFieldMethod = ExtractMethod(disguiseDefinitionSource, "private static void AddPortraitField");
+        var previousArrowIndex = portraitFieldMethod.IndexOf(".SetText(\"<\")", StringComparison.Ordinal);
+        var portraitIdIndex = portraitFieldMethod.IndexOf(".BindValue(model => model.PortraitInternalId)", StringComparison.Ordinal);
+        var nextArrowIndex = portraitFieldMethod.IndexOf(".SetText(\">\")", StringComparison.Ordinal);
+        previousArrowIndex.Should().BeGreaterThanOrEqualTo(0);
+        portraitIdIndex.Should().BeGreaterThan(previousArrowIndex);
+        nextArrowIndex.Should().BeGreaterThan(portraitIdIndex);
+        portraitFieldMethod.Should().Contain(".BindIsVisible(model => model.IsEditMode)");
+        portraitFieldMethod.Should().Contain(".SetMargin(0f)");
     }
 
     private static string ExtractMethod(string source, string signature)

--- a/SWLOR.Game.Server.Tests/Perks/FirstAidCombatUpgradeTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/FirstAidCombatUpgradeTests.cs
@@ -155,10 +155,15 @@ public class FirstAidCombatUpgradeTests
         var medKit = File.ReadAllText((root / "SWLOR.Game.Server" / "Feature" / "AbilityDefinition" / "FirstAid" / "MedKitAbilityDefinition.cs").FullName);
         medKit.Should().Contain("CombatPoint.AddCombatPointToAllTagged(activator, SkillType.FirstAid);");
 
-        var treatmentKit = File.ReadAllText((root / "SWLOR.Game.Server" / "Feature" / "AbilityDefinition" / "FirstAid" / "TreatmentKitAbilityDefinition.cs").FullName);
+        var treatmentKit = File.ReadAllText((root / "SWLOR.Game.Server" / "Feature" / "AbilityDefinition" / "FirstAid" / "TreatmentKitAbilityDefinition.cs").FullName)
+            .Replace("\r\n", "\n");
         treatmentKit.Should().Contain("StatusEffectCleanseType.TreatmentKit2");
         treatmentKit.Should().Contain("RemoveCleanseableStatusEffects(friendly, StatusEffectCleanseType.TreatmentKit2, false)");
-        treatmentKit.Should().Contain("CombatPoint.AddCombatPointToAllTagged(activator, SkillType.FirstAid);");
+        treatmentKit.Split("GrantFirstAidCombatPointIfApplied(activator, affectedCount);").Length.Should().Be(4);
+        treatmentKit.Should().Contain(
+            "if (affectedCount > 0)\n" +
+            "                CombatPoint.AddCombatPointToAllTagged(activator, SkillType.FirstAid);");
+        treatmentKit.Split("CombatPoint.AddCombatPointToAllTagged(activator, SkillType.FirstAid);").Length.Should().Be(2);
 
         var pain = File.ReadAllText((root / "SWLOR.Game.Server" / "Feature" / "AbilityDefinition" / "FirstAid" / "PainSuppressantAbilityDefinition.cs").FullName);
         pain.Should().Contain("AbilityEffectScaling.ApplyTemporaryHPPercent(activator, target, percent, durationSeconds)");

--- a/SWLOR.Game.Server.Tests/Perks/FirstAidCombatUpgradeTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/FirstAidCombatUpgradeTests.cs
@@ -158,6 +158,7 @@ public class FirstAidCombatUpgradeTests
         var treatmentKit = File.ReadAllText((root / "SWLOR.Game.Server" / "Feature" / "AbilityDefinition" / "FirstAid" / "TreatmentKitAbilityDefinition.cs").FullName);
         treatmentKit.Should().Contain("StatusEffectCleanseType.TreatmentKit2");
         treatmentKit.Should().Contain("RemoveCleanseableStatusEffects(friendly, StatusEffectCleanseType.TreatmentKit2, false)");
+        treatmentKit.Should().Contain("CombatPoint.AddCombatPointToAllTagged(activator, SkillType.FirstAid);");
 
         var pain = File.ReadAllText((root / "SWLOR.Game.Server" / "Feature" / "AbilityDefinition" / "FirstAid" / "PainSuppressantAbilityDefinition.cs").FullName);
         pain.Should().Contain("AbilityEffectScaling.ApplyTemporaryHPPercent(activator, target, percent, durationSeconds)");

--- a/SWLOR.Game.Server.Tests/Service/CacheTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/CacheTests.cs
@@ -1,0 +1,33 @@
+using System.Reflection;
+using FluentAssertions;
+using NUnit.Framework;
+using SWLOR.Game.Server.Service;
+
+namespace SWLOR.Game.Server.Tests.Service;
+
+public class CacheTests
+{
+    [Test]
+    public void ResolveSoundSetPreviewSoundResref_PaddedPlaceholderReturnsEmpty()
+    {
+        InvokeResolveSoundSetPreviewSoundResref(" **** ")
+            .Should()
+            .BeEmpty();
+    }
+
+    [Test]
+    public void ResolveSoundSetPreviewSoundResref_ValidResrefKeepsExistingSuffixBehavior()
+    {
+        InvokeResolveSoundSetPreviewSoundResref(" c_spider ")
+            .Should()
+            .Be("c_spider_bat1");
+    }
+
+    private static string InvokeResolveSoundSetPreviewSoundResref(string soundSetResref)
+    {
+        var method = typeof(Cache)
+            .GetMethod("ResolveSoundSetPreviewSoundResref", BindingFlags.Static | BindingFlags.NonPublic)!;
+
+        return (string)method.Invoke(null, new object[] { soundSetResref })!;
+    }
+}

--- a/SWLOR.Game.Server.Tests/Service/DialogPrivacyTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/DialogPrivacyTests.cs
@@ -1,0 +1,67 @@
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace SWLOR.Game.Server.Tests.Service;
+
+public class DialogPrivacyTests
+{
+    [Test]
+    public void SpawnedNpcDialogs_DefaultToPrivateConversations()
+    {
+        var source = ReadSource("SWLOR.Game.Server", "Service", "Spawn.cs").Replace("\r\n", "\n");
+        var adjustScripts = ExtractMethod(source, "private static void AdjustScripts(uint spawn)");
+
+        adjustScripts.Should().Contain("if (GetIsPC(spawn) || GetIsDM(spawn) || GetIsDMPossessed(spawn))");
+        adjustScripts.Should().Contain("ObjectPlugin.SetConversationPrivate(spawn, true);");
+        adjustScripts.IndexOf("ObjectPlugin.SetConversationPrivate(spawn, true);", StringComparison.Ordinal)
+            .Should()
+            .BeLessThan(adjustScripts.IndexOf("SetEventScript(spawn, EventScript.Creature_OnSpawnIn, \"x2_def_spawn\");", StringComparison.Ordinal));
+    }
+
+    private static string ReadSource(params string[] pathParts)
+    {
+        var fullPath = Path.Combine(new[] { FindRepositoryRoot().FullName }.Concat(pathParts).ToArray());
+        return File.ReadAllText(fullPath);
+    }
+
+    private static string ExtractMethod(string source, string signature)
+    {
+        var start = source.IndexOf(signature, StringComparison.Ordinal);
+        start.Should().BeGreaterThanOrEqualTo(0, $"signature '{signature}' should exist");
+
+        var openBrace = source.IndexOf('{', start);
+        openBrace.Should().BeGreaterThanOrEqualTo(0, $"signature '{signature}' should have an opening brace");
+
+        var depth = 0;
+        for (var i = openBrace; i < source.Length; i++)
+        {
+            if (source[i] == '{')
+            {
+                depth++;
+            }
+            else if (source[i] == '}')
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    return source.Substring(start, i - start + 1);
+                }
+            }
+        }
+
+        throw new InvalidOperationException($"Method '{signature}' was not closed.");
+    }
+
+    private static DirectoryInfo FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(TestContext.CurrentContext.TestDirectory);
+
+        while (directory != null && !Directory.Exists(Path.Combine(directory.FullName, ".git")))
+        {
+            directory = directory.Parent;
+        }
+
+        directory.Should().NotBeNull("the tests should run inside the repository checkout");
+        return directory!;
+    }
+}

--- a/SWLOR.Game.Server/Entity/Player.cs
+++ b/SWLOR.Game.Server/Entity/Player.cs
@@ -21,6 +21,7 @@ namespace SWLOR.Game.Server.Entity
     public class Player: EntityBase
     {
         public const int DefaultOutfitSlotLimit = 25;
+        public const int DefaultDisguiseSlotLimit = 1;
         public const int DefaultMarketListingLimit = 25;
 
         public Player()
@@ -89,7 +90,11 @@ namespace SWLOR.Game.Server.Entity
             CPBonus = new Dictionary<SkillType, int>();
             Currencies = new Dictionary<CurrencyType, int>();
             OutfitSlotLimit = DefaultOutfitSlotLimit;
+            DisguiseSlotLimit = DefaultDisguiseSlotLimit;
             MarketListingLimit = DefaultMarketListingLimit;
+            ActiveDisguiseId = string.Empty;
+            PreDisguisePortraitId = -1;
+            PreDisguiseSoundSetId = -1;
         }
 
 
@@ -144,6 +149,7 @@ namespace SWLOR.Game.Server.Entity
         public int CombatReadiness { get; set; }
         public int MarketTill { get; set; }
         public int OutfitSlotLimit { get; set; }
+        public int DisguiseSlotLimit { get; set; }
         public int MarketListingLimit { get; set; }
         [Indexed]
         public string CitizenPropertyId { get; set; }
@@ -153,6 +159,9 @@ namespace SWLOR.Game.Server.Entity
         public int Evasion { get; set; }
         public bool RebuildComplete { get; set; }
         public string ActiveBeastId { get; set; }
+        public string ActiveDisguiseId { get; set; }
+        public int PreDisguisePortraitId { get; set; }
+        public int PreDisguiseSoundSetId { get; set; }
 
         public PlayerSettings Settings { get; set; }
         public Dictionary<SkillType, int> Control { get; set; }

--- a/SWLOR.Game.Server/Entity/PlayerDisguise.cs
+++ b/SWLOR.Game.Server/Entity/PlayerDisguise.cs
@@ -1,0 +1,30 @@
+namespace SWLOR.Game.Server.Entity
+{
+    public class PlayerDisguise: EntityBase
+    {
+        public PlayerDisguise()
+        {
+            PlayerId = string.Empty;
+            PrivateName = string.Empty;
+            Descriptor = string.Empty;
+            PortraitInternalId = 1;
+            SoundSetId = -1;
+            IsRetired = false;
+            DateRetired = null;
+            DateLastActivated = null;
+            ScrambleAccountId = true;
+        }
+
+        [Indexed]
+        public string PlayerId { get; set; }
+        [Indexed]
+        public bool IsRetired { get; set; }
+        public string PrivateName { get; set; }
+        public string Descriptor { get; set; }
+        public int PortraitInternalId { get; set; }
+        public int SoundSetId { get; set; }
+        public bool ScrambleAccountId { get; set; }
+        public DateTime? DateRetired { get; set; }
+        public DateTime? DateLastActivated { get; set; }
+    }
+}

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/FirstAid/TreatmentKitAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/FirstAid/TreatmentKitAbilityDefinition.cs
@@ -95,6 +95,8 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.FirstAid
 
         private static void TreatmentKit1ImpactAction(uint activator, uint target, int level, Location targetLocation)
         {
+            var affectedCount = 0;
+
             foreach (var friendly in AbilityTargeting.GetFriendlyTargets(activator, target, false))
             {
                 foreach (var statusEffect in new[] { typeof(PoisonStatusEffect), typeof(BleedStatusEffect) })
@@ -102,28 +104,47 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.FirstAid
 
                 FirstAidTreatmentAdjustments.ApplyTraumaMedicRiders(activator, friendly);
                 ApplyEffectToObject(DurationType.Instant, EffectVisualEffect(VisualEffect.Vfx_Imp_Remove_Condition), friendly);
+                affectedCount++;
             }
+
+            GrantFirstAidCombatPointIfApplied(activator, affectedCount);
         }
 
         private static void TreatmentKit2ImpactAction(uint activator, uint target, int level, Location targetLocation)
         {
+            var affectedCount = 0;
+
             foreach (var friendly in AbilityTargeting.GetFriendlyTargets(activator, target, false))
             {
                 StatusEffect.RemoveCleanseableStatusEffects(friendly, StatusEffectCleanseType.TreatmentKit2, false);
                 FirstAidTreatmentAdjustments.ApplyTraumaMedicRiders(activator, friendly);
                 ApplyEffectToObject(DurationType.Instant, EffectVisualEffect(VisualEffect.Vfx_Imp_Remove_Condition), friendly);
+                affectedCount++;
             }
+
+            GrantFirstAidCombatPointIfApplied(activator, affectedCount);
         }
 
         private static void TreatmentKit3ImpactAction(uint activator, uint target, int level, Location targetLocation)
         {
+            var affectedCount = 0;
+
             foreach (var friendly in AbilityTargeting.GetFriendlyTargets(activator, target, false))
             {
                 StatusEffect.RemoveCleanseableStatusEffects(friendly, StatusEffectCleanseType.TreatmentKit2, false);
                 StatusEffect.ApplyStatusEffect(activator, friendly, typeof(AilmentResistance3StatusEffect), 8f);
                 FirstAidTreatmentAdjustments.ApplyTraumaMedicRiders(activator, friendly);
                 ApplyEffectToObject(DurationType.Instant, EffectVisualEffect(VisualEffect.Vfx_Imp_Remove_Condition), friendly);
+                affectedCount++;
             }
+
+            GrantFirstAidCombatPointIfApplied(activator, affectedCount);
+        }
+
+        private static void GrantFirstAidCombatPointIfApplied(uint activator, int affectedCount)
+        {
+            if (affectedCount > 0)
+                CombatPoint.AddCombatPointToAllTagged(activator, SkillType.FirstAid);
         }
 
 

--- a/SWLOR.Game.Server/Feature/ChatCommandDefinition/CharacterChatCommand.cs
+++ b/SWLOR.Game.Server/Feature/ChatCommandDefinition/CharacterChatCommand.cs
@@ -34,6 +34,7 @@ namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
             LanguageCommand();
             ToggleEmoteStyle();
             Customize();
+            Disguises();
             AlwaysWalk();
             AssociateCommands();
             Follow();
@@ -177,6 +178,17 @@ namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
                     Gui.TogglePlayerWindow(user, GuiWindowType.Perks);
                 });
 
+        }
+
+        private void Disguises()
+        {
+            _builder.Create("disguise", "disguises")
+                .Description("Toggles the disguises menu.")
+                .Permissions(AuthorizationLevel.Player)
+                .Action((user, target, location, args) =>
+                {
+                    Gui.TogglePlayerWindow(user, GuiWindowType.Disguises);
+                });
         }
 
         private void LanguageCommand()

--- a/SWLOR.Game.Server/Feature/ChatCommandDefinition/DMChatCommand.cs
+++ b/SWLOR.Game.Server/Feature/ChatCommandDefinition/DMChatCommand.cs
@@ -663,7 +663,7 @@ namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
         private void ResetAbilityRecastTimers()
         {
             _builder.Create("resetcooldown", "resetcooldowns")
-                .Description("Resets a player's ability cooldowns.")
+                .Description("Resets a player's ability and disguise cooldowns.")
                 .Permissions(AuthorizationLevel.DM, AuthorizationLevel.Admin)
                 .AvailableToAllOnTestEnvironment()
                 .RequiresTarget()
@@ -682,6 +682,7 @@ namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
                     dbPlayer.RecastTimes.Clear();
                     DB.Set(dbPlayer);
                     AbilityCooldownVisual.ClearAllRecastDelays(target);
+                    Disguise.ResetActivationCooldowns(target);
 
                     SendMessageToPC(user, $"You have reset all of {targetName}'s cooldowns.");
                     SendMessageToPC(target, "A DM has reset all of your cooldowns.");

--- a/SWLOR.Game.Server/Feature/DialogDefinition/IdentityBrokerDialog.cs
+++ b/SWLOR.Game.Server/Feature/DialogDefinition/IdentityBrokerDialog.cs
@@ -1,0 +1,148 @@
+using System.Linq;
+using SWLOR.Game.Server.Entity;
+using SWLOR.Game.Server.Service;
+using SWLOR.Game.Server.Service.DialogService;
+using SWLOR.Game.Server.Service.DisguiseService;
+
+namespace SWLOR.Game.Server.Feature.DialogDefinition
+{
+    public class IdentityBrokerDialog: DialogBase
+    {
+        private class Model
+        {
+            public string DisguiseId { get; set; }
+            public DisguisePaymentMethod PaymentMethod { get; set; }
+        }
+
+        private const string MainPageId = "MAIN_PAGE";
+        private const string PaymentPageId = "PAYMENT_PAGE";
+        private const string ConfirmationPageId = "CONFIRMATION_PAGE";
+
+        public override PlayerDialog SetUp(uint player)
+        {
+            var builder = new DialogBuilder()
+                .WithDataModel(new Model())
+                .AddPage(MainPageId, MainPageInit)
+                .AddPage(PaymentPageId, PaymentPageInit)
+                .AddPage(ConfirmationPageId, ConfirmationPageInit);
+
+            return builder.Build();
+        }
+
+        private void MainPageInit(DialogPage page)
+        {
+            var player = GetPC();
+            var playerId = GetObjectUUID(player);
+            var retiredDisguises = Disguise.GetDisguises(playerId, true);
+
+            if (retiredDisguises.Count <= 0)
+            {
+                page.Header = "I've got nothing to scrub for you. No retired disguise identities on the slate, no trail to burn, no fee to collect.";
+                return;
+            }
+
+            page.Header = "I deal in dead names and inconvenient paper trails. Pick a retired disguise identity and I'll burn it out of the starport registries, transit manifests, broker ledgers, and public ID mirrors.\n\n" +
+                          "When the scrub is done, that identity is gone for good and the disguise slot is clean again. Work like this is not cheap.";
+
+            foreach (var disguise in retiredDisguises)
+            {
+                page.AddResponse(disguise.PrivateName, () =>
+                {
+                    var model = GetDataModel<Model>();
+                    model.DisguiseId = disguise.Id;
+                    ChangePage(PaymentPageId);
+                });
+            }
+        }
+
+        private void PaymentPageInit(DialogPage page)
+        {
+            var player = GetPC();
+            var model = GetDataModel<Model>();
+            var disguise = DB.Get<PlayerDisguise>(model.DisguiseId);
+
+            if (!CanUseDisguise(player, disguise))
+            {
+                page.Header = "That file is no longer on my slate. Either it was already scrubbed, or someone pulled it out of retirement.";
+                return;
+            }
+
+            page.Header = BuildDisguiseSummary(disguise) +
+                          "\n\nA real wipe touches more than one ledger: customs pings, docking records, old warrants, and the mirrors people swear they do not keep.\n\n" +
+                          "Choose how you are paying for the silence.";
+
+            page.AddResponse($"Pay {Disguise.WipeCreditCost:N0} credits", () =>
+            {
+                model.PaymentMethod = DisguisePaymentMethod.Credits;
+                ChangePage(ConfirmationPageId);
+            });
+
+            page.AddResponse($"Spend {Disguise.WipeRoleplayXPCost:N0} RP XP", () =>
+            {
+                model.PaymentMethod = DisguisePaymentMethod.RoleplayXP;
+                ChangePage(ConfirmationPageId);
+            });
+        }
+
+        private void ConfirmationPageInit(DialogPage page)
+        {
+            var player = GetPC();
+            var model = GetDataModel<Model>();
+            var disguise = DB.Get<PlayerDisguise>(model.DisguiseId);
+
+            if (!CanUseDisguise(player, disguise))
+            {
+                page.Header = "That file is no longer on my slate. Either it was already scrubbed, or someone pulled it out of retirement.";
+                return;
+            }
+
+            var paymentText = model.PaymentMethod == DisguisePaymentMethod.Credits
+                ? $"{Disguise.WipeCreditCost:N0} credits"
+                : $"{Disguise.WipeRoleplayXPCost:N0} RP XP";
+
+            page.Header = $"{ColorToken.Red("Last chance.")} Once I send this job, the identity comes apart: the retired disguise record, the paper trail, and the names people attached to it. No refund, no restore, no quiet undo.\n\n" +
+                          BuildDisguiseSummary(disguise) +
+                          $"\n\nCost: {paymentText}";
+
+            page.AddResponse("Authorize the Scrub", () =>
+            {
+                var result = Disguise.DeleteRetiredDisguise(player, disguise.Id, model.PaymentMethod);
+                var message = GetResultMessage(result);
+
+                if (result == DeleteRetiredDisguiseResult.Success)
+                {
+                    SendMessageToPC(player, ColorToken.Green(message));
+                    EndConversation();
+                    return;
+                }
+
+                FloatingTextStringOnCreature(message, player, false);
+            });
+        }
+
+        private static string BuildDisguiseSummary(PlayerDisguise disguise)
+        {
+            return $"{ColorToken.Green("Private Slot Name:")} {disguise.PrivateName}\n" +
+                   $"{ColorToken.Green("Public Descriptor:")} {disguise.Descriptor}";
+        }
+
+        private static bool CanUseDisguise(uint player, PlayerDisguise disguise)
+        {
+            return disguise != null &&
+                   disguise.PlayerId == GetObjectUUID(player) &&
+                   disguise.IsRetired;
+        }
+
+        private static string GetResultMessage(DeleteRetiredDisguiseResult result)
+        {
+            return result switch
+            {
+                DeleteRetiredDisguiseResult.Success => "The identity is gone. Anyone chasing that name will find static.",
+                DeleteRetiredDisguiseResult.InsufficientCredits => "Your credit chip comes up light.",
+                DeleteRetiredDisguiseResult.InsufficientRoleplayXP => "You do not have enough RP XP.",
+                DeleteRetiredDisguiseResult.InvalidPaymentMethod => "Invalid payment method.",
+                _ => "The scrub failed. That identity is still on the books."
+            };
+        }
+    }
+}

--- a/SWLOR.Game.Server/Feature/GuiDefinition/CharacterSheetDefinition.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/CharacterSheetDefinition.cs
@@ -426,6 +426,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                         AddActionButton(actions, "Achievements", model => model.OnClickAchievements());
                         AddActionButton(actions, "Notes", model => model.OnClickNotes());
                         AddActionButton(actions, "Appearance", model => model.OnClickAppearance());
+                        AddActionButton(actions, "Disguises", model => model.OnClickDisguises());
                         AddActionButton(actions, "Settings", model => model.OnClickSettings());
                         AddActionButton(actions, "HoloCom", model => model.OnClickHoloCom(), model => model.IsHolocomEnabled);
                         AddActionButton(actions, "Key Items", model => model.OnClickKeyItems());

--- a/SWLOR.Game.Server/Feature/GuiDefinition/DisguiseDefinition.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/DisguiseDefinition.cs
@@ -1,0 +1,496 @@
+using SWLOR.Game.Server.Core.Beamdog;
+using SWLOR.Game.Server.Feature.GuiDefinition.ViewModel;
+using SWLOR.Game.Server.Service;
+using SWLOR.Game.Server.Service.GuiService;
+using SWLOR.Game.Server.Service.GuiService.Component;
+
+namespace SWLOR.Game.Server.Feature.GuiDefinition
+{
+    public class DisguiseDefinition: IGuiWindowDefinition
+    {
+        private readonly GuiWindowBuilder<DisguiseViewModel> _builder = new();
+        private const float WindowWidth = 760f;
+        private const float WindowHeight = 460f;
+        private const float ListRailWidth = 220f;
+        private const float PortraitRailWidth = 154f;
+        private const float DetailRailWidth = WindowWidth - ListRailWidth - PortraitRailWidth;
+        private const float TabWidth = 170f;
+        private const float TabHeight = 32f;
+        private const float LabelHeight = 20f;
+        private const float FieldHeight = 32f;
+        private const float DisguiseListHeight = 214f;
+        private const float ButtonHeight = 34f;
+        private const float PortraitWidth = 120f;
+        private const float PortraitHeight = 170f;
+        private const float PortraitButtonWidth = 28f;
+        private const float FormFieldWidth = 320f;
+        private const float PortraitIdFieldWidth = 72f;
+        private const float SoundSetFieldWidth = 238f;
+        private const float SoundSetPageButtonWidth = 32f;
+        private const float SoundSetPageComboWidth = 170f;
+        private const float SoundPreviewButtonWidth = 80f;
+        private const float SoundSetPageBottomPaddingHeight = 8f;
+        private const float ActionButtonWidth = 100f;
+        private const float SingleActionLeftPadding = 100f;
+        private const float DoubleActionLeftPadding = 60f;
+        private const float TripleActionLeftPadding = 10f;
+        private const float EmptyStatePanelWidth = 340f;
+        private const float EmptyStatePanelHeight = 128f;
+        private const float EmptyStateTopSpacerHeight = 48f;
+        private const float EmptyStateTitleHeight = 36f;
+        private const float EmptyStateTextHeight = 48f;
+
+        public GuiConstructedWindow BuildWindow()
+        {
+            _builder.CreateWindow(GuiWindowType.Disguises)
+                .SetIsResizable(true)
+                .SetIsCollapsible(true)
+                .SetInitialGeometry(0, 0, WindowWidth, WindowHeight)
+                .SetTitle("Disguises")
+                .DefinePartialView(DisguiseViewModel.DetailSelectedPartial, AddSelectedDetailArea)
+                .DefinePartialView(DisguiseViewModel.DetailEmptyPartial, AddEmptyDetailArea)
+                .DefinePartialView(DisguiseViewModel.PortraitSelectedPartial, AddSelectedPortraitRail)
+                .DefinePartialView(DisguiseViewModel.PortraitEmptyPartial, AddEmptyPortraitRail)
+                .DefinePartialView(DisguiseViewModel.ActionAvailablePartial, AddAvailableActionBand)
+                .DefinePartialView(DisguiseViewModel.ActionRetiredPartial, AddRetiredActionBand)
+                .DefinePartialView(DisguiseViewModel.ActionEditPartial, AddEditActionBand)
+                .DefinePartialView(DisguiseViewModel.ActionEmptyPartial, AddEmptyActionBand)
+
+                .AddColumn(root =>
+                {
+                    AddTabs(root);
+                    AddSlotCount(root);
+                    AddMainContent(root);
+                    AddActionBand(root);
+                });
+
+            return _builder.Build();
+        }
+
+        private static void AddTabs(GuiColumn<DisguiseViewModel> root)
+        {
+            root.AddRow(row =>
+            {
+                row.AddToggleButton()
+                    .SetText("Available")
+                    .SetWidth(TabWidth)
+                    .SetHeight(TabHeight)
+                    .BindIsToggled(model => model.IsAvailableSelected)
+                    .BindOnClicked(model => model.OnClickAvailable());
+
+                row.AddToggleButton()
+                    .SetText("Retired")
+                    .SetWidth(TabWidth)
+                    .SetHeight(TabHeight)
+                    .BindIsToggled(model => model.IsRetiredSelected)
+                    .BindOnClicked(model => model.OnClickRetired());
+
+                row.AddSpacer();
+            });
+        }
+
+        private static void AddSlotCount(GuiColumn<DisguiseViewModel> root)
+        {
+            root.AddRow(row =>
+            {
+                row.AddLabel()
+                    .BindText(model => model.SlotCountText)
+                    .SetHeight(LabelHeight)
+                    .SetHorizontalAlign(NuiHorizontalAlign.Left);
+            });
+        }
+
+        private static void AddMainContent(GuiColumn<DisguiseViewModel> root)
+        {
+            root.AddRow(row =>
+            {
+                row.AddColumn(AddListRail)
+                    .SetWidth(ListRailWidth);
+
+                row.AddPartialView(DisguiseViewModel.DetailPartialElement);
+
+                row.AddPartialView(DisguiseViewModel.PortraitPartialElement)
+                    .SetWidth(PortraitRailWidth);
+            });
+        }
+
+        private static void AddListRail(GuiColumn<DisguiseViewModel> col)
+        {
+            col.AddRow(listRow =>
+            {
+                listRow.AddList(template =>
+                {
+                    template.AddCell(cell =>
+                    {
+                        cell.AddToggleButton()
+                            .BindText(model => model.DisguiseNames)
+                            .BindIsToggled(model => model.DisguiseToggles)
+                            .BindOnClicked(model => model.OnClickDisguise());
+                    });
+                })
+                    .BindRowCount(model => model.DisguiseNames)
+                    .SetScrollbars(NuiScrollbars.Y)
+                    .SetShowBorders(true)
+                    .SetHeight(DisguiseListHeight);
+            });
+
+            col.AddRow(buttonRow =>
+            {
+                buttonRow.AddButton()
+                    .SetText("New")
+                    .SetWidth(ListRailWidth)
+                    .SetHeight(ButtonHeight)
+                    .BindIsVisible(model => model.IsAvailableSelected)
+                    .BindOnClicked(model => model.OnClickNew());
+            });
+        }
+
+        private static void AddSelectedPortraitRail(GuiGroup<DisguiseViewModel> group)
+        {
+            group.AddColumn(col =>
+            {
+                col.AddRow(portraitRow =>
+                {
+                    portraitRow.AddSpacer();
+
+                    portraitRow.AddImage()
+                        .BindResref(model => model.PortraitResref)
+                        .SetWidth(PortraitWidth)
+                        .SetHeight(PortraitHeight)
+                        .SetAspect(NuiAspect.ExactScaled)
+                        .SetHorizontalAlign(NuiHorizontalAlign.Center)
+                        .SetVerticalAlign(NuiVerticalAlign.Top);
+
+                    portraitRow.AddSpacer();
+                });
+
+                AddPortraitField(col);
+            });
+        }
+
+        private static void AddEmptyPortraitRail(GuiGroup<DisguiseViewModel> group)
+        {
+            group.AddColumn(col =>
+            {
+                col.AddRow(row =>
+                {
+                    row.AddSpacer();
+                });
+            });
+        }
+
+        private static void AddSelectedDetailArea(GuiGroup<DisguiseViewModel> group)
+        {
+            group.AddColumn(col =>
+            {
+                AddTextField(col, "Private Disguise Name", model => model.PrivateName, Disguise.MaxPrivateNameLength);
+                AddTextField(col, "Public Descriptor", model => model.Descriptor, PlayerName.MaxKnownNameLength);
+                AddSoundSetField(col);
+                AddScrambleCheckbox(col);
+            });
+        }
+
+        private static void AddEmptyDetailArea(GuiGroup<DisguiseViewModel> group)
+        {
+            group.AddColumn(AddEmptyState);
+        }
+
+        private static void AddEmptyState(GuiColumn<DisguiseViewModel> col)
+        {
+            col.AddRow(row =>
+            {
+                row.AddSpacer()
+                    .SetHeight(EmptyStateTopSpacerHeight);
+            });
+
+            col.AddRow(row =>
+            {
+                row.AddSpacer();
+
+                row.AddGroup(group =>
+                {
+                    group.SetShowBorder(true);
+                    group.SetScrollbars(NuiScrollbars.None);
+                    group.AddColumn(empty =>
+                    {
+                        empty.AddRow(titleRow =>
+                        {
+                            titleRow.AddLabel()
+                                .BindText(model => model.EmptyStateTitle)
+                                .SetHeight(EmptyStateTitleHeight)
+                                .SetHorizontalAlign(NuiHorizontalAlign.Center);
+                        });
+
+                        empty.AddRow(textRow =>
+                        {
+                            textRow.AddLabel()
+                                .BindText(model => model.EmptyStateText)
+                                .SetHeight(EmptyStateTextHeight)
+                                .SetHorizontalAlign(NuiHorizontalAlign.Center);
+                        });
+                    });
+                })
+                    .SetWidth(EmptyStatePanelWidth)
+                    .SetHeight(EmptyStatePanelHeight);
+
+                row.AddSpacer();
+            });
+        }
+
+        private static void AddTextField(
+            GuiColumn<DisguiseViewModel> col,
+            string label,
+            System.Linq.Expressions.Expression<Func<DisguiseViewModel, string>> bindValue,
+            int maxLength)
+        {
+            col.AddRow(row =>
+            {
+                row.AddLabel()
+                    .SetText(label)
+                    .SetHeight(LabelHeight)
+                    .SetHorizontalAlign(NuiHorizontalAlign.Left);
+            });
+
+            col.AddRow(row =>
+            {
+                row.AddTextEdit()
+                    .BindValue(bindValue)
+                    .SetMaxLength(maxLength)
+                    .SetWidth(FormFieldWidth)
+                    .SetHeight(FieldHeight)
+                    .BindIsEnabled(model => model.IsEditMode);
+            });
+        }
+
+        private static void AddPortraitField(GuiColumn<DisguiseViewModel> col)
+        {
+            col.AddRow(row =>
+            {
+                row.AddSpacer()
+                    .BindIsVisible(model => model.IsEditMode);
+
+                row.AddButton()
+                    .SetText("<")
+                    .SetWidth(PortraitButtonWidth)
+                    .SetHeight(FieldHeight)
+                    .SetMargin(0f)
+                    .BindIsVisible(model => model.IsEditMode)
+                    .BindOnClicked(model => model.OnClickPreviousPortrait());
+
+                row.AddTextEdit()
+                    .BindValue(model => model.PortraitInternalId)
+                    .SetMaxLength(6)
+                    .SetWidth(PortraitIdFieldWidth)
+                    .SetHeight(FieldHeight)
+                    .SetMargin(0f)
+                    .BindIsVisible(model => model.IsEditMode)
+                    .BindIsEnabled(model => model.IsEditMode);
+
+                row.AddButton()
+                    .SetText(">")
+                    .SetWidth(PortraitButtonWidth)
+                    .SetHeight(FieldHeight)
+                    .SetMargin(0f)
+                    .BindIsVisible(model => model.IsEditMode)
+                    .BindOnClicked(model => model.OnClickNextPortrait());
+
+                row.AddSpacer()
+                    .BindIsVisible(model => model.IsEditMode);
+            });
+
+            col.AddRow(row =>
+            {
+                row.AddSpacer()
+                    .SetHeight(SoundSetPageBottomPaddingHeight)
+                    .BindIsVisible(model => model.IsEditMode);
+            });
+        }
+
+        private static void AddSoundSetField(GuiColumn<DisguiseViewModel> col)
+        {
+            col.AddRow(row =>
+            {
+                row.AddLabel()
+                    .SetText("Sound Set")
+                    .SetHeight(LabelHeight)
+                    .SetHorizontalAlign(NuiHorizontalAlign.Left);
+            });
+
+            col.AddRow(row =>
+            {
+                row.AddComboBox()
+                    .BindOptions(model => model.SoundSetOptions)
+                    .BindSelectedIndex(model => model.SelectedSoundSetIndex)
+                    .SetWidth(SoundSetFieldWidth)
+                    .SetHeight(FieldHeight)
+                    .BindIsEnabled(model => model.IsEditMode);
+
+                row.AddButton()
+                    .SetText("Play")
+                    .SetWidth(SoundPreviewButtonWidth)
+                    .SetHeight(ButtonHeight)
+                    .BindIsVisible(model => model.IsEditMode)
+                    .BindOnClicked(model => model.OnClickPreviewSoundSet());
+            });
+
+            col.AddRow(row =>
+            {
+                row.AddSpacer()
+                    .BindIsVisible(model => model.IsEditMode);
+
+                row.AddButton()
+                    .SetText("<")
+                    .SetWidth(SoundSetPageButtonWidth)
+                    .SetHeight(FieldHeight)
+                    .SetMargin(0f)
+                    .BindIsVisible(model => model.IsEditMode)
+                    .BindOnClicked(model => model.OnClickPreviousSoundSetPage());
+
+                row.AddComboBox()
+                    .BindOptions(model => model.SoundSetPageNumbers)
+                    .BindSelectedIndex(model => model.SelectedSoundSetPageIndex)
+                    .SetWidth(SoundSetPageComboWidth)
+                    .SetHeight(FieldHeight)
+                    .BindIsVisible(model => model.IsEditMode);
+
+                row.AddButton()
+                    .SetText(">")
+                    .SetWidth(SoundSetPageButtonWidth)
+                    .SetHeight(FieldHeight)
+                    .SetMargin(0f)
+                    .BindIsVisible(model => model.IsEditMode)
+                    .BindOnClicked(model => model.OnClickNextSoundSetPage());
+
+                row.AddSpacer()
+                    .BindIsVisible(model => model.IsEditMode);
+            });
+        }
+
+        private static void AddScrambleCheckbox(GuiColumn<DisguiseViewModel> col)
+        {
+            col.AddRow(row =>
+            {
+                row.AddCheckBox()
+                    .SetText("Hide Account Name")
+                    .SetHeight(FieldHeight)
+                    .BindIsChecked(model => model.ScrambleAccountId)
+                    .BindIsEnabled(model => model.IsEditMode);
+            });
+        }
+
+        private static void AddActionBand(GuiColumn<DisguiseViewModel> root)
+        {
+            root.AddRow(row =>
+            {
+                row.AddSpacer()
+                    .SetWidth(ListRailWidth);
+
+                row.AddPartialView(DisguiseViewModel.ActionPartialElement)
+                    .SetWidth(DetailRailWidth);
+
+                row.AddSpacer()
+                    .SetWidth(PortraitRailWidth);
+            });
+        }
+
+        private static void AddAvailableActionBand(GuiGroup<DisguiseViewModel> group)
+        {
+            group.AddColumn(AddAvailableDetailActions);
+        }
+
+        private static void AddRetiredActionBand(GuiGroup<DisguiseViewModel> group)
+        {
+            group.AddColumn(AddRetiredDetailActions);
+        }
+
+        private static void AddEditActionBand(GuiGroup<DisguiseViewModel> group)
+        {
+            group.AddColumn(AddEditDetailActions);
+        }
+
+        private static void AddEmptyActionBand(GuiGroup<DisguiseViewModel> group)
+        {
+            group.AddColumn(col =>
+            {
+                col.AddRow(row =>
+                {
+                    row.AddSpacer()
+                        .SetHeight(ButtonHeight);
+                });
+            });
+        }
+
+        private static void AddAvailableDetailActions(GuiColumn<DisguiseViewModel> col)
+        {
+            col.AddRow(row =>
+            {
+                row.AddSpacer()
+                    .SetWidth(TripleActionLeftPadding);
+
+                row.AddButton()
+                    .BindText(model => model.ActivateButtonText)
+                    .SetWidth(ActionButtonWidth)
+                    .SetHeight(ButtonHeight)
+                    .BindOnClicked(model => model.OnClickActivateOrDeactivate());
+
+                row.AddButton()
+                    .SetText("Edit")
+                    .SetWidth(ActionButtonWidth)
+                    .SetHeight(ButtonHeight)
+                    .BindOnClicked(model => model.OnClickEdit());
+
+                row.AddButton()
+                    .SetText("Retire")
+                    .SetWidth(ActionButtonWidth)
+                    .SetHeight(ButtonHeight)
+                    .BindOnClicked(model => model.OnClickRetire());
+
+                row.AddSpacer()
+                    .SetWidth(TripleActionLeftPadding);
+            });
+        }
+
+        private static void AddRetiredDetailActions(GuiColumn<DisguiseViewModel> col)
+        {
+            col.AddRow(row =>
+            {
+                row.AddSpacer()
+                    .SetWidth(SingleActionLeftPadding);
+
+                row.AddButton()
+                    .SetText("Unretire")
+                    .SetWidth(ActionButtonWidth)
+                    .SetHeight(ButtonHeight)
+                    .BindOnClicked(model => model.OnClickUnretire());
+
+                row.AddSpacer()
+                    .SetWidth(SingleActionLeftPadding);
+            });
+        }
+
+        private static void AddEditDetailActions(GuiColumn<DisguiseViewModel> col)
+        {
+            col.AddRow(row =>
+            {
+                row.AddSpacer()
+                    .SetWidth(DoubleActionLeftPadding);
+
+                row.AddButton()
+                    .SetText("Save")
+                    .SetWidth(ActionButtonWidth)
+                    .SetHeight(ButtonHeight)
+                    .BindOnClicked(model => model.OnClickSave());
+
+                row.AddButton()
+                    .SetText("Cancel")
+                    .SetWidth(ActionButtonWidth)
+                    .SetHeight(ButtonHeight)
+                    .BindOnClicked(model => model.OnClickCancelEdit());
+
+                row.AddSpacer()
+                    .SetWidth(DoubleActionLeftPadding);
+            });
+        }
+
+    }
+}

--- a/SWLOR.Game.Server/Feature/GuiDefinition/RefreshEvent/DisguiseChangedRefreshEvent.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/RefreshEvent/DisguiseChangedRefreshEvent.cs
@@ -1,0 +1,8 @@
+using SWLOR.Game.Server.Service.GuiService;
+
+namespace SWLOR.Game.Server.Feature.GuiDefinition.RefreshEvent
+{
+    public class DisguiseChangedRefreshEvent: IGuiRefreshEvent
+    {
+    }
+}

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/CharacterSheetViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/CharacterSheetViewModel.cs
@@ -17,6 +17,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
 {
     public class CharacterSheetViewModel: GuiViewModelBase<CharacterSheetViewModel, CharacterSheetPayload>,
         IGuiRefreshable<ChangePortraitRefreshEvent>,
+        IGuiRefreshable<DisguiseChangedRefreshEvent>,
         IGuiRefreshable<SkillXPRefreshEvent>,
         IGuiRefreshable<EquipItemRefreshEvent>,
         IGuiRefreshable<UnequipItemRefreshEvent>,
@@ -474,6 +475,11 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
         public Action OnClickSettings() => () =>
         {
             Gui.TogglePlayerWindow(Player, GuiWindowType.Settings);
+        };
+
+        public Action OnClickDisguises() => () =>
+        {
+            Gui.TogglePlayerWindow(Player, GuiWindowType.Disguises);
         };
 
         private static int GetPurchasedAttributeScore(Player dbPlayer, AbilityType ability)
@@ -1177,6 +1183,12 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
         public void Refresh(ChangePortraitRefreshEvent payload)
         {
             RefreshPortrait();
+        }
+
+        public void Refresh(DisguiseChangedRefreshEvent payload)
+        {
+            RefreshPortrait();
+            RefreshStats();
         }
 
         public void Refresh(SkillXPRefreshEvent payload)

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/DisguiseViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/DisguiseViewModel.cs
@@ -1,0 +1,879 @@
+using System.Collections.Generic;
+using System.Linq;
+using SWLOR.Game.Server.Entity;
+using SWLOR.Game.Server.Service;
+using SWLOR.Game.Server.Service.GuiService;
+using SWLOR.Game.Server.Service.GuiService.Component;
+using SWLOR.NWN.API.NWNX;
+
+namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
+{
+    public class DisguiseViewModel: GuiViewModelBase<DisguiseViewModel, GuiPayloadBase>
+    {
+        public const string DetailPartialElement = "DISGUISE_DETAIL_PARTIAL";
+        public const string DetailSelectedPartial = "DISGUISE_DETAIL_SELECTED";
+        public const string DetailEmptyPartial = "DISGUISE_DETAIL_EMPTY";
+        public const string PortraitPartialElement = "DISGUISE_PORTRAIT_PARTIAL";
+        public const string PortraitSelectedPartial = "DISGUISE_PORTRAIT_SELECTED";
+        public const string PortraitEmptyPartial = "DISGUISE_PORTRAIT_EMPTY";
+        public const string ActionPartialElement = "DISGUISE_ACTION_PARTIAL";
+        public const string ActionAvailablePartial = "DISGUISE_ACTION_AVAILABLE";
+        public const string ActionRetiredPartial = "DISGUISE_ACTION_RETIRED";
+        public const string ActionEditPartial = "DISGUISE_ACTION_EDIT";
+        public const string ActionEmptyPartial = "DISGUISE_ACTION_EMPTY";
+
+        private const int SoundSetPageSize = 25;
+
+        private readonly List<string> _disguiseIds = new();
+        private readonly List<int> _soundSetIds = new();
+        private readonly Dictionary<int, int> _soundSetIndexesById = new();
+        private readonly List<GuiBindingList<GuiComboEntry>> _soundSetOptionPages = new();
+        private bool _suppressSoundSetPageChange;
+        private int _selectedDisguiseIndex = -1;
+        private string _selectedDisguiseId = string.Empty;
+        private int _activePortraitInternalId = 1;
+        private int _soundSetPageIndex;
+        private int _selectedSoundSetId = -1;
+
+        public GuiBindingList<string> DisguiseNames
+        {
+            get => Get<GuiBindingList<string>>();
+            set => Set(value);
+        }
+
+        public GuiBindingList<bool> DisguiseToggles
+        {
+            get => Get<GuiBindingList<bool>>();
+            set => Set(value);
+        }
+
+        public GuiBindingList<GuiComboEntry> SoundSetOptions
+        {
+            get => Get<GuiBindingList<GuiComboEntry>>();
+            set => Set(value);
+        }
+
+        public int SelectedSoundSetIndex
+        {
+            get => Get<int>();
+            set
+            {
+                var sanitizedIndex = SanitizeSoundSetIndex(value);
+                Set(sanitizedIndex);
+                SetSelectedSoundSetFromPageIndex(sanitizedIndex);
+
+                if (sanitizedIndex != value)
+                    DelayCommand(0.0f, () => SelectedSoundSetIndex = sanitizedIndex);
+            }
+        }
+
+        public GuiBindingList<GuiComboEntry> SoundSetPageNumbers
+        {
+            get => Get<GuiBindingList<GuiComboEntry>>();
+            set => Set(value);
+        }
+
+        public int SelectedSoundSetPageIndex
+        {
+            get => Get<int>();
+            set
+            {
+                var sanitizedIndex = SanitizeSoundSetPageIndex(value);
+                Set(sanitizedIndex);
+
+                if (_suppressSoundSetPageChange)
+                    return;
+
+                if (sanitizedIndex != value)
+                    DelayCommand(0.0f, () => SelectedSoundSetPageIndex = sanitizedIndex);
+
+                _soundSetPageIndex = sanitizedIndex;
+                LoadSoundSetPageOptions(GetSelectedSoundSetIndexOnCurrentPage(), true);
+            }
+        }
+
+        public bool IsAvailableSelected
+        {
+            get => Get<bool>();
+            set => Set(value);
+        }
+
+        public bool IsRetiredSelected
+        {
+            get => Get<bool>();
+            set => Set(value);
+        }
+
+        public bool HasSelection
+        {
+            get => Get<bool>();
+            set => Set(value);
+        }
+
+        public bool ShowEmptyState
+        {
+            get => Get<bool>();
+            set => Set(value);
+        }
+
+        public bool IsEditMode
+        {
+            get => Get<bool>();
+            set
+            {
+                Set(value);
+                IsViewMode = HasSelection && !value;
+                RefreshActionVisibility();
+            }
+        }
+
+        public bool IsViewMode
+        {
+            get => Get<bool>();
+            set => Set(value);
+        }
+
+        public bool ShowActivateButton
+        {
+            get => Get<bool>();
+            set => Set(value);
+        }
+
+        public bool ShowEditButton
+        {
+            get => Get<bool>();
+            set => Set(value);
+        }
+
+        public bool ShowRetireButton
+        {
+            get => Get<bool>();
+            set => Set(value);
+        }
+
+        public bool ShowUnretireButton
+        {
+            get => Get<bool>();
+            set => Set(value);
+        }
+
+        public string ActivateButtonText
+        {
+            get => Get<string>();
+            set => Set(value);
+        }
+
+        public string SlotCountText
+        {
+            get => Get<string>();
+            set => Set(value);
+        }
+
+        public string Instructions
+        {
+            get => Get<string>();
+            set => Set(value);
+        }
+
+        public string EmptyStateTitle
+        {
+            get => Get<string>();
+            set => Set(value);
+        }
+
+        public string EmptyStateText
+        {
+            get => Get<string>();
+            set => Set(value);
+        }
+
+        public string PrivateName
+        {
+            get => Get<string>();
+            set => Set(value);
+        }
+
+        public string Descriptor
+        {
+            get => Get<string>();
+            set => Set(value);
+        }
+
+        public string PortraitInternalId
+        {
+            get => Get<string>();
+            set
+            {
+                var maxPortraits = GetMaxPortraitCount();
+                if (!int.TryParse(value, out var parsed))
+                    parsed = _activePortraitInternalId;
+
+                parsed = Math.Clamp(parsed, 1, maxPortraits);
+                _activePortraitInternalId = parsed;
+                var sanitizedValue = parsed.ToString();
+                Set(sanitizedValue);
+                PortraitResref = ResolvePortraitResref(_activePortraitInternalId);
+
+                if (value != sanitizedValue)
+                    DelayCommand(0.0f, () => PortraitInternalId = sanitizedValue);
+            }
+        }
+
+        public string PortraitResref
+        {
+            get => Get<string>();
+            set => Set(value);
+        }
+
+        public string SoundSetName
+        {
+            get => Get<string>();
+            set => Set(value);
+        }
+
+        public bool ScrambleAccountId
+        {
+            get => Get<bool>();
+            set => Set(value);
+        }
+
+        protected override void Initialize(GuiPayloadBase initialPayload)
+        {
+            IsAvailableSelected = true;
+            IsRetiredSelected = false;
+            HasSelection = false;
+            ShowEmptyState = true;
+            IsEditMode = false;
+            IsViewMode = false;
+            PrivateName = string.Empty;
+            Descriptor = string.Empty;
+            PortraitInternalId = "1";
+            SoundSetName = string.Empty;
+            PortraitResref = string.Empty;
+            ScrambleAccountId = true;
+            EmptyStateTitle = string.Empty;
+            EmptyStateText = string.Empty;
+            SoundSetPageNumbers = new GuiBindingList<GuiComboEntry>();
+
+            LoadSoundSetOptions();
+            SelectSoundSet(GetDefaultSoundSetId());
+            LoadList();
+            RefreshLayoutPartials();
+
+            WatchOnClient(model => model.PrivateName);
+            WatchOnClient(model => model.Descriptor);
+            WatchOnClient(model => model.PortraitInternalId);
+            WatchOnClient(model => model.SelectedSoundSetIndex);
+            WatchOnClient(model => model.SelectedSoundSetPageIndex);
+            WatchOnClient(model => model.ScrambleAccountId);
+        }
+
+        public Action OnClickAvailable() => () =>
+        {
+            IsAvailableSelected = true;
+            IsRetiredSelected = false;
+            IsEditMode = false;
+            LoadList();
+        };
+
+        public Action OnClickRetired() => () =>
+        {
+            IsAvailableSelected = false;
+            IsRetiredSelected = true;
+            IsEditMode = false;
+            LoadList();
+        };
+
+        public Action OnClickDisguise() => () =>
+        {
+            if (_selectedDisguiseIndex > -1 && _selectedDisguiseIndex < DisguiseToggles.Count)
+                DisguiseToggles[_selectedDisguiseIndex] = false;
+
+            _selectedDisguiseIndex = NuiGetEventArrayIndex();
+            if (_selectedDisguiseIndex < 0 || _selectedDisguiseIndex >= _disguiseIds.Count)
+            {
+                ClearSelection();
+                ConfigureEmptyState(false);
+                RefreshLayoutPartials();
+                return;
+            }
+
+            SelectDisguiseAtIndex(_selectedDisguiseIndex);
+        };
+
+        public Action OnClickNew() => () =>
+        {
+            ShowModal("Creating a new disguise will consume one of your disguise slots. Retired disguises also occupy disguise slots until they are wiped. Are you sure?",
+                WithLayoutRestore(() =>
+                {
+                    var newDisguise = Disguise.CreateDisguise(Player);
+                    if (newDisguise == null)
+                    {
+                        FloatingTextStringOnCreature("You do not have any available disguise slots.", Player, false);
+                        return;
+                    }
+
+                    IsAvailableSelected = true;
+                    IsRetiredSelected = false;
+                    LoadList(newDisguise.Id);
+                    IsEditMode = true;
+                    RefreshLayoutPartials();
+                }),
+                RestoreLayoutPartials);
+        };
+
+        public Action OnClickEdit() => () =>
+        {
+            if (!HasSelection || IsRetiredSelected)
+                return;
+
+            IsEditMode = true;
+            RefreshLayoutPartials();
+        };
+
+        public Action OnClickCancelEdit() => () =>
+        {
+            IsEditMode = false;
+            LoadSelectedDisguise();
+        };
+
+        public Action OnClickSave() => () =>
+        {
+            if (!HasSelection)
+                return;
+
+            PortraitInternalId = _activePortraitInternalId.ToString();
+
+            var result = Disguise.SaveDisguise(
+                Player,
+                _selectedDisguiseId,
+                PrivateName,
+                Descriptor,
+                _activePortraitInternalId,
+                _selectedSoundSetId,
+                ScrambleAccountId);
+
+            if (!result.IsSuccessful)
+            {
+                FloatingTextStringOnCreature(result.ErrorMessage, Player, false);
+                return;
+            }
+
+            IsEditMode = false;
+            LoadList(_selectedDisguiseId);
+            SendMessageToPC(Player, ColorToken.Green("Disguise saved."));
+        };
+
+        public Action OnClickActivateOrDeactivate() => () =>
+        {
+            if (!HasSelection || IsRetiredSelected)
+                return;
+
+            var selectedDisguiseId = _selectedDisguiseId;
+
+            if (IsSelectedDisguiseActive())
+            {
+                ShowModal("Deactivating this disguise immediately restores your normal identity. Deactivation does not trigger the 30-minute delay between disguise activations. Are you sure?",
+                    WithLayoutRestore(() =>
+                    {
+                        if (Disguise.Deactivate(Player))
+                            SendMessageToPC(Player, ColorToken.Green("Disguise deactivated."));
+
+                        ReloadAvailableDisguise(selectedDisguiseId);
+                    }),
+                    RestoreLayoutPartials);
+            }
+            else
+            {
+                ShowModal("Activating this disguise starts a 30-minute delay before you can activate another disguise. Deactivation has no delay. Are you sure?",
+                    WithLayoutRestore(() =>
+                    {
+                        var result = Disguise.Activate(Player, selectedDisguiseId);
+                        if (!result.IsSuccessful)
+                        {
+                            FloatingTextStringOnCreature(result.ErrorMessage, Player, false);
+                            return;
+                        }
+
+                        SendMessageToPC(Player, ColorToken.Green("Disguise activated."));
+                        ReloadAvailableDisguise(selectedDisguiseId);
+                    }),
+                    RestoreLayoutPartials);
+            }
+        };
+
+        public Action OnClickRetire() => () =>
+        {
+            if (!HasSelection || IsRetiredSelected)
+                return;
+
+            ShowModal("Retiring this disguise will make it unavailable until an Identity Broker wipes it. Retired disguises still occupy disguise slots. Are you sure?",
+                WithLayoutRestore(() =>
+                {
+                    if (Disguise.Retire(Player, _selectedDisguiseId))
+                    {
+                        SendMessageToPC(Player, ColorToken.Green("Disguise retired."));
+                        LoadList();
+                    }
+                }),
+                RestoreLayoutPartials);
+        };
+
+        public Action OnClickUnretire() => () =>
+        {
+            if (!HasSelection || !IsRetiredSelected)
+                return;
+
+            ShowModal("Restoring this disguise will move it back to your available disguises. Are you sure?",
+                WithLayoutRestore(() =>
+                {
+                    if (!Disguise.Unretire(Player, _selectedDisguiseId))
+                    {
+                        FloatingTextStringOnCreature("Unable to restore that disguise.", Player, false);
+                        return;
+                    }
+
+                    SendMessageToPC(Player, ColorToken.Green("Disguise restored."));
+                    IsAvailableSelected = true;
+                    IsRetiredSelected = false;
+                    IsEditMode = false;
+                    LoadList(_selectedDisguiseId);
+                }),
+                RestoreLayoutPartials);
+        };
+
+        public Action OnClickPreviousPortrait() => () =>
+        {
+            var next = _activePortraitInternalId - 1;
+            if (next < 1)
+                next = GetMaxPortraitCount();
+
+            PortraitInternalId = next.ToString();
+        };
+
+        public Action OnClickNextPortrait() => () =>
+        {
+            var next = _activePortraitInternalId + 1;
+            if (next > GetMaxPortraitCount())
+                next = 1;
+
+            PortraitInternalId = next.ToString();
+        };
+
+        public Action OnClickPreviousSoundSetPage() => () =>
+        {
+            if (!IsEditMode)
+                return;
+
+            var newPage = SelectedSoundSetPageIndex - 1;
+            if (newPage < 0)
+                newPage = 0;
+
+            SelectedSoundSetPageIndex = newPage;
+        };
+
+        public Action OnClickNextSoundSetPage() => () =>
+        {
+            if (!IsEditMode)
+                return;
+
+            var newPage = SelectedSoundSetPageIndex + 1;
+            if (newPage > SoundSetPageNumbers.Count - 1)
+                newPage = SoundSetPageNumbers.Count - 1;
+
+            SelectedSoundSetPageIndex = newPage;
+        };
+
+        public Action OnClickPreviewSoundSet() => () =>
+        {
+            if (_selectedSoundSetId < 0)
+                return;
+
+            var previewSoundResref = Cache.GetSoundSetPreviewSoundResref(_selectedSoundSetId);
+            if (string.IsNullOrWhiteSpace(previewSoundResref))
+            {
+                SendMessageToPC(Player, ColorToken.Red("No preview sound is available for this sound set."));
+                return;
+            }
+
+            PlayerPlugin.PlaySound(Player, previewSoundResref, OBJECT_INVALID);
+        };
+
+        private void LoadList(string selectedDisguiseId = "")
+        {
+            var playerId = GetObjectUUID(Player);
+            var dbPlayer = DB.Get<Player>(playerId);
+            var usedSlots = Disguise.CountUsedSlots(playerId);
+            var slotLimit = Disguise.GetDisguiseSlotLimit(dbPlayer);
+            SlotCountText = $"Slots Used: {usedSlots} / {slotLimit}";
+
+            var disguises = Disguise.GetDisguises(playerId, IsRetiredSelected);
+            var disguiseNames = new GuiBindingList<string>();
+            var disguiseToggles = new GuiBindingList<bool>();
+            _disguiseIds.Clear();
+
+            foreach (var disguise in disguises)
+            {
+                var name = disguise.PrivateName;
+                if (!disguise.IsRetired && dbPlayer?.ActiveDisguiseId == disguise.Id)
+                    name += " (Active)";
+
+                _disguiseIds.Add(disguise.Id);
+                disguiseNames.Add(name);
+                disguiseToggles.Add(disguise.Id == selectedDisguiseId);
+            }
+
+            DisguiseNames = disguiseNames;
+            DisguiseToggles = disguiseToggles;
+
+            if (!string.IsNullOrWhiteSpace(selectedDisguiseId) && _disguiseIds.Contains(selectedDisguiseId))
+            {
+                SelectDisguiseAtIndex(_disguiseIds.IndexOf(selectedDisguiseId));
+                return;
+            }
+
+            if (_disguiseIds.Count > 0)
+            {
+                SelectDisguiseAtIndex(0);
+                return;
+            }
+
+            ClearSelection();
+            ConfigureEmptyState(_disguiseIds.Count > 0);
+            RefreshLayoutPartials();
+        }
+
+        private void LoadSelectedDisguise()
+        {
+            var disguise = DB.Get<PlayerDisguise>(_selectedDisguiseId);
+            if (disguise == null)
+            {
+                ClearSelection();
+                return;
+            }
+
+            HasSelection = true;
+            ShowEmptyState = false;
+            IsViewMode = !IsEditMode;
+            PrivateName = disguise.PrivateName;
+            Descriptor = disguise.Descriptor;
+            PortraitInternalId = disguise.PortraitInternalId.ToString();
+            ScrambleAccountId = disguise.ScrambleAccountId;
+            SelectSoundSet(disguise.SoundSetId);
+            Instructions = string.Empty;
+            EmptyStateTitle = string.Empty;
+            EmptyStateText = string.Empty;
+            RefreshActionVisibility();
+            RefreshLayoutPartials();
+        }
+
+        private void ClearSelection()
+        {
+            _selectedDisguiseIndex = -1;
+            _selectedDisguiseId = string.Empty;
+            HasSelection = false;
+            ShowEmptyState = true;
+            IsEditMode = false;
+            IsViewMode = false;
+            PrivateName = string.Empty;
+            Descriptor = string.Empty;
+            PortraitInternalId = "1";
+            SoundSetName = string.Empty;
+            PortraitResref = string.Empty;
+            SelectSoundSet(GetDefaultSoundSetId());
+            ScrambleAccountId = true;
+            RefreshActionVisibility();
+            RefreshLayoutPartials();
+        }
+
+        private void ConfigureEmptyState(bool hasDisguises)
+        {
+            Instructions = string.Empty;
+            ShowEmptyState = true;
+
+            if (hasDisguises)
+            {
+                EmptyStateTitle = "No Disguise Selected";
+                EmptyStateText = "Disguise details will appear here.";
+            }
+            else if (IsRetiredSelected)
+            {
+                EmptyStateTitle = "No Retired Disguises";
+                EmptyStateText = "Retired disguises will appear here.";
+            }
+            else
+            {
+                EmptyStateTitle = "No Available Disguises";
+                EmptyStateText = "Create a disguise to begin.";
+            }
+        }
+
+        private void ReloadAvailableDisguise(string selectedDisguiseId)
+        {
+            IsAvailableSelected = true;
+            IsRetiredSelected = false;
+            IsEditMode = false;
+            LoadList(selectedDisguiseId);
+        }
+
+        private void RefreshActionVisibility()
+        {
+            ShowActivateButton = HasSelection && IsAvailableSelected && !IsEditMode;
+            ShowEditButton = HasSelection && IsAvailableSelected && !IsEditMode;
+            ShowRetireButton = HasSelection && IsAvailableSelected && !IsEditMode;
+            ShowUnretireButton = HasSelection && IsRetiredSelected && !IsEditMode;
+            ActivateButtonText = IsSelectedDisguiseActive() ? "Deactivate" : "Activate";
+        }
+
+        private void SelectDisguiseAtIndex(int index)
+        {
+            _selectedDisguiseIndex = index;
+            _selectedDisguiseId = _disguiseIds[index];
+            DisguiseToggles[index] = true;
+            IsEditMode = false;
+            LoadSelectedDisguise();
+        }
+
+        private void RefreshLayoutPartials()
+        {
+            ChangePartialView(DetailPartialElement, HasSelection ? DetailSelectedPartial : DetailEmptyPartial);
+            ChangePartialView(PortraitPartialElement, HasSelection ? PortraitSelectedPartial : PortraitEmptyPartial);
+            ChangePartialView(ActionPartialElement, GetActionPartialName());
+
+            if (HasSelection)
+                RefreshSoundSetBindings();
+        }
+
+        private Action WithLayoutRestore(Action action)
+        {
+            return () =>
+            {
+                try
+                {
+                    action();
+                }
+                finally
+                {
+                    RestoreLayoutPartials();
+                }
+            };
+        }
+
+        private void RestoreLayoutPartials()
+        {
+            void ApplyLayoutPartials()
+            {
+                RefreshLayoutPartials();
+            }
+
+            ChangePartialView("_window_", "%%WINDOW_MAIN%%");
+            ApplyLayoutPartials();
+            DelayCommand(0.0f, ApplyLayoutPartials);
+        }
+
+        private string GetActionPartialName()
+        {
+            if (!HasSelection)
+                return ActionEmptyPartial;
+
+            if (IsEditMode)
+                return ActionEditPartial;
+
+            if (IsRetiredSelected)
+                return ActionRetiredPartial;
+
+            return IsAvailableSelected ? ActionAvailablePartial : ActionEmptyPartial;
+        }
+
+        private bool IsSelectedDisguiseActive()
+        {
+            if (string.IsNullOrWhiteSpace(_selectedDisguiseId))
+                return false;
+
+            var dbPlayer = DB.Get<Player>(GetObjectUUID(Player));
+            return dbPlayer?.ActiveDisguiseId == _selectedDisguiseId;
+        }
+
+        private void LoadSoundSetOptions()
+        {
+            _soundSetIds.Clear();
+            _soundSetIndexesById.Clear();
+            _soundSetOptionPages.Clear();
+
+            var currentPage = new GuiBindingList<GuiComboEntry>();
+            var optionIndex = 0;
+
+            foreach (var (soundSetId, label) in Cache.GetSoundSets())
+            {
+                var absoluteIndex = _soundSetIds.Count;
+                _soundSetIds.Add(soundSetId);
+                _soundSetIndexesById[soundSetId] = absoluteIndex;
+
+                if (currentPage.Count >= SoundSetPageSize)
+                {
+                    _soundSetOptionPages.Add(currentPage);
+                    currentPage = new GuiBindingList<GuiComboEntry>();
+                    optionIndex = 0;
+                }
+
+                currentPage.Add(new GuiComboEntry(label, optionIndex));
+                optionIndex++;
+            }
+
+            _soundSetOptionPages.Add(currentPage);
+            _soundSetPageIndex = 0;
+            LoadSoundSetPageOptions(0);
+        }
+
+        private void SelectSoundSet(int soundSetId)
+        {
+            if (!_soundSetIndexesById.TryGetValue(soundSetId, out var absoluteIndex))
+                absoluteIndex = _soundSetIds.Count > 0 ? 0 : -1;
+
+            if (absoluteIndex < 0)
+            {
+                _selectedSoundSetId = -1;
+                _soundSetPageIndex = 0;
+                LoadSoundSetPageOptions(-1);
+                return;
+            }
+
+            _selectedSoundSetId = _soundSetIds[absoluteIndex];
+            _soundSetPageIndex = absoluteIndex / SoundSetPageSize;
+            LoadSoundSetPageOptions(absoluteIndex % SoundSetPageSize);
+        }
+
+        private int GetDefaultSoundSetId()
+        {
+            return _soundSetIds.Count > 0
+                ? _soundSetIds[0]
+                : -1;
+        }
+
+        private int SanitizeSoundSetIndex(int index)
+        {
+            if (index < 0)
+                return -1;
+
+            var pageCount = GetCurrentSoundSetPageSize();
+            if (pageCount == 0)
+                return -1;
+
+            return Math.Clamp(index, 0, pageCount - 1);
+        }
+
+        private int SanitizeSoundSetPageIndex(int index)
+        {
+            return Math.Clamp(index, 0, GetSoundSetPageCount() - 1);
+        }
+
+        private int GetCurrentSoundSetPageSize()
+        {
+            if (_soundSetPageIndex < 0 || _soundSetPageIndex >= _soundSetOptionPages.Count)
+                return 0;
+
+            return _soundSetOptionPages[_soundSetPageIndex].Count;
+        }
+
+        private int GetSoundSetPageCount()
+        {
+            return Math.Max(1, _soundSetOptionPages.Count);
+        }
+
+        private void LoadSoundSetPageNumbers()
+        {
+            var pageNumbers = new GuiBindingList<GuiComboEntry>();
+
+            for (var pageIndex = 0; pageIndex < GetSoundSetPageCount(); pageIndex++)
+            {
+                pageNumbers.Add(new GuiComboEntry($"Page {pageIndex + 1}", pageIndex));
+            }
+
+            SoundSetPageNumbers = pageNumbers;
+        }
+
+        private void LoadSoundSetPageOptions(int selectedPageIndex)
+        {
+            LoadSoundSetPageOptions(selectedPageIndex, false);
+        }
+
+        private void LoadSoundSetPageOptions(int selectedPageIndex, bool selectFirstWhenInvalid)
+        {
+            _soundSetPageIndex = Math.Clamp(_soundSetPageIndex, 0, GetSoundSetPageCount() - 1);
+            LoadSoundSetPageNumbers();
+
+            SoundSetOptions = _soundSetOptionPages[_soundSetPageIndex];
+            _suppressSoundSetPageChange = true;
+            SelectedSoundSetPageIndex = _soundSetPageIndex;
+            _suppressSoundSetPageChange = false;
+
+            if (selectFirstWhenInvalid &&
+                (selectedPageIndex < 0 || selectedPageIndex >= GetCurrentSoundSetPageSize()))
+            {
+                selectedPageIndex = GetCurrentSoundSetPageSize() > 0 ? 0 : -1;
+            }
+
+            SelectedSoundSetIndex = selectedPageIndex;
+        }
+
+        private int GetSelectedSoundSetIndexOnCurrentPage()
+        {
+            if (!_soundSetIndexesById.TryGetValue(_selectedSoundSetId, out var absoluteIndex))
+                return -1;
+
+            if (absoluteIndex / SoundSetPageSize != _soundSetPageIndex)
+                return -1;
+
+            return absoluteIndex % SoundSetPageSize;
+        }
+
+        private void SetSelectedSoundSetFromPageIndex(int pageIndex)
+        {
+            var absoluteIndex = _soundSetPageIndex * SoundSetPageSize + pageIndex;
+            if (pageIndex < 0 || absoluteIndex < 0 || absoluteIndex >= _soundSetIds.Count)
+            {
+                _selectedSoundSetId = -1;
+                SoundSetName = string.Empty;
+                return;
+            }
+
+            _selectedSoundSetId = _soundSetIds[absoluteIndex];
+            SoundSetName = _soundSetOptionPages[_soundSetPageIndex][pageIndex].Label;
+        }
+
+        private void RefreshSoundSetBindings()
+        {
+            if (_selectedSoundSetId < 0)
+            {
+                LoadSoundSetPageOptions(-1);
+                return;
+            }
+
+            if (!_soundSetIndexesById.TryGetValue(_selectedSoundSetId, out var absoluteIndex))
+            {
+                SelectSoundSet(GetDefaultSoundSetId());
+                return;
+            }
+
+            _soundSetPageIndex = absoluteIndex / SoundSetPageSize;
+            LoadSoundSetPageOptions(absoluteIndex % SoundSetPageSize);
+        }
+
+        private static int GetMaxPortraitCount()
+        {
+            return Math.Max(1, Cache.PortraitCount);
+        }
+
+        private static string ResolvePortraitResref(int portraitInternalId)
+        {
+            try
+            {
+                return Cache.GetPortraitResrefByInternalId(portraitInternalId) + "l";
+            }
+            catch (KeyNotFoundException)
+            {
+                return string.Empty;
+            }
+        }
+    }
+}

--- a/SWLOR.Game.Server/Service/Cache.cs
+++ b/SWLOR.Game.Server/Service/Cache.cs
@@ -211,11 +211,12 @@ namespace SWLOR.Game.Server.Service
 
         private static string ResolveSoundSetPreviewSoundResref(string soundSetResref)
         {
-            if (string.IsNullOrWhiteSpace(soundSetResref) ||
-                soundSetResref == "****")
+            var trimmedResref = soundSetResref?.Trim();
+
+            if (string.IsNullOrWhiteSpace(trimmedResref) ||
+                trimmedResref == "****")
                 return string.Empty;
 
-            var trimmedResref = soundSetResref.Trim();
             if (CustomSoundSetPreviewSoundResrefs.TryGetValue(trimmedResref, out var customPreviewSoundResref))
                 return customPreviewSoundResref;
 

--- a/SWLOR.Game.Server/Service/Cache.cs
+++ b/SWLOR.Game.Server/Service/Cache.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using SWLOR.Game.Server.Core;
 using SWLOR.Game.Server.Core.NWNX.Enum;
@@ -21,6 +22,69 @@ namespace SWLOR.Game.Server.Service
         private static Dictionary<int, string> PortraitResrefByInternalId { get; } = new();
         private static Dictionary<string, int> PortraitInternalIdsByPortraitResref { get; } = new();
         private static Dictionary<int, string> SoundSets { get; set; } = new();
+        private static Dictionary<int, string> SoundSetPreviewSoundResrefs { get; set; } = new();
+        private static readonly ReadOnlyDictionary<string, string> CustomSoundSetPreviewSoundResrefs = new(
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["c_spiker"] = "c_spiker_bat1",
+                ["c_viper"] = "c_viper_bat1",
+                ["c_slime"] = "c_slime_bat1",
+                ["c_treant"] = "c_treant_bat1",
+                ["c_hsecat"] = "c_hsecat_bat1",
+                ["c_monodrn"] = "c_monodrone_bat1",
+                ["c_horsexxx"] = "c_horsexxx_slct",
+                ["c_parai"] = "c_parai_bat1",
+                ["c_secundus"] = "c_secundus_bat1",
+                ["c_primus"] = "c_primus_bat1",
+                ["c_marut"] = "c_marut_bat1",
+                ["c_codi_mane"] = "codi_c_mane_bat1",
+                ["aliengen"] = "a_aliengen_bat",
+                ["aqualish"] = "a_aqua_bat",
+                ["assdroid"] = "c_drdasasin_bat1",
+                ["bantha"] = "c_bantha_bat1",
+                ["bith1"] = "n_bith_bat1",
+                ["chandra"] = "a_chandra_bat",
+                ["darkjedif"] = "n_darkjedif_bat1",
+                ["darkjedim"] = "n_darkjedim_bat1",
+                ["devaronian"] = "a_devar_bat",
+                ["droid"] = "cs_droid",
+                ["duro1"] = "n_duros_bat1",
+                ["duro2"] = "a_duro_bat",
+                ["gamorean"] = "c_gamorean_bat1",
+                ["gand"] = "a_gand_bat",
+                ["gran"] = "a_gran_bat",
+                ["hssiss"] = "c_hssiss_atk1",
+                ["hutt"] = "c_hutt_bat1",
+                ["ithorian"] = "a_ithor_bat",
+                ["kathhounda"] = "c_khounda_bat1",
+                ["kathhoundb"] = "c_khoundb_bat1",
+                ["malerodian"] = "n_rodian_bat1",
+                ["mandaloriana"] = "p_mand_bat2",
+                ["mandalorianb"] = "n_mndlorian_bat1",
+                ["medicaldroid"] = "c_drdmse3_idle",
+                ["nikto"] = "a_nikto_bat",
+                ["repsoldier"] = "n_repsold_bat1",
+                ["republicoff"] = "n_repoff_bat1",
+                ["rodianf"] = "a_rodfem_bat",
+                ["sithassassin"] = "a_sithass_bat",
+                ["sithf"] = "n_sithcomf_bat1",
+                ["sithmale"] = "n_sithcomm_bat1",
+                ["sithsoldier"] = "n_sithsoldr_bat1",
+                ["spaceship"] = "amb_trafnear_01",
+                ["sullustan"] = "a_sullust_bat",
+                ["tankdroid"] = "c_drdmse1_idle",
+                ["toughrodian"] = "a_rodtough_bat",
+                ["toughtwilek"] = "a_twitough_bat",
+                ["trandoshan"] = "a_trando_bat",
+                ["twilekfemale"] = "n_twilekf_bat1",
+                ["twilekmale"] = "n_twilekm_bat1",
+                ["twilekmaleb"] = "a_twimale_bat",
+                ["weequay"] = "a_weequay_bat",
+                ["wookie"] = "p_zaalbar_bat1",
+                ["hk47"] = "p_hk47_bat1",
+                ["c_catfacts"] = "c_catfacts_bat1",
+                ["vs_ntuskenx"] = "vs_ntuskenx_bat1"
+            });
 
         [NWNEventHandler(ScriptName.OnModuleContentChange)]
         public static void CacheItemNamesByResref()
@@ -125,6 +189,9 @@ namespace SWLOR.Game.Server.Service
         {
             const string SoundSets2DA = "soundset";
             var soundSetCount = Get2DARowCount(SoundSets2DA);
+            var soundSets = new Dictionary<int, string>();
+            var previewSoundResrefs = new Dictionary<int, string>();
+
             for (var row = 0; row < soundSetCount; row++)
             {
                 var strRef = Get2DAString(SoundSets2DA, "STRREF", row);
@@ -133,11 +200,28 @@ namespace SWLOR.Game.Server.Service
                 if (!string.IsNullOrWhiteSpace(strRef) &&
                     !string.IsNullOrWhiteSpace(resref))
                 {
-                    SoundSets.Add(row, GetStringByStrRef(Convert.ToInt32(strRef)));
+                    soundSets.Add(row, GetStringByStrRef(Convert.ToInt32(strRef)));
+                    previewSoundResrefs[row] = ResolveSoundSetPreviewSoundResref(resref);
                 }
             }
 
-            SoundSets = SoundSets.OrderBy(o => o.Value).ToDictionary(x => x.Key, y => y.Value);
+            SoundSets = soundSets.OrderBy(o => o.Value).ToDictionary(x => x.Key, y => y.Value);
+            SoundSetPreviewSoundResrefs = previewSoundResrefs;
+        }
+
+        private static string ResolveSoundSetPreviewSoundResref(string soundSetResref)
+        {
+            if (string.IsNullOrWhiteSpace(soundSetResref) ||
+                soundSetResref == "****")
+                return string.Empty;
+
+            var trimmedResref = soundSetResref.Trim();
+            if (CustomSoundSetPreviewSoundResrefs.TryGetValue(trimmedResref, out var customPreviewSoundResref))
+                return customPreviewSoundResref;
+
+            return trimmedResref.Length <= 11
+                ? $"{trimmedResref}_bat1".ToLowerInvariant()
+                : string.Empty;
         }
 
         /// <summary>
@@ -183,6 +267,13 @@ namespace SWLOR.Game.Server.Service
         public static Dictionary<int, string> GetSoundSets()
         {
             return SoundSets.ToDictionary(x => x.Key, y => y.Value);
+        }
+
+        public static string GetSoundSetPreviewSoundResref(int soundSetId)
+        {
+            return SoundSetPreviewSoundResrefs.TryGetValue(soundSetId, out var previewSoundResref)
+                ? previewSoundResref
+                : string.Empty;
         }
     }
 }

--- a/SWLOR.Game.Server/Service/ChatCommand.cs
+++ b/SWLOR.Game.Server/Service/ChatCommand.cs
@@ -7,7 +7,6 @@ using SWLOR.Game.Server.Service.GuiService;
 using SWLOR.NWN.API.Engine;
 using SWLOR.NWN.API.NWNX;
 using SWLOR.NWN.API.NWScript.Enum;
-using ChatChannel = SWLOR.Game.Server.Core.NWNX.Enum.ChatChannel;
 
 namespace SWLOR.Game.Server.Service
 {
@@ -48,13 +47,6 @@ namespace SWLOR.Game.Server.Service
         {
             var sender = OBJECT_SELF;
             var originalMessage = ChatPlugin.GetMessage().Trim();
-
-            if (ChatPlugin.GetChannel() == ChatChannel.PlayerShout &&
-                !GetIsDM(sender) &&
-                !GetIsDMPossessed(sender))
-            {
-                return;
-            }
 
             if (!CanHandleChat(sender, originalMessage))
             {

--- a/SWLOR.Game.Server/Service/Communication.cs
+++ b/SWLOR.Game.Server/Service/Communication.cs
@@ -137,6 +137,11 @@ namespace SWLOR.Game.Server.Service
                 return;
             }
 
+            if (IsChatCommandMessage(message))
+            {
+                return;
+            }
+
             // Echo the message back to the player.
             if (messageToDm)
             {
@@ -176,11 +181,6 @@ namespace SWLOR.Game.Server.Service
                     IsTranslatable = false
                 };
                 chatComponents.Add(component);
-            }
-            // Another early out - if this is a chat command, exit.
-            else if (message.Length >= 1 && message.Substring(0, 1) == "/")
-            {
-                return;
             }
             // Another early out - a completely empty message will just be skipped.
             else if (string.IsNullOrWhiteSpace(message.Trim()))
@@ -446,6 +446,13 @@ namespace SWLOR.Game.Server.Service
                 receiver,
                 speaker,
                 () => ChatPlugin.SendMessage(finalChannel, message, speaker, receiver));
+        }
+
+        private static bool IsChatCommandMessage(string message)
+        {
+            return message.Length >= 2 &&
+                   message[0] == '/' &&
+                   message[1] != '/';
         }
 
         private static bool IsCommsReceiverInRange(uint sender, uint receiver)

--- a/SWLOR.Game.Server/Service/Disguise.cs
+++ b/SWLOR.Game.Server/Service/Disguise.cs
@@ -1,0 +1,579 @@
+using System.Collections.Generic;
+using System.Linq;
+using SWLOR.Game.Server.Core;
+using SWLOR.Game.Server.Entity;
+using SWLOR.Game.Server.Feature.GuiDefinition.RefreshEvent;
+using SWLOR.Game.Server.Service.DBService;
+using SWLOR.Game.Server.Service.DisguiseService;
+using SWLOR.Game.Server.Service.LogService;
+using SWLOR.NWN.API.NWNX;
+using SWLOR.NWN.API.NWScript.Enum;
+
+namespace SWLOR.Game.Server.Service
+{
+    public static class Disguise
+    {
+        public const string IdentityKeyPrefix = "disguise:";
+        public const int WipeCreditCost = 100000;
+        public const int WipeRoleplayXPCost = 25000;
+        public const int ActivationDelayMinutes = 30;
+
+        public const int MaxPrivateNameLength = 32;
+        private const int DisguiseQueryPageSize = 50;
+        private static readonly TimeSpan ActivationDelay = TimeSpan.FromMinutes(ActivationDelayMinutes);
+
+        [NWNEventHandler(ScriptName.OnModuleEnter)]
+        public static void ApplyActiveDisguiseOnEnter()
+        {
+            var player = GetEnteringObject();
+            if (!GetIsPC(player) || GetIsDM(player))
+                return;
+
+            var activeDisguise = GetActiveDisguise(player);
+            if (activeDisguise == null)
+                return;
+
+            ApplyAppearance(player, activeDisguise);
+        }
+
+        public static string BuildIdentityKey(string disguiseId)
+        {
+            return $"{IdentityKeyPrefix}{disguiseId}";
+        }
+
+        public static bool IsDisguiseIdentityKey(string identityKey)
+        {
+            return !string.IsNullOrWhiteSpace(identityKey) &&
+                   identityKey.StartsWith(IdentityKeyPrefix, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static string GetIdentityKey(uint player)
+        {
+            var activeDisguise = GetActiveDisguise(player);
+            return activeDisguise == null
+                ? GetObjectUUID(player)
+                : BuildIdentityKey(activeDisguise.Id);
+        }
+
+        public static string GetDisplayDescriptor(uint player)
+        {
+            var activeDisguise = GetActiveDisguise(player);
+            return activeDisguise == null
+                ? PlayerDescriptor.GetUnknownDisplayName(player)
+                : string.IsNullOrWhiteSpace(activeDisguise.Descriptor)
+                    ? PlayerDescriptor.GetUnknownDisplayName(player)
+                    : activeDisguise.Descriptor;
+        }
+
+        public static bool ShouldScrambleAccountName(uint player)
+        {
+            var activeDisguise = GetActiveDisguise(player);
+            if (activeDisguise != null)
+                return activeDisguise.ScrambleAccountId;
+
+            var playerId = GetObjectUUID(player);
+            var dbPlayer = DB.Get<Player>(playerId);
+            return dbPlayer?.Settings?.ScrambleAccountName ?? true;
+        }
+
+        public static PlayerDisguise GetActiveDisguise(uint player)
+        {
+            if (!GetIsObjectValid(player) || !GetIsPC(player) || GetIsDM(player))
+                return null;
+
+            var playerId = GetObjectUUID(player);
+            if (string.IsNullOrWhiteSpace(playerId))
+                return null;
+
+            var dbPlayer = DB.Get<Player>(playerId);
+            return GetActiveDisguise(dbPlayer);
+        }
+
+        public static PlayerDisguise GetActiveDisguise(Player dbPlayer)
+        {
+            if (dbPlayer == null ||
+                string.IsNullOrWhiteSpace(dbPlayer.ActiveDisguiseId))
+            {
+                return null;
+            }
+
+            var disguise = DB.Get<PlayerDisguise>(dbPlayer.ActiveDisguiseId);
+            if (disguise == null ||
+                disguise.IsRetired ||
+                disguise.PlayerId != dbPlayer.Id)
+            {
+                return null;
+            }
+
+            return disguise;
+        }
+
+        public static List<PlayerDisguise> GetDisguises(string playerId, bool retired)
+        {
+            var results = new List<PlayerDisguise>();
+            var offset = 0;
+
+            while (true)
+            {
+                var page = DB.Search(new DBQuery<PlayerDisguise>()
+                        .AddFieldSearch(nameof(PlayerDisguise.PlayerId), playerId, false)
+                        .AddFieldSearch(nameof(PlayerDisguise.IsRetired), retired)
+                        .AddPaging(DisguiseQueryPageSize, offset))
+                    .ToList();
+
+                results.AddRange(page);
+
+                if (page.Count < DisguiseQueryPageSize)
+                    break;
+
+                offset += DisguiseQueryPageSize;
+            }
+
+            return results
+                .OrderBy(disguise => disguise.PrivateName)
+                .ToList();
+        }
+
+        public static int GetDisguiseSlotLimit(Player dbPlayer)
+        {
+            return dbPlayer?.DisguiseSlotLimit > 0
+                ? dbPlayer.DisguiseSlotLimit
+                : Player.DefaultDisguiseSlotLimit;
+        }
+
+        public static int CountUsedSlots(string playerId)
+        {
+            return (int)DB.SearchCount(new DBQuery<PlayerDisguise>()
+                .AddFieldSearch(nameof(PlayerDisguise.PlayerId), playerId, false));
+        }
+
+        public static PlayerDisguise CreateDisguise(uint player)
+        {
+            var playerId = GetObjectUUID(player);
+            var dbPlayer = DB.Get<Player>(playerId);
+            var usedSlots = CountUsedSlots(playerId);
+            var slotLimit = GetDisguiseSlotLimit(dbPlayer);
+
+            if (usedSlots >= slotLimit)
+                return null;
+
+            var portraitInternalId = ResolvePortraitInternalId(player);
+            var disguise = new PlayerDisguise
+            {
+                PlayerId = playerId,
+                PrivateName = $"Disguise #{usedSlots + 1}",
+                Descriptor = PlayerDescriptor.GetUnknownDisplayName(player),
+                PortraitInternalId = portraitInternalId,
+                SoundSetId = GetSoundset(player),
+                ScrambleAccountId = true
+            };
+
+            DB.Set(disguise);
+            return disguise;
+        }
+
+        public static SaveDisguiseResult SaveDisguise(
+            uint player,
+            string disguiseId,
+            string privateName,
+            string descriptor,
+            int portraitInternalId,
+            int soundSetId,
+            bool scrambleAccountId)
+        {
+            var playerId = GetObjectUUID(player);
+            var disguise = DB.Get<PlayerDisguise>(disguiseId);
+            if (disguise == null || disguise.PlayerId != playerId)
+                return SaveDisguiseResult.Failure("Unable to locate that disguise.");
+
+            if (disguise.IsRetired)
+                return SaveDisguiseResult.Failure("Retired disguises cannot be edited.");
+
+            var privateNameError = ValidatePrivateName(privateName);
+            if (!string.IsNullOrWhiteSpace(privateNameError))
+                return SaveDisguiseResult.Failure(privateNameError);
+
+            var descriptorError = PlayerName.ValidateKnownNameInput(descriptor);
+            if (!string.IsNullOrWhiteSpace(descriptorError))
+                return SaveDisguiseResult.Failure(descriptorError);
+
+            portraitInternalId = Math.Clamp(portraitInternalId, 1, GetMaxPortraitCount());
+
+            disguise.PrivateName = PlayerName.SanitizeKnownName(privateName);
+            disguise.Descriptor = PlayerName.SanitizeKnownName(descriptor);
+            disguise.PortraitInternalId = portraitInternalId;
+            disguise.SoundSetId = soundSetId;
+            disguise.ScrambleAccountId = scrambleAccountId;
+            DB.Set(disguise);
+
+            if (IsActiveDisguise(player, disguise.Id))
+            {
+                ApplyAppearance(player, disguise);
+                RefreshDisguiseDisplay(player);
+            }
+
+            return SaveDisguiseResult.Success();
+        }
+
+        public static ActivateDisguiseResult Activate(uint player, string disguiseId)
+        {
+            var playerId = GetObjectUUID(player);
+            var dbPlayer = DB.Get<Player>(playerId);
+            var disguise = DB.Get<PlayerDisguise>(disguiseId);
+
+            if (dbPlayer == null ||
+                disguise == null ||
+                disguise.PlayerId != playerId ||
+                disguise.IsRetired)
+            {
+                return ActivateDisguiseResult.Failure("Unable to activate that disguise.");
+            }
+
+            var delayError = ValidateActivationDelay(playerId);
+            if (!string.IsNullOrWhiteSpace(delayError))
+                return ActivateDisguiseResult.Failure(delayError);
+
+            if (GetActiveDisguise(dbPlayer) == null)
+            {
+                dbPlayer.PreDisguisePortraitId = GetPortraitId(player);
+                dbPlayer.PreDisguiseSoundSetId = GetSoundset(player);
+            }
+
+            dbPlayer.ActiveDisguiseId = disguise.Id;
+            disguise.DateLastActivated = DateTime.UtcNow;
+            DB.Set(disguise);
+            DB.Set(dbPlayer);
+
+            ApplyAppearance(player, disguise);
+            RefreshDisguiseDisplay(player);
+            return ActivateDisguiseResult.Success();
+        }
+
+        public static bool Deactivate(uint player)
+        {
+            var playerId = GetObjectUUID(player);
+            var dbPlayer = DB.Get<Player>(playerId);
+            if (dbPlayer == null ||
+                string.IsNullOrWhiteSpace(dbPlayer.ActiveDisguiseId))
+            {
+                return false;
+            }
+
+            if (dbPlayer.PreDisguisePortraitId >= 0)
+                SetPortraitId(player, dbPlayer.PreDisguisePortraitId);
+
+            if (dbPlayer.PreDisguiseSoundSetId >= 0)
+                SetSoundset(player, dbPlayer.PreDisguiseSoundSetId);
+
+            dbPlayer.ActiveDisguiseId = string.Empty;
+            dbPlayer.PreDisguisePortraitId = -1;
+            dbPlayer.PreDisguiseSoundSetId = -1;
+            DB.Set(dbPlayer);
+
+            RefreshDisguiseDisplay(player);
+            return true;
+        }
+
+        public static bool Retire(uint player, string disguiseId)
+        {
+            var playerId = GetObjectUUID(player);
+            var disguise = DB.Get<PlayerDisguise>(disguiseId);
+            if (disguise == null ||
+                disguise.PlayerId != playerId ||
+                disguise.IsRetired)
+            {
+                return false;
+            }
+
+            if (IsActiveDisguise(player, disguiseId))
+                Deactivate(player);
+
+            disguise.IsRetired = true;
+            disguise.DateRetired = DateTime.UtcNow;
+            DB.Set(disguise);
+
+            Log.WriteStructured(
+                LogGroup.PlayerName,
+                "Disguise retired: PlayerId={PlayerId} PlayerName={PlayerName} DisguiseId={DisguiseId} PrivateName={PrivateName} Descriptor={Descriptor}",
+                playerId,
+                GetName(player),
+                disguise.Id,
+                disguise.PrivateName,
+                disguise.Descriptor);
+
+            return true;
+        }
+
+        public static bool Unretire(uint player, string disguiseId)
+        {
+            var playerId = GetObjectUUID(player);
+            var disguise = DB.Get<PlayerDisguise>(disguiseId);
+            if (disguise == null ||
+                disguise.PlayerId != playerId ||
+                !disguise.IsRetired)
+            {
+                return false;
+            }
+
+            disguise.IsRetired = false;
+            disguise.DateRetired = null;
+            DB.Set(disguise);
+
+            Log.WriteStructured(
+                LogGroup.PlayerName,
+                "Disguise restored: PlayerId={PlayerId} PlayerName={PlayerName} DisguiseId={DisguiseId} PrivateName={PrivateName} Descriptor={Descriptor}",
+                playerId,
+                GetName(player),
+                disguise.Id,
+                disguise.PrivateName,
+                disguise.Descriptor);
+
+            return true;
+        }
+
+        public static DeleteRetiredDisguiseResult DeleteRetiredDisguise(
+            uint player,
+            string disguiseId,
+            DisguisePaymentMethod paymentMethod)
+        {
+            var playerId = GetObjectUUID(player);
+            var dbPlayer = DB.Get<Player>(playerId);
+            var disguise = DB.Get<PlayerDisguise>(disguiseId);
+
+            if (disguise == null)
+                return DeleteRetiredDisguiseResult.NotFound;
+
+            if (disguise.PlayerId != playerId)
+                return DeleteRetiredDisguiseResult.NotOwner;
+
+            if (!disguise.IsRetired)
+                return DeleteRetiredDisguiseResult.NotRetired;
+
+            if (dbPlayer != null && dbPlayer.ActiveDisguiseId == disguise.Id)
+                return DeleteRetiredDisguiseResult.IsActive;
+
+            var amount = 0;
+            switch (paymentMethod)
+            {
+                case DisguisePaymentMethod.Credits:
+                    amount = WipeCreditCost;
+                    if (GetGold(player) < amount)
+                        return DeleteRetiredDisguiseResult.InsufficientCredits;
+
+                    TakeGoldFromCreature(amount, player, true);
+                    break;
+                case DisguisePaymentMethod.RoleplayXP:
+                    amount = WipeRoleplayXPCost;
+                    if (dbPlayer == null || dbPlayer.UnallocatedXP < amount)
+                        return DeleteRetiredDisguiseResult.InsufficientRoleplayXP;
+
+                    dbPlayer.UnallocatedXP -= amount;
+                    DB.Set(dbPlayer);
+                    Gui.PublishRefreshEvent(player, new RPXPRefreshEvent());
+                    break;
+                default:
+                    return DeleteRetiredDisguiseResult.InvalidPaymentMethod;
+            }
+
+            var identityKey = BuildIdentityKey(disguise.Id);
+            var removedKnownNames = PlayerName.DeleteKnownNameReferences(identityKey);
+
+            Log.WriteStructured(
+                LogGroup.PlayerName,
+                "Retired disguise deleted: PlayerId={PlayerId} PlayerName={PlayerName} PublicCDKey={PublicCDKey} DisguiseId={DisguiseId} PrivateName={PrivateName} Descriptor={Descriptor} PaymentMethod={PaymentMethod} PaymentAmount={PaymentAmount} RemovedKnownNameReferences={RemovedKnownNameReferences}",
+                playerId,
+                GetName(player),
+                GetPCPublicCDKey(player),
+                disguise.Id,
+                disguise.PrivateName,
+                disguise.Descriptor,
+                paymentMethod.ToString(),
+                amount,
+                removedKnownNames);
+
+            DB.Delete<PlayerDisguise>(disguise.Id);
+            return DeleteRetiredDisguiseResult.Success;
+        }
+
+        public static int ResetActivationCooldowns(uint player)
+        {
+            var playerId = GetObjectUUID(player);
+            var resetCount = 0;
+            var offset = 0;
+
+            while (true)
+            {
+                var page = DB.Search(new DBQuery<PlayerDisguise>()
+                        .AddFieldSearch(nameof(PlayerDisguise.PlayerId), playerId, false)
+                        .AddPaging(DisguiseQueryPageSize, offset))
+                    .ToList();
+
+                foreach (var disguise in page)
+                {
+                    if (!disguise.DateLastActivated.HasValue)
+                        continue;
+
+                    disguise.DateLastActivated = null;
+                    DB.Set(disguise);
+                    resetCount++;
+                }
+
+                if (page.Count < DisguiseQueryPageSize)
+                    break;
+
+                offset += DisguiseQueryPageSize;
+            }
+
+            return resetCount;
+        }
+
+        public static string GetPortraitResref(PlayerDisguise disguise)
+        {
+            if (disguise == null)
+                return string.Empty;
+
+            try
+            {
+                return Cache.GetPortraitResrefByInternalId(disguise.PortraitInternalId) + "l";
+            }
+            catch (KeyNotFoundException)
+            {
+                return string.Empty;
+            }
+        }
+
+        public static string GetSoundSetName(int soundSetId)
+        {
+            var soundSets = Cache.GetSoundSets();
+            return soundSets.TryGetValue(soundSetId, out var label)
+                ? label
+                : "Unknown";
+        }
+
+        private static string ValidatePrivateName(string privateName)
+        {
+            if (string.IsNullOrWhiteSpace(privateName))
+                return "Please enter a private disguise name.";
+
+            if (privateName.Length > MaxPrivateNameLength)
+                return $"Private disguise names may be no longer than {MaxPrivateNameLength} characters.";
+
+            if (privateName != UtilPlugin.StripColors(privateName))
+                return "Private disguise names may not contain color codes.";
+
+            return string.Empty;
+        }
+
+        private static bool IsActiveDisguise(uint player, string disguiseId)
+        {
+            var dbPlayer = DB.Get<Player>(GetObjectUUID(player));
+            return dbPlayer != null &&
+                   !string.IsNullOrWhiteSpace(disguiseId) &&
+                   dbPlayer.ActiveDisguiseId == disguiseId;
+        }
+
+        private static string ValidateActivationDelay(string playerId)
+        {
+            var latestActivation = GetLatestActivationDate(playerId);
+            if (!latestActivation.HasValue)
+                return string.Empty;
+
+            var remaining = ActivationDelay - (DateTime.UtcNow - latestActivation.Value);
+            if (remaining <= TimeSpan.Zero)
+                return string.Empty;
+
+            return $"There is a {ActivationDelayMinutes}-minute delay between disguise activations. You must wait {FormatRemainingDelay(remaining)} before activating another disguise. Deactivation is available immediately.";
+        }
+
+        private static DateTime? GetLatestActivationDate(string playerId)
+        {
+            DateTime? latestActivation = null;
+            var offset = 0;
+
+            while (true)
+            {
+                var page = DB.Search(new DBQuery<PlayerDisguise>()
+                        .AddFieldSearch(nameof(PlayerDisguise.PlayerId), playerId, false)
+                        .AddPaging(DisguiseQueryPageSize, offset))
+                    .ToList();
+
+                foreach (var disguise in page)
+                {
+                    if (!disguise.DateLastActivated.HasValue)
+                        continue;
+
+                    if (!latestActivation.HasValue ||
+                        disguise.DateLastActivated.Value > latestActivation.Value)
+                    {
+                        latestActivation = disguise.DateLastActivated.Value;
+                    }
+                }
+
+                if (page.Count < DisguiseQueryPageSize)
+                    break;
+
+                offset += DisguiseQueryPageSize;
+            }
+
+            return latestActivation;
+        }
+
+        private static string FormatRemainingDelay(TimeSpan remaining)
+        {
+            var minutes = (int)Math.Ceiling(remaining.TotalMinutes);
+            return minutes <= 1
+                ? "less than 1 minute"
+                : $"{minutes} minutes";
+        }
+
+        private static int ResolvePortraitInternalId(uint player)
+        {
+            var resref = GetPortraitResRef(player);
+            var internalId = Cache.GetPortraitInternalIdByResref(resref);
+            if (internalId > 0)
+                return internalId;
+
+            var portraitId = GetPortraitId(player);
+            try
+            {
+                internalId = Cache.GetPortraitInternalId(portraitId);
+                return internalId > 0
+                    ? internalId
+                    : 1;
+            }
+            catch (KeyNotFoundException)
+            {
+                return 1;
+            }
+        }
+
+        private static void ApplyAppearance(uint player, PlayerDisguise disguise)
+        {
+            if (disguise.PortraitInternalId > 0)
+            {
+                try
+                {
+                    SetPortraitId(player, Cache.GetPortraitByInternalId(disguise.PortraitInternalId));
+                }
+                catch (KeyNotFoundException)
+                {
+                    // Ignore invalid legacy portrait ids; the disguise descriptor still applies.
+                }
+            }
+
+            if (disguise.SoundSetId >= 0)
+                SetSoundset(player, disguise.SoundSetId);
+        }
+
+        private static void RefreshDisguiseDisplay(uint player)
+        {
+            PlayerName.RefreshNameOverridesForPlayer(player);
+            Gui.PublishRefreshEvent(player, new DisguiseChangedRefreshEvent());
+        }
+
+        private static int GetMaxPortraitCount()
+        {
+            return Math.Max(1, Cache.PortraitCount);
+        }
+    }
+}

--- a/SWLOR.Game.Server/Service/Disguise.cs
+++ b/SWLOR.Game.Server/Service/Disguise.cs
@@ -198,6 +198,7 @@ namespace SWLOR.Game.Server.Service
                 return SaveDisguiseResult.Failure(descriptorError);
 
             portraitInternalId = Math.Clamp(portraitInternalId, 1, GetMaxPortraitCount());
+            soundSetId = ResolveSoundSetId(soundSetId);
 
             disguise.PrivateName = PlayerName.SanitizeKnownName(privateName);
             disguise.Descriptor = PlayerName.SanitizeKnownName(descriptor);
@@ -561,8 +562,9 @@ namespace SWLOR.Game.Server.Service
                 }
             }
 
-            if (disguise.SoundSetId >= 0)
-                SetSoundset(player, disguise.SoundSetId);
+            var soundSetId = ResolveSoundSetId(disguise.SoundSetId);
+            if (soundSetId >= 0)
+                SetSoundset(player, soundSetId);
         }
 
         private static void RefreshDisguiseDisplay(uint player)
@@ -574,6 +576,13 @@ namespace SWLOR.Game.Server.Service
         private static int GetMaxPortraitCount()
         {
             return Math.Max(1, Cache.PortraitCount);
+        }
+
+        private static int ResolveSoundSetId(int soundSetId)
+        {
+            return Cache.GetSoundSets().ContainsKey(soundSetId)
+                ? soundSetId
+                : -1;
         }
     }
 }

--- a/SWLOR.Game.Server/Service/DisguiseService/ActivateDisguiseResult.cs
+++ b/SWLOR.Game.Server/Service/DisguiseService/ActivateDisguiseResult.cs
@@ -1,0 +1,24 @@
+namespace SWLOR.Game.Server.Service.DisguiseService
+{
+    public class ActivateDisguiseResult
+    {
+        public bool IsSuccessful { get; }
+        public string ErrorMessage { get; }
+
+        private ActivateDisguiseResult(bool isSuccessful, string errorMessage)
+        {
+            IsSuccessful = isSuccessful;
+            ErrorMessage = errorMessage;
+        }
+
+        public static ActivateDisguiseResult Success()
+        {
+            return new ActivateDisguiseResult(true, string.Empty);
+        }
+
+        public static ActivateDisguiseResult Failure(string errorMessage)
+        {
+            return new ActivateDisguiseResult(false, errorMessage);
+        }
+    }
+}

--- a/SWLOR.Game.Server/Service/DisguiseService/DeleteRetiredDisguiseResult.cs
+++ b/SWLOR.Game.Server/Service/DisguiseService/DeleteRetiredDisguiseResult.cs
@@ -1,0 +1,14 @@
+namespace SWLOR.Game.Server.Service.DisguiseService
+{
+    public enum DeleteRetiredDisguiseResult
+    {
+        Success = 0,
+        NotFound = 1,
+        NotOwner = 2,
+        NotRetired = 3,
+        IsActive = 4,
+        InsufficientCredits = 5,
+        InsufficientRoleplayXP = 6,
+        InvalidPaymentMethod = 7
+    }
+}

--- a/SWLOR.Game.Server/Service/DisguiseService/DisguisePaymentMethod.cs
+++ b/SWLOR.Game.Server/Service/DisguiseService/DisguisePaymentMethod.cs
@@ -1,0 +1,9 @@
+namespace SWLOR.Game.Server.Service.DisguiseService
+{
+    public enum DisguisePaymentMethod
+    {
+        Invalid = 0,
+        Credits = 1,
+        RoleplayXP = 2
+    }
+}

--- a/SWLOR.Game.Server/Service/DisguiseService/SaveDisguiseResult.cs
+++ b/SWLOR.Game.Server/Service/DisguiseService/SaveDisguiseResult.cs
@@ -1,0 +1,24 @@
+namespace SWLOR.Game.Server.Service.DisguiseService
+{
+    public class SaveDisguiseResult
+    {
+        public bool IsSuccessful { get; }
+        public string ErrorMessage { get; }
+
+        private SaveDisguiseResult(bool isSuccessful, string errorMessage)
+        {
+            IsSuccessful = isSuccessful;
+            ErrorMessage = errorMessage;
+        }
+
+        public static SaveDisguiseResult Success()
+        {
+            return new SaveDisguiseResult(true, string.Empty);
+        }
+
+        public static SaveDisguiseResult Failure(string errorMessage)
+        {
+            return new SaveDisguiseResult(false, errorMessage);
+        }
+    }
+}

--- a/SWLOR.Game.Server/Service/GuiService/GuiWindowType.cs
+++ b/SWLOR.Game.Server/Service/GuiService/GuiWindowType.cs
@@ -62,6 +62,7 @@ namespace SWLOR.Game.Server.Service.GuiService
         GuildTasks = 57,
         PlayerGuide = 58,
         PropertyDiagnostics = 59,
+        Disguises = 60,
 
         DebugEnmity = 900,
         ChangePortrait = 9999

--- a/SWLOR.Game.Server/Service/PlayerName.cs
+++ b/SWLOR.Game.Server/Service/PlayerName.cs
@@ -11,7 +11,7 @@ namespace SWLOR.Game.Server.Service
 {
     public static class PlayerName
     {
-        private const int MaxKnownNameLength = 64;
+        public const int MaxKnownNameLength = 64;
         public const string UnknownName = PlayerDescriptor.DefaultUnknownDisplayName;
         private static readonly Dictionary<string, PlayerKnownName> KnownNamesByObserverId = new();
         private static readonly Dictionary<string, bool> ShowDescriptorsForNamedPlayersByObserverId = new();
@@ -179,6 +179,7 @@ namespace SWLOR.Game.Server.Service
 
             return dbKnownNames.KnownNames
                 .Where(x => !string.IsNullOrWhiteSpace(x.Value) &&
+                            !Disguise.IsDisguiseIdentityKey(x.Key) &&
                             x.Value.ToLower().Contains(sanitizedSearch))
                 .Select(x => x.Key)
                 .Take(maxResults)
@@ -193,14 +194,14 @@ namespace SWLOR.Game.Server.Service
             var displayName = ResolveDisplayName(observer, target, out var isUnknown);
             if (!isUnknown && CanUseKnownName(observer, target) && TryGetKnownName(observer, target, out var knownName))
                 return ShouldShowDescriptorForNamedPlayers(observer)
-                    ? BuildColoredDisplayNameWithDescriptor(knownName, PlayerDescriptor.GetUnknownDisplayName(target))
+                    ? BuildColoredDisplayNameWithDescriptor(knownName, Disguise.GetDisplayDescriptor(target))
                     : ColorToken.GetPCColor(knownName);
 
             if (!isUnknown &&
                 GetIsObjectValid(observer) &&
                 (GetIsDM(observer) || GetIsDMPossessed(observer)))
             {
-                return BuildColoredDisplayNameWithDescriptor(GetName(target), PlayerDescriptor.GetUnknownDisplayName(target));
+                return BuildColoredDisplayNameWithDescriptor(GetName(target), Disguise.GetDisplayDescriptor(target));
             }
 
             return isUnknown
@@ -275,7 +276,7 @@ namespace SWLOR.Game.Server.Service
                 return validationError;
 
             var sanitizedName = SanitizeKnownName(name);
-            var targetId = GetObjectUUID(target);
+            var targetId = Disguise.GetIdentityKey(target);
             if (string.IsNullOrWhiteSpace(targetId))
                 return "Unable to identify that player.";
 
@@ -291,7 +292,7 @@ namespace SWLOR.Game.Server.Service
                 throw new ArgumentException(validationError);
 
             var sanitizedName = SanitizeKnownName(name);
-            var targetId = GetObjectUUID(target);
+            var targetId = Disguise.GetIdentityKey(target);
 
             var dbKnownNames = GetKnownNames(observer, true);
 
@@ -337,7 +338,7 @@ namespace SWLOR.Game.Server.Service
 
         public static void ForgetKnownName(uint observer, uint target)
         {
-            var targetId = GetObjectUUID(target);
+            var targetId = Disguise.GetIdentityKey(target);
             var dbKnownNames = GetKnownNames(observer, false);
 
             if (dbKnownNames?.KnownNames == null ||
@@ -351,6 +352,43 @@ namespace SWLOR.Game.Server.Service
             DB.Set(dbKnownNames);
 
             ApplyNameOverride(observer, target);
+        }
+
+        public static int DeleteKnownNameReferences(string targetIdentityKey)
+        {
+            if (string.IsNullOrWhiteSpace(targetIdentityKey))
+                return 0;
+
+            var removed = 0;
+            var offset = 0;
+            const int PageSize = 50;
+
+            while (true)
+            {
+                var page = DB.Search(new DBQuery<PlayerKnownName>()
+                        .AddPaging(PageSize, offset))
+                    .ToList();
+
+                foreach (var dbKnownNames in page)
+                {
+                    if (dbKnownNames.KnownNames == null ||
+                        !dbKnownNames.KnownNames.Remove(targetIdentityKey))
+                    {
+                        continue;
+                    }
+
+                    removed++;
+                    DB.Set(dbKnownNames);
+                    KnownNamesByObserverId.Remove(dbKnownNames.ObserverPlayerId);
+                }
+
+                if (page.Count < PageSize)
+                    break;
+
+                offset += PageSize;
+            }
+
+            return removed;
         }
 
         public static void RefreshNameOverridesForObserver(uint observer)
@@ -421,11 +459,11 @@ namespace SWLOR.Game.Server.Service
             if (!GetIsObjectValid(player) || !GetIsPC(player) || GetIsDM(player))
                 return;
 
-            var unknownDisplayName = PlayerDescriptor.GetUnknownDisplayName(player);
+            var unknownDisplayName = Disguise.GetDisplayDescriptor(player);
             var ownDisplayName = ShouldShowOwnDescriptor(player)
                 ? BuildDisplayNameWithDescriptor(GetName(player), unknownDisplayName)
                 : GetName(player);
-            var shouldScrambleAccountName = ShouldScrambleAccountName(player);
+            var shouldScrambleAccountName = Disguise.ShouldScrambleAccountName(player);
 
             if (!shouldScrambleAccountName)
                 RenamePlugin.ClearPCNameOverride(player);
@@ -505,7 +543,7 @@ namespace SWLOR.Game.Server.Service
         private static string BuildStaffDisplayName(uint target)
         {
             var trueName = GetName(target);
-            var unknownDisplayName = PlayerDescriptor.GetUnknownDisplayName(target);
+            var unknownDisplayName = Disguise.GetDisplayDescriptor(target);
 
             return $"{trueName} [{ColorToken.Gray(unknownDisplayName)}]";
         }
@@ -539,7 +577,7 @@ namespace SWLOR.Game.Server.Service
             if (observer == target)
             {
                 var ownDisplayName = ShouldShowOwnDescriptor(target)
-                    ? BuildDisplayNameWithDescriptor(GetName(target), PlayerDescriptor.GetUnknownDisplayName(target))
+                    ? BuildDisplayNameWithDescriptor(GetName(target), Disguise.GetDisplayDescriptor(target))
                     : GetName(target);
 
                 RenamePlugin.SetPCNameOverride(target, ownDisplayName, string.Empty, string.Empty, PlayerNameOverrideType.Default, observer);
@@ -575,7 +613,7 @@ namespace SWLOR.Game.Server.Service
                 return knownName;
 
             isUnknown = true;
-            return PlayerDescriptor.GetUnknownDisplayName(target);
+            return Disguise.GetDisplayDescriptor(target);
         }
 
         private static string ResolveDisplayName(uint observer, uint target, out bool isUnknown)
@@ -595,18 +633,18 @@ namespace SWLOR.Game.Server.Service
             }
 
             if (GetIsDM(observer) || GetIsDMPossessed(observer))
-                return BuildDisplayNameWithDescriptor(GetName(target), PlayerDescriptor.GetUnknownDisplayName(target));
+                return BuildDisplayNameWithDescriptor(GetName(target), Disguise.GetDisplayDescriptor(target));
 
             if (!GetIsPC(observer))
                 return GetName(target);
 
             if (TryGetKnownName(observer, target, out var knownName))
                 return ShouldShowDescriptorForNamedPlayers(observer)
-                    ? BuildDisplayNameWithDescriptor(knownName, PlayerDescriptor.GetUnknownDisplayName(target))
+                    ? BuildDisplayNameWithDescriptor(knownName, Disguise.GetDisplayDescriptor(target))
                     : knownName;
 
             isUnknown = true;
-            return PlayerDescriptor.GetUnknownDisplayName(target);
+            return Disguise.GetDisplayDescriptor(target);
         }
 
         private static string BuildDisplayNameWithDescriptor(string primaryName, string descriptor)
@@ -669,27 +707,9 @@ namespace SWLOR.Game.Server.Service
             return dbPlayer?.Settings?.ShowOwnDescriptor ?? true;
         }
 
-        private static bool ShouldScrambleAccountName(uint player)
-        {
-            if (!GetIsObjectValid(player) ||
-                !GetIsPC(player) ||
-                GetIsDM(player) ||
-                GetIsDMPossessed(player))
-            {
-                return false;
-            }
-
-            var playerId = GetObjectUUID(player);
-            if (string.IsNullOrWhiteSpace(playerId))
-                return true;
-
-            var dbPlayer = DB.Get<Player>(playerId);
-            return dbPlayer?.Settings?.ScrambleAccountName ?? true;
-        }
-
         private static bool TryGetKnownName(uint observer, uint target, out string knownName)
         {
-            var targetId = GetObjectUUID(target);
+            var targetId = Disguise.GetIdentityKey(target);
             return TryGetKnownName(observer, targetId, out knownName);
         }
 

--- a/SWLOR.Game.Server/Service/Spawn.cs
+++ b/SWLOR.Game.Server/Service/Spawn.cs
@@ -599,6 +599,7 @@ namespace SWLOR.Game.Server.Service
             if (type == ObjectType.Creature)
             {
                 var originalSpawnScript = GetEventScript(spawn, EventScript.Creature_OnSpawnIn);
+                ObjectPlugin.SetConversationPrivate(spawn, true);
 
                 SetEventScript(spawn, EventScript.Creature_OnBlockedByDoor, "x2_def_onblocked");
                 SetEventScript(spawn, EventScript.Creature_OnEndCombatRound, "x2_def_endcombat");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Disguises** window for managing available and retired disguises, including activate/deactivate and edit flows.
  * Added chat commands **/disguise** (alias **/disguises**) and a **Disguises** button on the character sheet to open the UI.
  * Added an **Identity Broker** dialog to permanently wipe retired disguise identities for a fee (with sound-set previews).
* **Bug Fixes**
  * Improved chat handling so **“/” alone** no longer triggers command behavior.
  * NPC dialogs now default to **private conversations** in more spawn cases.
  * First Aid treatment kit now grants combat points only when friendly targets are affected.
* **Game Data Updates**
  * Added Identity Broker identity/creature content, updated area versions/localization, and adjusted a tileset/area config setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->