### PR TITLE
Show item icons in Property Item Storage

### DIFF
--- a/SWLOR.Game.Server/Feature/GuiDefinition/PropertyItemStorageDefinition.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/PropertyItemStorageDefinition.cs
@@ -108,6 +108,21 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                                 {
                                     template.AddCell(cell =>
                                     {
+                                        cell.SetWidth(32f);
+                                        cell.SetIsVariable(false);
+
+                                        cell.AddGroup(group =>
+                                        {
+                                            group.AddImage()
+                                                .BindResref(model => model.ItemResrefs)
+                                                .SetHorizontalAlign(NuiHorizontalAlign.Center)
+                                                .SetVerticalAlign(NuiVerticalAlign.Top)
+                                                .BindTooltip(model => model.ItemNames);
+                                        });
+                                    });
+
+                                    template.AddCell(cell =>
+                                    {
                                         cell.AddToggleButton()
                                             .BindIsToggled(model => model.ItemToggles)
                                             .BindTooltip(model => model.ItemNames)


### PR DESCRIPTION
## Summary
- Property Item Storage's item list only showed item names as text; adds the icon-image cell used by Bank, Market, and Quest Contract windows so stored items display their icon consistently.

## Test plan
- [x] `dotnet build SWLOR.Game.Server/SWLOR.Game.Server.csproj -p:RunPostBuildEvent=Never` succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Item storage lists now display an image for each item.
  - Item images include tooltips with the corresponding item name.
  - Existing item selection controls remain available alongside the new visuals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->