### PR TITLE
Preserve Espionage XP on stealth detection

### DIFF
--- a/SWLOR.Game.Server.Tests/Perks/EspionageSystemTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/EspionageSystemTests.cs
@@ -174,22 +174,27 @@ public class EspionageSystemTests
         EspionageInfiltration.MeetsSuccessRequirements(true, 4f, true, true).Should().BeFalse();
     }
 
-    [TestCase(true, true, false, false)]
-    [TestCase(true, false, false, false)]
-    [TestCase(true, true, true, true)]
-    [TestCase(true, false, true, true)]
-    [TestCase(false, true, false, true)]
-    [TestCase(false, false, false, false)]
-    [TestCase(false, true, true, true)]
-    [TestCase(false, false, true, true)]
-    public void InfiltrationDetectionOutcome_AllowsOnlyDetectionPairCombat(
+    [TestCase(true, false, true, false, false)]
+    [TestCase(true, false, false, false, false)]
+    [TestCase(true, false, true, true, true)]
+    [TestCase(true, false, false, true, true)]
+    [TestCase(false, false, true, false, true)]
+    [TestCase(false, false, false, false, false)]
+    [TestCase(false, false, true, true, true)]
+    [TestCase(false, false, false, true, true)]
+    [TestCase(true, true, true, false, true)]
+    [TestCase(true, true, false, false, true)]
+    [TestCase(false, true, false, false, true)]
+    public void InfiltrationDetectionOutcome_RejectsPlayerInitiatedAndUnrelatedCombat(
         bool detected,
+        bool playerInitiatedCombat,
         bool hasPairCombatEnmity,
         bool hasUnrelatedCombatEnmity,
         bool expected)
     {
         EspionageInfiltration.ShouldRejectDetectionOutcome(
                 detected,
+                playerInitiatedCombat,
                 hasPairCombatEnmity,
                 hasUnrelatedCombatEnmity)
             .Should()
@@ -226,6 +231,8 @@ public class EspionageSystemTests
         stealthStatusSource.Should().NotContain("HostileScanRadiusMeters");
         stealthStatusSource.Should().Contain("EspionageInfiltration.UpdateMovement(creature);");
         stealthSource.Should().Contain("EspionageInfiltration.RecordDetection(observer, target, detected);");
+        stealthSource.Should().Contain("[NWNEventHandler(ScriptName.OnCreatureAttackBefore)]");
+        stealthSource.Should().Contain("EspionageInfiltration.RecordPlayerCombatInitiation(attacker);");
         stealthSource.Should().Contain("EspionageInfiltration.CancelPlayer(creature);");
         aiSource.Should().Contain("EspionageInfiltration.TryBegin(entering, self);");
         aiSource.Should().Contain("EspionageInfiltration.Complete(exiting, self);");

--- a/SWLOR.Game.Server.Tests/Perks/EspionageSystemTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/EspionageSystemTests.cs
@@ -175,6 +175,15 @@ public class EspionageSystemTests
     }
 
     [Test]
+    public void InfiltrationDetectionFailure_AllowsCombatEnmityCreatedByDetection()
+    {
+        EspionageInfiltration.ShouldRejectDetectionOutcome(true, true).Should().BeFalse();
+        EspionageInfiltration.ShouldRejectDetectionOutcome(true, false).Should().BeFalse();
+        EspionageInfiltration.ShouldRejectDetectionOutcome(false, true).Should().BeTrue();
+        EspionageInfiltration.ShouldRejectDetectionOutcome(false, false).Should().BeFalse();
+    }
+
+    [Test]
     public void InfiltrationXp_IsDrivenByAggroAndDetectionEventsRatherThanElapsedStealthTime()
     {
         var root = FindRepositoryRoot();
@@ -211,7 +220,7 @@ public class EspionageSystemTests
         infiltrationSource.Should().Contain("DelayCommand(MovementSampleIntervalSeconds, () => SampleMovement(player, samplerId));");
         infiltrationSource.Should().Contain("CreaturePlugin.GetFaction(npc) != HostileFactionId");
         infiltrationSource.Should().Contain("Enmity.HasNonProximityEnmity(npc)");
-        infiltrationSource.Should().Contain("if (HasCombatEnmity(target, observer))");
+        infiltrationSource.Should().Contain("ShouldRejectDetectionOutcome(detected, HasCombatEnmity(target, observer))");
         infiltrationSource.Should().Contain("Enmity.HasNonProximityEnmityForCreature(player) ||");
         infiltrationSource.Should().Contain("var master = GetMaster(npc);");
     }

--- a/SWLOR.Game.Server.Tests/Perks/EspionageSystemTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/EspionageSystemTests.cs
@@ -174,13 +174,26 @@ public class EspionageSystemTests
         EspionageInfiltration.MeetsSuccessRequirements(true, 4f, true, true).Should().BeFalse();
     }
 
-    [Test]
-    public void InfiltrationDetectionFailure_AllowsCombatEnmityCreatedByDetection()
+    [TestCase(true, true, false, false)]
+    [TestCase(true, false, false, false)]
+    [TestCase(true, true, true, true)]
+    [TestCase(true, false, true, true)]
+    [TestCase(false, true, false, true)]
+    [TestCase(false, false, false, false)]
+    [TestCase(false, true, true, true)]
+    [TestCase(false, false, true, true)]
+    public void InfiltrationDetectionOutcome_AllowsOnlyDetectionPairCombat(
+        bool detected,
+        bool hasPairCombatEnmity,
+        bool hasUnrelatedCombatEnmity,
+        bool expected)
     {
-        EspionageInfiltration.ShouldRejectDetectionOutcome(true, true).Should().BeFalse();
-        EspionageInfiltration.ShouldRejectDetectionOutcome(true, false).Should().BeFalse();
-        EspionageInfiltration.ShouldRejectDetectionOutcome(false, true).Should().BeTrue();
-        EspionageInfiltration.ShouldRejectDetectionOutcome(false, false).Should().BeFalse();
+        EspionageInfiltration.ShouldRejectDetectionOutcome(
+                detected,
+                hasPairCombatEnmity,
+                hasUnrelatedCombatEnmity)
+            .Should()
+            .Be(expected);
     }
 
     [Test]
@@ -220,7 +233,8 @@ public class EspionageSystemTests
         infiltrationSource.Should().Contain("DelayCommand(MovementSampleIntervalSeconds, () => SampleMovement(player, samplerId));");
         infiltrationSource.Should().Contain("CreaturePlugin.GetFaction(npc) != HostileFactionId");
         infiltrationSource.Should().Contain("Enmity.HasNonProximityEnmity(npc)");
-        infiltrationSource.Should().Contain("ShouldRejectDetectionOutcome(detected, HasCombatEnmity(target, observer))");
+        infiltrationSource.Should().Contain("Enmity.HasNonProximityEnmity(target, observer)");
+        infiltrationSource.Should().Contain("Enmity.HasNonProximityEnmityOutsidePair(target, observer)");
         infiltrationSource.Should().Contain("Enmity.HasNonProximityEnmityForCreature(player) ||");
         infiltrationSource.Should().Contain("var master = GetMaster(npc);");
     }

--- a/SWLOR.Game.Server.Tests/Service/EnmityTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/EnmityTests.cs
@@ -226,6 +226,45 @@ public class EnmityTests
     }
 
     [Test]
+    public void HasNonProximityEnmityOutsidePair_IgnoresPairCombatAndAuraTrafficButRejectsOtherCombat()
+    {
+        const uint player = 1;
+        const uint otherPlayer = 2;
+        const uint npc = 100;
+        const uint otherNpc = 200;
+
+        CreatureToEnemies()[player] = new List<uint> { npc, otherNpc };
+        EnemyEnmityTables()[npc] = new Dictionary<uint, int>
+        {
+            [player] = 5
+        };
+        EnemyEnmityTables()[otherNpc] = new Dictionary<uint, int>
+        {
+            [player] = 1
+        };
+        ProximityEnmityAmounts()[otherNpc] = new Dictionary<uint, int>
+        {
+            [player] = 1
+        };
+
+        Enmity.HasNonProximityEnmity(player, npc).Should().BeTrue();
+        Enmity.HasNonProximityEnmity(player, otherNpc).Should().BeFalse();
+        Enmity.HasNonProximityEnmityOutsidePair(player, npc).Should().BeFalse();
+
+        EnemyEnmityTables()[otherNpc][player] = 2;
+        Enmity.HasNonProximityEnmityOutsidePair(player, npc).Should().BeTrue();
+
+        EnemyEnmityTables()[otherNpc][player] = 1;
+        EnemyEnmityTables()[npc][otherPlayer] = 3;
+        ProximityEnmityAmounts()[npc] = new Dictionary<uint, int>
+        {
+            [otherPlayer] = 1
+        };
+
+        Enmity.HasNonProximityEnmityOutsidePair(player, npc).Should().BeTrue();
+    }
+
+    [Test]
     public void ShouldIssueAttackCommand_ReissuesWhenTargetIsStaleButNoAttackActionIsRunning()
     {
         ShouldIssueAttackCommand(1, 1, ActionType.Invalid, false, commandIssuedAt: DateTime.UtcNow.AddSeconds(-7))

--- a/SWLOR.Game.Server.Tests/Service/EnmityTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/EnmityTests.cs
@@ -262,6 +262,17 @@ public class EnmityTests
         };
 
         Enmity.HasNonProximityEnmityOutsidePair(player, npc).Should().BeTrue();
+
+        EnemyEnmityTables()[npc].Remove(otherPlayer);
+        ProximityEnmityAmounts().Remove(npc);
+        CreatureToEnemies()[npc] = new List<uint> { otherNpc };
+        EnemyEnmityTables()[otherNpc][npc] = 1;
+        ProximityEnmityAmounts()[otherNpc][npc] = 1;
+
+        Enmity.HasNonProximityEnmityOutsidePair(player, npc).Should().BeFalse();
+
+        EnemyEnmityTables()[otherNpc][npc] = 2;
+        Enmity.HasNonProximityEnmityOutsidePair(player, npc).Should().BeTrue();
     }
 
     [Test]

--- a/SWLOR.Game.Server/Service/Enmity.cs
+++ b/SWLOR.Game.Server/Service/Enmity.cs
@@ -415,6 +415,16 @@ namespace SWLOR.Game.Server.Service
         }
 
         /// <summary>
+        /// Returns true when a specific creature/enemy pair has enmity beyond the amount created
+        /// solely by the enemy's aggro aura.
+        /// </summary>
+        public static bool HasNonProximityEnmity(uint creature, uint enemy)
+        {
+            return GetRawEnmityAmount(creature, enemy) > 0 &&
+                   !HasOnlyProximityEnmity(creature, enemy);
+        }
+
+        /// <summary>
         /// Returns true when an enemy has any enmity that did not come solely from its aggro aura.
         /// Attack, damage, and ability enmity make the enemy an active combatant and therefore an
         /// invalid source for a new Espionage infiltration attempt.
@@ -424,7 +434,7 @@ namespace SWLOR.Game.Server.Service
             if (!_enemyEnmityTables.TryGetValue(enemy, out var table))
                 return false;
 
-            return table.Any(entry => !HasOnlyProximityEnmity(entry.Key, enemy));
+            return table.Keys.Any(creature => HasNonProximityEnmity(creature, enemy));
         }
 
         /// <summary>
@@ -437,7 +447,26 @@ namespace SWLOR.Game.Server.Service
             if (!_creatureToEnemies.TryGetValue(creature, out var enemies))
                 return false;
 
-            return enemies.Any(enemy => !HasOnlyProximityEnmity(creature, enemy));
+            return enemies.Any(enemy => HasNonProximityEnmity(creature, enemy));
+        }
+
+        /// <summary>
+        /// Returns true when either member of a creature/enemy pair has combat enmity involving
+        /// someone outside that pair. Pair-specific checks use this to distinguish an expected
+        /// aggro transition from unrelated combat.
+        /// </summary>
+        public static bool HasNonProximityEnmityOutsidePair(uint creature, uint enemy)
+        {
+            var creatureHasOtherCombat =
+                _creatureToEnemies.TryGetValue(creature, out var enemies) &&
+                enemies.Any(otherEnemy =>
+                    otherEnemy != enemy && HasNonProximityEnmity(creature, otherEnemy));
+            var enemyHasOtherCombat =
+                _enemyEnmityTables.TryGetValue(enemy, out var table) &&
+                table.Keys.Any(otherCreature =>
+                    otherCreature != creature && HasNonProximityEnmity(otherCreature, enemy));
+
+            return creatureHasOtherCombat || enemyHasOtherCombat;
         }
 
         /// <summary>

--- a/SWLOR.Game.Server/Service/Enmity.cs
+++ b/SWLOR.Game.Server/Service/Enmity.cs
@@ -455,18 +455,26 @@ namespace SWLOR.Game.Server.Service
         /// someone outside that pair. Pair-specific checks use this to distinguish an expected
         /// aggro transition from unrelated combat.
         /// </summary>
-        public static bool HasNonProximityEnmityOutsidePair(uint creature, uint enemy)
+        public static bool HasNonProximityEnmityOutsidePair(uint first, uint second)
         {
-            var creatureHasOtherCombat =
-                _creatureToEnemies.TryGetValue(creature, out var enemies) &&
-                enemies.Any(otherEnemy =>
-                    otherEnemy != enemy && HasNonProximityEnmity(creature, otherEnemy));
-            var enemyHasOtherCombat =
-                _enemyEnmityTables.TryGetValue(enemy, out var table) &&
-                table.Keys.Any(otherCreature =>
-                    otherCreature != creature && HasNonProximityEnmity(otherCreature, enemy));
+            return HasNonProximityEnmityAsCreatureOutsidePair(first, second) ||
+                   HasNonProximityEnmityAsEnemyOutsidePair(first, second) ||
+                   HasNonProximityEnmityAsCreatureOutsidePair(second, first) ||
+                   HasNonProximityEnmityAsEnemyOutsidePair(second, first);
+        }
 
-            return creatureHasOtherCombat || enemyHasOtherCombat;
+        private static bool HasNonProximityEnmityAsCreatureOutsidePair(uint creature, uint pairedEnemy)
+        {
+            return _creatureToEnemies.TryGetValue(creature, out var enemies) &&
+                   enemies.Any(enemy =>
+                       enemy != pairedEnemy && HasNonProximityEnmity(creature, enemy));
+        }
+
+        private static bool HasNonProximityEnmityAsEnemyOutsidePair(uint enemy, uint pairedCreature)
+        {
+            return _enemyEnmityTables.TryGetValue(enemy, out var table) &&
+                   table.Keys.Any(creature =>
+                       creature != pairedCreature && HasNonProximityEnmity(creature, enemy));
         }
 
         /// <summary>

--- a/SWLOR.Game.Server/Service/EspionageInfiltration.cs
+++ b/SWLOR.Game.Server/Service/EspionageInfiltration.cs
@@ -75,10 +75,15 @@ namespace SWLOR.Game.Server.Service
 
             UpdateMaximumTravelDistance(target, attempt);
 
-            // A successful Detection result can establish combat enmity before this callback
-            // finishes. That is the expected failure outcome and still earns the reduced award.
-            // Only an undetected attempt with real combat enmity is invalid.
-            if (ShouldRejectDetectionOutcome(detected, HasCombatEnmity(target, observer)))
+            // Detection can establish combat enmity between this player and observer before the
+            // callback finishes. That pair-specific enmity is the expected failure outcome, but
+            // combat involving either participant and someone else still invalidates the attempt.
+            var hasPairCombatEnmity = Enmity.HasNonProximityEnmity(target, observer);
+            var hasUnrelatedCombatEnmity = Enmity.HasNonProximityEnmityOutsidePair(target, observer);
+            if (ShouldRejectDetectionOutcome(
+                    detected,
+                    hasPairCombatEnmity,
+                    hasUnrelatedCombatEnmity))
             {
                 _activeAttempts.Remove(key);
                 return;
@@ -176,9 +181,12 @@ namespace SWLOR.Game.Server.Service
                 : baseXp;
         }
 
-        public static bool ShouldRejectDetectionOutcome(bool detected, bool hasCombatEnmity)
+        public static bool ShouldRejectDetectionOutcome(
+            bool detected,
+            bool hasPairCombatEnmity,
+            bool hasUnrelatedCombatEnmity)
         {
-            return !detected && hasCombatEnmity;
+            return hasUnrelatedCombatEnmity || (!detected && hasPairCombatEnmity);
         }
 
         public static void CancelPlayer(uint player)

--- a/SWLOR.Game.Server/Service/EspionageInfiltration.cs
+++ b/SWLOR.Game.Server/Service/EspionageInfiltration.cs
@@ -75,7 +75,10 @@ namespace SWLOR.Game.Server.Service
 
             UpdateMaximumTravelDistance(target, attempt);
 
-            if (HasCombatEnmity(target, observer))
+            // A successful Detection result can establish combat enmity before this callback
+            // finishes. That is the expected failure outcome and still earns the reduced award.
+            // Only an undetected attempt with real combat enmity is invalid.
+            if (ShouldRejectDetectionOutcome(detected, HasCombatEnmity(target, observer)))
             {
                 _activeAttempts.Remove(key);
                 return;
@@ -171,6 +174,11 @@ namespace SWLOR.Game.Server.Service
             return wasDetected
                 ? (int)(baseXp * DetectionFailureXpPercent)
                 : baseXp;
+        }
+
+        public static bool ShouldRejectDetectionOutcome(bool detected, bool hasCombatEnmity)
+        {
+            return !detected && hasCombatEnmity;
         }
 
         public static void CancelPlayer(uint player)

--- a/SWLOR.Game.Server/Service/EspionageInfiltration.cs
+++ b/SWLOR.Game.Server/Service/EspionageInfiltration.cs
@@ -28,6 +28,7 @@ namespace SWLOR.Game.Server.Service
             public Location EntryLocation { get; init; }
             public float MaximumTravelDistance { get; set; }
             public bool EvadedDetection { get; set; }
+            public bool PlayerInitiatedCombat { get; set; }
         }
 
         private static readonly Dictionary<(uint Player, uint Npc), InfiltrationAttempt> _activeAttempts = new();
@@ -76,12 +77,13 @@ namespace SWLOR.Game.Server.Service
             UpdateMaximumTravelDistance(target, attempt);
 
             // Detection can establish combat enmity between this player and observer before the
-            // callback finishes. That pair-specific enmity is the expected failure outcome, but
-            // combat involving either participant and someone else still invalidates the attempt.
+            // callback finishes. That pair-specific enmity is the expected failure outcome only
+            // when the player did not initiate combat and neither participant is fighting elsewhere.
             var hasPairCombatEnmity = Enmity.HasNonProximityEnmity(target, observer);
             var hasUnrelatedCombatEnmity = Enmity.HasNonProximityEnmityOutsidePair(target, observer);
             if (ShouldRejectDetectionOutcome(
                     detected,
+                    attempt.PlayerInitiatedCombat,
                     hasPairCombatEnmity,
                     hasUnrelatedCombatEnmity))
             {
@@ -123,7 +125,7 @@ namespace SWLOR.Game.Server.Service
 
             UpdateMaximumTravelDistance(player, attempt);
             var isStealthed = GetActionMode(player, ActionMode.Stealth);
-            var hasCombatEnmity = HasCombatEnmity(player, npc);
+            var hasCombatEnmity = attempt.PlayerInitiatedCombat || HasCombatEnmity(player, npc);
             if (!MeetsSuccessRequirements(
                     attempt.EvadedDetection,
                     attempt.MaximumTravelDistance,
@@ -183,10 +185,26 @@ namespace SWLOR.Game.Server.Service
 
         public static bool ShouldRejectDetectionOutcome(
             bool detected,
+            bool playerInitiatedCombat,
             bool hasPairCombatEnmity,
             bool hasUnrelatedCombatEnmity)
         {
-            return hasUnrelatedCombatEnmity || (!detected && hasPairCombatEnmity);
+            return playerInitiatedCombat ||
+                   hasUnrelatedCombatEnmity ||
+                   (!detected && hasPairCombatEnmity);
+        }
+
+        /// <summary>
+        /// Marks every active attempt for a player before their attack can create pair enmity.
+        /// The later Spot callback can then distinguish that hostile action from detection aggro.
+        /// </summary>
+        public static void RecordPlayerCombatInitiation(uint player)
+        {
+            foreach (var (key, attempt) in _activeAttempts)
+            {
+                if (key.Player == player)
+                    attempt.PlayerInitiatedCombat = true;
+            }
         }
 
         public static void CancelPlayer(uint player)

--- a/SWLOR.Game.Server/Service/Stealth.cs
+++ b/SWLOR.Game.Server/Service/Stealth.cs
@@ -86,6 +86,22 @@ namespace SWLOR.Game.Server.Service
         }
 
         /// <summary>
+        /// Records player-initiated combat before the attack event can add pair enmity. This lets
+        /// infiltration distinguish the attack from combat caused by a successful detection.
+        /// </summary>
+        [NWNEventHandler(ScriptName.OnCreatureAttackBefore)]
+        public static void RecordPlayerCombatInitiation()
+        {
+            var enemy = OBJECT_SELF;
+            var attacker = GetLastAttacker(enemy);
+
+            if (!GetIsPC(attacker) || GetIsDM(attacker))
+                return;
+
+            EspionageInfiltration.RecordPlayerCombatInitiation(attacker);
+        }
+
+        /// <summary>
         /// Landing a hit is a hostile action, so it reveals the attacker. Abilities flagged
         /// BreaksStealth are already handled on activation; this covers auto-attacks and any
         /// damage-dealing path that does not route through an ability.


### PR DESCRIPTION
## What changed

- Preserve the reduced Espionage XP award when a hostile NPC detects a stealthed player.
- Continue rejecting undetected infiltration attempts if real combat enmity appears.
- Add a regression matrix covering detected/undetected outcomes with and without combat enmity.

## Root cause

A successful Detection result can establish combat enmity before the infiltration callback finishes. The existing combat guard treated that expected detection consequence as pre-existing combat and discarded the attempt before granting the designed 15% failure award.

## Player impact

Stealth detection failures now grant their reduced Espionage XP as designed. Successful bypass requirements, one-award-per-NPC-life behavior, stamina drain, toggling, combat cancellation, and icon timing are unchanged.

## Validation

- `dotnet build SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj -p:RunPostBuildEvent=Never`
- `dotnet test SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj --no-build --filter "FullyQualifiedName~EspionageSystemTests|FullyQualifiedName~EnmityTests"` (40 passed)