### PR TITLE
Fix stealth exit on detection

### DIFF
--- a/SWLOR.Game.Server.Tests/Perks/EspionageSystemTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/EspionageSystemTests.cs
@@ -114,6 +114,23 @@ public class EspionageSystemTests
     }
 
     [Test]
+    public void SuccessfulSpotDetection_ExitsPlayerStealth()
+    {
+        var stealthSource = File.ReadAllText(Path.Combine(
+            FindRepositoryRoot(),
+            "SWLOR.Game.Server",
+            "Service",
+            "Stealth.cs"));
+
+        stealthSource.Should().MatchRegex(@"if \(detected\)\s+ExitDetectedPlayerStealth\(target\);");
+        stealthSource.Should().Contain("private static void ExitDetectedPlayerStealth(uint target)");
+        stealthSource.Should().Contain("!GetIsPC(target) ||");
+        stealthSource.Should().Contain("GetIsDM(target) ||");
+        stealthSource.Should().Contain("!GetActionMode(target, ActionMode.Stealth)");
+        stealthSource.Should().Contain("SetActionMode(target, ActionMode.Stealth, false);");
+    }
+
+    [Test]
     public void SlicingRanksReduceLockboxUseDelayAtTheDocumentedBands()
     {
         LockboxItemDefinition.CalculateUseDelaySeconds(0).Should().BeApproximately(2f, 0.001f);

--- a/SWLOR.Game.Server/Readmes/EspionageImplementationPlan.md
+++ b/SWLOR.Game.Server/Readmes/EspionageImplementationPlan.md
@@ -34,6 +34,7 @@ Perk-only adjustments such as flat Stealth rating, stealthed movement speed, ste
 
 - Baseline stealth requires Stealth I-IV and can only be entered out of combat. Ghost Protocol is the sole in-combat entry window.
 - Spot detection replaces the vanilla roll with one opposed check: `d20 + Detection` versus `d20 + Stealth`. The verdict is cached per observer/target pair for 30 seconds. Ties favor the stealthed target.
+- A successful Spot check against a player exits that player's stealth and reveals them globally. NPC stealth retains the engine's observer-specific visibility behavior.
 - Listen detection is suppressed so there is one detection model rather than separate Spot and Listen rolls.
 - Cache entries for a stealthed target are cleared on stealth exit; expired entries are pruned as the cache grows.
 - Stealth drains 2 STM every 6 seconds. Silent Stride reduces the drain rate by 20%, producing 2 STM every 7.5 seconds, and grants +30% Movement Speed while stealthed without removing stealth's running restriction.

--- a/SWLOR.Game.Server/Service/Stealth.cs
+++ b/SWLOR.Game.Server/Service/Stealth.cs
@@ -136,6 +136,9 @@ namespace SWLOR.Game.Server.Service
 
             var detected = GetOrRollVerdict(observer, target);
             EventsPlugin.SetEventResult(detected ? "1" : "0");
+
+            if (detected)
+                ExitDetectedPlayerStealth(target);
         }
 
         [NWNEventHandler(ScriptName.OnDoListenDetectionBefore)]
@@ -162,6 +165,25 @@ namespace SWLOR.Game.Server.Service
 
             _verdicts[key] = (detected, now.AddSeconds(DetectionCheckIntervalSeconds));
             return detected;
+        }
+
+        /// <summary>
+        /// A successful detection reveals a player to everyone by ending their stealth mode. NPC
+        /// stealth keeps the engine's observer-specific behavior so creature encounters are not
+        /// globally revealed when a single observer succeeds.
+        /// </summary>
+        private static void ExitDetectedPlayerStealth(uint target)
+        {
+            if (!GetIsPC(target) ||
+                GetIsDM(target) ||
+                !GetActionMode(target, ActionMode.Stealth))
+                return;
+
+            AssignCommand(target, () =>
+            {
+                SetActionMode(target, ActionMode.Stealth, false);
+            });
+            SendMessageToPC(target, ColorToken.Red("You have been detected and are forced out of stealth."));
         }
 
         private static void ClearVerdictsForTarget(uint target)


### PR DESCRIPTION
## Summary

- Exit a player's stealth mode when an opposed Spot check successfully detects them.
- Notify the detected player while preserving observer-specific stealth behavior for NPCs and DMs.
- Add regression coverage and document the player reveal behavior.

## Root cause

The custom Spot detection handler returned a successful detection result to the engine but never cleared the target player's `ActionMode.Stealth`. The player therefore remained in stealth and kept the associated status and stamina drain active after being detected.

## Player impact

Detected players now leave stealth immediately and the existing stealth-exit handler removes the status effect, clears cached verdicts, and stops stamina drain. NPC encounter behavior is unchanged.

## Validation

- `dotnet build SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj -p:RunPostBuildEvent=Never`
- `dotnet test SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj --no-build --filter "FullyQualifiedName~EspionageSystemTests"` — 12 passed