### PR TITLE
Add Comms range warning setting

### DIFF
--- a/SWLOR.Game.Server.Tests/Feature/PlayerFacingNameBroadcastTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/PlayerFacingNameBroadcastTests.cs
@@ -140,6 +140,7 @@ public class PlayerFacingNameBroadcastTests
         communicationSource.Should().Contain("Nearby non-party listeners can still overhear it.");
         normalizedCommunicationSource.Should().Contain("recipients.AddRange(allDMs);\n\n                needsAreaCheck = true;\n                distanceCheck = 20.0f;");
         communicationSource.Should().NotContain("AddSameStarshipCommsRecipients");
+        communicationSource.Should().Contain("if (dbSender?.Settings?.DisplayCommsOutOfRangeWarnings ?? true)");
         communicationSource.Should().Contain("SendMessageToPC(sender, ColorToken.Red(CommsOutOfRangeMessage));");
         communicationSource.Should().NotContain("SendCommsOutOfRangeMessage(sender);");
         communicationSource.Should().NotContain("ChatPlugin.SendMessage(ChatChannel.ServerMessage, ColorToken.Red(CommsOutOfRangeMessage), sender, sender);");

--- a/SWLOR.Game.Server.Tests/Feature/SettingsWindowTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/SettingsWindowTests.cs
@@ -63,6 +63,28 @@ public class SettingsWindowTests
         definitionSource.Should().Contain(".SetIsClosable(true)");
     }
 
+    [Test]
+    public void CommsRangeWarnings_AreEnabledByDefaultAndPersistedFromChatSettings()
+    {
+        var root = FindRepositoryRoot();
+        var playerSource = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "SWLOR.Game.Server",
+            "Entity",
+            "Player.cs"));
+        var (definitionSource, viewModelSource) = LoadSettingsSources();
+
+        playerSource.Should().Contain("public bool? DisplayCommsOutOfRangeWarnings { get; set; }");
+        playerSource.Should().Contain("DisplayCommsOutOfRangeWarnings = true;");
+        definitionSource.Should().Contain(".SetText(\"Comms Range Warnings\")");
+        definitionSource.Should().Contain(".BindIsChecked(model => model.DisplayCommsOutOfRangeWarnings)");
+        viewModelSource.Should().Contain("WatchOnClient(model => model.DisplayCommsOutOfRangeWarnings);");
+        viewModelSource.Should().Contain(
+            "DisplayCommsOutOfRangeWarnings = dbPlayer.Settings.DisplayCommsOutOfRangeWarnings ?? true;");
+        viewModelSource.Should().Contain(
+            "dbPlayer.Settings.DisplayCommsOutOfRangeWarnings = DisplayCommsOutOfRangeWarnings;");
+    }
+
     private static string ExtractMethod(string source, string startMarker, string endMarker)
     {
         var start = source.IndexOf(startMarker, StringComparison.Ordinal);

--- a/SWLOR.Game.Server/Entity/Player.cs
+++ b/SWLOR.Game.Server/Entity/Player.cs
@@ -250,6 +250,7 @@ namespace SWLOR.Game.Server.Entity
         public bool? ShowDescriptorsForNamedPlayers { get; set; }
         public bool? ShowOwnDescriptor { get; set; }
         public bool? ScrambleAccountName { get; set; }
+        public bool? DisplayCommsOutOfRangeWarnings { get; set; }
 
         // When enabled, Stamina and FP are shown as thin bars overlaid on the character portrait
         // instead of the standalone HP/STM/FP window docked in the lower-right corner.
@@ -268,6 +269,7 @@ namespace SWLOR.Game.Server.Entity
             ShowDescriptorsForNamedPlayers = true;
             ShowOwnDescriptor = true;
             ScrambleAccountName = true;
+            DisplayCommsOutOfRangeWarnings = true;
             PortraitVitals = true;
 
             LanguageChatColors = new Dictionary<SkillType, PlayerColor>();

--- a/SWLOR.Game.Server/Feature/GuiDefinition/SettingsDefinition.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/SettingsDefinition.cs
@@ -139,6 +139,18 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                 {
                     view.AddColumn(col =>
                     {
+                        col.AddRow(row =>
+                        {
+                            row.AddSpacer()
+                                .SetWidth(28f);
+
+                            row.AddCheckBox()
+                                .SetText("Comms Range Warnings")
+                                .SetTooltip("Warns you when one or more party members are outside the range of a Comms message and do not receive it.")
+                                .SetWidth(230f)
+                                .BindIsChecked(model => model.DisplayCommsOutOfRangeWarnings);
+                        })
+                            .SetHeight(30f);
 
                         col.AddRow(row =>
                         {

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/PlayerGuideViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/PlayerGuideViewModel.cs
@@ -334,7 +334,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
                     new[]
                     {
                         new ArticleBlock("Talk, Whisper, and Comms",
-                            "Normal Talk reaches players within 20 meters. Whisper reaches 4 meters. Party chat acts as Comms: it reaches party members in the same ship, space region, supported event area, or planet, and nearby non-party listeners within 20 meters can overhear it when they share that scope. You receive a warning when party members are out of range."),
+                            "Normal Talk reaches players within 20 meters. Whisper reaches 4 meters. Party chat acts as Comms: it reaches party members in the same ship, space region, supported event area, or planet, and nearby non-party listeners within 20 meters can overhear it when they share that scope. By default, you receive a warning when party members are out of range; this warning can be disabled in Chat Settings."),
                         new ArticleBlock("Disabled Shout Channel",
                             "The Shout chat channel is disabled for players. DMs can still use Shout for server-wide messages."),
                         new ArticleBlock("HoloNet Broadcast Window",

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/SettingsViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/SettingsViewModel.cs
@@ -67,6 +67,12 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             set => Set(value);
         }
 
+        public bool DisplayCommsOutOfRangeWarnings
+        {
+            get => Get<bool>();
+            set => Set(value);
+        }
+
         public bool IsGeneralSelected
         {
             get => Get<bool>();
@@ -158,6 +164,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             WatchOnClient(model => model.ShowDescriptorsForNamedPlayers);
             WatchOnClient(model => model.ShowOwnDescriptor);
             WatchOnClient(model => model.ScrambleAccountName);
+            WatchOnClient(model => model.DisplayCommsOutOfRangeWarnings);
             WatchOnClient(model => model.SelectedColor);
         }
 
@@ -190,6 +197,8 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             var dbPlayer = DB.Get<Player>(playerId);
             var colorSettings = dbPlayer.Settings.LanguageChatColors;
             var languages = Skill.GetActiveSkillsByCategory(SkillCategoryType.Languages);
+
+            DisplayCommsOutOfRangeWarnings = dbPlayer.Settings.DisplayCommsOutOfRangeWarnings ?? true;
 
             _languages = new List<SkillType>();
             var chatColorNames = new GuiBindingList<string>();
@@ -312,6 +321,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             dbPlayer.Settings.IsSubdualModeEnabled = SubdualMode;
             dbPlayer.Settings.DisplayServerResetReminders = DisplayServerResetReminders;
             dbPlayer.Settings.PortraitVitals = PortraitVitals;
+            dbPlayer.Settings.DisplayCommsOutOfRangeWarnings = DisplayCommsOutOfRangeWarnings;
             if (!GetIsDM(Player) && !GetIsDMPossessed(Player))
             {
                 dbPlayer.Settings.ShowDescriptorsForNamedPlayers = ShowDescriptorsForNamedPlayers;

--- a/SWLOR.Game.Server/Service/Communication.cs
+++ b/SWLOR.Game.Server/Service/Communication.cs
@@ -309,7 +309,11 @@ namespace SWLOR.Game.Server.Service
 
             if (outOfRangeCommsPartyMembers > 0)
             {
-                SendMessageToPC(sender, ColorToken.Red(CommsOutOfRangeMessage));
+                var dbSender = DB.Get<Player>(GetObjectUUID(sender));
+                if (dbSender?.Settings?.DisplayCommsOutOfRangeWarnings ?? true)
+                {
+                    SendMessageToPC(sender, ColorToken.Red(CommsOutOfRangeMessage));
+                }
             }
 
             // The speaker and the language being spoken are the same for every recipient, so resolve


### PR DESCRIPTION
## Summary

- add a **Comms Range Warnings** toggle to Settings > Chat
- persist the preference with a default-on fallback for existing players
- suppress only the sender warning when disabled, without changing Comms delivery rules
- update the player guide and regression coverage

## Why

Comms reports when one or more party members are outside the sender's current Comms scope and do not receive the message. Repeated sends can make this warning spammy, so players need control over whether it is displayed.

## Player impact

The warning remains enabled by default. Players who do not want it can disable **Comms Range Warnings** under Chat settings; message routing and recipient eligibility are unchanged.

## Validation

- `dotnet build SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj -p:RunPostBuildEvent=Never`
- `dotnet test SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj --no-build --filter "FullyQualifiedName~SettingsWindowTests|FullyQualifiedName~PlayerFacingNameBroadcastTests"` (9 passed)