### PR TITLE
Fix disguise/chat identity bugs and harden Communication

### DIFF
--- a/SWLOR.Game.Server.Tests/Service/CommunicationEmoteParsingTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/CommunicationEmoteParsingTests.cs
@@ -1,0 +1,81 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using FluentAssertions;
+using NUnit.Framework;
+using SWLOR.Game.Server.Service;
+
+namespace SWLOR.Game.Server.Tests.Service;
+
+// Covers the pure emote-splitting parser used to color and translate in-character chat.
+// These methods make no NWN native calls, so they can be exercised directly via reflection.
+public class CommunicationEmoteParsingTests
+{
+    private sealed class ParsedComponent
+    {
+        public string Text { get; init; }
+        public bool IsTranslatable { get; init; }
+        public bool IsCustomColor { get; init; }
+    }
+
+    [Test]
+    public void RegularStyle_BracketEmote_IsCustomColoredAndNotTranslatable()
+    {
+        var components = SplitRegular("[waves]");
+
+        var emote = components.Single(c => c.Text == "waves");
+        emote.IsCustomColor.Should().BeTrue("bracketed emotes must carry the emote color");
+        emote.IsTranslatable.Should().BeFalse("emotes are never language-translated");
+    }
+
+    [Test]
+    public void RegularStyle_AsteriskEmote_IsCustomColored()
+    {
+        var components = SplitRegular("*waves*");
+
+        var emote = components.Single(c => c.Text == "*waves*");
+        emote.IsCustomColor.Should().BeTrue();
+        emote.IsTranslatable.Should().BeFalse();
+    }
+
+    [Test]
+    public void RegularStyle_BracketEmoteWithSpokenText_SplitsColorAndTranslationCorrectly()
+    {
+        var components = SplitRegular("hello [waves] there");
+
+        var spokenBefore = components.Single(c => c.Text == "hello ");
+        spokenBefore.IsTranslatable.Should().BeTrue();
+        spokenBefore.IsCustomColor.Should().BeFalse();
+
+        var emote = components.Single(c => c.Text == "waves");
+        emote.IsCustomColor.Should().BeTrue();
+        emote.IsTranslatable.Should().BeFalse();
+
+        var spokenAfter = components.Single(c => c.Text == " there");
+        spokenAfter.IsTranslatable.Should().BeTrue();
+        spokenAfter.IsCustomColor.Should().BeFalse();
+    }
+
+    private static List<ParsedComponent> SplitRegular(string message)
+    {
+        var result = (IEnumerable)typeof(Communication)
+            .GetMethod(
+                "SplitMessageIntoComponents_Regular",
+                BindingFlags.Static | BindingFlags.NonPublic)!
+            .Invoke(null, new object[] { message })!;
+
+        return result.Cast<object>().Select(Project).ToList();
+    }
+
+    private static ParsedComponent Project(object component)
+    {
+        var type = component.GetType();
+        return new ParsedComponent
+        {
+            Text = (string)type.GetProperty("Text")!.GetValue(component),
+            IsTranslatable = (bool)type.GetProperty("IsTranslatable")!.GetValue(component),
+            IsCustomColor = (bool)type.GetProperty("IsCustomColor")!.GetValue(component)
+        };
+    }
+}

--- a/SWLOR.Game.Server/Service/Communication.cs
+++ b/SWLOR.Game.Server/Service/Communication.cs
@@ -290,6 +290,20 @@ namespace SWLOR.Game.Server.Service
                 SendMessageToPC(sender, ColorToken.Red(CommsOutOfRangeMessage));
             }
 
+            // The speaker and the language being spoken are the same for every recipient, so resolve
+            // them once before dispatching rather than recomputing (and re-writing language state)
+            // per receiver.
+            var speaker = GetEffectiveChatSpeaker(sender);
+            var language = Language.GetActiveLanguage(speaker);
+
+            // Wookiees cannot speak any other language (but they can understand them).
+            // Swap their language if they attempt to speak in any other language.
+            if (GetRacialType(speaker) == RacialType.Wookiee && language != SkillType.Shyriiwook)
+            {
+                Language.SetActiveLanguage(speaker, SkillType.Shyriiwook);
+                language = SkillType.Shyriiwook;
+            }
+
             // Now we have a list of who is going to actually receive a message, we need to modify
             // the message for each recipient then dispatch them.
             foreach (var receiver in recipients.Distinct())
@@ -338,22 +352,9 @@ namespace SWLOR.Game.Server.Service
                         finalMessage.Append(" } ");
                     }
                 }
-                var speaker = GetEffectiveChatSpeaker(sender);
-                var language = Language.GetActiveLanguage(speaker);
-
-                // Wookiees cannot speak any other language (but they can understand them).
-                // Swap their language if they attempt to speak in any other language.
-                var race = GetRacialType(speaker);
-                if (race == RacialType.Wookiee && language != SkillType.Shyriiwook)
-                {
-                    Language.SetActiveLanguage(speaker, SkillType.Shyriiwook);
-                    language = SkillType.Shyriiwook;
-                }
-
                 var (r, g, b) = Language.GetColor(language);
 
-                if (dbReceiver != null &&
-                    dbReceiver.Settings.LanguageChatColors != null &&
+                if (dbReceiver?.Settings?.LanguageChatColors != null &&
                     dbReceiver.Settings.LanguageChatColors.ContainsKey(language))
                 {
                     r = dbReceiver.Settings.LanguageChatColors[language].Red;
@@ -378,8 +379,7 @@ namespace SWLOR.Game.Server.Service
 
                     if (component.IsOOC)
                     {
-                        if (dbReceiver != null &&
-                            dbReceiver.Settings.OOCChatColor != null)
+                        if (dbReceiver?.Settings?.OOCChatColor != null)
                         {
                             r = dbReceiver.Settings.OOCChatColor.Red;
                             g = dbReceiver.Settings.OOCChatColor.Green;
@@ -397,8 +397,7 @@ namespace SWLOR.Game.Server.Service
                     {
                         byte emoteRed, emoteGreen, emoteBlue;
 
-                        if (dbReceiver != null &&
-                            dbReceiver.Settings.EmoteChatColor != null)
+                        if (dbReceiver?.Settings?.EmoteChatColor != null)
                         {
                             emoteRed = dbReceiver.Settings.EmoteChatColor.Red;
                             emoteGreen = dbReceiver.Settings.EmoteChatColor.Green;
@@ -737,9 +736,13 @@ namespace SWLOR.Game.Server.Service
 
                 if (length != -1)
                 {
+                    // This block only runs when an emote delimiter has closed (bracket, asterisk, or
+                    // double-colon), so the captured segment is always an emote and must carry the
+                    // emote (custom) color. The previous bracket-specific condition left bracketed
+                    // emotes uncolored and untranslated, rendering them as plain language-colored text.
                     var component = new CommunicationComponent
                     {
-                        IsCustomColor = workingOn != WorkingOnEmoteStyle.Bracket || message[indexStart] == '[',
+                        IsCustomColor = true,
                         IsTranslatable = false,
                         Text = message.Substring(indexStart, length)
                     };
@@ -867,7 +870,7 @@ namespace SWLOR.Game.Server.Service
                 var playerId = GetObjectUUID(player);
                 var dbPlayer = DB.Get<Player>(playerId);
 
-                return dbPlayer.EmoteStyle;
+                return dbPlayer?.EmoteStyle ?? EmoteStyle.Regular;
             }
 
             return EmoteStyle.Regular;
@@ -879,6 +882,9 @@ namespace SWLOR.Game.Server.Service
             {
                 var playerId = GetObjectUUID(player);
                 var dbPlayer = DB.Get<Player>(playerId);
+                if (dbPlayer == null)
+                    return;
+
                 dbPlayer.EmoteStyle = style;
                 DB.Set(dbPlayer);
             }

--- a/SWLOR.Game.Server/Service/Disguise.cs
+++ b/SWLOR.Game.Server/Service/Disguise.cs
@@ -230,11 +230,23 @@ namespace SWLOR.Game.Server.Service
                 return ActivateDisguiseResult.Failure("Unable to activate that disguise.");
             }
 
+            // Re-activating the disguise that is already active is a harmless no-op. Return early so
+            // the activation delay does not falsely block it and DateLastActivated is not re-stamped.
+            if (dbPlayer.ActiveDisguiseId == disguise.Id)
+            {
+                ApplyAppearance(player, disguise);
+                RefreshDisguiseDisplay(player);
+                return ActivateDisguiseResult.Success();
+            }
+
             var delayError = ValidateActivationDelay(playerId);
             if (!string.IsNullOrWhiteSpace(delayError))
                 return ActivateDisguiseResult.Failure(delayError);
 
-            if (GetActiveDisguise(dbPlayer) == null)
+            // Only snapshot the undisguised baseline when transitioning from no active disguise.
+            // Keying off the stored id (rather than a resolved disguise) avoids capturing an
+            // already-applied disguise appearance as the baseline if the stored id is ever stale.
+            if (string.IsNullOrWhiteSpace(dbPlayer.ActiveDisguiseId))
             {
                 dbPlayer.UndisguisedPortraitId = GetPortraitId(player);
                 dbPlayer.UndisguisedPortraitResref = GetPortraitResRef(player);


### PR DESCRIPTION
Fixes bugs and oversights found while reviewing the disguise system and its integration with the chat/communication pipeline.

## Communication
- **Bracket emotes lost their color.** `[action]` segments were rendered as plain language-colored text (and untranslated), unlike `*asterisk*` and `::colon::` emotes. The reset block only runs when an emote delimiter has closed, so the captured segment is always an emote and now carries the emote color.
- **Per-receiver recomputation.** The effective speaker, spoken language, and the Wookiee→Shyriiwook language swap are now resolved once before the dispatch loop instead of being recomputed (and re-writing language state) for every recipient.
- **NRE hardening.** `dbReceiver.Settings` dereferences use null-conditional access so a legacy record with a null `Settings` can't throw mid-dispatch, and `GetEmoteStyle`/`SetEmoteStyle` no longer throw on a missing DB record.

## Disguise
- **Re-activating the active disguise** returns early as a no-op, so it isn't falsely blocked by the 30-minute activation delay and `DateLastActivated` isn't re-stamped.
- **Undisguised baseline capture** now keys off `ActiveDisguiseId` emptiness rather than a resolved disguise, so a stale/invalid stored id can't capture an already-applied disguise appearance as the "undisguised" baseline.

## Tests
- Added `CommunicationEmoteParsingTests` covering bracket/asterisk emote coloring and mixed spoken+emote splitting (the parser is pure, exercised via reflection).

## Verification
Built with `-p:RunPostBuildEvent=Never -p:OS=Unix`; targeted suites pass (emote parsing, name recognition, name broadcast, messaging).

## Notes
- Left the immediate name-override restore for talk/whisper/party (vs. the delayed restore for tells) as-is — that is the correct handling of the NWNX Rename quirk.
- The `PlayerParty → DMTalk` channel mapping is unchanged; worth noting that players who hide the DM channel client-side won't see Comms (design/documentation call, not a code bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
