### PR TITLE
Make Espionage stealth XP event-driven

### DIFF
--- a/SWLOR.Game.Server.Tests/Perks/EspionageSystemTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/EspionageSystemTests.cs
@@ -211,6 +211,8 @@ public class EspionageSystemTests
         infiltrationSource.Should().Contain("DelayCommand(MovementSampleIntervalSeconds, () => SampleMovement(player, samplerId));");
         infiltrationSource.Should().Contain("CreaturePlugin.GetFaction(npc) != HostileFactionId");
         infiltrationSource.Should().Contain("Enmity.HasNonProximityEnmity(npc)");
+        infiltrationSource.Should().Contain("if (HasCombatEnmity(target, observer))");
+        infiltrationSource.Should().Contain("Enmity.HasNonProximityEnmityForCreature(player) ||");
         infiltrationSource.Should().Contain("var master = GetMaster(npc);");
     }
 

--- a/SWLOR.Game.Server.Tests/Perks/EspionageSystemTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/EspionageSystemTests.cs
@@ -149,6 +149,72 @@ public class EspionageSystemTests
     }
 
     [Test]
+    public void InfiltrationXp_UsesFullSuccessAndFifteenPercentDetectionFailureAwards()
+    {
+        EspionageInfiltration.RequiredTravelDistanceMeters.Should().Be(4f);
+        EspionageInfiltration.DetectionFailureXpPercent.Should().Be(0.15f);
+        EspionageInfiltration.HostileFactionId.Should().Be(1);
+
+        EspionageInfiltration.CalculateXp(20, 20, false).Should().Be(600);
+        EspionageInfiltration.CalculateXp(20, 20, true).Should().Be(90);
+        EspionageInfiltration.CalculateXp(16, 20, false).Should().Be(76);
+        EspionageInfiltration.CalculateXp(16, 20, true).Should().Be(11);
+        EspionageInfiltration.CalculateXp(15, 20, false).Should().Be(0);
+        EspionageInfiltration.CalculateXp(15, 20, true).Should().Be(0);
+    }
+
+    [Test]
+    public void InfiltrationSuccess_RequiresDetectionEvasionTravelStealthAndNoCombatEnmity()
+    {
+        EspionageInfiltration.MeetsSuccessRequirements(true, 4f, true, false).Should().BeTrue();
+
+        EspionageInfiltration.MeetsSuccessRequirements(false, 4f, true, false).Should().BeFalse();
+        EspionageInfiltration.MeetsSuccessRequirements(true, 3.99f, true, false).Should().BeFalse();
+        EspionageInfiltration.MeetsSuccessRequirements(true, 4f, false, false).Should().BeFalse();
+        EspionageInfiltration.MeetsSuccessRequirements(true, 4f, true, true).Should().BeFalse();
+    }
+
+    [Test]
+    public void InfiltrationXp_IsDrivenByAggroAndDetectionEventsRatherThanElapsedStealthTime()
+    {
+        var root = FindRepositoryRoot();
+        var stealthStatusSource = File.ReadAllText(Path.Combine(
+            root,
+            "SWLOR.Game.Server",
+            "Feature",
+            "StatusEffectDefinition",
+            "StealthStatusEffect.cs"));
+        var stealthSource = File.ReadAllText(Path.Combine(
+            root,
+            "SWLOR.Game.Server",
+            "Service",
+            "Stealth.cs"));
+        var aiSource = File.ReadAllText(Path.Combine(
+            root,
+            "SWLOR.Game.Server",
+            "Service",
+            "AI.cs"));
+        var infiltrationSource = File.ReadAllText(Path.Combine(
+            root,
+            "SWLOR.Game.Server",
+            "Service",
+            "EspionageInfiltration.cs"));
+
+        stealthStatusSource.Should().NotContain("GrantTimeInStealthXP");
+        stealthStatusSource.Should().NotContain("HostileScanRadiusMeters");
+        stealthStatusSource.Should().Contain("EspionageInfiltration.UpdateMovement(creature);");
+        stealthSource.Should().Contain("EspionageInfiltration.RecordDetection(observer, target, detected);");
+        stealthSource.Should().Contain("EspionageInfiltration.CancelPlayer(creature);");
+        aiSource.Should().Contain("EspionageInfiltration.TryBegin(entering, self);");
+        aiSource.Should().Contain("EspionageInfiltration.Complete(exiting, self);");
+        infiltrationSource.Should().Contain("private const float MovementSampleIntervalSeconds = 1f;");
+        infiltrationSource.Should().Contain("DelayCommand(MovementSampleIntervalSeconds, () => SampleMovement(player, samplerId));");
+        infiltrationSource.Should().Contain("CreaturePlugin.GetFaction(npc) != HostileFactionId");
+        infiltrationSource.Should().Contain("Enmity.HasNonProximityEnmity(npc)");
+        infiltrationSource.Should().Contain("var master = GetMaster(npc);");
+    }
+
+    [Test]
     public void LastingCoatingsRaisesChargesFromTwentyToThirty()
     {
         VenomCoatingItemDefinition.CalculateCharges(0).Should().Be(20);

--- a/SWLOR.Game.Server.Tests/Service/EnmityTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/EnmityTests.cs
@@ -162,6 +162,70 @@ public class EnmityTests
     }
 
     [Test]
+    public void HasNonProximityEnmity_AllowsAuraOnlyTrafficButRejectsCombatEnmity()
+    {
+        const uint proximityOnlyEnemy = 100;
+        const uint combatEnemy = 200;
+        const uint untrackedEnemy = 300;
+        const uint target = 1;
+
+        EnemyEnmityTables()[proximityOnlyEnemy] = new Dictionary<uint, int>
+        {
+            [target] = 1
+        };
+        EnemyEnmityTables()[combatEnemy] = new Dictionary<uint, int>
+        {
+            [target] = 5
+        };
+        EnemyEnmityTables()[untrackedEnemy] = new Dictionary<uint, int>
+        {
+            [target] = 3
+        };
+        ProximityEnmityAmounts()[proximityOnlyEnemy] = new Dictionary<uint, int>
+        {
+            [target] = 1
+        };
+        ProximityEnmityAmounts()[combatEnemy] = new Dictionary<uint, int>
+        {
+            [target] = 2
+        };
+
+        Enmity.HasNonProximityEnmity(proximityOnlyEnemy).Should().BeFalse();
+        Enmity.HasNonProximityEnmity(combatEnemy).Should().BeTrue();
+        Enmity.HasNonProximityEnmity(untrackedEnemy).Should().BeTrue();
+        Enmity.HasNonProximityEnmity(999).Should().BeFalse();
+    }
+
+    [Test]
+    public void HasNonProximityEnmityForCreature_AllowsOverlappingAuraTrafficButRejectsRealCombat()
+    {
+        const uint creature = 1;
+        const uint proximityOnlyEnemy = 100;
+        const uint combatEnemy = 200;
+
+        CreatureToEnemies()[creature] = new List<uint> { proximityOnlyEnemy };
+        EnemyEnmityTables()[proximityOnlyEnemy] = new Dictionary<uint, int>
+        {
+            [creature] = 1
+        };
+        ProximityEnmityAmounts()[proximityOnlyEnemy] = new Dictionary<uint, int>
+        {
+            [creature] = 1
+        };
+
+        Enmity.HasNonProximityEnmityForCreature(creature).Should().BeFalse();
+
+        CreatureToEnemies()[creature].Add(combatEnemy);
+        EnemyEnmityTables()[combatEnemy] = new Dictionary<uint, int>
+        {
+            [creature] = 3
+        };
+
+        Enmity.HasNonProximityEnmityForCreature(creature).Should().BeTrue();
+        Enmity.HasNonProximityEnmityForCreature(999).Should().BeFalse();
+    }
+
+    [Test]
     public void ShouldIssueAttackCommand_ReissuesWhenTargetIsStaleButNoAttackActionIsRunning()
     {
         ShouldIssueAttackCommand(1, 1, ActionType.Invalid, false, commandIssuedAt: DateTime.UtcNow.AddSeconds(-7))

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/PlayerGuideViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/PlayerGuideViewModel.cs
@@ -687,7 +687,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
                         new ArticleBlock("Detecting and Disarming",
                             "Kit-built traps can be concealed. Characters with sufficient detection and trap tier can reveal or disarm them. A failed disarm triggers the trap; successful enemy triggers and successful disarms can grant Espionage XP."),
                         new ArticleBlock("Espionage XP",
-                            "Espionage XP comes from successful undetected stealth movement, slicing, crafting espionage items, enemy trap triggers, and successful trap disarms.")
+                            "Espionage XP comes from bypassing hostile NPCs while stealthed, slicing, crafting espionage items, enemy trap triggers, and successful trap disarms. A stealth bypass requires you to evade Detection, move through the NPC's nearby threat area, and leave it while still hidden. Each NPC grants XP only once per life; being detected grants a smaller amount.")
                     },
                     new[]
                     {

--- a/SWLOR.Game.Server/Feature/StatusEffectDefinition/StealthStatusEffect.cs
+++ b/SWLOR.Game.Server/Feature/StatusEffectDefinition/StealthStatusEffect.cs
@@ -1,9 +1,4 @@
-using System.Linq;
-using SWLOR.Game.Server.Entity;
-using SWLOR.Game.Server.Feature.AbilityDefinition;
 using SWLOR.Game.Server.Service;
-using SWLOR.Game.Server.Service.DBService;
-using SWLOR.Game.Server.Service.SkillService;
 using SWLOR.Game.Server.Service.StatService;
 using SWLOR.Game.Server.Service.StatusEffectService;
 using SWLOR.NWN.API.NWScript.Enum;
@@ -12,19 +7,13 @@ namespace SWLOR.Game.Server.Feature.StatusEffectDefinition
 {
     /// <summary>
     /// Active while a player moves in stealth. Carries the Stealth perk rank's effectiveness bonus,
-    /// drains stamina every tick (stealth breaks when stamina runs out), and awards Espionage XP for
-    /// time spent hidden near hostile NPCs.
+    /// drains stamina every tick (stealth breaks when stamina runs out), and samples movement for
+    /// active Espionage infiltration attempts.
     /// </summary>
     public sealed class StealthStatusEffect : StatusEffectBase
     {
         private const int StaminaDrainPerTick = 2;
         private const float BaseFrequencySeconds = 6f;
-
-        // XP is granted once per detection window (30s) rather than every tick, so the reward is
-        // paced to "another check survived while hidden" rather than raw seconds in stealth.
-        private const int TicksPerXpGrant = 5;
-        private const float HostileScanRadiusMeters = 15f;
-        private const string TickCounterVariable = "ESPIONAGE_STEALTH_XP_TICKS";
 
         private float _frequency = BaseFrequencySeconds;
 
@@ -36,8 +25,6 @@ namespace SWLOR.Game.Server.Feature.StatusEffectDefinition
 
         protected override void Apply(uint creature, int durationTicks)
         {
-            DeleteLocalInt(creature, TickCounterVariable);
-
             // Drain-slowing stats stretch the tick interval rather than shrinking the
             // per-tick amount so small reductions are not lost to integer rounding.
             var drainReduction = Stat.GetStatAdjustment(creature, StatType.StealthStaminaDrainReductionPercent);
@@ -71,7 +58,7 @@ namespace SWLOR.Game.Server.Feature.StatusEffectDefinition
                 return;
             }
 
-            GrantTimeInStealthXP(creature);
+            EspionageInfiltration.UpdateMovement(creature);
 
             Stat.ReduceStamina(creature, StaminaDrainPerTick);
 
@@ -85,41 +72,5 @@ namespace SWLOR.Game.Server.Feature.StatusEffectDefinition
             });
         }
 
-        /// <summary>
-        /// Awards Espionage XP for staying hidden near hostiles. Only non-player hostiles count, so
-        /// the grant cannot be farmed off another player, and the amount is a level-vs-rank delta so
-        /// sneaking past trivial enemies stops paying once the skill outgrows them.
-        /// </summary>
-        private static void GrantTimeInStealthXP(uint creature)
-        {
-            var ticks = GetLocalInt(creature, TickCounterVariable) + 1;
-            if (ticks < TicksPerXpGrant)
-            {
-                SetLocalInt(creature, TickCounterVariable, ticks);
-                return;
-            }
-
-            DeleteLocalInt(creature, TickCounterVariable);
-
-            var highestHostileLevel = CombatAreaPulses
-                .GetHostileCreatures(creature, GetLocation(creature), HostileScanRadiusMeters)
-                .Where(hostile => !GetIsPC(hostile) && !GetIsDM(hostile))
-                .Select(hostile => Stat.GetNPCStats(hostile).Level)
-                .DefaultIfEmpty(0)
-                .Max();
-
-            if (highestHostileLevel <= 0)
-                return;
-
-            var playerId = GetObjectUUID(creature);
-            var dbPlayer = DB.Get<Player>(playerId);
-            var rank = dbPlayer.Skills[SkillType.Espionage].Rank;
-            var xp = Skill.GetDeltaXP(highestHostileLevel - rank);
-
-            if (xp <= 0)
-                return;
-
-            Skill.GiveSkillXP(creature, SkillType.Espionage, xp, false, false);
-        }
     }
 }

--- a/SWLOR.Game.Server/Service/AI.cs
+++ b/SWLOR.Game.Server/Service/AI.cs
@@ -262,6 +262,7 @@ namespace SWLOR.Game.Server.Service
                 return;
             }
 
+            EspionageInfiltration.TryBegin(entering, self);
             TryAcquireAggro(self, entering);
         }
 
@@ -276,6 +277,7 @@ namespace SWLOR.Game.Server.Service
             if (!IsAIEnabled(self) || !GetIsObjectValid(exiting))
                 return;
 
+            EspionageInfiltration.Complete(exiting, self);
             RemoveProximityEnmity(exiting, self);
 
             if (!_creatureAllies.TryGetValue(self, out var allies))
@@ -835,6 +837,11 @@ namespace SWLOR.Game.Server.Service
                 return;
 
             AssignCommand(enemy, () => ClearAllActions());
+        }
+
+        public static bool IsCreatureAIEnabled(uint creature)
+        {
+            return IsAIEnabled(creature);
         }
 
         private static bool IsAIEnabled(uint creature)

--- a/SWLOR.Game.Server/Service/Enmity.cs
+++ b/SWLOR.Game.Server/Service/Enmity.cs
@@ -415,6 +415,32 @@ namespace SWLOR.Game.Server.Service
         }
 
         /// <summary>
+        /// Returns true when an enemy has any enmity that did not come solely from its aggro aura.
+        /// Attack, damage, and ability enmity make the enemy an active combatant and therefore an
+        /// invalid source for a new Espionage infiltration attempt.
+        /// </summary>
+        public static bool HasNonProximityEnmity(uint enemy)
+        {
+            if (!_enemyEnmityTables.TryGetValue(enemy, out var table))
+                return false;
+
+            return table.Any(entry => !HasOnlyProximityEnmity(entry.Key, enemy));
+        }
+
+        /// <summary>
+        /// Returns true when a creature appears on any enemy table for more than aggro proximity.
+        /// This distinguishes real combat from the proximity-only entries created as multiple
+        /// stealthed players cross overlapping aggro auras.
+        /// </summary>
+        public static bool HasNonProximityEnmityForCreature(uint creature)
+        {
+            if (!_creatureToEnemies.TryGetValue(creature, out var enemies))
+                return false;
+
+            return enemies.Any(enemy => !HasOnlyProximityEnmity(creature, enemy));
+        }
+
+        /// <summary>
         /// Clears every creature from an enemy's enmity table.
         /// </summary>
         /// <param name="enemy">The enemy whose enmity table will be cleared.</param>

--- a/SWLOR.Game.Server/Service/EspionageInfiltration.cs
+++ b/SWLOR.Game.Server/Service/EspionageInfiltration.cs
@@ -75,6 +75,12 @@ namespace SWLOR.Game.Server.Service
 
             UpdateMaximumTravelDistance(target, attempt);
 
+            if (HasCombatEnmity(target, observer))
+            {
+                _activeAttempts.Remove(key);
+                return;
+            }
+
             if (!detected)
             {
                 attempt.EvadedDetection = true;
@@ -109,12 +115,12 @@ namespace SWLOR.Game.Server.Service
 
             UpdateMaximumTravelDistance(player, attempt);
             var isStealthed = GetActionMode(player, ActionMode.Stealth);
-            var npcHasCombatEnmity = Enmity.HasNonProximityEnmity(npc);
+            var hasCombatEnmity = HasCombatEnmity(player, npc);
             if (!MeetsSuccessRequirements(
                     attempt.EvadedDetection,
                     attempt.MaximumTravelDistance,
                     isStealthed,
-                    npcHasCombatEnmity) ||
+                    hasCombatEnmity) ||
                 !TryMarkResolved(player, npc))
             {
                 return;
@@ -151,12 +157,12 @@ namespace SWLOR.Game.Server.Service
             bool evadedDetection,
             float maximumTravelDistance,
             bool isStealthed,
-            bool npcHasCombatEnmity)
+            bool hasCombatEnmity)
         {
             return evadedDetection &&
                    maximumTravelDistance >= RequiredTravelDistanceMeters &&
                    isStealthed &&
-                   !npcHasCombatEnmity;
+                   !hasCombatEnmity;
         }
 
         public static int CalculateXp(int npcLevel, int espionageRank, bool wasDetected)
@@ -266,6 +272,12 @@ namespace SWLOR.Game.Server.Service
             var samplerId = ++_nextMovementSamplerId;
             _movementSamplerIdsByPlayer[player] = samplerId;
             DelayCommand(MovementSampleIntervalSeconds, () => SampleMovement(player, samplerId));
+        }
+
+        private static bool HasCombatEnmity(uint player, uint npc)
+        {
+            return Enmity.HasNonProximityEnmityForCreature(player) ||
+                   Enmity.HasNonProximityEnmity(npc);
         }
 
         private static void SampleMovement(uint player, long samplerId)

--- a/SWLOR.Game.Server/Service/EspionageInfiltration.cs
+++ b/SWLOR.Game.Server/Service/EspionageInfiltration.cs
@@ -1,0 +1,323 @@
+using System.Collections.Generic;
+using System.Linq;
+using SWLOR.Game.Server.Core;
+using SWLOR.Game.Server.Entity;
+using SWLOR.Game.Server.Service.DBService;
+using SWLOR.Game.Server.Service.SkillService;
+using SWLOR.Game.Server.Service.StatService;
+using SWLOR.NWN.API.Engine;
+using SWLOR.NWN.API.NWNX;
+using SWLOR.NWN.API.NWScript.Enum;
+
+namespace SWLOR.Game.Server.Service
+{
+    /// <summary>
+    /// Tracks one infiltration attempt per player/hostile pair. A player succeeds by evading at
+    /// least one Detection check, moving meaningfully through the hostile's aggro aura, and leaving
+    /// that aura while still stealthed. Detection resolves the pair for a smaller failure award.
+    /// </summary>
+    public static class EspionageInfiltration
+    {
+        public const float RequiredTravelDistanceMeters = 4f;
+        public const float DetectionFailureXpPercent = 0.15f;
+        public const int HostileFactionId = 1;
+        private const float MovementSampleIntervalSeconds = 1f;
+
+        private sealed class InfiltrationAttempt
+        {
+            public Location EntryLocation { get; init; }
+            public float MaximumTravelDistance { get; set; }
+            public bool EvadedDetection { get; set; }
+        }
+
+        private static readonly Dictionary<(uint Player, uint Npc), InfiltrationAttempt> _activeAttempts = new();
+        private static readonly Dictionary<uint, HashSet<string>> _resolvedPlayerIdsByNpc = new();
+        private static readonly Dictionary<uint, long> _movementSamplerIdsByPlayer = new();
+        private static long _nextMovementSamplerId;
+
+        /// <summary>
+        /// Starts an attempt when a stealthed player enters an eligible hostile's real aggro range.
+        /// The same method is also safe to call from Spot detection, which covers gaining line of
+        /// sight after entering the aura behind an obstruction.
+        /// </summary>
+        public static bool TryBegin(uint player, uint npc)
+        {
+            var key = (player, npc);
+            if (_activeAttempts.ContainsKey(key))
+                return true;
+
+            if (!CanStartAttempt(player, npc) || HasResolved(player, npc))
+                return false;
+
+            _activeAttempts[key] = new InfiltrationAttempt
+            {
+                EntryLocation = GetLocation(player)
+            };
+            StartMovementSampler(player);
+            return true;
+        }
+
+        /// <summary>
+        /// Records the engine's resolved Spot verdict. Detection pays the small failure award
+        /// immediately; an undetected verdict qualifies the attempt for a later successful exit.
+        /// </summary>
+        public static void RecordDetection(uint observer, uint target, bool detected)
+        {
+            var key = (target, observer);
+            if (!_activeAttempts.TryGetValue(key, out var attempt))
+            {
+                if (!TryBegin(target, observer) || !_activeAttempts.TryGetValue(key, out attempt))
+                    return;
+            }
+
+            if (!AI.IsInAggroRange(observer, target))
+                return;
+
+            UpdateMaximumTravelDistance(target, attempt);
+
+            if (!detected)
+            {
+                attempt.EvadedDetection = true;
+                return;
+            }
+
+            _activeAttempts.Remove(key);
+            if (!TryMarkResolved(target, observer))
+                return;
+
+            GrantXp(target, observer, wasDetected: true);
+        }
+
+        /// <summary>
+        /// Completes an attempt when NWN reports that the player left the hostile's aggro aura.
+        /// </summary>
+        public static void Complete(uint player, uint npc)
+        {
+            var key = (player, npc);
+            if (!_activeAttempts.Remove(key, out var attempt))
+                return;
+
+            if (!GetIsObjectValid(player) ||
+                !GetIsObjectValid(npc) ||
+                GetIsDead(player) ||
+                GetIsDead(npc) ||
+                GetCurrentHitPoints(player) <= 0 ||
+                GetCurrentHitPoints(npc) <= 0)
+            {
+                return;
+            }
+
+            UpdateMaximumTravelDistance(player, attempt);
+            var isStealthed = GetActionMode(player, ActionMode.Stealth);
+            var npcHasCombatEnmity = Enmity.HasNonProximityEnmity(npc);
+            if (!MeetsSuccessRequirements(
+                    attempt.EvadedDetection,
+                    attempt.MaximumTravelDistance,
+                    isStealthed,
+                    npcHasCombatEnmity) ||
+                !TryMarkResolved(player, npc))
+            {
+                return;
+            }
+
+            GrantXp(player, npc, wasDetected: false);
+        }
+
+        /// <summary>
+        /// Samples movement for active attempts. The dedicated one-second sampler catches quick
+        /// traversals, while stealth ticks, Spot events, and aura exit provide additional samples.
+        /// </summary>
+        public static void UpdateMovement(uint player)
+        {
+            var attempts = _activeAttempts
+                .Where(x => x.Key.Player == player)
+                .ToArray();
+
+            foreach (var (key, attempt) in attempts)
+            {
+                if (!GetIsObjectValid(key.Npc) ||
+                    GetIsDead(key.Npc) ||
+                    GetArea(player) != GetArea(key.Npc))
+                {
+                    _activeAttempts.Remove(key);
+                    continue;
+                }
+
+                UpdateMaximumTravelDistance(player, attempt);
+            }
+        }
+
+        public static bool MeetsSuccessRequirements(
+            bool evadedDetection,
+            float maximumTravelDistance,
+            bool isStealthed,
+            bool npcHasCombatEnmity)
+        {
+            return evadedDetection &&
+                   maximumTravelDistance >= RequiredTravelDistanceMeters &&
+                   isStealthed &&
+                   !npcHasCombatEnmity;
+        }
+
+        public static int CalculateXp(int npcLevel, int espionageRank, bool wasDetected)
+        {
+            var baseXp = Skill.GetDeltaXP(npcLevel - espionageRank);
+            return wasDetected
+                ? (int)(baseXp * DetectionFailureXpPercent)
+                : baseXp;
+        }
+
+        public static void CancelPlayer(uint player)
+        {
+            var keys = _activeAttempts.Keys
+                .Where(x => x.Player == player)
+                .ToArray();
+
+            foreach (var key in keys)
+            {
+                _activeAttempts.Remove(key);
+            }
+
+            _movementSamplerIdsByPlayer.Remove(player);
+        }
+
+        public static void ClearNpc(uint npc)
+        {
+            var keys = _activeAttempts.Keys
+                .Where(x => x.Npc == npc)
+                .ToArray();
+
+            foreach (var key in keys)
+            {
+                _activeAttempts.Remove(key);
+            }
+
+            _resolvedPlayerIdsByNpc.Remove(npc);
+        }
+
+        [NWNEventHandler(ScriptName.OnModuleExit)]
+        [NWNEventHandler(ScriptName.OnAreaExit)]
+        public static void OnPlayerExit()
+        {
+            var exiting = GetExitingObject();
+            if (GetIsPC(exiting))
+            {
+                CancelPlayer(exiting);
+            }
+        }
+
+        [NWNEventHandler(ScriptName.OnModuleDeath)]
+        public static void OnPlayerDeath()
+        {
+            CancelPlayer(GetLastPlayerDied());
+        }
+
+        [NWNEventHandler(ScriptName.OnCreatureDeathAfter)]
+        [NWNEventHandler(ScriptName.OnObjectDestroyed)]
+        public static void OnNpcRemoved()
+        {
+            ClearNpc(OBJECT_SELF);
+        }
+
+        private static bool CanStartAttempt(uint player, uint npc)
+        {
+            if (!GetIsObjectValid(player) ||
+                !GetIsObjectValid(npc) ||
+                !GetIsPC(player) ||
+                GetIsDM(player) ||
+                GetIsPC(npc) ||
+                GetIsDM(npc) ||
+                GetIsDead(player) ||
+                GetIsDead(npc) ||
+                GetCurrentHitPoints(player) <= 0 ||
+                GetCurrentHitPoints(npc) <= 0 ||
+                !GetActionMode(player, ActionMode.Stealth) ||
+                GetLocalInt(player, Stealth.CombatEntryWindowVariable) != 0 ||
+                Enmity.HasNonProximityEnmityForCreature(player) ||
+                !AI.IsCreatureAIEnabled(npc) ||
+                CreaturePlugin.GetFaction(npc) != HostileFactionId ||
+                !GetIsEnemy(player, npc) ||
+                !AI.IsInAggroRange(npc, player) ||
+                Enmity.HasNonProximityEnmity(npc) ||
+                Stat.GetNPCStats(npc).Level <= 0)
+            {
+                return false;
+            }
+
+            var master = GetMaster(npc);
+            return !GetIsObjectValid(master) || (!GetIsPC(master) && !GetIsDM(master));
+        }
+
+        private static void UpdateMaximumTravelDistance(uint player, InfiltrationAttempt attempt)
+        {
+            var currentLocation = GetLocation(player);
+            if (GetAreaFromLocation(currentLocation) != GetAreaFromLocation(attempt.EntryLocation))
+                return;
+
+            var distance = GetDistanceBetweenLocations(attempt.EntryLocation, currentLocation);
+            attempt.MaximumTravelDistance = Math.Max(attempt.MaximumTravelDistance, distance);
+        }
+
+        private static void StartMovementSampler(uint player)
+        {
+            if (_movementSamplerIdsByPlayer.ContainsKey(player))
+                return;
+
+            var samplerId = ++_nextMovementSamplerId;
+            _movementSamplerIdsByPlayer[player] = samplerId;
+            DelayCommand(MovementSampleIntervalSeconds, () => SampleMovement(player, samplerId));
+        }
+
+        private static void SampleMovement(uint player, long samplerId)
+        {
+            if (!_movementSamplerIdsByPlayer.TryGetValue(player, out var activeSamplerId) ||
+                activeSamplerId != samplerId)
+            {
+                return;
+            }
+
+            if (!GetIsObjectValid(player) || !_activeAttempts.Keys.Any(x => x.Player == player))
+            {
+                _movementSamplerIdsByPlayer.Remove(player);
+                return;
+            }
+
+            UpdateMovement(player);
+            DelayCommand(MovementSampleIntervalSeconds, () => SampleMovement(player, samplerId));
+        }
+
+        private static bool HasResolved(uint player, uint npc)
+        {
+            var playerId = GetObjectUUID(player);
+            return !string.IsNullOrWhiteSpace(playerId) &&
+                   _resolvedPlayerIdsByNpc.TryGetValue(npc, out var playerIds) &&
+                   playerIds.Contains(playerId);
+        }
+
+        private static bool TryMarkResolved(uint player, uint npc)
+        {
+            var playerId = GetObjectUUID(player);
+            if (string.IsNullOrWhiteSpace(playerId))
+                return false;
+
+            if (!_resolvedPlayerIdsByNpc.TryGetValue(npc, out var playerIds))
+            {
+                playerIds = new HashSet<string>();
+                _resolvedPlayerIdsByNpc[npc] = playerIds;
+            }
+
+            return playerIds.Add(playerId);
+        }
+
+        private static void GrantXp(uint player, uint npc, bool wasDetected)
+        {
+            var playerId = GetObjectUUID(player);
+            var dbPlayer = DB.Get<Player>(playerId);
+            var npcLevel = Stat.GetNPCStats(npc).Level;
+            var espionageRank = dbPlayer.Skills[SkillType.Espionage].Rank;
+            var xp = CalculateXp(npcLevel, espionageRank, wasDetected);
+
+            Skill.GiveSkillXP(player, SkillType.Espionage, xp, false, false);
+        }
+    }
+}

--- a/SWLOR.Game.Server/Service/Stealth.cs
+++ b/SWLOR.Game.Server/Service/Stealth.cs
@@ -112,6 +112,7 @@ namespace SWLOR.Game.Server.Service
         {
             var creature = OBJECT_SELF;
 
+            EspionageInfiltration.CancelPlayer(creature);
             StatusEffect.RemoveStatusEffect<StealthStatusEffect>(creature);
             ClearVerdictsForTarget(creature);
         }
@@ -135,6 +136,7 @@ namespace SWLOR.Game.Server.Service
             }
 
             var detected = GetOrRollVerdict(observer, target);
+            EspionageInfiltration.RecordDetection(observer, target, detected);
             EventsPlugin.SetEventResult(detected ? "1" : "0");
 
             if (detected)


### PR DESCRIPTION
## What changed

- Replaced passive time-in-stealth XP with per-player, per-NPC infiltration attempts driven by NWN aggro-aura and Spot detection events.
- Awards full level-delta Espionage XP after the player evades at least one Detection check, reaches 4m maximum displacement inside the NPC's threat area, and exits it while still stealthed.
- Awards 15% of the same level-delta XP immediately when Detection succeeds, then forces the existing detected-player stealth exit.
- Limits attempts to autonomous NPCs on the module Hostile faction, excluding PCs, DMs, associates, provoked neutral NPCs, and NPCs or players already carrying non-proximity combat enmity.
- Resolves each player/NPC pair once per NPC life, while cancellations grant no XP and do not consume the pair.
- Updated the player guide and added regression coverage for XP scaling, success requirements, event wiring, combat-enmity classification, and overlapping aggro traffic.

## Why

The previous implementation periodically awarded XP for remaining stealthed near hostiles. That allowed players to leech Espionage progression from outside meaningful aggro interactions. This makes progression reward an actual stealth bypass while working within the existing NWN aggro-AOE model and without introducing an encounter system.

## Verification

- `dotnet build SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj -p:RunPostBuildEvent=Never`
- 42 focused Espionage, Enmity, and aggro-hook tests passed
- 34 broader `AIModelTests` passed
- GitHub comparison confirms the branch is current with `feature/combat-upgrade` and changes only the eight intended files

The unrelated persistent-AOE asset fixture was excluded because this fresh worktree could not initialize `SWLOR_Haks` through the machine's TLS issuer error; no submodule pointer or asset was changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added stealth infiltration gameplay, rewarding XP for successfully bypassing hostile NPCs while stealthed.
  - Detection can end an infiltration attempt and grant reduced XP.
  - Infiltration now considers travel distance, detection evasion, stealth status, and combat engagement.

- **Documentation**
  - Expanded the Player Guide with details about Espionage XP sources and requirements.

- **Tests**
  - Added coverage for infiltration rewards, success conditions, detection behavior, and enmity handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->