### PR TITLE
Color the Comms label orange

### DIFF
--- a/SWLOR.Game.Server.Tests/Feature/PlayerFacingNameBroadcastTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/PlayerFacingNameBroadcastTests.cs
@@ -24,7 +24,7 @@ public class PlayerFacingNameBroadcastTests
         var moduleEnterHandlerIndex = normalizedSource.IndexOf("[NWNEventHandler(ScriptName.OnModuleEnter)]", StringComparison.Ordinal);
         var applyChannelNameIndex = normalizedSource.IndexOf("public static void ApplyCommsChannelName()", StringComparison.Ordinal);
         var applyChannelNameOverrideIndex = normalizedSource.IndexOf(
-            "PlayerPlugin.SetTlkOverride(player, PartyChatChannelNameStrRef, CommsChannelName);",
+            "PlayerPlugin.SetTlkOverride(player, PartyChatChannelNameStrRef, ColorToken.Orange(CommsChannelName));",
             StringComparison.Ordinal);
         var applyMessagePrefixOverrideIndex = normalizedSource.IndexOf(
             "PlayerPlugin.SetTlkOverride(player, PartyChatMessagePrefixStrRef, CommsMessagePrefix);",
@@ -290,7 +290,7 @@ public class PlayerFacingNameBroadcastTests
             "TlkOverrides.cs"));
         tlkOverrideSource.Should().Contain("SetTlkOverride(10303, \"[Comms] \");");
         tlkOverrideSource.Should().Contain("SetTlkOverride(66751, \"Disabled\");");
-        tlkOverrideSource.Should().Contain("SetTlkOverride(66755, \"Comms\");");
+        tlkOverrideSource.Should().Contain("SetTlkOverride(66755, ColorToken.Orange(\"Comms\"));");
 
         var settingsDefinitionSource = File.ReadAllText(Path.Combine(
             root.FullName,

--- a/SWLOR.Game.Server/Feature/TlkOverrides.cs
+++ b/SWLOR.Game.Server/Feature/TlkOverrides.cs
@@ -100,7 +100,7 @@ namespace SWLOR.Game.Server.Feature
 
             SetTlkOverride(10303, "[Comms] ");
             SetTlkOverride(66751, "Disabled");
-            SetTlkOverride(66755, "Comms");
+            SetTlkOverride(66755, ColorToken.Orange("Comms"));
 
             SetTlkOverride(83393, "Poison"); // Acid
         }

--- a/SWLOR.Game.Server/Service/Communication.cs
+++ b/SWLOR.Game.Server/Service/Communication.cs
@@ -58,7 +58,7 @@ namespace SWLOR.Game.Server.Service
             if (!GetIsPC(player))
                 return;
 
-            PlayerPlugin.SetTlkOverride(player, PartyChatChannelNameStrRef, CommsChannelName);
+            PlayerPlugin.SetTlkOverride(player, PartyChatChannelNameStrRef, ColorToken.Orange(CommsChannelName));
             PlayerPlugin.SetTlkOverride(player, PartyChatMessagePrefixStrRef, CommsMessagePrefix);
         }
 


### PR DESCRIPTION
## Summary

- render the Comms chat-input label with the standard orange color token
- apply the color consistently through both module-wide and per-player TLK overrides
- update regression coverage for the colored override

## Why

The renamed party-chat input label was rendered gray because the override supplied plain text. Applying the existing orange color token makes `Comms` match the orange `Master` label.

## Validation

- `dotnet build SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj -p:RunPostBuildEvent=Never`
- `dotnet test SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj --no-build --filter "FullyQualifiedName~PlayerFacingNameBroadcastTests"` (5 passed)