### PR TITLE
Restore legacy Docker Compose schema declaration

### DIFF
--- a/SWLOR.Game.Server/Docker/docker-compose.yml
+++ b/SWLOR.Game.Server/Docker/docker-compose.yml
@@ -1,3 +1,4 @@
+version: "3.7"
 services:
     redis:
         hostname: redis


### PR DESCRIPTION
## Summary

Restore the Docker Compose file's historical `version: "3.7"` declaration.

## Root cause

The Linux deployment uses legacy `docker-compose`. Without a top-level schema version, that parser assumes Compose file format v1, which has no `services` key. It therefore treats `services` and `volumes` as service names and reports:

- `Unsupported config option for services: 'redis'`
- `Unsupported config option for volumes: 'influxdb'`

The declaration was present from the file's introduction and was removed in `df6b72d8d7` during the .NET 10/NWNX image update.

## Compatibility

Legacy Compose uses the 3.7 declaration to select the correct schema. Modern Compose ignores it and emits a non-fatal obsolete-field warning, while continuing to parse the file successfully.

## Validation

- Windows: `docker-compose config --quiet`
- Ubuntu/WSL2: `docker-compose config --quiet`
- `git diff --check`