### PR TITLE
Fix transient module packing failures

### DIFF
--- a/SWLOR.CLI/ModulePacker.cs
+++ b/SWLOR.CLI/ModulePacker.cs
@@ -15,6 +15,8 @@ namespace SWLOR.CLI
         private const int MaxDefaultWorkerCount = 12;
         private const int ProgressInterval = 100;
         private const int ReservedProcessorCount = 2;
+        private const int ResourceConversionRetryCount = 3;
+        private const int ResourceConversionRetryDelayMilliseconds = 250;
         private const string PackingDirectory = "./packing";
         private const string WorkerCountEnvironmentVariable = "SWLOR_RESOURCE_CONVERSION_WORKERS";
 
@@ -45,8 +47,9 @@ namespace SWLOR.CLI
                         var fileNameNoJson = Path.GetFileNameWithoutExtension(file);
                         var outputFile = Path.Combine(PackingDirectory, fileNameNoJson);
 
-                        RunProcess(
-                            "nwn_gff.exe",
+                        RunResourceConversion(
+                            file,
+                            outputFile,
                             "-l", "json",
                             "-i", file,
                             "-o", outputFile,
@@ -107,8 +110,7 @@ namespace SWLOR.CLI
 
             sw.Stop();
             Console.WriteLine($"Packing module completed in {sw.ElapsedMilliseconds}ms");
-            Console.WriteLine("Program finished. Press any key to end.");
-            Console.ReadKey();
+            WaitForKeyIfInteractive();
         }
 
         public void UnpackModule(string filePath)
@@ -167,10 +169,12 @@ namespace SWLOR.CLI
                 {
                     var extension = Path.GetExtension(file)?.Replace(".", string.Empty);
 
-                    RunProcess(
-                        "nwn_gff.exe",
+                    var outputFile = $"./{extension}/{file}.json";
+                    RunResourceConversion(
+                        file,
+                        outputFile,
                         "-i", file,
-                        "-o", $"./{extension}/{file}.json",
+                        "-o", outputFile,
                         "-p");
 
                     // Remove the extracted file.
@@ -196,8 +200,7 @@ namespace SWLOR.CLI
 
             sw.Stop();
             Console.WriteLine($"Unpacking module completed in {sw.ElapsedMilliseconds}ms"); 
-            Console.WriteLine("Program finished. Press any key to end.");
-            Console.ReadKey();
+            WaitForKeyIfInteractive();
         }
 
 
@@ -236,6 +239,47 @@ namespace SWLOR.CLI
                         $"Command failed with exit code {process.ExitCode}: {command}{Environment.NewLine}{standardOutput}{standardError}");
                 }
             }
+        }
+
+        private static void RunResourceConversion(
+            string resource,
+            string outputFile,
+            params string[] arguments)
+        {
+            Exception lastException = null;
+
+            for (var attempt = 1; attempt <= ResourceConversionRetryCount; attempt++)
+            {
+                try
+                {
+                    if (attempt > 1)
+                    {
+                        DeleteFileWithRetry(outputFile);
+                    }
+
+                    RunProcess("nwn_gff.exe", arguments);
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    lastException = ex;
+                }
+
+                if (attempt < ResourceConversionRetryCount)
+                {
+                    var retryDelay = ResourceConversionRetryDelayMilliseconds * attempt;
+                    Console.Error.WriteLine(
+                        $"Resource conversion failed for '{resource}' " +
+                        $"(attempt {attempt}/{ResourceConversionRetryCount}). " +
+                        $"Retrying in {retryDelay}ms...");
+                    Thread.Sleep(retryDelay);
+                }
+            }
+
+            DeleteFileWithRetry(outputFile);
+            throw new InvalidOperationException(
+                $"Resource conversion failed after {ResourceConversionRetryCount} attempts.",
+                lastException);
         }
 
         private static string ResolveToolPath(string fileName)
@@ -303,6 +347,17 @@ namespace SWLOR.CLI
             {
                 Console.WriteLine($"{label} {completedCount:N0}/{totalCount:N0}");
             }
+        }
+
+        private static void WaitForKeyIfInteractive()
+        {
+            if (Console.IsInputRedirected)
+            {
+                return;
+            }
+
+            Console.WriteLine("Program finished. Press any key to end.");
+            Console.ReadKey();
         }
 
         private static void RecreateDirectory(string directory)

--- a/SWLOR.CLI/Readmes/README_ModulePacker.md
+++ b/SWLOR.CLI/Readmes/README_ModulePacker.md
@@ -63,6 +63,7 @@ The tool processes the following module folder types:
 ## Performance
 - **Bounded Parallel Processing**: Uses a limited worker pool for resource conversion so packing and unpacking do not saturate the machine. By default it reserves two processors for system responsiveness and caps conversion workers at 12.
 - **Worker Count Override**: Set `SWLOR_RESOURCE_CONVERSION_WORKERS` to control the maximum number of concurrent `nwn_gff` conversions
+- **Transient Failure Recovery**: Retries an individual `nwn_gff` conversion up to three times before failing the full pack or unpack operation
 - **Progress Reporting**: Displays periodic progress information during operations
 - **Timing**: Reports completion time for both pack and unpack operations
 
@@ -107,4 +108,4 @@ This tool is used during development to:
 - Handles both source and compiled scripts
 - Maintains file extensions in lowercase for compatibility
 - Provides detailed progress and timing information
-- Waits for user input before completing operations 
+- Waits for user input before completing operations when launched interactively


### PR DESCRIPTION
## Summary

- Retry individual `nwn_gff` resource conversions up to three times with short backoff.
- Remove partial conversion output before retrying and retain the final converter error when retries are exhausted.
- Skip the final key prompt for redirected input while preserving the interactive pause.
- Update the module-packer documentation and republish the tracked CLI executable.

## Root cause

`nwn_gff.exe` intermittently exits with code 1 during sustained parallel module packing even when the resource is valid. The initially reported `imp_poly_3.uti.json` converts successfully by itself, and repeated full packs surfaced first-attempt failures on different unrelated resources.

## Impact

Transient native converter failures no longer discard an otherwise healthy multi-minute pack. Persistently invalid resources still fail the operation after three attempts. Noninteractive invocations also finish cleanly after successful module assembly.

## Validation

- `dotnet build SWLOR.CLI\SWLOR.CLI.csproj -p:RunPostBuildEvent=Never`
- Published the self-contained CLI using `FolderProfile`
- Completed a full pack of 19,173 resources and 310 scripts with exit code 0
- Confirmed multiple transient first-attempt failures recovered automatically