### PR TITLE
Fix Settings window tab and save behavior

### DIFF
--- a/SWLOR.Game.Server.Tests/Feature/SettingsWindowTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/SettingsWindowTests.cs
@@ -1,0 +1,75 @@
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace SWLOR.Game.Server.Tests.Feature;
+
+public class SettingsWindowTests
+{
+    [Test]
+    public void Tabs_UseVisibilityBindingsWithoutRedrawingTheWindow()
+    {
+        var (definitionSource, viewModelSource) = LoadSettingsSources();
+
+        definitionSource.Should().Contain(".DefinePartialView(SettingsViewModel.ContentPartial");
+        definitionSource.Should().Contain(".BindIsVisible(model => model.IsGeneralSelected)");
+        definitionSource.Should().Contain(".BindIsVisible(model => model.IsIdentitySelected)");
+        definitionSource.Should().Contain(".BindIsVisible(model => model.IsChatSelected)");
+
+        viewModelSource.Should().Contain("ChangePartialView(SettingsView, ContentPartial);");
+        viewModelSource
+            .Split("ChangePartialView(SettingsView, ContentPartial);", StringSplitOptions.None)
+            .Should().HaveCount(2, "the content layout should only be mounted when the window initializes");
+        viewModelSource.Should().NotContain("ChangePartialView(SettingsView, GeneralPartial)");
+        viewModelSource.Should().NotContain("ChangePartialView(SettingsView, IdentityPartial)");
+        viewModelSource.Should().NotContain("ChangePartialView(SettingsView, ChatPartial)");
+    }
+
+    [Test]
+    public void Save_PersistsWithoutClosingTheWindow()
+    {
+        var (definitionSource, viewModelSource) = LoadSettingsSources();
+        var saveStart = viewModelSource.IndexOf("public Action OnSave()", StringComparison.Ordinal);
+        var cancelStart = viewModelSource.IndexOf("public Action OnCancel()", StringComparison.Ordinal);
+
+        saveStart.Should().BeGreaterThanOrEqualTo(0);
+        cancelStart.Should().BeGreaterThan(saveStart);
+
+        var saveMethod = viewModelSource[saveStart..cancelStart];
+        saveMethod.Should().Contain("DB.Set(dbPlayer);");
+        saveMethod.Should().NotContain("Gui.TogglePlayerWindow");
+        definitionSource.Should().Contain(".SetIsClosable(true)");
+    }
+
+    private static (string DefinitionSource, string ViewModelSource) LoadSettingsSources()
+    {
+        var root = FindRepositoryRoot();
+        var definitionSource = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "SWLOR.Game.Server",
+            "Feature",
+            "GuiDefinition",
+            "SettingsDefinition.cs"));
+        var viewModelSource = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "SWLOR.Game.Server",
+            "Feature",
+            "GuiDefinition",
+            "ViewModel",
+            "SettingsViewModel.cs"));
+
+        return (definitionSource, viewModelSource);
+    }
+
+    private static DirectoryInfo FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(TestContext.CurrentContext.TestDirectory);
+
+        while (directory != null && !File.Exists(Path.Combine(directory.FullName, "SWLOR.Game.Server.sln")))
+        {
+            directory = directory.Parent;
+        }
+
+        directory.Should().NotBeNull("repository root should be discoverable from the test directory");
+        return directory!;
+    }
+}

--- a/SWLOR.Game.Server.Tests/Feature/SettingsWindowTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/SettingsWindowTests.cs
@@ -6,22 +6,44 @@ namespace SWLOR.Game.Server.Tests.Feature;
 public class SettingsWindowTests
 {
     [Test]
-    public void Tabs_UseVisibilityBindingsWithoutRedrawingTheWindow()
+    public void Tabs_UseSeparatePartialViewsAndPreserveWindowGeometry()
     {
         var (definitionSource, viewModelSource) = LoadSettingsSources();
 
-        definitionSource.Should().Contain(".DefinePartialView(SettingsViewModel.ContentPartial");
-        definitionSource.Should().Contain(".BindIsVisible(model => model.IsGeneralSelected)");
-        definitionSource.Should().Contain(".BindIsVisible(model => model.IsIdentitySelected)");
-        definitionSource.Should().Contain(".BindIsVisible(model => model.IsChatSelected)");
+        definitionSource.Should().Contain(".DefinePartialView(SettingsViewModel.GeneralPartial");
+        definitionSource.Should().Contain(".DefinePartialView(SettingsViewModel.IdentityPartial");
+        definitionSource.Should().Contain(".DefinePartialView(SettingsViewModel.ChatPartial");
+        definitionSource.Should().NotContain(".BindIsVisible(model => model.IsGeneralSelected)");
+        definitionSource.Should().NotContain(".BindIsVisible(model => model.IsIdentitySelected)");
+        definitionSource.Should().NotContain(".BindIsVisible(model => model.IsChatSelected)");
 
-        viewModelSource.Should().Contain("ChangePartialView(SettingsView, ContentPartial);");
-        viewModelSource
-            .Split("ChangePartialView(SettingsView, ContentPartial);", StringSplitOptions.None)
-            .Should().HaveCount(2, "the content layout should only be mounted when the window initializes");
-        viewModelSource.Should().NotContain("ChangePartialView(SettingsView, GeneralPartial)");
-        viewModelSource.Should().NotContain("ChangePartialView(SettingsView, IdentityPartial)");
-        viewModelSource.Should().NotContain("ChangePartialView(SettingsView, ChatPartial)");
+        var changeSettingsView = ExtractMethod(
+            viewModelSource,
+            "private void ChangeSettingsView",
+            "private string GetSelectedPartial");
+        var geometryCapture = changeSettingsView.IndexOf("UpdatePropertyFromClient(nameof(Geometry));", StringComparison.Ordinal);
+        var partialSwap = changeSettingsView.IndexOf("ChangePartialView(SettingsView, partialName);", StringComparison.Ordinal);
+
+        geometryCapture.Should().BeGreaterThanOrEqualTo(0);
+        partialSwap.Should().BeGreaterThan(geometryCapture);
+        viewModelSource.Should().Contain("ChangeSettingsView(GeneralPartial);");
+        viewModelSource.Should().Contain("ChangeSettingsView(IdentityPartial);");
+        viewModelSource.Should().Contain("ChangeSettingsView(ChatPartial);");
+    }
+
+    [Test]
+    public void TabChanges_DoNotReloadUnsavedSettings()
+    {
+        var (_, viewModelSource) = LoadSettingsSources();
+        var initializeMethod = ExtractMethod(viewModelSource, "protected override void Initialize", "private void LoadGeneralView");
+        var tabMethods = ExtractMethod(viewModelSource, "public Action OnClickGeneral", "public Action OnClickSelectChat");
+
+        initializeMethod.Should().Contain("LoadGeneralView();");
+        initializeMethod.Should().Contain("LoadIdentityView();");
+        initializeMethod.Should().Contain("LoadChatView();");
+        tabMethods.Should().NotContain("LoadGeneralView();");
+        tabMethods.Should().NotContain("LoadIdentityView();");
+        tabMethods.Should().NotContain("LoadChatView();");
     }
 
     [Test]
@@ -36,8 +58,19 @@ public class SettingsWindowTests
 
         var saveMethod = viewModelSource[saveStart..cancelStart];
         saveMethod.Should().Contain("DB.Set(dbPlayer);");
+        saveMethod.Should().Contain("Log.Write(LogGroup.Server, $\"Settings saved for player {playerId}.\");");
         saveMethod.Should().NotContain("Gui.TogglePlayerWindow");
         definitionSource.Should().Contain(".SetIsClosable(true)");
+    }
+
+    private static string ExtractMethod(string source, string startMarker, string endMarker)
+    {
+        var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+        var end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+
+        start.Should().BeGreaterThanOrEqualTo(0);
+        end.Should().BeGreaterThan(start);
+        return source[start..end];
     }
 
     private static (string DefinitionSource, string ViewModelSource) LoadSettingsSources()

--- a/SWLOR.Game.Server/Feature/GuiDefinition/SettingsDefinition.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/SettingsDefinition.cs
@@ -16,7 +16,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                 .SetInitialGeometry(0, 0, 375f, 340f)
                 .SetTitle("Settings")
 
-                .DefinePartialView(SettingsViewModel.ContentPartial, view =>
+                .DefinePartialView(SettingsViewModel.GeneralPartial, view =>
                 {
                     view.AddColumn(col =>
                     {
@@ -31,8 +31,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                                 .SetWidth(230f)
                                 .BindIsChecked(model => model.DisplayAchievementNotification);
                         })
-                        .SetHeight(30f)
-                        .BindIsVisible(model => model.IsGeneralSelected);
+                        .SetHeight(30f);
 
                         col.AddRow(row =>
                         {
@@ -45,8 +44,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                                 .SetWidth(230f)
                                 .BindIsChecked(model => model.SubdualMode);
                         })
-                            .SetHeight(30f)
-                            .BindIsVisible(model => model.IsGeneralSelected);
+                            .SetHeight(30f);
 
 
                         col.AddRow(row =>
@@ -60,8 +58,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                                 .SetWidth(230f)
                                 .BindIsChecked(model => model.DisplayServerResetReminders);
                         })
-                            .SetHeight(30f)
-                            .BindIsVisible(model => model.IsGeneralSelected);
+                            .SetHeight(30f);
 
                         col.AddRow(row =>
                         {
@@ -74,8 +71,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                                 .SetWidth(230f)
                                 .BindIsChecked(model => model.PortraitVitals);
                         })
-                            .SetHeight(30f)
-                            .BindIsVisible(model => model.IsGeneralSelected);
+                            .SetHeight(30f);
 
                         col.AddRow(row =>
                         {
@@ -88,8 +84,15 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                                 .BindOnClicked(model => model.OnClickChangeDescription())
                                 .SetWidth(230f)
                                 .SetHeight(32f);
-                        })
-                            .BindIsVisible(model => model.IsGeneralSelected);
+                        });
+
+                    });
+                })
+
+                .DefinePartialView(SettingsViewModel.IdentityPartial, view =>
+                {
+                    view.AddColumn(col =>
+                    {
 
                         col.AddRow(row =>
                         {
@@ -102,8 +105,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                                 .SetWidth(230f)
                                 .BindIsChecked(model => model.ShowOwnDescriptor);
                         })
-                            .SetHeight(30f)
-                            .BindIsVisible(model => model.IsIdentitySelected);
+                            .SetHeight(30f);
 
                         col.AddRow(row =>
                         {
@@ -116,8 +118,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                                 .SetWidth(230f)
                                 .BindIsChecked(model => model.ShowDescriptorsForNamedPlayers);
                         })
-                            .SetHeight(30f)
-                            .BindIsVisible(model => model.IsIdentitySelected);
+                            .SetHeight(30f);
 
                         col.AddRow(row =>
                         {
@@ -130,8 +131,14 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                                 .SetWidth(230f)
                                 .BindIsChecked(model => model.ScrambleAccountName);
                         })
-                            .SetHeight(30f)
-                            .BindIsVisible(model => model.IsIdentitySelected);
+                            .SetHeight(30f);
+                    });
+                })
+
+                .DefinePartialView(SettingsViewModel.ChatPartial, view =>
+                {
+                    view.AddColumn(col =>
+                    {
 
                         col.AddRow(row =>
                         {
@@ -180,15 +187,13 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                                 });
                             })
                                 .BindRowCount(model => model.ChatColorNames);
-                        })
-                            .BindIsVisible(model => model.IsChatSelected);
+                        });
 
                         col.AddRow(row =>
                         {
                             row.AddColorPicker()
                                 .BindSelectedColor(model => model.SelectedColor);
-                        })
-                            .BindIsVisible(model => model.IsChatSelected);
+                        });
 
                         col.AddRow(row =>
                         {
@@ -213,8 +218,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                                 .SetIsEnabled(false);
 
                             row.AddSpacer();
-                        })
-                            .BindIsVisible(model => model.IsChatSelected);
+                        });
                     });
                 })
 

--- a/SWLOR.Game.Server/Feature/GuiDefinition/SettingsDefinition.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/SettingsDefinition.cs
@@ -12,10 +12,11 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
             _builder.CreateWindow(GuiWindowType.Settings)
                 .SetIsResizable(true)
                 .SetIsCollapsible(true)
+                .SetIsClosable(true)
                 .SetInitialGeometry(0, 0, 375f, 340f)
                 .SetTitle("Settings")
 
-                .DefinePartialView(SettingsViewModel.GeneralPartial, view =>
+                .DefinePartialView(SettingsViewModel.ContentPartial, view =>
                 {
                     view.AddColumn(col =>
                     {
@@ -30,7 +31,8 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                                 .SetWidth(230f)
                                 .BindIsChecked(model => model.DisplayAchievementNotification);
                         })
-                        .SetHeight(30f);
+                        .SetHeight(30f)
+                        .BindIsVisible(model => model.IsGeneralSelected);
 
                         col.AddRow(row =>
                         {
@@ -43,7 +45,8 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                                 .SetWidth(230f)
                                 .BindIsChecked(model => model.SubdualMode);
                         })
-                            .SetHeight(30f);
+                            .SetHeight(30f)
+                            .BindIsVisible(model => model.IsGeneralSelected);
 
 
                         col.AddRow(row =>
@@ -57,7 +60,8 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                                 .SetWidth(230f)
                                 .BindIsChecked(model => model.DisplayServerResetReminders);
                         })
-                            .SetHeight(30f);
+                            .SetHeight(30f)
+                            .BindIsVisible(model => model.IsGeneralSelected);
 
                         col.AddRow(row =>
                         {
@@ -70,7 +74,8 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                                 .SetWidth(230f)
                                 .BindIsChecked(model => model.PortraitVitals);
                         })
-                            .SetHeight(30f);
+                            .SetHeight(30f)
+                            .BindIsVisible(model => model.IsGeneralSelected);
 
                         col.AddRow(row =>
                         {
@@ -83,15 +88,9 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                                 .BindOnClicked(model => model.OnClickChangeDescription())
                                 .SetWidth(230f)
                                 .SetHeight(32f);
-                        });
+                        })
+                            .BindIsVisible(model => model.IsGeneralSelected);
 
-                    });
-                })
-
-                .DefinePartialView(SettingsViewModel.IdentityPartial, view =>
-                {
-                    view.AddColumn(col =>
-                    {
                         col.AddRow(row =>
                         {
                             row.AddSpacer()
@@ -103,7 +102,8 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                                 .SetWidth(230f)
                                 .BindIsChecked(model => model.ShowOwnDescriptor);
                         })
-                            .SetHeight(30f);
+                            .SetHeight(30f)
+                            .BindIsVisible(model => model.IsIdentitySelected);
 
                         col.AddRow(row =>
                         {
@@ -116,7 +116,8 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                                 .SetWidth(230f)
                                 .BindIsChecked(model => model.ShowDescriptorsForNamedPlayers);
                         })
-                            .SetHeight(30f);
+                            .SetHeight(30f)
+                            .BindIsVisible(model => model.IsIdentitySelected);
 
                         col.AddRow(row =>
                         {
@@ -129,14 +130,9 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                                 .SetWidth(230f)
                                 .BindIsChecked(model => model.ScrambleAccountName);
                         })
-                            .SetHeight(30f);
-                    });
-                })
+                            .SetHeight(30f)
+                            .BindIsVisible(model => model.IsIdentitySelected);
 
-                .DefinePartialView(SettingsViewModel.ChatPartial, view =>
-                {
-                    view.AddColumn(col =>
-                    {
                         col.AddRow(row =>
                         {
                             row.AddList(template =>
@@ -184,13 +180,15 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                                 });
                             })
                                 .BindRowCount(model => model.ChatColorNames);
-                        });
+                        })
+                            .BindIsVisible(model => model.IsChatSelected);
 
                         col.AddRow(row =>
                         {
                             row.AddColorPicker()
                                 .BindSelectedColor(model => model.SelectedColor);
-                        });
+                        })
+                            .BindIsVisible(model => model.IsChatSelected);
 
                         col.AddRow(row =>
                         {
@@ -215,7 +213,8 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                                 .SetIsEnabled(false);
 
                             row.AddSpacer();
-                        });
+                        })
+                            .BindIsVisible(model => model.IsChatSelected);
                     });
                 })
 

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/SettingsViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/SettingsViewModel.cs
@@ -4,6 +4,7 @@ using SWLOR.Game.Server.Enumeration;
 using SWLOR.Game.Server.Service;
 using SWLOR.Game.Server.Service.GuiService;
 using SWLOR.Game.Server.Service.GuiService.Component;
+using SWLOR.Game.Server.Service.LogService;
 using SWLOR.Game.Server.Service.SkillService;
 
 namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
@@ -11,7 +12,10 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
     public class SettingsViewModel: GuiViewModelBase<SettingsViewModel, GuiPayloadBase>
     {
         public const string SettingsView = "SETTINGS_VIEW";
-        public const string ContentPartial = "CONTENT_VIEW";
+
+        public const string GeneralPartial = "GENERAL_VIEW";
+        public const string IdentityPartial = "IDENTITY_VIEW";
+        public const string ChatPartial = "CHAT_VIEW";
 
         private const int NumberOfSystemColors = 2; // OOC, Emotes
 
@@ -143,8 +147,9 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
 
             LoadGeneralView();
             LoadIdentityView();
+            LoadChatView();
 
-            ChangePartialView(SettingsView, ContentPartial);
+            ChangePartialView(SettingsView, GeneralPartial);
 
             WatchOnClient(model => model.DisplayAchievementNotification);
             WatchOnClient(model => model.SubdualMode);
@@ -255,6 +260,30 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             ChatColorToggles = chatToggles;
         }
 
+        private void ChangeSettingsView(string partialName)
+        {
+            // Capture the client's current position before the partial-view redraw workaround
+            // temporarily changes the window geometry.
+            UpdatePropertyFromClient(nameof(Geometry));
+            ChangePartialView(SettingsView, partialName);
+        }
+
+        private string GetSelectedPartial()
+        {
+            if (IsIdentitySelected)
+                return IdentityPartial;
+
+            if (IsChatSelected)
+                return ChatPartial;
+
+            return GeneralPartial;
+        }
+
+        protected override void OnMainViewRestored()
+        {
+            ChangePartialView(SettingsView, GetSelectedPartial());
+        }
+
         private void LoadColor()
         {
             if (SelectedIndex < 0)
@@ -312,6 +341,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             }
 
             DB.Set(dbPlayer);
+            Log.Write(LogGroup.Server, $"Settings saved for player {playerId}.");
 
             // Apply the vitals display preference immediately (portrait overlay vs. docked window).
             PlayerStatusWindow.ApplyStatusDisplay(Player);
@@ -337,7 +367,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             IsGeneralSelected = true;
             IsIdentitySelected = false;
             IsChatSelected = false;
-            LoadGeneralView();
+            ChangeSettingsView(GeneralPartial);
         };
 
         public Action OnClickIdentity() => () =>
@@ -345,7 +375,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             IsGeneralSelected = false;
             IsIdentitySelected = true;
             IsChatSelected = false;
-            LoadIdentityView();
+            ChangeSettingsView(IdentityPartial);
         };
 
         public Action OnClickChat() => () =>
@@ -353,7 +383,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             IsGeneralSelected = false;
             IsIdentitySelected = false;
             IsChatSelected = true;
-            LoadChatView();
+            ChangeSettingsView(ChatPartial);
         };
 
         public Action OnClickSelectChat() => () =>
@@ -371,6 +401,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
         public Action OnClickResetColor() => () =>
         {
             var index = NuiGetEventArrayIndex();
+            UpdatePropertyFromClient(nameof(Geometry));
 
             ShowModal("Are you sure you want to reset this color to the default?", () =>
             {

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/SettingsViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/SettingsViewModel.cs
@@ -11,10 +11,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
     public class SettingsViewModel: GuiViewModelBase<SettingsViewModel, GuiPayloadBase>
     {
         public const string SettingsView = "SETTINGS_VIEW";
-
-        public const string GeneralPartial = "GENERAL_VIEW";
-        public const string IdentityPartial = "IDENTITY_VIEW";
-        public const string ChatPartial = "CHAT_VIEW";
+        public const string ContentPartial = "CONTENT_VIEW";
 
         private const int NumberOfSystemColors = 2; // OOC, Emotes
 
@@ -147,7 +144,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             LoadGeneralView();
             LoadIdentityView();
 
-            ChangePartialView(SettingsView, GeneralPartial);
+            ChangePartialView(SettingsView, ContentPartial);
 
             WatchOnClient(model => model.DisplayAchievementNotification);
             WatchOnClient(model => model.SubdualMode);
@@ -319,8 +316,6 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             // Apply the vitals display preference immediately (portrait overlay vs. docked window).
             PlayerStatusWindow.ApplyStatusDisplay(Player);
 
-            Gui.TogglePlayerWindow(Player, GuiWindowType.Settings);
-
             PlayerName.RefreshNameOverridesForObserver(Player);
             PlayerName.RefreshNameOverridesForPlayer(Player);
 
@@ -342,7 +337,6 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             IsGeneralSelected = true;
             IsIdentitySelected = false;
             IsChatSelected = false;
-            ChangePartialView(SettingsView, GeneralPartial);
             LoadGeneralView();
         };
 
@@ -351,7 +345,6 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             IsGeneralSelected = false;
             IsIdentitySelected = true;
             IsChatSelected = false;
-            ChangePartialView(SettingsView, IdentityPartial);
             LoadIdentityView();
         };
 
@@ -360,7 +353,6 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             IsGeneralSelected = false;
             IsIdentitySelected = false;
             IsChatSelected = true;
-            ChangePartialView(SettingsView, ChatPartial);
             LoadChatView();
         };
 
@@ -402,8 +394,6 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
                     var (red, green, blue) = Language.GetColor(type);
                     ChatColors[index] = new GuiColor(red, green, blue);
                 }
-
-                ChangePartialView(SettingsView, ChatPartial);
             });
         };
     }


### PR DESCRIPTION
## Summary

- keep the General, Identity, and Chat Settings content mounted and switch tabs with visibility bindings
- preserve the Settings window position while changing tabs
- save preferences without automatically closing the window
- explicitly keep the window closable through its X control
- add regression coverage for tab redraws and Save behavior

## Root cause

Each tab click replaced a partial view. The GUI framework refresh workaround changes the bound window geometry after a partial swap, which could reapply the initial top-left coordinates. Separately, the Save handler explicitly toggled the Settings window closed after persistence.

## Player impact

Players can move Settings anywhere on screen and switch tabs without losing its position. Save now confirms and applies changes while leaving the window open so the player decides when to close it.

## Validation

- `dotnet build SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj --no-restore -p:RunPostBuildEvent=Never`
- `dotnet test SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj --no-build --filter "Name~Settings_ControlIdentityNameplateAndAccountPrivacyForPlayersOnly|FullyQualifiedName~SettingsWindowTests"` (3 passed)

An additional broader identity/name run passed 22 tests; its remaining unrelated test could not run because this worktree's `SWLOR_Haks` submodule is not initialized and `appearance.2da` is absent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a closable Settings window with a defined initial size.
  * Settings tabs now switch content visibility without redrawing the window.
  * Saving settings keeps the window open and displays the updated confirmation.
  * Improved visibility handling for General, Identity, and Chat settings sections.

* **Tests**
  * Added coverage validating tab visibility, window behavior, and save functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->