### PR TITLE
Warn players when skill XP is blocked at the skill cap

### DIFF
--- a/SWLOR.Game.Server/Service/Skill.cs
+++ b/SWLOR.Game.Server/Service/Skill.cs
@@ -179,7 +179,10 @@ namespace SWLOR.Game.Server.Service
 
             // If player is at the skill cap and no skills are available for decay, exit early.
             if (details.ContributesToSkillCap && skillsPossibleToDecay.Count <= 0 && totalRanks >= SkillCap)
+            {
+                SendMessageToPC(player, ColorToken.Red($"You cannot gain {details.Name} XP. You are at the skill cap of {SkillCap} and all of your other skills are locked from decay. Unlock a skill in the Skills menu to resume gaining {details.Name} XP."));
                 return;
+            }
 
             SendMessageToPC(player, $"You earned {details.Name} skill experience. ({xp})");
             pcSkill.XP += xp;
@@ -237,6 +240,7 @@ namespace SWLOR.Game.Server.Service
                     if (skillsPossibleToDecay.Count <= 0)
                     {
                         dbPlayer.Skills[skill].XP = 0;
+                        SendMessageToPC(player, ColorToken.Red($"You have reached the skill cap of {SkillCap} and all of your other skills are locked from decay. Excess {details.Name} XP was lost."));
                         break;
                     }
 


### PR DESCRIPTION
## Summary
- Players at the skill cap (400) with all other skills decay-locked previously received no feedback when an action that should grant skill XP silently discarded it. `GiveSkillXP` now sends a red warning explaining the XP was blocked and how to fix it (unlock a skill in the Skills menu).
- Also adds a message for the partial case: when a rank-up sequence hits the cap and runs out of decayable skills mid-loop, the player is told the excess XP was lost.

The messages fire at the same cadence as the existing "You earned X skill experience" line (per kill/craft action via CombatPoint etc.), so no added spam.

## Testing
- Built with `-p:RunPostBuildEvent=Never`
- `DeadPlayerXPTests` + `PlayerSkillPointAccountingTests`: 11/11 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added clearer player-facing messages when skill XP cannot be gained because the skill cap has been reached.
  * Players are now notified when excess skill XP is lost because no other skills are available for decay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->