### PR TITLE
Render telegraphs for instant area abilities

### DIFF
--- a/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
@@ -396,8 +396,7 @@ public class CombatDamageTests
                     source.Contains("ConfigureWeapon(") ||
                     source.Contains("ConfigureCastedTarget(") ||
                     source.Contains("ConfigureMultiHit(") ||
-                    source.Contains("ConfigureInterrupt(") ||
-                    source.Contains("ConfigureTelegraphedArea(");
+                    source.Contains("ConfigureInterrupt(");
                 if (!usesDirectCombatImpact && !usesCombatImpactHelper)
                     continue;
 

--- a/SWLOR.Game.Server.Tests/Service/TelegraphTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/TelegraphTests.cs
@@ -59,8 +59,40 @@ public class TelegraphTests
             -1,
             "the instant-cast branch must still be recognisable; update this test's anchor if it was reworded");
 
-        source[branchStart..].IndexOf("ShowAreaImpactFlash(", StringComparison.Ordinal)
+        // Scope the assertion to the branch body. Searching to end-of-file would also match the
+        // ShowAreaImpactFlash method declaration further down, so deleting the call from the branch
+        // would still pass.
+        var branchBody = ExtractBlockBody(source, branchStart);
+
+        branchBody.IndexOf("ShowAreaImpactFlash(", StringComparison.Ordinal)
             .Should().BeGreaterThan(-1, "the instant-cast path must flash the area it just struck");
+    }
+
+    /// <summary>
+    /// Returns the brace-delimited block that opens after <paramref name="searchFrom"/>, excluding the
+    /// braces themselves.
+    /// </summary>
+    private static string ExtractBlockBody(string source, int searchFrom)
+    {
+        var open = source.IndexOf('{', searchFrom);
+        open.Should().BeGreaterThan(-1, "the branch must open a block");
+
+        var depth = 0;
+        for (var i = open; i < source.Length; i++)
+        {
+            if (source[i] == '{')
+            {
+                depth++;
+            }
+            else if (source[i] == '}')
+            {
+                depth--;
+                if (depth == 0)
+                    return source[(open + 1)..i];
+            }
+        }
+
+        throw new AssertionException("Could not find the closing brace for the instant-cast branch.");
     }
 
     [Test]

--- a/SWLOR.Game.Server.Tests/Service/TelegraphTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/TelegraphTests.cs
@@ -53,9 +53,13 @@ public class TelegraphTests
     {
         // Guards the wiring itself: the zero-telegraph branch must still render something.
         var source = File.ReadAllText(ResolveRepositoryPath("SWLOR.Game.Server", "Service", "Ability.cs"));
-        var instantBranch = source[source.IndexOf("if (telegraphDuration <= 0f)", StringComparison.Ordinal)..];
+        var branchStart = source.IndexOf("if (telegraphDuration <= 0f)", StringComparison.Ordinal);
 
-        instantBranch.IndexOf("ShowAreaImpactFlash(", StringComparison.Ordinal)
+        branchStart.Should().BeGreaterThan(
+            -1,
+            "the instant-cast branch must still be recognisable; update this test's anchor if it was reworded");
+
+        source[branchStart..].IndexOf("ShowAreaImpactFlash(", StringComparison.Ordinal)
             .Should().BeGreaterThan(-1, "the instant-cast path must flash the area it just struck");
     }
 

--- a/SWLOR.Game.Server.Tests/Service/TelegraphTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/TelegraphTests.cs
@@ -1,5 +1,9 @@
+using System;
+using System.IO;
+using System.Linq;
 using System.Numerics;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using FluentAssertions;
 using NUnit.Framework;
 using SWLOR.Game.Server.Service;
@@ -26,6 +30,62 @@ public class TelegraphTests
         var packed = InvokePackTelegraphData(TelegraphType.Cone, 0f);
 
         ExtractPackedRotation(packed).Should().Be(0);
+    }
+
+    [Test]
+    public void ApplyTelegraphedCombatImpact_DefaultsToAVisibleImpactFlash()
+    {
+        // Instant-cast area abilities cannot gate damage behind a pre-cast telegraph without
+        // contradicting the Bible, so the impact flash is what makes them visible at all. If this
+        // default is ever zeroed, every instant area ability silently stops rendering.
+        var parameter = typeof(Ability)
+            .GetMethod(nameof(Ability.ApplyTelegraphedCombatImpact), BindingFlags.Static | BindingFlags.Public)!
+            .GetParameters()
+            .Single(x => x.Name == "impactFlashDuration");
+
+        parameter.HasDefaultValue.Should().BeTrue();
+        parameter.DefaultValue.Should().Be(Ability.DefaultImpactFlashDuration);
+        Ability.DefaultImpactFlashDuration.Should().BeGreaterThan(0f);
+    }
+
+    [Test]
+    public void ApplyTelegraphedCombatImpact_FlashesTheShapeOnTheInstantPath()
+    {
+        // Guards the wiring itself: the zero-telegraph branch must still render something.
+        var source = File.ReadAllText(ResolveRepositoryPath("SWLOR.Game.Server", "Service", "Ability.cs"));
+        var instantBranch = source[source.IndexOf("if (telegraphDuration <= 0f)", StringComparison.Ordinal)..];
+
+        instantBranch.IndexOf("ShowAreaImpactFlash(", StringComparison.Ordinal)
+            .Should().BeGreaterThan(-1, "the instant-cast path must flash the area it just struck");
+    }
+
+    [Test]
+    public void GeneratedWeaponAbilities_DoNotStackAPrecastTelegraphOnTopOfTheActivationDelay()
+    {
+        // UsePerkFeat already draws a pre-cast telegraph from the activation delay. TelegraphDuration
+        // runs at impact, after the cast resolves, so deriving it from casting time would delay damage
+        // twice and draw the shape twice. The generator must not emit it from CastingTime.
+        var generator = File.ReadAllText(ResolveRepositoryPath("tools", "GenerateWeaponArchetypeImplementation.py"));
+        var emitsTelegraphDuration = Regex.IsMatch(
+            generator,
+            @"add_profile_property\(\s*""TelegraphDuration""");
+
+        emitsTelegraphDuration.Should().BeFalse(
+            "TelegraphDuration is an impact-time delay and must stay hand-set, not derived from CastingTime");
+    }
+
+    private static string ResolveRepositoryPath(params string[] segments)
+    {
+        var directory = new DirectoryInfo(TestContext.CurrentContext.TestDirectory);
+
+        while (directory != null && !File.Exists(Path.Combine(directory.FullName, "SWLOR.Game.Server.sln")))
+        {
+            directory = directory.Parent;
+        }
+
+        directory.Should().NotBeNull("the repository root must be locatable from the test directory");
+
+        return Path.Combine(new[] { directory!.FullName }.Concat(segments).ToArray());
     }
 
     private static int InvokePackTelegraphData(TelegraphType type, float rotation)

--- a/SWLOR.Game.Server/Core/ScriptName.cs
+++ b/SWLOR.Game.Server/Core/ScriptName.cs
@@ -311,9 +311,6 @@ namespace SWLOR.Game.Server.Core
 
         // Telegraph events
         public const string TelegraphEffect = "telegraph_effect";
-        public const string TelegraphApplied = "telegraph_applied";
-        public const string TelegraphTicked = "telegraph_ticked";
-        public const string TelegraphRemoved = "telegraph_removed";
 
         // Communication events
         public const string OnNWNXChat = "on_nwnx_chat";

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/WeaponActiveAbilityDefinitionBase.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/WeaponActiveAbilityDefinitionBase.cs
@@ -25,6 +25,14 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition
             public bool IsQueuedWeaponAbility { get; init; }
             public CombatDamageType DamageType { get; init; } = CombatDamageType.Physical;
             public int MaximumAreaTargets { get; init; }
+
+            /// <summary>
+            /// How long the pre-cast telegraph is shown before an area impact lands, in seconds.
+            /// Leave at 0 for abilities the Bible marks "Instant" — they gate no damage and instead
+            /// get the visual-only impact flash from <see cref="Ability.ApplyTelegraphedCombatImpact"/>.
+            /// Only set this to match a Bible-granted casting time.
+            /// </summary>
+            public float TelegraphDuration { get; init; }
             public int ExtraDamageIfRecentTarget { get; init; }
             public float RecentTargetWindowSeconds { get; init; }
             public int ExtraDamageIfHighResources { get; init; }
@@ -1202,7 +1210,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition
                             duration,
                             statusEffect,
                             ToCombatImpactAreaShape(targetingShape),
-                            0f,
+                            profile.TelegraphDuration,
                             targetingSizeX > 0f ? targetingSizeX : 5.0f,
                             targetingSizeY,
                             additionalStatusEffects,
@@ -1554,51 +1562,6 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition
                         combatImpactDamageAbility: combatImpactDamageAbility);
                 })
                 .IsWeaponAbility()
-                .IsHostileAbility()
-                .BreaksStealth();
-
-            if (stamina > 0)
-                ability.RequirementStamina(stamina);
-        }
-
-        protected static void ConfigureTelegraphedArea(
-            AbilityBuilder ability,
-            SkillType skill,
-            CombatImpactAreaShape shape,
-            int baseDamage,
-            int duration,
-            Type statusEffect,
-            float lengthOrRadius,
-            float width,
-            int stamina,
-            bool centerOnActivator = false,
-            int maxTargets = 0,
-            AbilityType combatImpactDamageAbility = AbilityType.Invalid)
-        {
-            ApplyCombatImpactDamageAbility(ability, combatImpactDamageAbility);
-
-            ability.HasActivationDelay(0f)
-                .SkillType(skill)
-                .IsAreaAbility()
-                .HasImpactAction((activator, target, level, targetLocation) =>
-                {
-                    Ability.ApplyTelegraphedCombatImpact(
-                        activator,
-                        target,
-                        targetLocation,
-                        skill,
-                        baseDamage,
-                        duration,
-                        statusEffect,
-                        shape,
-                        0.4f,
-                        lengthOrRadius,
-                        width,
-                        centerOnActivator: centerOnActivator,
-                        maxTargets: maxTargets,
-                        combatImpactDamageAbility: combatImpactDamageAbility);
-                })
-                .IsCastedAbility()
                 .IsHostileAbility()
                 .BreaksStealth();
 

--- a/SWLOR.Game.Server/Service/Ability.cs
+++ b/SWLOR.Game.Server/Service/Ability.cs
@@ -23,6 +23,12 @@ namespace SWLOR.Game.Server.Service
         private static readonly Dictionary<uint, PlayerAura> _playerAuras = new();
         private static readonly Dictionary<uint, TrackedAbilityImpact> _trackedAbilityImpacts = new();
 
+        /// <summary>
+        /// How long the visual-only impact flash lingers on an instant area ability, in seconds.
+        /// Long enough to read the shape, short enough not to be mistaken for a pre-cast telegraph.
+        /// </summary>
+        public const float DefaultImpactFlashDuration = 0.3f;
+
         private const int MaxNumberOfAuras = 4;
         private const int HostileAbilityBaseEnmity = 100;
         private const int HostileAbilityMissEnmity = 1;
@@ -1153,12 +1159,26 @@ namespace SWLOR.Game.Server.Service
             AbilityType combatImpactDamageAbility = AbilityType.Invalid,
             bool sendsNoTargetMessage = true,
             bool resolvesHit = true,
-            bool canCritical = true)
+            bool canCritical = true,
+            float impactFlashDuration = DefaultImpactFlashDuration)
         {
             RecordAbilityImpactShape(activator, skillType, true);
 
             if (telegraphDuration <= 0f)
             {
+                // Instant-cast area abilities cannot use a pre-cast telegraph without violating the
+                // Bible's "Instant" activation time, so they flash their shape at impact instead.
+                // The flash is purely visual: damage below is still applied immediately.
+                ShowAreaImpactFlash(
+                    activator,
+                    target,
+                    targetLocation,
+                    shape,
+                    lengthOrRadius,
+                    width,
+                    centerOnActivator,
+                    impactFlashDuration);
+
                 var totalDamage = ApplyCombatImpactInShape(
                     activator,
                     target,
@@ -1285,6 +1305,67 @@ namespace SWLOR.Game.Server.Service
                 PlayCombatImpactAnimation(activator, impactAnimation);
 
             return 0;
+        }
+
+        /// <summary>
+        /// Renders a short, purely visual telegraph showing the area an instant ability just struck.
+        /// Unlike a pre-cast telegraph this carries no action and does not gate damage, so it gives
+        /// positional feedback without changing an ability's Bible-mandated "Instant" activation time.
+        /// </summary>
+        private static void ShowAreaImpactFlash(
+            uint activator,
+            uint target,
+            Location targetLocation,
+            CombatImpactAreaShape shape,
+            float lengthOrRadius,
+            float width,
+            bool centerOnActivator,
+            float flashDuration)
+        {
+            if (flashDuration <= 0f || lengthOrRadius <= 0f)
+                return;
+
+            if (shape != CombatImpactAreaShape.Sphere &&
+                shape != CombatImpactAreaShape.Cone &&
+                shape != CombatImpactAreaShape.Line)
+                return;
+
+            var rotation = GetImpactRotationRadians(activator, target, targetLocation);
+
+            switch (shape)
+            {
+                case CombatImpactAreaShape.Sphere:
+                    Telegraph.CreateSphereTelegraph(
+                        activator,
+                        GetAreaImpactPosition(activator, target, targetLocation, centerOnActivator),
+                        lengthOrRadius,
+                        flashDuration,
+                        true,
+                        null);
+                    break;
+                case CombatImpactAreaShape.Cone:
+                    Telegraph.CreateConeTelegraph(
+                        activator,
+                        GetPosition(activator),
+                        rotation,
+                        lengthOrRadius,
+                        width > 0f ? width : lengthOrRadius,
+                        flashDuration,
+                        true,
+                        null);
+                    break;
+                case CombatImpactAreaShape.Line:
+                    Telegraph.CreateLineTelegraph(
+                        activator,
+                        GetPosition(activator),
+                        rotation,
+                        lengthOrRadius,
+                        width > 0f ? width : 2.0f,
+                        flashDuration,
+                        true,
+                        null);
+                    break;
+            }
         }
 
         private static int ApplyCombatImpactInShape(

--- a/SWLOR.Game.Server/Service/Ability.cs
+++ b/SWLOR.Game.Server/Service/Ability.cs
@@ -1325,11 +1325,6 @@ namespace SWLOR.Game.Server.Service
             if (flashDuration <= 0f || lengthOrRadius <= 0f)
                 return;
 
-            if (shape != CombatImpactAreaShape.Sphere &&
-                shape != CombatImpactAreaShape.Cone &&
-                shape != CombatImpactAreaShape.Line)
-                return;
-
             var rotation = GetImpactRotationRadians(activator, target, targetLocation);
 
             switch (shape)

--- a/SWLOR.Game.Server/Service/Telegraph.cs
+++ b/SWLOR.Game.Server/Service/Telegraph.cs
@@ -73,7 +73,7 @@ namespace SWLOR.Game.Server.Service
             }
 
             _allTelegraphs.Remove(telegraphId);
-            UpdateShadersForAllPlayers();
+            UpdateShadersForArea(telegraph.Area);
             // RemoveEffectByLinkId is not available in SWLOR, effects are removed automatically
         }
 
@@ -118,7 +118,7 @@ namespace SWLOR.Game.Server.Service
 
             OnApply(telegrapher, data, effect);
             ApplyEffectToObject(DurationType.Temporary, effect, telegrapher, data.Duration);
-            UpdateShadersForAllPlayers();
+            UpdateShadersForArea(area);
 
             return GetEffectLinkId(effect);
         }
@@ -141,7 +141,13 @@ namespace SWLOR.Game.Server.Service
 
         public static void OnRemoved(uint telegrapher, string telegraphId)
         {
-            var area = GetArea(telegrapher);
+            // Resolve the area from the telegraph's own record rather than the telegrapher's current
+            // area. A creature that moved (or zoned) between creation and expiry would otherwise miss
+            // the lookup, leaking the entry and leaving a stale shape rendered for everyone in it.
+            if (!_allTelegraphs.TryGetValue(telegraphId, out var telegraph))
+                return;
+
+            var area = telegraph.Area;
 
             if (!_telegraphsByArea.ContainsKey(area))
                 return;
@@ -149,11 +155,11 @@ namespace SWLOR.Game.Server.Service
             if (!_telegraphsByArea[area].ContainsKey(telegraphId))
                 return;
 
-            RunTelegraphAction(area, _telegraphsByArea[area][telegraphId].Data);
+            RunTelegraphAction(area, telegraph.Data);
 
             _telegraphsByArea[area].Remove(telegraphId);
             _allTelegraphs.Remove(telegraphId);
-            UpdateShadersForAllPlayers();
+            UpdateShadersForArea(area);
         }
 
         [NWNEventHandler(ScriptName.TelegraphEffect)]
@@ -357,6 +363,39 @@ namespace SWLOR.Game.Server.Service
             {
                 UpdateShaderForPlayer(player);
             }
+        }
+
+        /// <summary>
+        /// Updates shader uniforms only for players standing in the given area. Telegraph shader slots
+        /// are per-area, so a telegraph created or removed in one area cannot affect players elsewhere.
+        /// Instant abilities now flash their shape on every use, so this runs far more often than the
+        /// original create/destroy-only path and must not touch every player on the server.
+        /// </summary>
+        private static void UpdateShadersForArea(uint area)
+        {
+            if (!GetIsObjectValid(area))
+                return;
+
+            for (var player = GetFirstPC(); GetIsObjectValid(player); player = GetNextPC())
+            {
+                if (GetArea(player) == area)
+                    UpdateShaderForPlayer(player);
+            }
+        }
+
+        /// <summary>
+        /// Pushes the current telegraph state to a player entering an area. Without this, a player who
+        /// zones in (or logs in) while a telegraph is already running sees nothing until some unrelated
+        /// telegraph happens to be created or removed in that same area.
+        /// </summary>
+        [NWNEventHandler(ScriptName.OnAreaEnter)]
+        public static void OnAreaEnter()
+        {
+            var player = GetEnteringObject();
+            if (!GetIsPC(player) && !GetIsDM(player))
+                return;
+
+            UpdateShaderForPlayer(player);
         }
 
         /// <summary>

--- a/SWLOR.Game.Server/Service/TelegraphService/README.md
+++ b/SWLOR.Game.Server/Service/TelegraphService/README.md
@@ -12,7 +12,7 @@ The Telegraph System provides visual indicators for area-of-effect abilities, al
 
 ## Core Components
 
-### TelegraphService
+### Telegraph
 The main service class that manages all telegraph functionality.
 
 ### Telegraph Types
@@ -32,7 +32,7 @@ The main service class that manages all telegraph functionality.
 
 ```csharp
 // Create a simple sphere telegraph
-var telegraphId = TelegraphHelper.CreateSphereTelegraph(
+var telegraphId = Telegraph.CreateSphereTelegraph(
     attacker,           // Creator of the telegraph
     position,           // Center position
     5.0f,              // Radius in meters
@@ -54,7 +54,7 @@ var telegraphId = TelegraphHelper.CreateSphereTelegraph(
 ### Cone Telegraph
 
 ```csharp
-var telegraphId = TelegraphHelper.CreateConeTelegraph(
+var telegraphId = Telegraph.CreateConeTelegraph(
     attacker,
     position,
     facing,             // Direction in radians
@@ -68,7 +68,7 @@ var telegraphId = TelegraphHelper.CreateConeTelegraph(
 ### Line Telegraph
 
 ```csharp
-var telegraphId = TelegraphHelper.CreateLineTelegraph(
+var telegraphId = Telegraph.CreateLineTelegraph(
     attacker,
     position,
     facing,             // Direction in radians
@@ -83,7 +83,7 @@ var telegraphId = TelegraphHelper.CreateLineTelegraph(
 
 ```csharp
 // Create telegraph at a specific creature's position
-var telegraphId = TelegraphHelper.CreateTelegraphAtCreature(
+var telegraphId = Telegraph.CreateTelegraphAtCreature(
     creator,
     target,
     TelegraphType.Sphere,
@@ -93,7 +93,7 @@ var telegraphId = TelegraphHelper.CreateTelegraphAtCreature(
     action);
 
 // Create telegraph in front of a creature
-var telegraphId = TelegraphHelper.CreateTelegraphInFrontOfCreature(
+var telegraphId = Telegraph.CreateTelegraphInFrontOfCreature(
     creator,
     target,
     2.0f,                    // Distance in front
@@ -106,7 +106,7 @@ var telegraphId = TelegraphHelper.CreateTelegraphInFrontOfCreature(
 
 ## API Reference
 
-### TelegraphService Methods
+### Telegraph Methods
 
 - `CreateTelegraph()` - Create a custom telegraph
 - `CancelTelegraph(string telegraphId)` - Cancel a telegraph before completion
@@ -114,7 +114,7 @@ var telegraphId = TelegraphHelper.CreateTelegraphInFrontOfCreature(
 - `IsCreatureInTelegraph(uint creature, string telegraphId)` - Check if creature is in telegraph
 - `ClearAllTelegraphs()` - Clear all telegraphs (cleanup)
 
-### TelegraphHelper Methods
+### Telegraph Shape Helpers
 
 - `CreateSphereTelegraph()` - Create a sphere telegraph
 - `CreateConeTelegraph()` - Create a cone telegraph
@@ -124,29 +124,43 @@ var telegraphId = TelegraphHelper.CreateTelegraphInFrontOfCreature(
 
 ## Event System
 
-The telegraph system integrates with SWLOR's event system:
+A telegraph is backed by a temporary `EffectRunScript` effect on its creator. When that
+effect expires, the `telegraph_effect` handler (`ScriptName.TelegraphEffect`) fires
+`Telegraph.OnRemoved`, which runs the telegraph's action against the creatures inside its
+shape and then clears the entry. There is no separate applied/ticked event.
 
-- `TelegraphEvents.TelegraphApplied` - Fired when telegraph is applied
-- `TelegraphEvents.TelegraphTicked` - Fired during telegraph duration
-- `TelegraphEvents.TelegraphRemoved` - Fired when telegraph is removed
+Shader uniforms are refreshed when a telegraph is created or removed in an area, and when a
+player enters an area. There is no periodic tick.
+
+## Pre-cast telegraphs vs the impact flash
+
+Two distinct paths render a shape, and they are not interchangeable:
+
+- **Pre-cast telegraph** — drawn by `UsePerkFeat` for the length of an ability's activation
+  delay, or by `Ability.ApplyTelegraphedCombatImpact` when `telegraphDuration > 0`. This
+  *gates* the effect: the action runs when the telegraph expires. Only use it for abilities
+  the Design Bible grants a real casting time.
+- **Impact flash** — drawn by `Ability.ApplyTelegraphedCombatImpact` when
+  `telegraphDuration <= 0`. Purely visual, carries no action, and does not delay damage.
+  This is what makes Bible-"Instant" area abilities visible without changing their
+  activation time. Duration comes from `Ability.DefaultImpactFlashDuration`.
+
+Do not set `GeneratedWeaponAbilityProfile.TelegraphDuration` from a Bible casting time: the
+pre-cast telegraph already covers the activation delay, and this one applies at impact, so
+the two would stack into a double delay and a double render.
 
 ## Testing
 
-Use the `TelegraphTest` class for testing telegraph functionality:
-
-- `TestSphereTelegraph()` - Test sphere telegraphs
-- `TestConeTelegraph()` - Test cone telegraphs
-- `TestLineTelegraph()` - Test line telegraphs
-- `TestBeneficialTelegraph()` - Test beneficial telegraphs
-- `TestMultipleTelegraphs()` - Test multiple simultaneous telegraphs
-- `ClearAllTelegraphs()` - Clear all active telegraphs
+`SWLOR.Game.Server.Tests/Service/TelegraphTests.cs` covers the shader bit-packing, the
+impact-flash default, and the double-delay invariant. Rendering itself needs an in-game
+check; there is no headless harness for it.
 
 ## Performance Considerations
 
 - Maximum of 16 telegraphs rendered per player at once
-- Telegraphs are automatically cleaned up when areas are unloaded
-- Shader updates are limited to 30 FPS to maintain performance
-- Telegraphs are tracked by area for efficient management
+- Telegraphs are tracked by area, and shader updates only touch players in that area
+- The impact flash fires on every instant area ability, so anything added to the
+  create/remove path runs in the combat hot path
 
 ## Integration with Abilities
 
@@ -165,7 +179,7 @@ public static void FireballAbility(uint caster, uint target)
     var position = GetPosition(target);
 
     // Create telegraph
-    var telegraphId = TelegraphHelper.CreateSphereTelegraph(
+    var telegraphId = Telegraph.CreateSphereTelegraph(
         caster,
         position,
         5.0f,  // 5 meter radius

--- a/tools/GenerateWeaponArchetypeImplementation.py
+++ b/tools/GenerateWeaponArchetypeImplementation.py
@@ -1770,6 +1770,11 @@ def profile_property_lines(row, level, primary_status):
     if max_targets:
         add_profile_property("MaximumAreaTargets", str(max_targets))
 
+    # TelegraphDuration is deliberately not derived from CastingTime. The pre-cast telegraph is
+    # already drawn by UsePerkFeat from the activation delay; this one runs at impact, after the
+    # cast has finished, so setting it from CastingTime would delay damage twice and draw the shape
+    # twice. It stays 0 unless a definition hand-sets it for a genuinely delayed detonation.
+
     match = re.search(
         r"If you attacked this target in the last (\d+) seconds, .*?\+(\d+) DMG",
         description,


### PR DESCRIPTION
## Problem

The Telegraph service, its shader, and its event plumbing are all live and unflagged — but almost nothing reached them.

`Ability.ApplyTelegraphedCombatImpact` skips the telegraph entirely when `telegraphDuration <= 0f`. **45 of 62 call sites passed `0f`**, as did **all 213 generated weapon abilities** (hardcoded, with no field on `GeneratedWeaponAbilityProfile` and no `telegraph` anywhere in the generator). The other rendering path, the pre-cast telegraph in `UsePerkFeat`, requires `activationDelay > 0`.

Between the two gaps, **46 area ability chains rendered nothing at all** — every instant-cast weapon area ability: TwinBlade (8), Spear (7), Staff (7), Rifle (5), Saberstaff (5), Pistol (4), Force (3), Lightsaber (3), Katar (2), Throwing (2).

Existing tests hid this: they only string-matched `"ApplyTelegraphedCombatImpact("` in source, which proves nothing about whether a telegraph renders. No test asserted a nonzero duration anywhere.

## Why not just give them cast times

The Design Bible marks **65 area-worded perks "Instant"**, and `AGENTS.md` requires implementations to match the Bible's activation time. A pre-cast telegraph gates damage behind its duration, so using one here would both delay damage and contradict the Bible.

## Approach

Add a **visual-only impact flash**: on the instant path the shape renders for 0.3s at impact while damage still lands immediately. It carries no action and gates nothing. Because it hangs off the existing `telegraphDuration <= 0` branch, all 45 zero-duration call sites and all 213 generated abilities get it with no per-site edits.

## Changes

- **`ShowAreaImpactFlash`** on the instant path — default `Ability.DefaultImpactFlashDuration` (0.3s), overridable via the new trailing `impactFlashDuration` parameter.
- **Generator plumbing** — the hardcoded `0f` becomes `profile.TelegraphDuration`. Deliberately *not* derived from `CastingTime`: the impact telegraph fires after the activation delay, and `UsePerkFeat` already draws the pre-cast telegraph, so deriving it would delay damage twice and draw the shape twice. A test locks that invariant in.
- **Area-enter refresh** — players zoning or logging in mid-telegraph previously saw nothing until an unrelated telegraph happened to fire in the same area.
- **Area-scoped shader updates** — the flash turns a near-idle path into a per-AoE-use one, so the previous server-wide 16-uniform push per create/destroy would have become a hot path.
- **Leak fix in `OnRemoved`** — the area was resolved from the telegrapher's *current* area, so a caster who moved before expiry leaked the dictionary entry and stranded a rendered shape.
- **Dead code removal** — `ConfigureTelegraphedArea` (zero callers) and three orphan `telegraph_*` `ScriptName` constants (no handlers).
- **Real tests** replacing the string-match ones, plus a README rewrite (it documented `TelegraphHelper`, `TelegraphEvents` and a `TelegraphTest` class, none of which exist).

## Verification

Full suite **834/835**. The single failure, `ForceDarkRavagerStatusEffects_MatchCombatBible`, was confirmed pre-existing by stashing and re-running against the base branch.

Rendering itself cannot be verified headlessly — the flash needs an in-game check, which requires a hak rebuild and module repack on a deploy machine.

## Reviewer notes

1. **`OnRemoved` is a gameplay change, not only a rendering fix.** Delayed AoEs such as Remote Charge that previously *silently fizzled* when the caster changed area will now detonate. Correct behavior, but it changes live combat outcomes — worth a playtest look.
2. **One known efficiency item left unfixed.** `UpdateShadersForArea` still scans every online PC per event. A per-area player index would remove that, but it adds cache-invalidation risk to a path this PR just made hot, and the current form is already strictly cheaper than what it replaced. Easy follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Instant area abilities now render a brief impact flash when there is no pre-cast telegraph.
  * Weapon abilities can define a dedicated impact telegraph duration.
  * Telegraph visuals now initialize correctly for players when they enter an area.
* **Bug Fixes**
  * Improved telegraph cancellation/cleanup so rendering and removal apply only to the relevant area.
* **Documentation**
  * Updated telegraph API guidance and event system documentation (including pre-cast vs impact behavior).
* **Tests**
  * Added coverage for impact flashes, telegraph timing, and generated weapon ability settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->