### PR TITLE
Prevent Guard procs on discarded attacks

### DIFF
--- a/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
@@ -555,6 +555,11 @@ public class CombatDamageTests
         guard.IndexOf("!isLandedAttack", StringComparison.Ordinal).Should().BeLessThan(
             guard.IndexOf("var guardChance", StringComparison.Ordinal),
             "discarded swings must never enter the Guard roll");
+        var guardableSource = ExtractMethod(combatSource, "private static bool IsGuardableAttackSource(");
+        guardableSource.Should().Contain("GetIsReactionTypeHostile(attacker, defender)");
+        guardableSource.Should().Contain("GetIsReactionTypeHostile(defender, attacker)");
+        guardableSource.Should().Contain("GetIsEnemy(attacker, defender)");
+        guardableSource.Should().Contain("GetIsEnemy(defender, attacker)");
         damageRollSource.Should().Contain("private static bool IsLandedAttackOnDamageableTarget(");
         damageRollSource.Should().Contain("targetObject.m_bPlotObject == 1");
         damageRollSource.Should().Contain("ResolveAttackRoll.IsSuccessfulAttackResult(attackData.m_nAttackResult)");

--- a/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
@@ -295,7 +295,7 @@ public class CombatDamageTests
             "var damage = CalculateTargetSpecificDamage",
             StringComparison.Ordinal);
         var guardedHitIndex = damageRollSource.IndexOf(
-            "Combat.ApplyGuardedHitModifiers(target.m_idSelf, attacker.m_idSelf, damage, damageType);",
+            "Combat.ApplyGuardedHitModifiers(",
             StringComparison.Ordinal);
 
         queuedAbilitySuppressionIndex.Should().BeGreaterThanOrEqualTo(0);
@@ -544,17 +544,21 @@ public class CombatDamageTests
         var combatSource = File.ReadAllText(Path.Combine(root.FullName, "SWLOR.Game.Server", "Service", "Combat.cs"));
         var damageRollSource = File.ReadAllText(Path.Combine(root.FullName, "SWLOR.Game.Server", "Native", "GetDamageRoll.cs"));
 
-        combatSource.Should().Contain("ApplyGuardedHitModifiers(uint defender, uint attacker, int damage, CombatDamageType damageType)");
+        combatSource.Should().Contain("bool isLandedAttack)");
         var guard = ExtractMethod(combatSource, "public static int ApplyGuardedHitModifiers(");
+        guard.Should().Contain("!isLandedAttack");
         guard.Should().Contain("!GetIsObjectValid(attacker)");
         guard.Should().Contain("defender == attacker");
         guard.Should().Contain("damage <= 0");
         guard.Should().Contain("!damageType.IsPhysicalDamageType()");
-        guard.IndexOf("damage <= 0", StringComparison.Ordinal).Should().BeLessThan(
+        guard.Should().Contain("!IsGuardableAttackSource(defender, attacker)");
+        guard.IndexOf("!isLandedAttack", StringComparison.Ordinal).Should().BeLessThan(
             guard.IndexOf("var guardChance", StringComparison.Ordinal),
-            "idle, self, and zero-damage events must never enter the Guard roll");
-        damageRollSource.Should().Contain("Combat.ApplyGuardedHitModifiers(target.m_idSelf, attacker.m_idSelf, damage, damageType);");
-        damageRollSource.Should().NotContain("Combat.ApplyGuardedHitModifiers(target.m_idSelf, attacker.m_idSelf, damage);");
+            "discarded swings must never enter the Guard roll");
+        damageRollSource.Should().Contain("private static bool IsLandedAttackOnDamageableTarget(");
+        damageRollSource.Should().Contain("targetObject.m_bPlotObject == 1");
+        damageRollSource.Should().Contain("ResolveAttackRoll.IsSuccessfulAttackResult(attackData.m_nAttackResult)");
+        damageRollSource.Should().Contain("isLandedAttack);");
     }
 
     [Test]

--- a/SWLOR.Game.Server/Native/GetDamageRoll.cs
+++ b/SWLOR.Game.Server/Native/GetDamageRoll.cs
@@ -128,8 +128,14 @@ namespace SWLOR.Game.Server.Native
                 var attackerAttack = weapon == null ? 0 : Stat.GetAttackNative(attacker, (BaseItem)weapon.m_nBaseItem, attackerStatType, useForceAttack);
                 var totalDamage = 0;
 
+                // The engine calls this hook for swings it later discards. On-hit riders such as
+                // Guard must only fire when the attack roll actually landed against a target that
+                // can take damage.
+                var isLandedAttack = IsLandedAttackOnDamageableTarget(pAttackData, defender);
+
                 var physicalDamage = ProcessDamage(pTarget, attacker, damageProfile, pAttackData,
                     attackerAttack, attackerStat, critical, weaponDeltaCap, attackType, damageFlags, bOffHand, defender, weaponSkillType,
+                    isLandedAttack,
                     out totalDamage,
                     out var effectiveCritical);
 
@@ -187,10 +193,21 @@ namespace SWLOR.Game.Server.Native
                 $"DAMAGE: attacker attribute modifier: {attackerStat}, weapon damage rating {damageProfile.DamageType}: {damageProfile.Damage}");
         }
 
+        private static bool IsLandedAttackOnDamageableTarget(void* pAttackData, CNWSObject targetObject)
+        {
+            if (targetObject == null || targetObject.m_bPlotObject == 1 || pAttackData == null)
+                return false;
+
+            var attackData = CNWSCombatAttackData.FromPointer(pAttackData);
+            return attackData != null &&
+                   ResolveAttackRoll.IsSuccessfulAttackResult(attackData.m_nAttackResult);
+        }
+
         private static int ProcessDamage(void* pTarget, CNWSCreature attacker,
             WeaponDamageProfile damageProfile, void* pAttackData, int attackerAttack,
             int attackerStat, int critical, int weaponDeltaCap, uint attackType, uint damageFlags,
-            int bOffHand, CNWSObject targetObject, SkillType skillType, out int totalDamage, out int effectiveCritical)
+            int bOffHand, CNWSObject targetObject, SkillType skillType, bool isLandedAttack,
+            out int totalDamage, out int effectiveCritical)
         {
             var physicalDamage = 0;
             effectiveCritical = critical;
@@ -204,7 +221,8 @@ namespace SWLOR.Game.Server.Native
             }
 
             var damage = CalculateTargetSpecificDamage(pTarget, attacker, damageProfile,
-                attackerAttack, attackerStat, critical, weaponDeltaCap, attackType, damageFlags, bOffHand, skillType, out effectiveCritical);
+                attackerAttack, attackerStat, critical, weaponDeltaCap, attackType, damageFlags, bOffHand, skillType,
+                isLandedAttack, out effectiveCritical);
 
             // Plot target takes no damage
             if (targetObject.m_bPlotObject == 1)
@@ -472,7 +490,8 @@ namespace SWLOR.Game.Server.Native
 
         private static int CalculateTargetSpecificDamage(void* pTarget, CNWSCreature attacker,
             WeaponDamageProfile damageProfile, int attackerAttack,
-            int attackerStat, int critical, int weaponDeltaCap, uint attackType, uint damageFlags, int bOffHand, SkillType skillType, out int effectiveCritical)
+            int attackerStat, int critical, int weaponDeltaCap, uint attackType, uint damageFlags, int bOffHand, SkillType skillType,
+            bool isLandedAttack, out int effectiveCritical)
         {
             effectiveCritical = critical;
             var targetObject = CNWSObject.FromPointer(pTarget);
@@ -481,7 +500,8 @@ namespace SWLOR.Game.Server.Native
             {
                 case (int)ObjectType.Creature:
                     return CalculateCreatureDamage(pTarget, attacker, damageProfile, attackerAttack,
-                        attackerStat, critical, weaponDeltaCap, attackType, damageFlags, bOffHand, skillType, out effectiveCritical);
+                        attackerStat, critical, weaponDeltaCap, attackType, damageFlags, bOffHand, skillType,
+                        isLandedAttack, out effectiveCritical);
 
                 case (int)ObjectType.Placeable:
                     var plc = CNWSPlaceable.FromPointer(pTarget);
@@ -500,7 +520,8 @@ namespace SWLOR.Game.Server.Native
 
         private static int CalculateCreatureDamage(void* pTarget, CNWSCreature attacker, WeaponDamageProfile damageProfile,
             int attackerAttack, int attackerStat, int critical, int weaponDeltaCap,
-            uint attackType, uint damageFlags, int bOffHand, SkillType skillType, out int effectiveCritical)
+            uint attackType, uint damageFlags, int bOffHand, SkillType skillType,
+            bool isLandedAttack, out int effectiveCritical)
         {
             effectiveCritical = critical;
             var target = CNWSCreature.FromPointer(pTarget);
@@ -586,7 +607,12 @@ namespace SWLOR.Game.Server.Native
                 damage = target.DoDamageReduction(attacker, damage, damagePower, 0, 1, bRangedAttack);
             }
 
-            damage = Combat.ApplyGuardedHitModifiers(target.m_idSelf, attacker.m_idSelf, damage, damageType);
+            damage = Combat.ApplyGuardedHitModifiers(
+                target.m_idSelf,
+                attacker.m_idSelf,
+                damage,
+                damageType,
+                isLandedAttack);
             if (damage > 0 && attackType == (uint)AttackType.Melee)
             {
                 Combat.ApplyMeleeDamageTakenEffects(target.m_idSelf, attacker.m_idSelf);

--- a/SWLOR.Game.Server/Native/ResolveAttackRoll.cs
+++ b/SWLOR.Game.Server/Native/ResolveAttackRoll.cs
@@ -389,7 +389,12 @@ namespace SWLOR.Game.Server.Native
                 hitRate);
         }
 
-        private static bool IsSuccessfulAttackResult(int attackResultType)
+        /// <summary>
+        /// Returns whether the native attack result represents a landed hit. The damage-roll hook
+        /// also runs for attacks that the engine later discards, so on-hit riders must use this
+        /// result instead of treating every damage calculation as a successful attack.
+        /// </summary>
+        internal static bool IsSuccessfulAttackResult(int attackResultType)
         {
             return attackResultType == AttackResultAutomaticHit ||
                    attackResultType == AttackResultRegularHit ||

--- a/SWLOR.Game.Server/Service/Combat.cs
+++ b/SWLOR.Game.Server/Service/Combat.cs
@@ -3086,7 +3086,9 @@ namespace SWLOR.Game.Server.Service
                 return true;
 
             return GetIsReactionTypeHostile(attacker, defender) ||
-                   GetIsEnemy(attacker, defender);
+                   GetIsReactionTypeHostile(defender, attacker) ||
+                   GetIsEnemy(attacker, defender) ||
+                   GetIsEnemy(defender, attacker);
         }
 
         private static void SendGuardedHitFeedback(uint defender, uint attacker, int preventedDamage)

--- a/SWLOR.Game.Server/Service/Combat.cs
+++ b/SWLOR.Game.Server/Service/Combat.cs
@@ -3045,13 +3045,20 @@ namespace SWLOR.Game.Server.Service
             ApplyEffectToObject(DurationType.Instant, EffectVisualEffect(VisualEffect.Vfx_Imp_Poison_S), attacker);
         }
 
-        public static int ApplyGuardedHitModifiers(uint defender, uint attacker, int damage, CombatDamageType damageType)
+        public static int ApplyGuardedHitModifiers(
+            uint defender,
+            uint attacker,
+            int damage,
+            CombatDamageType damageType,
+            bool isLandedAttack)
         {
-            if (!GetIsObjectValid(defender) ||
+            if (!isLandedAttack ||
+                !GetIsObjectValid(defender) ||
                 !GetIsObjectValid(attacker) ||
                 defender == attacker ||
                 damage <= 0 ||
-                !damageType.IsPhysicalDamageType())
+                !damageType.IsPhysicalDamageType() ||
+                !IsGuardableAttackSource(defender, attacker))
                 return damage;
 
             var guardChance = Stat.GetGuardChance(defender);
@@ -3070,6 +3077,16 @@ namespace SWLOR.Game.Server.Service
             SendGuardedHitFeedback(defender, attacker, preventedDamage);
 
             return adjustedDamage;
+        }
+
+        private static bool IsGuardableAttackSource(uint defender, uint attacker)
+        {
+            // Preserve PvP and DM-driven testing while rejecting clearly non-hostile NPC swings.
+            if (GetIsPC(attacker) || GetIsDM(attacker) || GetIsDMPossessed(attacker))
+                return true;
+
+            return GetIsReactionTypeHostile(attacker, defender) ||
+                   GetIsEnemy(attacker, defender);
         }
 
         private static void SendGuardedHitFeedback(uint defender, uint attacker, int preventedDamage)


### PR DESCRIPTION
## Summary

- thread the native attack result from `GetDamageRoll` into Guard resolution
- reject discarded, plot-target, and clearly non-hostile NPC swings before rolling Guard
- add regression coverage for the landed-hit gate and native attack-result plumbing

## Root cause

The landed-attack gate from an earlier Guard fix was lost during a later combat-service restoration. Neverwinter Nights invokes the native damage-roll hook for some swings it later discards. Because Guard was again checking only calculated positive physical damage, those discarded attacks could trigger Guard feedback, Counter Ready, Retaliation Pulse, recovery, and enmity while the player appeared idle or far from an enemy.

## Player impact

Guard and its riders now activate only for actual landed hostile physical attacks. Intended Guard mitigation, retaliation damage, and enmity behavior are unchanged.

## Validation

- `dotnet build SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj -p:RunPostBuildEvent=Never` — passed
- `dotnet test SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj --no-build --filter "FullyQualifiedName~CombatDamageTests.GuardedHitModifiers_OnlyRunForPhysicalDamageFromDamageRoll"` — passed
- broader `CombatDamageTests` run: 47 passed; 3 unrelated asset tests could not run because this worktree's `SWLOR_Haks` submodule content is not checked out

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Guard mitigation and related effects now trigger only when a physical attack successfully lands on a valid target.
  - Discarded, unsuccessful, non-physical, and invalid-target attacks no longer incorrectly activate guarded-hit mechanics.
  - Non-hostile NPC attacks are excluded from guard processing, while supported player- and DM-driven combat scenarios continue to work correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->