### PR TITLE
Fix Comms channel token rendering

### DIFF
--- a/SWLOR.Game.Server.Tests/Feature/PlayerFacingNameBroadcastTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/PlayerFacingNameBroadcastTests.cs
@@ -24,7 +24,7 @@ public class PlayerFacingNameBroadcastTests
         var moduleEnterHandlerIndex = normalizedSource.IndexOf("[NWNEventHandler(ScriptName.OnModuleEnter)]", StringComparison.Ordinal);
         var applyChannelNameIndex = normalizedSource.IndexOf("public static void ApplyCommsChannelName()", StringComparison.Ordinal);
         var applyChannelNameOverrideIndex = normalizedSource.IndexOf(
-            "PlayerPlugin.SetTlkOverride(player, PartyChatChannelNameStrRef, ColorToken.Orange(CommsChannelName));",
+            "PlayerPlugin.SetTlkOverride(player, PartyChatChannelNameStrRef, CommsChannelName);",
             StringComparison.Ordinal);
         var applyMessagePrefixOverrideIndex = normalizedSource.IndexOf(
             "PlayerPlugin.SetTlkOverride(player, PartyChatMessagePrefixStrRef, CommsMessagePrefix);",
@@ -290,7 +290,7 @@ public class PlayerFacingNameBroadcastTests
             "TlkOverrides.cs"));
         tlkOverrideSource.Should().Contain("SetTlkOverride(10303, \"[Comms] \");");
         tlkOverrideSource.Should().Contain("SetTlkOverride(66751, \"Disabled\");");
-        tlkOverrideSource.Should().Contain("SetTlkOverride(66755, ColorToken.Orange(\"Comms\"));");
+        tlkOverrideSource.Should().Contain("SetTlkOverride(66755, \"Comms\");");
 
         var settingsDefinitionSource = File.ReadAllText(Path.Combine(
             root.FullName,

--- a/SWLOR.Game.Server/Feature/TlkOverrides.cs
+++ b/SWLOR.Game.Server/Feature/TlkOverrides.cs
@@ -100,7 +100,7 @@ namespace SWLOR.Game.Server.Feature
 
             SetTlkOverride(10303, "[Comms] ");
             SetTlkOverride(66751, "Disabled");
-            SetTlkOverride(66755, ColorToken.Orange("Comms"));
+            SetTlkOverride(66755, "Comms");
 
             SetTlkOverride(83393, "Poison"); // Acid
         }

--- a/SWLOR.Game.Server/Service/Communication.cs
+++ b/SWLOR.Game.Server/Service/Communication.cs
@@ -58,7 +58,8 @@ namespace SWLOR.Game.Server.Service
             if (!GetIsPC(player))
                 return;
 
-            PlayerPlugin.SetTlkOverride(player, PartyChatChannelNameStrRef, ColorToken.Orange(CommsChannelName));
+            // The chat-channel selector treats angle-bracket color markup as TLK substitution tokens.
+            PlayerPlugin.SetTlkOverride(player, PartyChatChannelNameStrRef, CommsChannelName);
             PlayerPlugin.SetTlkOverride(player, PartyChatMessagePrefixStrRef, CommsMessagePrefix);
         }
 


### PR DESCRIPTION
## What changed

- Restore the PlayerParty chat-selector label to plain `Comms` in both the global TLK override and per-player module-entry override.
- Update the focused source-guard tests to require the plain label.
- Document why chat color markup is unsafe for this selector.

## Root cause

The orange-label change placed NWN `<c...>` color markup inside TLK entry `66755`. The chat-channel selector interprets angle-bracket content as TLK substitution tokens, so the label rendered as `<UNRECOGNIZED TOKEN>` instead of orange `Comms`.

## Player impact

The chat selector once again displays a recognized `Comms` label. It uses the normal selector color rather than orange.

## Validation

- `dotnet build SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj -p:RunPostBuildEvent=Never`
- `dotnet test SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj --no-build --filter "FullyQualifiedName~PlayerFacingNameBroadcastTests"` (5 passed)