### PR TITLE
Fix duplicate Party and Comms chat labels

### DIFF
--- a/SWLOR.Game.Server.Tests/Feature/PlayerFacingNameBroadcastTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/PlayerFacingNameBroadcastTests.cs
@@ -7,6 +7,35 @@ namespace SWLOR.Game.Server.Tests.Feature;
 public class PlayerFacingNameBroadcastTests
 {
     [Test]
+    public void CommsChannel_UsesOneCommsLabelWithoutExposingPlayerNames()
+    {
+        var root = FindRepositoryRoot();
+        var source = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "SWLOR.Game.Server",
+            "Service",
+            "Communication.cs"));
+        var normalizedSource = source.Replace("\r\n", "\n");
+
+        source.Should().Contain("private const int PartyChatChannelNameStrRef = 66755;");
+        source.Should().Contain("private const string CommsChannelName = \"Comms\";");
+        var moduleEnterHandlerIndex = normalizedSource.IndexOf("[NWNEventHandler(ScriptName.OnModuleEnter)]", StringComparison.Ordinal);
+        var applyChannelNameIndex = normalizedSource.IndexOf("public static void ApplyCommsChannelName()", StringComparison.Ordinal);
+        var applyTlkOverrideIndex = normalizedSource.IndexOf(
+            "PlayerPlugin.SetTlkOverride(player, PartyChatChannelNameStrRef, CommsChannelName);",
+            StringComparison.Ordinal);
+        moduleEnterHandlerIndex.Should().BeGreaterThanOrEqualTo(0);
+        applyChannelNameIndex.Should().BeGreaterThan(moduleEnterHandlerIndex);
+        applyTlkOverrideIndex.Should().BeGreaterThan(applyChannelNameIndex);
+        normalizedSource.Should().Contain("var player = GetEnteringObject();");
+        normalizedSource.Should().Contain("if (!GetIsPC(player))");
+
+        source.Should().NotContain("finalMessage.Append(\"[Comms] \");");
+        source.Should().Contain("ChatPlugin.SendMessage(channel, message, speaker, receiver)");
+        source.Should().NotContain("ChatChannel.DMTalk");
+    }
+
+    [Test]
     public void CombatAndSpaceBroadcasts_DoNotInterpolateRawPlayerNames()
     {
         var root = FindRepositoryRoot();

--- a/SWLOR.Game.Server.Tests/Feature/PlayerFacingNameBroadcastTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/PlayerFacingNameBroadcastTests.cs
@@ -150,6 +150,12 @@ public class PlayerFacingNameBroadcastTests
         communicationSource.Should().Contain("DB.Get<PlayerShip>(dbPlayer.ActiveShipId)");
         communicationSource.Should().Contain("distanceCheck = 20.0f;");
         communicationSource.Should().Contain("var distance = GetDistanceBetween(sender, target);");
+        normalizedCommunicationSource.Should().Contain(
+            "if (GetArea(target) == GetArea(sender) &&\n" +
+            "                        distance <= distanceCheck &&\n" +
+            "                        !recipients.Contains(target))");
+        communicationSource.Should().NotContain("channel != ChatChannel.PlayerParty || IsCommsReceiverInRange(sender, target)");
+        communicationSource.Should().Contain("Comms scope applies only to the party");
         communicationSource.Should().Contain("else if (channel == ChatChannel.PlayerWhisper)");
         communicationSource.Should().NotContain("finalMessage.Append(\"[Whisper] \");");
         communicationSource.Should().NotContain("finalMessage.Append(\"[Holonet] \");");

--- a/SWLOR.Game.Server.Tests/Feature/PlayerNameRecognitionTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/PlayerNameRecognitionTests.cs
@@ -333,6 +333,7 @@ public class PlayerNameRecognitionTests
 
         var resolveChatDisplayMethod = ExtractMethod(source, "private static string ResolveChatDisplayName(uint observer, uint target, out bool isUnknown)");
         resolveChatDisplayMethod.Should().Contain("GetIsDM(observer)");
+        resolveChatDisplayMethod.Should().Contain("return BuildStaffDisplayName(target);");
         resolveChatDisplayMethod.Should().Contain("TryGetKnownName(observer, target, out var knownName)");
         resolveChatDisplayMethod.Should().Contain("return knownName;");
         resolveChatDisplayMethod.Should().Contain("return Disguise.GetDisplayDescriptor(target);");

--- a/SWLOR.Game.Server/Service/Communication.cs
+++ b/SWLOR.Game.Server/Service/Communication.cs
@@ -290,10 +290,13 @@ namespace SWLOR.Game.Server.Service
 
                     var distance = GetDistanceBetween(sender, target);
 
+                    // Preserve the Master behavior for overhearing: anyone in the same area and
+                    // within the channel's local range can hear the message, regardless of party
+                    // membership or long-range Comms scope. Comms scope applies only to the party
+                    // member delivery pass above.
                     if (GetArea(target) == GetArea(sender) &&
                         distance <= distanceCheck &&
-                        !recipients.Contains(target) &&
-                        (channel != ChatChannel.PlayerParty || IsCommsReceiverInRange(sender, target)))
+                        !recipients.Contains(target))
                     {
                         recipients.Add(target);
                     }

--- a/SWLOR.Game.Server/Service/Communication.cs
+++ b/SWLOR.Game.Server/Service/Communication.cs
@@ -21,6 +21,11 @@ namespace SWLOR.Game.Server.Service
         public const string EventCommsAreaVariable = "COMMS_EVENT_AREA";
         private const string DisabledChannelMessage = "This chat channel is disabled.";
         private const string CommsOutOfRangeMessage = "Your Comms message could not reach one or more out-of-range receivers.";
+        // Base-game dialog.tlk 66755 is the PlayerParty chat-channel label. Comms must still
+        // use the native Party packet so NWNX_Rename can apply observer-specific player names,
+        // but the player-facing channel is Comms rather than Party.
+        private const int PartyChatChannelNameStrRef = 66755;
+        private const string CommsChannelName = "Comms";
 
         public static (byte, byte, byte) OOCChatColor { get; } = (64, 64, 64);
         public static (byte, byte, byte) EmoteChatColor { get; } = (0, 255, 0);
@@ -42,6 +47,16 @@ namespace SWLOR.Game.Server.Service
             ColonForward,
             ColonBackward
         };
+
+        [NWNEventHandler(ScriptName.OnModuleEnter)]
+        public static void ApplyCommsChannelName()
+        {
+            var player = GetEnteringObject();
+            if (!GetIsPC(player))
+                return;
+
+            PlayerPlugin.SetTlkOverride(player, PartyChatChannelNameStrRef, CommsChannelName);
+        }
 
         /// <summary>
         /// Whenever a DM possesses a creature, track the NPC on their object so that messages can be
@@ -316,8 +331,6 @@ namespace SWLOR.Game.Server.Service
 
                 if (channel == ChatChannel.PlayerParty)
                 {
-                    finalMessage.Append("[Comms] ");
-
                     if (GetIsDM(receiver))
                     {
                         // Convenience for DMs - append the party members.

--- a/SWLOR.Game.Server/Service/PlayerName.cs
+++ b/SWLOR.Game.Server/Service/PlayerName.cs
@@ -638,12 +638,13 @@ namespace SWLOR.Game.Server.Service
 
             if (!GetIsObjectValid(observer) ||
                 observer == target ||
-                GetIsDM(observer) ||
-                GetIsDMPossessed(observer) ||
                 !GetIsPC(observer))
             {
                 return GetName(target);
             }
+
+            if (GetIsDM(observer) || GetIsDMPossessed(observer))
+                return BuildStaffDisplayName(target);
 
             if (TryGetKnownName(observer, target, out var knownName))
                 return knownName;


### PR DESCRIPTION
## Summary

Render Party-routed chat as **Comms** with exactly one channel descriptor, preserve observer-specific player identities, and retain the custom Comms recipient routing used by the server.

## Root cause

Master routed Comms through `DMTalk`, which avoided NWN's native `[Party]` label and displayed the manually added `[Comms]` prefix. The later cross-area identity privacy fix correctly moved delivery to native `PlayerParty` so NWNX_Rename could apply observer-specific names, but it left the manual prefix in place. NWN therefore rendered both `[Party]` and `[Comms]`.

## Fix

- Keep native `PlayerParty` packets so observer-specific player names remain protected across areas.
- Continue suppressing NWN's original broadcast and explicitly construct the recipient list before sending once per recipient; native party membership does not determine delivery.
- Preserve Master's local overhearing rule exactly: every player in the speaker's area within 20m receives Comms, whether or not they are in the party.
- Deliver to eligible long-range party members under the current Comms scope rules and warn the sender when party members are out of range.
- Deliver to DMs and suppress duplicate deliveries when a recipient qualifies through more than one path.
- Reapply base-game chat channel strref `66755` as `Comms` for each client on module entry.
- Remove the manually prepended `[Comms]` text.
- Ensure staff chat identity renders the canonical name plus the current gray descriptor, matching the player-identity rules.

The label change affects presentation only. Recipient routing remains custom and explicitly includes nearby non-party listeners.

## Recipient behavior

- The sender receives their own message.
- All players in the same area within 20m receive it, regardless of party membership.
- Party members in the sender's valid Comms scope receive it even when they are in another area.
- Out-of-scope party members do not receive it, and the sender receives one warning.
- DMs receive it.
- A recipient qualifying through multiple rules receives only one copy.
- Every recipient receives an individually targeted native Party packet so observer-specific names and disguises remain private.

## Identity behavior verified

- A name selected by an observer through `/name` is used only for that observer and current identity.
- An active disguise uses its own identity key: observers see a name assigned to that disguise, otherwise its disguise descriptor; the underlying identity does not leak.
- Unnamed/forgotten identities use the current unknown or disguise descriptor.
- Self-view remains canonical as allowed for messages shown only to that player.
- Staff see canonical name plus the current gray descriptor.
- Temporary chat overrides are restored after every per-recipient dispatch.

## Validation

- Build succeeded: 0 errors
- 29 communication, identity, and RP-chat regression tests passed
- Regression coverage requires:
  - the Party-channel TLK override and no manual `[Comms]` prefix
  - native Party packet delivery and no fallback to identity-leaking `DMTalk`
  - Master's exact same-area/20m nearby-recipient condition without a party or Comms-scope gate
  - scoped party delivery, duplicate suppression, and staff descriptor preservation
- `git diff --check`: clean
- Haks submodule: clean and aligned

Live NWN testing is still required to verify the client-rendered label and the full recipient/identity matrix. The available testing workbook is perk-only and has no chat/system rows, so it was intentionally left unchanged.