### PR TITLE
Fix Settings Chat tab bindings

### DIFF
--- a/SWLOR.Game.Server.Tests/Feature/SettingsWindowTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/SettingsWindowTests.cs
@@ -47,6 +47,30 @@ public class SettingsWindowTests
     }
 
     [Test]
+    public void ChatTab_RepublishesExistingListBindingsAfterItsPartialIsInserted()
+    {
+        var (_, viewModelSource) = LoadSettingsSources();
+        var changeSettingsView = ExtractMethod(
+            viewModelSource,
+            "private void ChangeSettingsView",
+            "private string GetSelectedPartial");
+        var partialSwap = changeSettingsView.IndexOf(
+            "ChangePartialView(SettingsView, partialName);",
+            StringComparison.Ordinal);
+        var refresh = changeSettingsView.IndexOf(
+            "RefreshChatBindings();",
+            StringComparison.Ordinal);
+
+        partialSwap.Should().BeGreaterThanOrEqualTo(0);
+        refresh.Should().BeGreaterThan(partialSwap);
+        changeSettingsView.Should().Contain("if (partialName == ChatPartial)");
+        changeSettingsView.Should().Contain("ChatColorNames?.ResetBindings();");
+        changeSettingsView.Should().Contain("ChatColors?.ResetBindings();");
+        changeSettingsView.Should().Contain("ChatColorToggles?.ResetBindings();");
+        changeSettingsView.Should().NotContain("LoadChatView();");
+    }
+
+    [Test]
     public void Save_PersistsWithoutClosingTheWindow()
     {
         var (definitionSource, viewModelSource) = LoadSettingsSources();

--- a/SWLOR.Game.Server.Tests/Feature/SettingsWindowTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/SettingsWindowTests.cs
@@ -47,7 +47,7 @@ public class SettingsWindowTests
     }
 
     [Test]
-    public void ChatTab_RepublishesExistingListBindingsAfterItsPartialIsInserted()
+    public void PartialChanges_RepublishExistingListBindingsAfterInsertion()
     {
         var (_, viewModelSource) = LoadSettingsSources();
         var changeSettingsView = ExtractMethod(
@@ -58,16 +58,22 @@ public class SettingsWindowTests
             "ChangePartialView(SettingsView, partialName);",
             StringComparison.Ordinal);
         var refresh = changeSettingsView.IndexOf(
-            "RefreshChatBindings();",
+            "RefreshPartialViewBindings();",
             StringComparison.Ordinal);
+        var restoreMainView = ExtractMethod(
+            viewModelSource,
+            "protected override void OnMainViewRestored",
+            "private void LoadColor");
 
         partialSwap.Should().BeGreaterThanOrEqualTo(0);
         refresh.Should().BeGreaterThan(partialSwap);
-        changeSettingsView.Should().Contain("if (partialName == ChatPartial)");
+        changeSettingsView.Should().NotContain("partialName == ChatPartial");
         changeSettingsView.Should().Contain("ChatColorNames?.ResetBindings();");
         changeSettingsView.Should().Contain("ChatColors?.ResetBindings();");
         changeSettingsView.Should().Contain("ChatColorToggles?.ResetBindings();");
         changeSettingsView.Should().NotContain("LoadChatView();");
+        restoreMainView.Should().Contain("ChangeSettingsView(GetSelectedPartial());");
+        restoreMainView.Should().NotContain("ChangePartialView(SettingsView");
     }
 
     [Test]

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/SettingsViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/SettingsViewModel.cs
@@ -274,16 +274,13 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             // temporarily changes the window geometry.
             UpdatePropertyFromClient(nameof(Geometry));
             ChangePartialView(SettingsView, partialName);
-
-            if (partialName == ChatPartial)
-                RefreshChatBindings();
+            RefreshPartialViewBindings();
         }
 
-        private void RefreshChatBindings()
+        private void RefreshPartialViewBindings()
         {
-            // The Chat partial is not present when its list binds are initialized. Republish the
-            // existing lists after inserting the partial so the client can populate its rows
-            // without reloading persisted values over unsaved color changes.
+            // Republish list bindings after replacing the partial so any newly inserted list can
+            // populate its rows without reloading persisted values over unsaved changes.
             ChatColorNames?.ResetBindings();
             ChatColors?.ResetBindings();
             ChatColorToggles?.ResetBindings();
@@ -302,7 +299,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
 
         protected override void OnMainViewRestored()
         {
-            ChangePartialView(SettingsView, GetSelectedPartial());
+            ChangeSettingsView(GetSelectedPartial());
         }
 
         private void LoadColor()

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/SettingsViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/SettingsViewModel.cs
@@ -274,6 +274,19 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             // temporarily changes the window geometry.
             UpdatePropertyFromClient(nameof(Geometry));
             ChangePartialView(SettingsView, partialName);
+
+            if (partialName == ChatPartial)
+                RefreshChatBindings();
+        }
+
+        private void RefreshChatBindings()
+        {
+            // The Chat partial is not present when its list binds are initialized. Republish the
+            // existing lists after inserting the partial so the client can populate its rows
+            // without reloading persisted values over unsaved color changes.
+            ChatColorNames?.ResetBindings();
+            ChatColors?.ResetBindings();
+            ChatColorToggles?.ResetBindings();
         }
 
         private string GetSelectedPartial()


### PR DESCRIPTION
## What changed

- Republish the Settings Chat tab's existing list bindings after its partial view is inserted.
- Preserve unsaved chat-color edits when switching between Settings tabs.
- Add regression coverage for the partial-swap and binding-refresh ordering.

## Why

The Chat tab loaded its OOC, Emotes, and language color data while the General partial was displayed. When the Chat partial was inserted later, the client did not receive fresh vector/list bindings, leaving the list visually empty even though the data had been loaded.

## Impact

The Chat tab now displays its color rows correctly after switching tabs. Existing in-memory edits remain intact instead of being overwritten from persisted settings.

## Validation

- `dotnet build SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj -p:RunPostBuildEvent=Never`
- `dotnet test SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj --no-build --filter "FullyQualifiedName~SettingsWindowTests"` — 5 passed
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chat color settings so newly inserted list entries display correctly without overwriting unsaved changes.
  * Improved settings view restoration to consistently refresh list bindings after returning to the main view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->