### PR TITLE
Build CLI project references during store sync

### DIFF
--- a/tools/SyncStoreInstances.ps1
+++ b/tools/SyncStoreInstances.ps1
@@ -33,7 +33,8 @@ if ($Build -or !(Test-Path $cliDll)) {
         exit $LASTEXITCODE
     }
 
-    dotnet build $project --no-restore --no-dependencies
+    # Clean checkouts need the CLI's project references built, but not the server deployment step.
+    dotnet build $project --no-restore -p:RunPostBuildEvent=Never
     if ($LASTEXITCODE -ne 0) {
         exit $LASTEXITCODE
     }


### PR DESCRIPTION
## Summary

- Remove `--no-dependencies` from the store-sync CLI build so clean checkouts build the required `SWLOR.Game.Server` and `SWLOR.NWN.API` project references.
- Pass `RunPostBuildEvent=Never` so compiling those references does not trigger the Game Server deployment step.

## Root cause

The restore added by #2120 creates NuGet/MSBuild assets but does not create project-reference assemblies. On a clean checkout, the subsequent `dotnet build --no-dependencies` compiled only `SWLOR.CLI` and failed with `CS0006` because the .NET 10 reference assemblies for `SWLOR.Game.Server` and `SWLOR.NWN.API` did not exist.

## Impact

`SyncStoreInstances.ps1 -Build` and the automatic build path now work from clean and upgraded checkouts without requiring a prior solution build or unexpectedly deploying server outputs.

## Validation

- Reproduced from the merged `feature/combat-upgrade` commit after a clean restore: the old command failed with `CS0006` for both missing project-reference assemblies.
- Confirmed both reference assemblies were absent before running the updated script.
- Ran `SyncStoreInstances.ps1 -Build -Check`; `SWLOR.NWN.API`, `SWLOR.Game.Server`, and `SWLOR.CLI` all built successfully.
- The read-only store check changed zero files. It retained its expected nonzero exit because the branch currently contains pre-existing store-instance drift.