### PR TITLE
Head Scaling

### DIFF
--- a/SWLOR.Game.Server/Entity/Player.cs
+++ b/SWLOR.Game.Server/Entity/Player.cs
@@ -87,6 +87,7 @@ namespace SWLOR.Game.Server.Entity
             ObjectVisibilities = new Dictionary<string, VisibilityType>();
             WindowGeometries = new Dictionary<GuiWindowType, GuiRectangle>();
             AppearanceScale = 1.0f;
+            HeadAppearanceScale = 1.0f;
             Control = new Dictionary<SkillType, int>();
             Craftsmanship = new Dictionary<SkillType, int>();
             CPBonus = new Dictionary<SkillType, int>();
@@ -184,6 +185,7 @@ namespace SWLOR.Game.Server.Entity
         public Dictionary<AbilityToggleType, bool> AbilityToggles { get; set; }
         public Dictionary<CurrencyType, int> Currencies { get; set; }
         public float AppearanceScale { get; set; }
+        public float HeadAppearanceScale { get; set; }
     }
 
     public class MapPin

--- a/SWLOR.Game.Server/Feature/AppearanceDefinition/RacialAppearance/IRacialAppearanceDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AppearanceDefinition/RacialAppearance/IRacialAppearanceDefinition.cs
@@ -4,6 +4,8 @@
     {
         float MaximumScale { get; }
         float MinimumScale { get; }
+        float MaximumHeadScale { get; }
+        float MinimumHeadScale { get; }
         int[] MaleHeads { get; }
         int[] FemaleHeads { get; }
 

--- a/SWLOR.Game.Server/Feature/AppearanceDefinition/RacialAppearance/RacialAppearanceBaseDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AppearanceDefinition/RacialAppearance/RacialAppearanceBaseDefinition.cs
@@ -4,6 +4,8 @@
     {
         public virtual float MaximumScale => 1.15f;
         public virtual float MinimumScale => 0.85f;
+        public virtual float MaximumHeadScale => 1.15f;
+        public virtual float MinimumHeadScale => 0.85f;
         public abstract int[] MaleHeads { get; }
         public abstract int[] FemaleHeads { get; }
         public virtual int[] Torsos { get; } = { 1, 2};

--- a/SWLOR.Game.Server/Feature/AppearanceDefinition/RacialAppearance/RacialAppearanceRegistry.cs
+++ b/SWLOR.Game.Server/Feature/AppearanceDefinition/RacialAppearance/RacialAppearanceRegistry.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using SWLOR.NWN.API.NWScript.Enum;
+
+namespace SWLOR.Game.Server.Feature.AppearanceDefinition.RacialAppearance
+{
+    public static class RacialAppearanceRegistry
+    {
+        private static readonly Dictionary<AppearanceType, IRacialAppearanceDefinition> Definitions = new();
+        private static bool _isLoaded;
+
+        public static void EnsureLoaded()
+        {
+            if (_isLoaded)
+                return;
+
+            Definitions[AppearanceType.Human] = new HumanRacialAppearanceDefinition();
+            Definitions[AppearanceType.Bothan] = new BothanRacialAppearanceDefinition();
+            Definitions[AppearanceType.Chiss] = new ChissRacialAppearanceDefinition();
+            Definitions[AppearanceType.Zabrak] = new ZabrakRacialAppearanceDefinition();
+            Definitions[AppearanceType.Twilek] = new TwilekRacialAppearanceDefinition();
+            Definitions[AppearanceType.Mirialan] = new MirialanRacialAppearanceDefinition();
+            Definitions[AppearanceType.Echani] = new EchaniRacialAppearanceDefinition();
+            Definitions[AppearanceType.KelDor] = new KelDorRacialAppearanceDefinition();
+            Definitions[AppearanceType.Cyborg] = new CyborgRacialAppearanceDefinition();
+            Definitions[AppearanceType.Cathar] = new CatharRacialAppearanceDefinition();
+            Definitions[AppearanceType.Rodian] = new RodianRacialAppearanceDefinition();
+            Definitions[AppearanceType.Trandoshan] = new TrandoshanRacialAppearanceDefinition();
+            Definitions[AppearanceType.Togruta] = new TogrutaRacialAppearanceDefinition();
+            Definitions[AppearanceType.Wookiee] = new WookieeRacialAppearanceDefinition();
+            Definitions[AppearanceType.MonCalamari] = new MonCalamariRacialAppearanceDefinition();
+            Definitions[AppearanceType.Ugnaught] = new UgnaughtRacialAppearanceDefinition();
+            Definitions[AppearanceType.Droid] = new DroidRacialAppearanceDefinition();
+            Definitions[AppearanceType.Nautolan] = new NautolanRacialAppearanceDefinition();
+            Definitions[AppearanceType.Ewok] = new EwokRacialAppearanceDefinition();
+
+            _isLoaded = true;
+        }
+
+        public static bool TryGet(AppearanceType appearanceType, out IRacialAppearanceDefinition definition)
+        {
+            EnsureLoaded();
+            return Definitions.TryGetValue(appearanceType, out definition);
+        }
+    }
+}

--- a/SWLOR.Game.Server/Feature/ChatCommandDefinition/CharacterChatCommand.cs
+++ b/SWLOR.Game.Server/Feature/ChatCommandDefinition/CharacterChatCommand.cs
@@ -35,6 +35,7 @@ namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
             ToggleEmoteStyle();
             ConcentrationAbility();
             Customize();
+            HeadScale();
             AlwaysWalk();
             AssociateCommands();
             Follow();
@@ -371,6 +372,91 @@ namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
 
                     var payload = new AppearanceEditorPayload(user);
                     Gui.TogglePlayerWindow(player, GuiWindowType.AppearanceEditor, payload, OBJECT_INVALID, uiTarget);
+                });
+        }
+
+        private void HeadScale()
+        {
+            const float MinScale = 0.85f;
+            const float MaxScale = 1.15f;
+            const float Increment = 0.01f;
+
+            _builder.Create("headscale")
+                .Description($"Adjusts your head size separately from body height. Usage: /headscale [value|{MinScale}-{MaxScale}|+/-]. Omit value to view current size.")
+                .Permissions(AuthorizationLevel.All)
+                .Validate((user, args) =>
+                {
+                    if (GetIsDM(user) || GetIsDMPossessed(user))
+                    {
+                        return "This command can only be used by players.";
+                    }
+
+                    if (args.Length <= 0)
+                        return string.Empty;
+
+                    var arg = args[0];
+                    if (arg == "+" || arg == "-" || arg.Equals("up", StringComparison.OrdinalIgnoreCase) ||
+                        arg.Equals("down", StringComparison.OrdinalIgnoreCase))
+                    {
+                        return string.Empty;
+                    }
+
+                    if (!float.TryParse(arg, NumberStyles.Float, CultureInfo.InvariantCulture, out var value))
+                    {
+                        return $"Please specify a value between {MinScale} and {MaxScale}, or use + / -.";
+                    }
+
+                    if (value < MinScale || value > MaxScale)
+                    {
+                        return $"Please specify a value between {MinScale} and {MaxScale}.";
+                    }
+
+                    return string.Empty;
+                })
+                .Action((user, target, location, args) =>
+                {
+                    var playerId = GetObjectUUID(user);
+                    var dbPlayer = DB.Get<Player>(playerId);
+                    var current = dbPlayer.HeadAppearanceScale <= 0f ? 1.0f : dbPlayer.HeadAppearanceScale;
+                    float newScale;
+
+                    if (args.Length <= 0)
+                    {
+                        SendMessageToPC(user, $"Head Size: {current:0.##} (range {MinScale}-{MaxScale}). Use /headscale <value>, /headscale +, or /headscale -.");
+                        return;
+                    }
+
+                    var arg = args[0];
+                    if (arg == "+" || arg.Equals("up", StringComparison.OrdinalIgnoreCase))
+                    {
+                        newScale = Math.Min(MaxScale, current + Increment);
+                    }
+                    else if (arg == "-" || arg.Equals("down", StringComparison.OrdinalIgnoreCase))
+                    {
+                        newScale = Math.Max(MinScale, current - Increment);
+                    }
+                    else
+                    {
+                        newScale = float.Parse(arg, NumberStyles.Float, CultureInfo.InvariantCulture);
+                    }
+
+                    if (Math.Abs(newScale - current) < 0.0001f &&
+                        (arg == "+" || arg == "-" || arg.Equals("up", StringComparison.OrdinalIgnoreCase) ||
+                         arg.Equals("down", StringComparison.OrdinalIgnoreCase)))
+                    {
+                        SendMessageToPC(user, newScale >= MaxScale
+                            ? "You cannot increase your head size any further."
+                            : "You cannot decrease your head size any further.");
+                        return;
+                    }
+
+                    dbPlayer.HeadAppearanceScale = newScale;
+                    DB.Set(dbPlayer);
+
+                    SetObjectVisualTransform(user, ObjectVisualTransform.Scale, newScale,
+                        nScope: ObjectVisualTransformDataScopeType.CreatureHead);
+
+                    SendMessageToPC(user, $"Head Size: {newScale:0.##}");
                 });
         }
 

--- a/SWLOR.Game.Server/Feature/ChatCommandDefinition/CharacterChatCommand.cs
+++ b/SWLOR.Game.Server/Feature/ChatCommandDefinition/CharacterChatCommand.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using SWLOR.Game.Server.Enumeration;
 using SWLOR.Game.Server.Feature.GuiDefinition.Payload;
+using SWLOR.Game.Server.Feature.AppearanceDefinition.RacialAppearance;
 using SWLOR.Game.Server.Service;
 using SWLOR.Game.Server.Service.AbilityService;
 using SWLOR.Game.Server.Service.ChatCommandService;
@@ -377,18 +378,21 @@ namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
 
         private void HeadScale()
         {
-            const float MinScale = 0.85f;
-            const float MaxScale = 1.15f;
             const float Increment = 0.01f;
 
             _builder.Create("headscale")
-                .Description($"Adjusts your head size separately from body height. Usage: /headscale [value|{MinScale}-{MaxScale}|+/-]. Omit value to view current size.")
+                .Description("Adjusts your head size separately from body height. Usage: /headscale [value|+/-]. Omit value to view current size. Limits depend on your race.")
                 .Permissions(AuthorizationLevel.All)
                 .Validate((user, args) =>
                 {
                     if (GetIsDM(user) || GetIsDMPossessed(user))
                     {
                         return "This command can only be used by players.";
+                    }
+
+                    if (!RacialAppearanceRegistry.TryGet(GetAppearanceType(user), out var appearance))
+                    {
+                        return "Your appearance type does not support head scaling.";
                     }
 
                     if (args.Length <= 0)
@@ -403,18 +407,26 @@ namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
 
                     if (!float.TryParse(arg, NumberStyles.Float, CultureInfo.InvariantCulture, out var value))
                     {
-                        return $"Please specify a value between {MinScale} and {MaxScale}, or use + / -.";
+                        return $"Please specify a value between {appearance.MinimumHeadScale} and {appearance.MaximumHeadScale}, or use + / -.";
                     }
 
-                    if (value < MinScale || value > MaxScale)
+                    if (value < appearance.MinimumHeadScale || value > appearance.MaximumHeadScale)
                     {
-                        return $"Please specify a value between {MinScale} and {MaxScale}.";
+                        return $"Please specify a value between {appearance.MinimumHeadScale} and {appearance.MaximumHeadScale}.";
                     }
 
                     return string.Empty;
                 })
                 .Action((user, target, location, args) =>
                 {
+                    if (!RacialAppearanceRegistry.TryGet(GetAppearanceType(user), out var appearance))
+                    {
+                        SendMessageToPC(user, "Your appearance type does not support head scaling.");
+                        return;
+                    }
+
+                    var minScale = appearance.MinimumHeadScale;
+                    var maxScale = appearance.MaximumHeadScale;
                     var playerId = GetObjectUUID(user);
                     var dbPlayer = DB.Get<Player>(playerId);
                     var current = dbPlayer.HeadAppearanceScale <= 0f ? 1.0f : dbPlayer.HeadAppearanceScale;
@@ -422,18 +434,18 @@ namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
 
                     if (args.Length <= 0)
                     {
-                        SendMessageToPC(user, $"Head Size: {current:0.##} (range {MinScale}-{MaxScale}). Use /headscale <value>, /headscale +, or /headscale -.");
+                        SendMessageToPC(user, $"Head Size: {current:0.##} (range {minScale}-{maxScale}). Use /headscale <value>, /headscale +, or /headscale -.");
                         return;
                     }
 
                     var arg = args[0];
                     if (arg == "+" || arg.Equals("up", StringComparison.OrdinalIgnoreCase))
                     {
-                        newScale = Math.Min(MaxScale, current + Increment);
+                        newScale = Math.Min(maxScale, current + Increment);
                     }
                     else if (arg == "-" || arg.Equals("down", StringComparison.OrdinalIgnoreCase))
                     {
-                        newScale = Math.Max(MinScale, current - Increment);
+                        newScale = Math.Max(minScale, current - Increment);
                     }
                     else
                     {
@@ -444,7 +456,7 @@ namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
                         (arg == "+" || arg == "-" || arg.Equals("up", StringComparison.OrdinalIgnoreCase) ||
                          arg.Equals("down", StringComparison.OrdinalIgnoreCase)))
                     {
-                        SendMessageToPC(user, newScale >= MaxScale
+                        SendMessageToPC(user, newScale >= maxScale
                             ? "You cannot increase your head size any further."
                             : "You cannot decrease your head size any further.");
                         return;

--- a/SWLOR.Game.Server/Feature/GuiDefinition/AppearanceEditorDefinition.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/AppearanceEditorDefinition.cs
@@ -888,6 +888,25 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                 col.AddRow(row =>
                 {
                     row.AddSpacer();
+
+                    row.AddButton()
+                        .SetText("Increase Head")
+                        .SetHeight(32f)
+                        .SetWidth(128f)
+                        .BindOnClicked(model => model.OnIncreaseHeadScale());
+
+                    row.AddButton()
+                        .SetText("Decrease Head")
+                        .SetHeight(32f)
+                        .SetWidth(128f)
+                        .BindOnClicked(model => model.OnDecreaseHeadScale());
+
+                    row.AddSpacer();
+                });
+
+                col.AddRow(row =>
+                {
+                    row.AddSpacer();
                     row.AddButton()
                         .SetText("Save")
                         .SetHeight(32f)

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/AppearanceEditorViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/AppearanceEditorViewModel.cs
@@ -1349,6 +1349,64 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             }
         };
 
+        public Action OnDecreaseHeadScale() => () =>
+        {
+            var appearanceType = GetAppearanceType(_target);
+            if (!_racialAppearances.ContainsKey(appearanceType))
+            {
+                Gui.TogglePlayerWindow(_target, GuiWindowType.AppearanceEditor);
+                return;
+            }
+
+            var appearance = _racialAppearances[appearanceType];
+            var scale = GetObjectVisualTransform(_target, ObjectVisualTransform.Scale,
+                nScope: ObjectVisualTransformDataScopeType.CreatureHead);
+            if (scale <= 0f)
+                scale = 1.0f;
+
+            const float Increment = 0.01f;
+
+            if (scale - Increment < appearance.MinimumHeadScale)
+            {
+                SendMessageToPC(_target, "You cannot decrease your head size any further.");
+            }
+            else
+            {
+                SetObjectVisualTransform(_target, ObjectVisualTransform.Scale, scale - Increment,
+                    nScope: ObjectVisualTransformDataScopeType.CreatureHead);
+                SendMessageToPC(_target, $"Head Size: {GetObjectVisualTransform(_target, ObjectVisualTransform.Scale, nScope: ObjectVisualTransformDataScopeType.CreatureHead)}");
+            }
+        };
+
+        public Action OnIncreaseHeadScale() => () =>
+        {
+            var appearanceType = GetAppearanceType(_target);
+            if (!_racialAppearances.ContainsKey(appearanceType))
+            {
+                Gui.TogglePlayerWindow(_target, GuiWindowType.AppearanceEditor);
+                return;
+            }
+
+            var appearance = _racialAppearances[appearanceType];
+            var scale = GetObjectVisualTransform(_target, ObjectVisualTransform.Scale,
+                nScope: ObjectVisualTransformDataScopeType.CreatureHead);
+            if (scale <= 0f)
+                scale = 1.0f;
+
+            const float Increment = 0.01f;
+
+            if (scale + Increment > appearance.MaximumHeadScale)
+            {
+                SendMessageToPC(_target, "You cannot increase your head size any further.");
+            }
+            else
+            {
+                SetObjectVisualTransform(_target, ObjectVisualTransform.Scale, scale + Increment,
+                    nScope: ObjectVisualTransformDataScopeType.CreatureHead);
+                SendMessageToPC(_target, $"Head Size: {GetObjectVisualTransform(_target, ObjectVisualTransform.Scale, nScope: ObjectVisualTransformDataScopeType.CreatureHead)}");
+            }
+        };
+
         public Action OnSelectColorCategory() => () =>
         {
             ToggleItemEquippedFlags();
@@ -1775,8 +1833,11 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
 
             var playerId = GetObjectUUID(_target);
             var dbPlayer = DB.Get<Player>(playerId);
+            var headScale = dbPlayer.HeadAppearanceScale <= 0f ? 1.0f : dbPlayer.HeadAppearanceScale;
 
             SetObjectVisualTransform(_target, ObjectVisualTransform.Scale, dbPlayer.AppearanceScale);
+            SetObjectVisualTransform(_target, ObjectVisualTransform.Scale, headScale,
+                nScope: ObjectVisualTransformDataScopeType.CreatureHead);
         };
 
         public Action OnClickSaveSettings() => () =>
@@ -1789,6 +1850,12 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
 
             var newHeight = GetObjectVisualTransform(_target, ObjectVisualTransform.Scale);
             dbPlayer.AppearanceScale = newHeight;
+
+            var newHeadScale = GetObjectVisualTransform(_target, ObjectVisualTransform.Scale,
+                nScope: ObjectVisualTransformDataScopeType.CreatureHead);
+            if (newHeadScale <= 0f)
+                newHeadScale = 1.0f;
+            dbPlayer.HeadAppearanceScale = newHeadScale;
 
             DB.Set(dbPlayer);
             SendMessageToPC(_target, ColorToken.Green("Appearance settings saved successfully."));

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/AppearanceEditorViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/AppearanceEditorViewModel.cs
@@ -63,7 +63,6 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
         private const int ColorHeightCells = 11;
 
         private static readonly Dictionary<AppearanceType, IArmorAppearanceDefinition> _armorAppearances = new();
-        private static readonly Dictionary<AppearanceType, IRacialAppearanceDefinition> _racialAppearances = new();
         private static readonly Dictionary<BaseItem, IWeaponAppearanceDefinition> _weaponAppearances = new();
         private Dictionary<int, int> _partIdToIndex = new();
 
@@ -78,7 +77,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
         [NWNEventHandler(ScriptName.OnModuleLoad)]
         public static void LoadAppearances()
         {
-            LoadRacialAppearances();
+            RacialAppearanceRegistry.EnsureLoaded();
             LoadArmorAppearances();
             LoadWeaponAppearances();
         }
@@ -101,30 +100,6 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
                 if (Gui.IsWindowOpen(dm, GuiWindowType.AppearanceEditor))
                     Gui.TogglePlayerWindow(dm, GuiWindowType.AppearanceEditor);
             }
-        }
-
-        private static void LoadRacialAppearances()
-        {
-            _racialAppearances[AppearanceType.Human] = new HumanRacialAppearanceDefinition();
-            _racialAppearances[AppearanceType.Bothan] = new BothanRacialAppearanceDefinition();
-            _racialAppearances[AppearanceType.Chiss] = new ChissRacialAppearanceDefinition();
-            _racialAppearances[AppearanceType.Zabrak] = new ZabrakRacialAppearanceDefinition();
-            _racialAppearances[AppearanceType.Twilek] = new TwilekRacialAppearanceDefinition();
-            _racialAppearances[AppearanceType.Mirialan] = new MirialanRacialAppearanceDefinition();
-            _racialAppearances[AppearanceType.Echani] = new EchaniRacialAppearanceDefinition();
-            _racialAppearances[AppearanceType.KelDor] = new KelDorRacialAppearanceDefinition();
-            _racialAppearances[AppearanceType.Cyborg] = new CyborgRacialAppearanceDefinition();
-            _racialAppearances[AppearanceType.Cathar] = new CatharRacialAppearanceDefinition();
-            _racialAppearances[AppearanceType.Rodian] = new RodianRacialAppearanceDefinition();
-            _racialAppearances[AppearanceType.Trandoshan] = new TrandoshanRacialAppearanceDefinition();
-            _racialAppearances[AppearanceType.Togruta] = new TogrutaRacialAppearanceDefinition();
-            _racialAppearances[AppearanceType.Wookiee] = new WookieeRacialAppearanceDefinition();
-            _racialAppearances[AppearanceType.MonCalamari] = new MonCalamariRacialAppearanceDefinition();
-            _racialAppearances[AppearanceType.Ugnaught] = new UgnaughtRacialAppearanceDefinition();
-            _racialAppearances[AppearanceType.Droid] = new DroidRacialAppearanceDefinition();
-            _racialAppearances[AppearanceType.Nautolan] = new NautolanRacialAppearanceDefinition(); 
-            _racialAppearances[AppearanceType.Ewok] = new EwokRacialAppearanceDefinition();
-            
         }
 
         private static void LoadArmorAppearances()
@@ -1018,13 +993,12 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             var appearanceType = GetAppearanceType(_target);
             var gender = GetGender(_target);
 
-            if (!_racialAppearances.ContainsKey(appearanceType))
+            if (!RacialAppearanceRegistry.TryGet(appearanceType, out var appearance))
             {
                 Gui.TogglePlayerWindow(_target, GuiWindowType.AppearanceEditor);
                 return;
             }
 
-            var appearance = _racialAppearances[appearanceType];
             int[] partIds;
             int selectedPartId;
 
@@ -1304,13 +1278,12 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
         public Action OnDecreaseAppearanceScale() => () =>
         {
             var appearanceType = GetAppearanceType(_target);
-            if (!_racialAppearances.ContainsKey(appearanceType))
+            if (!RacialAppearanceRegistry.TryGet(appearanceType, out var appearance))
             {
                 Gui.TogglePlayerWindow(_target, GuiWindowType.AppearanceEditor);
                 return;
             }
 
-            var appearance = _racialAppearances[appearanceType];
             var scale = GetObjectVisualTransform(_target, ObjectVisualTransform.Scale);
             const float Increment = 0.01f;
 
@@ -1327,13 +1300,11 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
         public Action OnIncreaseAppearanceScale() => () =>
         {
             var appearanceType = GetAppearanceType(_target);
-            if (!_racialAppearances.ContainsKey(appearanceType))
+            if (!RacialAppearanceRegistry.TryGet(appearanceType, out var appearance))
             {
                 Gui.TogglePlayerWindow(_target, GuiWindowType.AppearanceEditor);
                 return;
             }
-
-            var appearance = _racialAppearances[appearanceType];
 
             var scale = GetObjectVisualTransform(_target, ObjectVisualTransform.Scale);
             const float Increment = 0.01f;
@@ -1352,13 +1323,12 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
         public Action OnDecreaseHeadScale() => () =>
         {
             var appearanceType = GetAppearanceType(_target);
-            if (!_racialAppearances.ContainsKey(appearanceType))
+            if (!RacialAppearanceRegistry.TryGet(appearanceType, out var appearance))
             {
                 Gui.TogglePlayerWindow(_target, GuiWindowType.AppearanceEditor);
                 return;
             }
 
-            var appearance = _racialAppearances[appearanceType];
             var scale = GetObjectVisualTransform(_target, ObjectVisualTransform.Scale,
                 nScope: ObjectVisualTransformDataScopeType.CreatureHead);
             if (scale <= 0f)
@@ -1381,13 +1351,12 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
         public Action OnIncreaseHeadScale() => () =>
         {
             var appearanceType = GetAppearanceType(_target);
-            if (!_racialAppearances.ContainsKey(appearanceType))
+            if (!RacialAppearanceRegistry.TryGet(appearanceType, out var appearance))
             {
                 Gui.TogglePlayerWindow(_target, GuiWindowType.AppearanceEditor);
                 return;
             }
 
-            var appearance = _racialAppearances[appearanceType];
             var scale = GetObjectVisualTransform(_target, ObjectVisualTransform.Scale,
                 nScope: ObjectVisualTransformDataScopeType.CreatureHead);
             if (scale <= 0f)
@@ -1654,7 +1623,8 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
         {
             var appearanceType = GetAppearanceType(_target);
             var gender = GetGender(_target);
-            var appearance = _racialAppearances[appearanceType];
+            if (!RacialAppearanceRegistry.TryGet(appearanceType, out var appearance))
+                return;
 
             switch (SelectedPartCategoryIndex)
             {

--- a/SWLOR.Game.Server/Feature/PlayerTemporaryEffects.cs
+++ b/SWLOR.Game.Server/Feature/PlayerTemporaryEffects.cs
@@ -17,6 +17,7 @@ namespace SWLOR.Game.Server.Feature
 
             ApplyCutsceneGhostToPlayer(player);
             ApplyHeight(player);
+            ApplyHeadScale(player);
             RemoveImmobility(player);
             ReapplyBAB(player);
             ReapplySpeed(player);
@@ -34,6 +35,16 @@ namespace SWLOR.Game.Server.Feature
             var dbPlayer = DB.Get<Player>(playerId);
 
             SetObjectVisualTransform(player, ObjectVisualTransform.Scale, dbPlayer.AppearanceScale);
+        }
+
+        private static void ApplyHeadScale(uint player)
+        {
+            var playerId = GetObjectUUID(player);
+            var dbPlayer = DB.Get<Player>(playerId);
+            var headScale = dbPlayer.HeadAppearanceScale <= 0f ? 1.0f : dbPlayer.HeadAppearanceScale;
+
+            SetObjectVisualTransform(player, ObjectVisualTransform.Scale, headScale,
+                nScope: ObjectVisualTransformDataScopeType.CreatureHead);
         }
 
         private static void RemoveImmobility(uint player)

--- a/SWLOR.NWN.API/NWScript/VisualFunctions.cs
+++ b/SWLOR.NWN.API/NWScript/VisualFunctions.cs
@@ -95,10 +95,16 @@ namespace SWLOR.NWN.API.NWScript
         /// </summary>
         /// <param name="oObject">Any valid Creature, Placeable, Item or Door</param>
         /// <param name="nTransform">One of OBJECT_VISUAL_TRANSFORM_* constants</param>
+        /// <param name="bCurrentLerp">If true, returns the current interpolated value; otherwise the final set value</param>
+        /// <param name="nScope">One of OBJECT_VISUAL_TRANSFORM_DATA_SCOPE_* constants, specific to the object type being transformed</param>
         /// <returns>The current (or default) value of the visual transform</returns>
-        public static float GetObjectVisualTransform(uint oObject, ObjectVisualTransform nTransform)
+        public static float GetObjectVisualTransform(
+            uint oObject,
+            ObjectVisualTransform nTransform,
+            bool bCurrentLerp = false,
+            ObjectVisualTransformDataScopeType nScope = ObjectVisualTransformDataScopeType.Base)
         {
-            return global::NWN.Core.NWScript.GetObjectVisualTransform(oObject, (int)nTransform);
+            return global::NWN.Core.NWScript.GetObjectVisualTransform(oObject, (int)nTransform, bCurrentLerp ? 1 : 0, (int)nScope);
         }
 
         /// <summary>


### PR DESCRIPTION
/headscale command added
Added buttons to the appearance changer.

Just ties on to CreatureHead for the scope. Same as regular height, you have to hit "save" for it to apply. Racial min/max defaults just tied to whatever their defaults are per-race.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added independent head-size customization in the appearance editor, with head-only scaling and “Increase Head” / “Decrease Head” controls.
  * Added a new `/headscale` chat command to view and adjust head size (including incremental changes and absolute values).
  * Head-size changes are now constrained by configurable racial limits and are persisted between sessions.
  * Head scaling is applied separately from overall appearance scaling when characters load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->