### PR TITLE
Use default icon for empty Key Items

### DIFF
--- a/SWLOR.Game.Server.Tests/Feature/KeyItemsWindowTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/KeyItemsWindowTests.cs
@@ -60,7 +60,7 @@ public class KeyItemsWindowTests
         viewModel.LoadKeyItems(Array.Empty<KeyItemType>());
 
         viewModel.Selections.Should().BeEmpty();
-        viewModel.SelectedIcon.Should().BeEmpty();
+        viewModel.SelectedIcon.Should().Be(KeyItemIcon.Default);
         viewModel.SelectedName.Should().Be("No Key Items");
         viewModel.SelectedType.Should().BeEmpty();
         viewModel.SelectedDescription.Should().Be("You do not have any Key Items.");
@@ -76,6 +76,7 @@ public class KeyItemsWindowTests
 
         viewModel.LoadKeyItems(Array.Empty<KeyItemType>());
 
+        viewModel.SelectedIcon.Should().Be(KeyItemIcon.Default);
         viewModel.SelectedDescription.Should().Be("No Key Items match the selected category.");
     }
 

--- a/SWLOR.Game.Server.Tests/Service/KeyItemIconTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/KeyItemIconTests.cs
@@ -9,6 +9,20 @@ namespace SWLOR.Game.Server.Tests.Service;
 public class KeyItemIconTests
 {
     [Test]
+    public void DefaultIcon_HasValidResrefAndExpectedTgaFormat()
+    {
+        KeyItemIcon.Default.Should().NotBeNullOrWhiteSpace();
+        KeyItemIcon.Default.Length.Should().BeLessThanOrEqualTo(16,
+            "NWN resource names are limited to 16 characters");
+
+        var root = FindRepositoryRoot();
+        var path = Path.Combine(root.FullName, "SWLOR_Haks", "sw_item", $"{KeyItemIcon.Default}.tga");
+
+        File.Exists(path).Should().BeTrue($"the Key Items empty state should reference a packaged icon at {path}");
+        AssertIconTga(path, "Default Key Item icon");
+    }
+
+    [Test]
     public void ActiveKeyItems_HaveValidIconResrefs()
     {
         var entries = GetActiveEntries();

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/KeyItemsViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/KeyItemsViewModel.cs
@@ -196,7 +196,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             _selectedIndex = index;
             if (_selectedIndex < 0 || _selectedIndex >= _visibleKeyItems.Count)
             {
-                SelectedIcon = string.Empty;
+                SelectedIcon = KeyItemIcon.Default;
                 SelectedName = "No Key Items";
                 SelectedType = string.Empty;
                 SelectedDescription = SelectedCategoryId == 0

--- a/SWLOR.Game.Server/Readmes/KeyItemIconStandards.md
+++ b/SWLOR.Game.Server/Readmes/KeyItemIconStandards.md
@@ -13,6 +13,8 @@ Key Item icons use the `iki_` prefix, are stored in `SWLOR_Haks/sw_item`, and ar
 
 Category accents are amber-gold for Maps, violet-magenta for Quest Items, ivory-gold for Documents, red-orange for Keys, and emerald-green for Field Notes.
 
+The empty Key Items view uses the neutral archive placeholder `iki_default` instead of an empty resref, which NWN renders as its error icon.
+
 `tools/GetKeyItemIconPrompts.ps1` produces the complete prompt for every Key, Quest Item, and Document icon from its canonical `KeyItemType` name and description.
 
 ## Reuse Rules

--- a/SWLOR.Game.Server/Service/KeyItemService/KeyItemIcon.cs
+++ b/SWLOR.Game.Server/Service/KeyItemService/KeyItemIcon.cs
@@ -8,6 +8,8 @@ namespace SWLOR.Game.Server.Service.KeyItemService
 {
     public static class KeyItemIcon
     {
+        public const string Default = "iki_default";
+
         public const string PublishedFieldGuide = "iki_fn_guide";
         public const string LicensedResearchDatapad = "iki_fn_datapad";
         public const string HandwrittenDiscoveryJournal = "iki_fn_journal";


### PR DESCRIPTION
## Summary

- use a packaged `iki_default` archive placeholder when the Key Items list has no selection
- cover both an entirely empty inventory and an empty category filter
- validate the fallback resref and packaged TGA format
- document the empty-state icon convention
- advance `SWLOR_Haks` to include the new texture

## Root cause

The empty-state path assigned `string.Empty` to `SelectedIcon`. Neverwinter Nights treats that missing image resource as an error and displays its red-X texture.

## Player impact

Players with no key items, or no items in the selected category, now see a deliberate neutral archive icon instead of an error icon.

## HAK dependency

- https://github.com/zunath/SWLOR_Haks/pull/354

## Validation

- `dotnet build SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj -p:RunPostBuildEvent=Never --no-restore`
- `dotnet test SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj --no-build --filter "FullyQualifiedName~KeyItemsWindowTests|FullyQualifiedName~KeyItemIconTests"`
- 9 focused tests passed
- `git diff --check` passed in both repositories
