### PR TITLE
Add /hpset NPC HP tracker with above-the-head name-plate bar

### DIFF
--- a/SWLOR.Game.Server/Feature/ChatCommandDefinition/HPTrackerChatCommand.cs
+++ b/SWLOR.Game.Server/Feature/ChatCommandDefinition/HPTrackerChatCommand.cs
@@ -1,0 +1,209 @@
+using System.Collections.Generic;
+using SWLOR.Game.Server.Enumeration;
+using SWLOR.Game.Server.Service;
+using SWLOR.Game.Server.Service.ChatCommandService;
+using SWLOR.NWN.API.NWScript.Enum;
+
+namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
+{
+    /// <summary>
+    /// Chat commands for a temporary, narrative HP tracker shown as a bar above an NPC.
+    /// See <see cref="HPTracker"/> for the display/lifecycle logic. These commands never
+    /// affect a creature's real combat hit points.
+    ///
+    /// All four require the caller to click a creature target. Trackers are NPC-only and
+    /// DM/Admin-only: player-character name display is owned by the recognition/disguise
+    /// system (<see cref="PlayerName"/>), so keeping HP trackers off PCs guarantees the two
+    /// systems remain independent and never fight over the same displayed name.
+    /// </summary>
+    public class HPTrackerChatCommand : IChatCommandListDefinition
+    {
+        private readonly ChatCommandBuilder _builder = new ChatCommandBuilder();
+
+        public Dictionary<string, ChatCommandDetail> BuildChatCommands()
+        {
+            SetHP();
+            IncreaseHP();
+            DecreaseHP();
+            DeleteHP();
+
+            return _builder.Build();
+        }
+
+        private void SetHP()
+        {
+            _builder.Create("hpset", "sethp")
+                .Description("Creates/updates a temporary HP tracker shown above an NPC. Usage: /hpset <hp> (starts full) or /hpset <current> <max>. DM/Admin only; NPC targets only.")
+                .Permissions(AuthorizationLevel.All)
+                .RequiresTarget(ObjectType.Creature)
+                .Validate((user, args) =>
+                {
+                    if (args.Length < 1 || args.Length > 2)
+                        return "Usage: /hpset <hp>   or   /hpset <current> <max>";
+
+                    if (args.Length == 1)
+                    {
+                        if (!int.TryParse(args[0], out var hp) || hp < 1)
+                            return "HP must be a whole number of 1 or greater.";
+                    }
+                    else
+                    {
+                        if (!int.TryParse(args[0], out var current) || current < 0)
+                            return "Current HP must be a whole number of 0 or greater.";
+                        if (!int.TryParse(args[1], out var max) || max < 1)
+                            return "Max HP must be a whole number of 1 or greater.";
+                        if (current > max)
+                            return "Current HP cannot be greater than max HP.";
+                    }
+
+                    return string.Empty;
+                })
+                .Action((user, target, _, args) =>
+                {
+                    if (!CanTarget(user, target)) return;
+
+                    int current, max;
+                    if (args.Length == 2)
+                    {
+                        current = int.Parse(args[0]);
+                        max = int.Parse(args[1]);
+                    }
+                    else
+                    {
+                        current = int.Parse(args[0]);
+                        max = current;
+                    }
+
+                    HPTracker.Set(target, current, max);
+                    BroadcastNearby(target, ColorToken.Green($"{GetName(target)}'s HP tracker set to {current}/{max}."));
+                });
+        }
+
+        private void IncreaseHP()
+        {
+            _builder.Create("hpinc", "inchp")
+                .Description("Increases the current HP on a target's HP tracker. Usage: /hpinc [amount] (default 1).")
+                .Permissions(AuthorizationLevel.All)
+                .RequiresTarget(ObjectType.Creature)
+                .Validate((user, args) => ValidateAmount(args))
+                .Action((user, target, _, args) => AdjustHP(user, target, ParseAmount(args)));
+        }
+
+        private void DecreaseHP()
+        {
+            _builder.Create("hpdec", "dechp")
+                .Description("Decreases the current HP on a target's HP tracker. Usage: /hpdec [amount] (default 1).")
+                .Permissions(AuthorizationLevel.All)
+                .RequiresTarget(ObjectType.Creature)
+                .Validate((user, args) => ValidateAmount(args))
+                .Action((user, target, _, args) => AdjustHP(user, target, -ParseAmount(args)));
+        }
+
+        private void DeleteHP()
+        {
+            _builder.Create("hpdel", "delhp")
+                .Description("Removes a target's HP tracker entirely. Usage: /hpdel.")
+                .Permissions(AuthorizationLevel.All)
+                .RequiresTarget(ObjectType.Creature)
+                .Action((user, target, _, _) =>
+                {
+                    if (!CanTarget(user, target)) return;
+
+                    if (!HPTracker.Has(target))
+                    {
+                        SendMessageToPC(user, ColorToken.Red($"{GetName(target)} does not have an HP tracker."));
+                        return;
+                    }
+
+                    HPTracker.Remove(target);
+                    SendMessageToPC(user, ColorToken.Green($"HP tracker removed from {GetName(target)}."));
+                });
+        }
+
+        // ---- Helpers ----
+
+        /// <summary>
+        /// Validates the optional single amount argument for /hpinc and /hpdec.
+        /// An empty argument list is valid (defaults to 1).
+        /// </summary>
+        private static string ValidateAmount(string[] args)
+        {
+            if (args.Length == 0)
+                return string.Empty;
+            if (args.Length > 1)
+                return "Provide a single amount, e.g. /hpdec 3";
+            if (!int.TryParse(args[0], out var amount) || amount < 1)
+                return "Amount must be a whole number of 1 or greater.";
+            return string.Empty;
+        }
+
+        private static int ParseAmount(string[] args)
+        {
+            if (args.Length >= 1 && int.TryParse(args[0], out var amount) && amount >= 1)
+                return amount;
+            return 1;
+        }
+
+        private void AdjustHP(uint user, uint target, int delta)
+        {
+            if (!CanTarget(user, target)) return;
+
+            if (!HPTracker.Has(target))
+            {
+                SendMessageToPC(user, ColorToken.Red($"{GetName(target)} does not have an HP tracker. Use /hpset first."));
+                return;
+            }
+
+            HPTracker.Adjust(target, delta);
+            var (current, max) = HPTracker.Get(target);
+            BroadcastNearby(target, ColorToken.Green($"{GetName(target)}'s HP tracker is now {current}/{max}."));
+        }
+
+        /// <summary>
+        /// HP trackers are NPC-only and DM/Admin-only. NPC-only keeps this feature fully
+        /// independent of the player recognition/disguise system, which owns PC name display.
+        /// Sends an error to the user and returns false if the target is invalid or not permitted.
+        /// </summary>
+        private static bool CanTarget(uint user, uint target)
+        {
+            if (!GetIsObjectValid(target) || GetObjectType(target) != ObjectType.Creature)
+            {
+                SendMessageToPC(user, ColorToken.Red("You must target a creature."));
+                return false;
+            }
+
+            // NPC-only: player-character name display is owned by the recognition/disguise system
+            // (PlayerName). Keeping HP trackers off PCs guarantees the two systems never fight over
+            // the same displayed name.
+            if (GetIsPC(target) || GetIsDM(target))
+            {
+                SendMessageToPC(user, ColorToken.Red("HP trackers can only be placed on NPCs."));
+                return false;
+            }
+
+            var level = Authorization.GetAuthorizationLevel(user);
+            var isStaff = level == AuthorizationLevel.DM || level == AuthorizationLevel.Admin;
+            if (!isStaff)
+            {
+                SendMessageToPC(user, ColorToken.Red("Only DMs and Admins can manage HP trackers."));
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Sends a message to every player and DM in the same area as the origin creature
+        /// (matching where the HP bar itself is visible).
+        /// </summary>
+        private static void BroadcastNearby(uint origin, string message)
+        {
+            var area = GetArea(origin);
+            for (var pc = GetFirstPC(); GetIsObjectValid(pc); pc = GetNextPC())
+            {
+                if (GetArea(pc) == area)
+                    SendMessageToPC(pc, message);
+            }
+        }
+    }
+}

--- a/SWLOR.Game.Server/Service/HPTracker.cs
+++ b/SWLOR.Game.Server/Service/HPTracker.cs
@@ -1,0 +1,227 @@
+﻿using System.Collections.Generic;
+using SWLOR.Game.Server.Core;
+using SWLOR.NWN.API.NWNX;
+
+namespace SWLOR.Game.Server.Service
+{
+    /// <summary>
+    /// A temporary, in-memory, *narrative* hit-point tracker rendered as a bar in a
+    /// creature's name-plate (above its model). This is purely a display / bookkeeping
+    /// tool: it never applies damage or heal effects and never touches a creature's real
+    /// combat hit points. Trackers are transient and are cleared on object destruction
+    /// and on the tracked player's logout (they do not survive a server restart).
+    ///
+    /// Display is driven by <see cref="PlayerPlugin.SetCreatureNameOverride"/>, which is a
+    /// per-observer, client-side override. Because it is client-side, server-side
+    /// GetName(creature) still returns the true name, so the label is rebuilt on demand and
+    /// only the {current, max} pair is persisted here.
+    /// </summary>
+    public static class HPTracker
+    {
+        private class TrackerState
+        {
+            public int Current;
+            public int Max;
+        }
+
+        // Creature -> tracked HP. Keyed by object id; purged on destroy / logout so a reused
+        // object id can never inherit a stale tracker (mirrors the lifecycle in Enmity).
+        private static readonly Dictionary<uint, TrackerState> _trackers = new();
+
+        private const int BarSegments = 10;
+
+        // Block characters for the bar, written as escapes to stay independent of source encoding.
+        private const char FilledSegment = '█'; // full block
+        private const char EmptySegment = '░';  // light shade
+
+        /// <summary>
+        /// Creates or replaces a tracker on the given creature and refreshes its name-plate.
+        /// A single-value call passes current == max (starts full).
+        /// </summary>
+        public static void Set(uint creature, int current, int max)
+        {
+            if (max < 1) max = 1;
+            if (current < 0) current = 0;
+            if (current > max) current = max;
+
+            _trackers[creature] = new TrackerState { Current = current, Max = max };
+            Refresh(creature);
+        }
+
+        /// <summary>
+        /// Adjusts the current HP of an existing tracker by delta, clamped to [0, Max].
+        /// Does nothing if the creature has no tracker.
+        /// </summary>
+        public static void Adjust(uint creature, int delta)
+        {
+            if (!_trackers.TryGetValue(creature, out var state))
+                return;
+
+            state.Current += delta;
+            if (state.Current < 0) state.Current = 0;
+            if (state.Current > state.Max) state.Current = state.Max;
+
+            Refresh(creature);
+        }
+
+        /// <summary>
+        /// Removes a tracker and clears the name-plate override from all observers.
+        /// </summary>
+        public static void Remove(uint creature)
+        {
+            if (!_trackers.ContainsKey(creature))
+                return;
+
+            Clear(creature);
+            _trackers.Remove(creature);
+        }
+
+        /// <summary>
+        /// Returns whether the creature currently has a tracker.
+        /// </summary>
+        public static bool Has(uint creature)
+        {
+            return _trackers.ContainsKey(creature);
+        }
+
+        /// <summary>
+        /// Returns the current/max pair of a tracked creature. Only call after Has() is true.
+        /// </summary>
+        public static (int Current, int Max) Get(uint creature)
+        {
+            var state = _trackers[creature];
+            return (state.Current, state.Max);
+        }
+
+        /// <summary>
+        /// Re-applies the name-plate override for a tracked creature to every observing
+        /// player (including DM clients) currently in the creature's area.
+        /// </summary>
+        private static void Refresh(uint creature)
+        {
+            if (!_trackers.TryGetValue(creature, out var state))
+                return;
+
+            var label = BuildLabel(creature, state);
+            var area = GetArea(creature);
+
+            // GetFirstPC/GetNextPC includes DM clients (unlike Area.GetPlayersInArea), and DMs
+            // are the primary audience for these bars.
+            for (var observer = GetFirstPC(); GetIsObjectValid(observer); observer = GetNextPC())
+            {
+                if (GetArea(observer) != area) continue;
+                PlayerPlugin.SetCreatureNameOverride(observer, creature, label);
+            }
+        }
+
+        /// <summary>
+        /// Clears the name-plate override for a creature from every observer in its area.
+        /// </summary>
+        private static void Clear(uint creature)
+        {
+            // Sweep ALL online players (not just the creature's current area): an observer may
+            // have received the override and then moved to another area before the tracker was
+            // removed. Clearing an override a client never had is harmless, and doing so here
+            // prevents a stale "ghost" bar from lingering when that observer returns.
+            for (var observer = GetFirstPC(); GetIsObjectValid(observer); observer = GetNextPC())
+            {
+                PlayerPlugin.SetCreatureNameOverride(observer, creature, string.Empty);
+            }
+        }
+
+        /// <summary>
+        /// Applies the override for a single tracked creature to a single observer. Used when
+        /// a player enters an area so they immediately see any existing trackers there.
+        /// </summary>
+        private static void ApplyToObserver(uint observer, uint creature)
+        {
+            if (!_trackers.TryGetValue(creature, out var state))
+                return;
+
+            PlayerPlugin.SetCreatureNameOverride(observer, creature, BuildLabel(creature, state));
+        }
+
+        private static string BuildLabel(uint creature, TrackerState state)
+        {
+            var bar = BuildBar(state.Current, state.Max);
+            return $"{GetName(creature)}\n{bar} {state.Current}/{state.Max}";
+        }
+
+        private static string BuildBar(int current, int max)
+        {
+            var ratio = max <= 0 ? 0f : (float)current / max;
+            if (ratio < 0f) ratio = 0f;
+            if (ratio > 1f) ratio = 1f;
+
+            var filled = (int)(ratio * BarSegments + 0.5f);
+            if (current > 0 && filled == 0) filled = 1; // never render an empty bar while HP > 0
+            if (filled > BarSegments) filled = BarSegments;
+            var empty = BarSegments - filled;
+
+            var bar = new string(FilledSegment, filled) + new string(EmptySegment, empty);
+
+            // Gradient: green (full) -> yellow (half) -> red (empty).
+            byte r, g;
+            if (ratio >= 0.5f)
+            {
+                r = (byte)(255 * (1f - ratio) * 2f); // 0 at full, 255 at half
+                g = 255;
+            }
+            else
+            {
+                r = 255;
+                g = (byte)(255 * ratio * 2f);        // 255 at half, 0 at empty
+            }
+
+            return ColorToken.Custom(bar, r, g, 0);
+        }
+
+        // ---- Lifecycle ----
+
+        /// <summary>
+        /// When a player/DM enters an area, show them the trackers of creatures already there.
+        /// When a *tracked creature* enters a new area, refresh its bar for that area's observers.
+        /// </summary>
+        [NWNEventHandler(ScriptName.OnAreaEnter)]
+        public static void ApplyTrackersOnAreaEnter()
+        {
+            var entering = GetEnteringObject();
+            var area = OBJECT_SELF;
+
+            // A tracked creature moved into this area: refresh it for everyone here.
+            if (_trackers.ContainsKey(entering))
+                Refresh(entering);
+
+            // A player/DM arrived: push every tracker in this area to them.
+            if (GetIsPC(entering) || GetIsDM(entering))
+            {
+                foreach (var creature in _trackers.Keys)
+                {
+                    if (GetArea(creature) == area)
+                        ApplyToObserver(entering, creature);
+                }
+            }
+        }
+
+        /// <summary>
+        /// When a tracked creature is destroyed, clear its name-plate override and drop its
+        /// tracker. Clearing first matters because NWN reuses object ids — a lingering override
+        /// could otherwise "ghost" onto a new object that reuses the same id. Uses Remove(),
+        /// which no-ops for untracked objects (the common case for this frequent event).
+        /// </summary>
+        [NWNEventHandler(ScriptName.OnObjectDestroyed)]
+        public static void RemoveTrackerOnDestroyed()
+        {
+            Remove(OBJECT_SELF);
+        }
+
+        /// <summary>
+        /// When a tracked player logs out, clear their name-plate override and drop their tracker.
+        /// </summary>
+        [NWNEventHandler(ScriptName.OnModuleExit)]
+        public static void RemoveTrackerOnExit()
+        {
+            Remove(GetExitingObject());
+        }
+    }
+}


### PR DESCRIPTION
Rebased onto `feature/combat-upgrade` and reworked from #2077 (which targeted `master`) to stay independent of the player recognition/disguise system on this branch.

## Summary
A temporary, **narrative** HP tracker shown as a colored bar in an **NPC's** name-plate (above its model), completely separate from the engine's real combat HP — e.g. track `4/5` on a scene NPC without ever damaging or healing it.

## Scope: NPC-only, by design
The recognition/disguise system (`PlayerName` + NWNX Rename) owns **PC** displayed names. Rather than piggyback on that (which would put the bar inside the Rename override — and Rename has no name-plate/chat split, so it would leak into a tracked PC's chat/tooltip), this feature is **NPC-only**: it renders via a different channel (`PlayerPlugin.SetCreatureNameOverride`) that never touches PCs. The two systems therefore stay fully independent — no clobbering, no chat leak, no disguise conflict.

- Targets are restricted to non-PC, non-DM creatures; PC/DM targets are rejected with a clear message.
- Commands are DM/Admin-only (a scene-management tool). They register with `AuthorizationLevel.All` so non-staff get a real message rather than the generic "invalid command."

## Commands (click-to-target an NPC)
| Command | Alias | Behavior |
|---|---|---|
| `/hpset <current> [max]` | `/sethp` | Create/replace a tracker. One arg starts full; two args set `current/max` (e.g. `/hpset 3 8` → 3/8). |
| `/hpinc [amount]` | `/inchp` | Raise current HP (default +1), capped at max. |
| `/hpdec [amount]` | `/dechp` | Lower current HP (default -1), floored at 0. |
| `/hpdel` | `/delhp` | Remove the tracker. |

`/hpset`, `/hpinc`, `/hpdec` broadcast the new value to everyone in the target's area; `/hpdel` is private to the caller.

## Implementation
- **`Service/HPTracker.cs`** — in-memory `Dictionary<uint,(Current,Max)>` registry (transient). Renders the bar per-observer via `PlayerPlugin.SetCreatureNameOverride` to players/DMs in the NPC's area, re-applied on `OnAreaEnter`, cleared on `OnObjectDestroyed` (and player logout), clearing the override before dropping the tracker so a reused object id can't inherit a ghost bar. 10-segment green→yellow→red gradient via `ColorToken`.
- **`Feature/ChatCommandDefinition/HPTrackerChatCommand.cs`** — the four commands (auto-discovered `IChatCommandListDefinition`), argument validation, the NPC-only + DM/Admin gate, and the area broadcast.

No existing files are modified; the tracker never touches real hit points.

## Notes
- The bar renders as thin colored strokes, not solid blocks — NWN's name-plate font has no Unicode block glyphs (verified in-game by probing `█ ▓ ■ ▬ ▮ #`).
- Trackers are in-memory and cleared on server restart (matches the "temporary" intent).

## Open question — PC support
If PC HP bars are wanted later, they'd need to compose into `PlayerName` (there's no other persistent above-the-model surface), which means the bar rides the Rename name override and would also appear in the PC's chat/tooltip name. Happy to add that (with or without a chat-event swap to strip it during messages) if desired — left out here to keep this change independent and low-risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
