### PR TITLE
Fix legacy Compose and Grafana port compatibility

### DIFF
--- a/SWLOR.Game.Server/Docker/docker-compose.yml
+++ b/SWLOR.Game.Server/Docker/docker-compose.yml
@@ -77,7 +77,7 @@ services:
             - ./grafana-provisioning:/etc/grafana/provisioning
             - grafana:/var/lib/grafana
         ports:
-            - "3000:3000"
+            - "3001:3000"
             
 volumes:
     influxdb:

--- a/SWLOR.Game.Server/Docker/docker-compose.yml
+++ b/SWLOR.Game.Server/Docker/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.7"
+version: "3.3"
 services:
     redis:
         hostname: redis


### PR DESCRIPTION
## Summary

- Change the Docker Compose schema declaration from `3.7` to `3.3`.
- Publish Grafana on host port `3001` while preserving container port `3000`.

## Root causes

The production Linux server uses a legacy `docker-compose` release that requires a top-level schema declaration but does not support Compose file format 3.7. Its validation error explicitly identifies 3.3 as supported.

After schema validation succeeded, Grafana could not start because the host's Node web process already listens on `127.0.0.1:3000` (`pid 1118`). Docker's `0.0.0.0:3000` publication overlaps that listener. Mapping `3001:3000` avoids the collision without changing Grafana's internal port.

## Impact

- Legacy Compose parses the file using its supported 3.3 schema.
- The existing Node service keeps host port 3000.
- Grafana is available on host port 3001.

## Validation

- Windows: `docker-compose config --quiet`
- Ubuntu/WSL2: `docker-compose config --quiet`
- `git diff --check`

Modern Compose accepts the version declaration and emits its expected non-fatal warning that versioned schemas are obsolete.