### PR TITLE
Fix Chat settings tab layout

### DIFF
--- a/SWLOR.Game.Server.Tests/Feature/SettingsWindowTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/SettingsWindowTests.cs
@@ -64,7 +64,7 @@ public class SettingsWindowTests
     }
 
     [Test]
-    public void CommsRangeWarnings_AreEnabledByDefaultAndPersistedFromChatSettings()
+    public void CommsRangeWarnings_AreEnabledByDefaultAndPersistedFromGeneralSettings()
     {
         var root = FindRepositoryRoot();
         var playerSource = File.ReadAllText(Path.Combine(
@@ -73,16 +73,38 @@ public class SettingsWindowTests
             "Entity",
             "Player.cs"));
         var (definitionSource, viewModelSource) = LoadSettingsSources();
+        var generalPartial = ExtractSection(
+            definitionSource,
+            ".DefinePartialView(SettingsViewModel.GeneralPartial",
+            ".DefinePartialView(SettingsViewModel.IdentityPartial");
+        var chatPartial = ExtractSection(
+            definitionSource,
+            ".DefinePartialView(SettingsViewModel.ChatPartial",
+            "\n                .AddColumn(col =>");
 
         playerSource.Should().Contain("public bool? DisplayCommsOutOfRangeWarnings { get; set; }");
         playerSource.Should().Contain("DisplayCommsOutOfRangeWarnings = true;");
-        definitionSource.Should().Contain(".SetText(\"Comms Range Warnings\")");
-        definitionSource.Should().Contain(".BindIsChecked(model => model.DisplayCommsOutOfRangeWarnings)");
+        generalPartial.Should().Contain(".SetText(\"Comms Range Warnings\")");
+        generalPartial.Should().Contain(".BindIsChecked(model => model.DisplayCommsOutOfRangeWarnings)");
+        chatPartial.Should().NotContain("DisplayCommsOutOfRangeWarnings");
         viewModelSource.Should().Contain("WatchOnClient(model => model.DisplayCommsOutOfRangeWarnings);");
-        viewModelSource.Should().Contain(
+        var loadGeneralView = ExtractMethod(viewModelSource, "private void LoadGeneralView", "private void LoadIdentityView");
+        var loadChatView = ExtractMethod(viewModelSource, "private void LoadChatView", "private void ChangeSettingsView");
+        loadGeneralView.Should().Contain(
             "DisplayCommsOutOfRangeWarnings = dbPlayer.Settings.DisplayCommsOutOfRangeWarnings ?? true;");
+        loadChatView.Should().NotContain("DisplayCommsOutOfRangeWarnings");
         viewModelSource.Should().Contain(
             "dbPlayer.Settings.DisplayCommsOutOfRangeWarnings = DisplayCommsOutOfRangeWarnings;");
+    }
+
+    private static string ExtractSection(string source, string startMarker, string endMarker)
+    {
+        var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+        var end = source.IndexOf(endMarker, start + startMarker.Length, StringComparison.Ordinal);
+
+        start.Should().BeGreaterThanOrEqualTo(0);
+        end.Should().BeGreaterThan(start);
+        return source[start..end];
     }
 
     private static string ExtractMethod(string source, string startMarker, string endMarker)

--- a/SWLOR.Game.Server/Feature/GuiDefinition/SettingsDefinition.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/SettingsDefinition.cs
@@ -78,6 +78,19 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                             row.AddSpacer()
                                 .SetWidth(28f);
 
+                            row.AddCheckBox()
+                                .SetText("Comms Range Warnings")
+                                .SetTooltip("Warns you when one or more party members are outside the range of a Comms message and do not receive it.")
+                                .SetWidth(230f)
+                                .BindIsChecked(model => model.DisplayCommsOutOfRangeWarnings);
+                        })
+                            .SetHeight(30f);
+
+                        col.AddRow(row =>
+                        {
+                            row.AddSpacer()
+                                .SetWidth(28f);
+
                             row.AddButton()
                                 .SetText("Change Description")
                                 .SetTooltip("Modify your publicly-viewable description which displays when you are examined.")
@@ -139,19 +152,6 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                 {
                     view.AddColumn(col =>
                     {
-                        col.AddRow(row =>
-                        {
-                            row.AddSpacer()
-                                .SetWidth(28f);
-
-                            row.AddCheckBox()
-                                .SetText("Comms Range Warnings")
-                                .SetTooltip("Warns you when one or more party members are outside the range of a Comms message and do not receive it.")
-                                .SetWidth(230f)
-                                .BindIsChecked(model => model.DisplayCommsOutOfRangeWarnings);
-                        })
-                            .SetHeight(30f);
-
                         col.AddRow(row =>
                         {
                             row.AddList(template =>

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/PlayerGuideViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/PlayerGuideViewModel.cs
@@ -334,7 +334,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
                     new[]
                     {
                         new ArticleBlock("Talk, Whisper, and Comms",
-                            "Normal Talk reaches players within 20 meters. Whisper reaches 4 meters. Party chat acts as Comms: it reaches party members in the same ship, space region, supported event area, or planet, and nearby non-party listeners within 20 meters can overhear it when they share that scope. By default, you receive a warning when party members are out of range; this warning can be disabled in Chat Settings."),
+                            "Normal Talk reaches players within 20 meters. Whisper reaches 4 meters. Party chat acts as Comms: it reaches party members in the same ship, space region, supported event area, or planet, and nearby non-party listeners within 20 meters can overhear it when they share that scope. By default, you receive a warning when party members are out of range; this warning can be disabled in General Settings."),
                         new ArticleBlock("Disabled Shout Channel",
                             "The Shout chat channel is disabled for players. DMs can still use Shout for server-wide messages."),
                         new ArticleBlock("HoloNet Broadcast Window",

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/SettingsViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/SettingsViewModel.cs
@@ -179,6 +179,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             SubdualMode = dbPlayer.Settings.IsSubdualModeEnabled;
             DisplayServerResetReminders = dbPlayer.Settings.DisplayServerResetReminders;
             PortraitVitals = dbPlayer.Settings.PortraitVitals ?? true;
+            DisplayCommsOutOfRangeWarnings = dbPlayer.Settings.DisplayCommsOutOfRangeWarnings ?? true;
         }
 
         private void LoadIdentityView()
@@ -197,8 +198,6 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             var dbPlayer = DB.Get<Player>(playerId);
             var colorSettings = dbPlayer.Settings.LanguageChatColors;
             var languages = Skill.GetActiveSkillsByCategory(SkillCategoryType.Languages);
-
-            DisplayCommsOutOfRangeWarnings = dbPlayer.Settings.DisplayCommsOutOfRangeWarnings ?? true;
 
             _languages = new List<SkillType>();
             var chatColorNames = new GuiBindingList<string>();


### PR DESCRIPTION
## Summary

- move the Comms range warning toggle from Chat to General settings
- restore the Chat color controls to their previous layout
- load the toggle through the General settings path and update the Player Guide
- add regression coverage for the control's partial-view placement

## Why

Adding a fixed-height Comms warning row to the Chat partial reduced the space available to its variable-height list, color picker, and RGB rows. NUI redistributed the remaining height and collapsed the chat color controls. General has enough fixed-height room for the toggle without affecting the Chat layout.

## Impact

Players can use the Chat color controls normally again. The Comms warning preference retains its existing default and persistence behavior and is now configured from the General tab.

## Validation

- `dotnet build SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj -p:RunPostBuildEvent=Never`
- `dotnet test SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj --no-build --filter "FullyQualifiedName~SettingsWindowTests|FullyQualifiedName~PlayerFacingNameBroadcastTests"` (9 passed)