### PR TITLE
Fix respawn waypoint and build Veles taxi network

### DIFF
--- a/Module/git/veles_exterior.git.json
+++ b/Module/git/veles_exterior.git.json
@@ -393913,6 +393913,2776 @@
           "type": "float",
           "value": 15.20000839233398
         }
+      },
+      {
+          "__struct_id":  9,
+          "AnimationState":  {
+                                 "type":  "byte",
+                                 "value":  0
+                             },
+          "Appearance":  {
+                             "type":  "dword",
+                             "value":  20627
+                         },
+          "AutoRemoveKey":  {
+                                "type":  "byte",
+                                "value":  0
+                            },
+          "Bearing":  {
+                          "type":  "float",
+                          "value":  1.5707962512969971
+                      },
+          "BodyBag":  {
+                          "type":  "byte",
+                          "value":  0
+                      },
+          "CloseLockDC":  {
+                              "type":  "byte",
+                              "value":  0
+                          },
+          "Conversation":  {
+                               "type":  "resref",
+                               "value":  ""
+                           },
+          "CurrentHP":  {
+                            "type":  "short",
+                            "value":  10
+                        },
+          "Description":  {
+                              "type":  "cexolocstring",
+                              "value":  {
+                                            "0":  ""
+                                        }
+                          },
+          "DisarmDC":  {
+                           "type":  "byte",
+                           "value":  0
+                       },
+          "Faction":  {
+                          "type":  "dword",
+                          "value":  1
+                      },
+          "Fort":  {
+                       "type":  "byte",
+                       "value":  5
+                   },
+          "Hardness":  {
+                           "type":  "byte",
+                           "value":  5
+                       },
+          "HasInventory":  {
+                               "type":  "byte",
+                               "value":  0
+                           },
+          "HP":  {
+                     "type":  "short",
+                     "value":  10
+                 },
+          "Interruptable":  {
+                                "type":  "byte",
+                                "value":  1
+                            },
+          "KeyName":  {
+                          "type":  "cexostring",
+                          "value":  ""
+                      },
+          "KeyRequired":  {
+                              "type":  "byte",
+                              "value":  0
+                          },
+          "Lockable":  {
+                           "type":  "byte",
+                           "value":  0
+                       },
+          "Locked":  {
+                         "type":  "byte",
+                         "value":  0
+                     },
+          "LocName":  {
+                          "type":  "cexolocstring",
+                          "value":  {
+                                        "0":  "Taxi Terminal"
+                                    }
+                      },
+          "OnClick":  {
+                          "type":  "resref",
+                          "value":  ""
+                      },
+          "OnClosed":  {
+                           "type":  "resref",
+                           "value":  ""
+                       },
+          "OnDamaged":  {
+                            "type":  "resref",
+                            "value":  ""
+                        },
+          "OnDeath":  {
+                          "type":  "resref",
+                          "value":  ""
+                      },
+          "OnDisarm":  {
+                           "type":  "resref",
+                           "value":  ""
+                       },
+          "OnHeartbeat":  {
+                              "type":  "resref",
+                              "value":  ""
+                          },
+          "OnInvDisturbed":  {
+                                 "type":  "resref",
+                                 "value":  ""
+                             },
+          "OnLock":  {
+                         "type":  "resref",
+                         "value":  ""
+                     },
+          "OnMeleeAttacked":  {
+                                  "type":  "resref",
+                                  "value":  ""
+                              },
+          "OnOpen":  {
+                         "type":  "resref",
+                         "value":  ""
+                     },
+          "OnSpellCastAt":  {
+                                "type":  "resref",
+                                "value":  ""
+                            },
+          "OnTrapTriggered":  {
+                                  "type":  "resref",
+                                  "value":  ""
+                              },
+          "OnUnlock":  {
+                           "type":  "resref",
+                           "value":  ""
+                       },
+          "OnUsed":  {
+                         "type":  "resref",
+                         "value":  "dialog_start"
+                     },
+          "OnUserDefined":  {
+                                "type":  "resref",
+                                "value":  ""
+                            },
+          "OpenLockDC":  {
+                             "type":  "byte",
+                             "value":  0
+                         },
+          "Plot":  {
+                       "type":  "byte",
+                       "value":  1
+                   },
+          "PortraitId":  {
+                             "type":  "word",
+                             "value":  0
+                         },
+          "Ref":  {
+                      "type":  "byte",
+                      "value":  0
+                  },
+          "Static":  {
+                         "type":  "byte",
+                         "value":  0
+                     },
+          "Tag":  {
+                      "type":  "cexostring",
+                      "value":  "taxi_terminal"
+                  },
+          "TemplateResRef":  {
+                                 "type":  "resref",
+                                 "value":  "taxi_terminal"
+                             },
+          "TrapDetectable":  {
+                                 "type":  "byte",
+                                 "value":  1
+                             },
+          "TrapDetectDC":  {
+                               "type":  "byte",
+                               "value":  0
+                           },
+          "TrapDisarmable":  {
+                                 "type":  "byte",
+                                 "value":  1
+                             },
+          "TrapFlag":  {
+                           "type":  "byte",
+                           "value":  0
+                       },
+          "TrapOneShot":  {
+                              "type":  "byte",
+                              "value":  1
+                          },
+          "TrapType":  {
+                           "type":  "byte",
+                           "value":  0
+                       },
+          "Type":  {
+                       "type":  "byte",
+                       "value":  0
+                   },
+          "Useable":  {
+                          "type":  "byte",
+                          "value":  1
+                      },
+          "VarTable":  {
+                           "type":  "list",
+                           "value":  [
+                                         {
+                                             "__struct_id":  0,
+                                             "Name":  {
+                                                          "type":  "cexostring",
+                                                          "value":  "TAXI_REGION_ID"
+                                                      },
+                                             "Type":  {
+                                                          "type":  "dword",
+                                                          "value":  1
+                                                      },
+                                             "Value":  {
+                                                           "type":  "int",
+                                                           "value":  1
+                                                       }
+                                         },
+                                         {
+                                             "__struct_id":  0,
+                                             "Name":  {
+                                                          "type":  "cexostring",
+                                                          "value":  "CONVERSATION"
+                                                      },
+                                             "Type":  {
+                                                          "type":  "dword",
+                                                          "value":  3
+                                                      },
+                                             "Value":  {
+                                                           "type":  "cexostring",
+                                                           "value":  "TaxiTerminalDialog"
+                                                       }
+                                         },
+                                         {
+                                             "__struct_id":  0,
+                                             "Name":  {
+                                                          "type":  "cexostring",
+                                                          "value":  "TAXI_DESTINATION_ID"
+                                                      },
+                                             "Type":  {
+                                                          "type":  "dword",
+                                                          "value":  1
+                                                      },
+                                             "Value":  {
+                                                           "type":  "int",
+                                                           "value":  1
+                                                       }
+                                         }
+                                     ]
+                       },
+          "Will":  {
+                       "type":  "byte",
+                       "value":  0
+                   },
+          "X":  {
+                    "type":  "float",
+                    "value":  96.9102249145508
+                },
+          "Y":  {
+                    "type":  "float",
+                    "value":  4.16548839409883
+                },
+          "Z":  {
+                    "type":  "float",
+                    "value":  0.19999885559082031
+                }
+      },
+      {
+          "__struct_id":  9,
+          "AnimationState":  {
+                                 "type":  "byte",
+                                 "value":  0
+                             },
+          "Appearance":  {
+                             "type":  "dword",
+                             "value":  20627
+                         },
+          "AutoRemoveKey":  {
+                                "type":  "byte",
+                                "value":  0
+                            },
+          "Bearing":  {
+                          "type":  "float",
+                          "value":  0
+                      },
+          "BodyBag":  {
+                          "type":  "byte",
+                          "value":  0
+                      },
+          "CloseLockDC":  {
+                              "type":  "byte",
+                              "value":  0
+                          },
+          "Conversation":  {
+                               "type":  "resref",
+                               "value":  ""
+                           },
+          "CurrentHP":  {
+                            "type":  "short",
+                            "value":  10
+                        },
+          "Description":  {
+                              "type":  "cexolocstring",
+                              "value":  {
+                                            "0":  ""
+                                        }
+                          },
+          "DisarmDC":  {
+                           "type":  "byte",
+                           "value":  0
+                       },
+          "Faction":  {
+                          "type":  "dword",
+                          "value":  1
+                      },
+          "Fort":  {
+                       "type":  "byte",
+                       "value":  5
+                   },
+          "Hardness":  {
+                           "type":  "byte",
+                           "value":  5
+                       },
+          "HasInventory":  {
+                               "type":  "byte",
+                               "value":  0
+                           },
+          "HP":  {
+                     "type":  "short",
+                     "value":  10
+                 },
+          "Interruptable":  {
+                                "type":  "byte",
+                                "value":  1
+                            },
+          "KeyName":  {
+                          "type":  "cexostring",
+                          "value":  ""
+                      },
+          "KeyRequired":  {
+                              "type":  "byte",
+                              "value":  0
+                          },
+          "Lockable":  {
+                           "type":  "byte",
+                           "value":  0
+                       },
+          "Locked":  {
+                         "type":  "byte",
+                         "value":  0
+                     },
+          "LocName":  {
+                          "type":  "cexolocstring",
+                          "value":  {
+                                        "0":  "Taxi Terminal"
+                                    }
+                      },
+          "OnClick":  {
+                          "type":  "resref",
+                          "value":  ""
+                      },
+          "OnClosed":  {
+                           "type":  "resref",
+                           "value":  ""
+                       },
+          "OnDamaged":  {
+                            "type":  "resref",
+                            "value":  ""
+                        },
+          "OnDeath":  {
+                          "type":  "resref",
+                          "value":  ""
+                      },
+          "OnDisarm":  {
+                           "type":  "resref",
+                           "value":  ""
+                       },
+          "OnHeartbeat":  {
+                              "type":  "resref",
+                              "value":  ""
+                          },
+          "OnInvDisturbed":  {
+                                 "type":  "resref",
+                                 "value":  ""
+                             },
+          "OnLock":  {
+                         "type":  "resref",
+                         "value":  ""
+                     },
+          "OnMeleeAttacked":  {
+                                  "type":  "resref",
+                                  "value":  ""
+                              },
+          "OnOpen":  {
+                         "type":  "resref",
+                         "value":  ""
+                     },
+          "OnSpellCastAt":  {
+                                "type":  "resref",
+                                "value":  ""
+                            },
+          "OnTrapTriggered":  {
+                                  "type":  "resref",
+                                  "value":  ""
+                              },
+          "OnUnlock":  {
+                           "type":  "resref",
+                           "value":  ""
+                       },
+          "OnUsed":  {
+                         "type":  "resref",
+                         "value":  "dialog_start"
+                     },
+          "OnUserDefined":  {
+                                "type":  "resref",
+                                "value":  ""
+                            },
+          "OpenLockDC":  {
+                             "type":  "byte",
+                             "value":  0
+                         },
+          "Plot":  {
+                       "type":  "byte",
+                       "value":  1
+                   },
+          "PortraitId":  {
+                             "type":  "word",
+                             "value":  0
+                         },
+          "Ref":  {
+                      "type":  "byte",
+                      "value":  0
+                  },
+          "Static":  {
+                         "type":  "byte",
+                         "value":  0
+                     },
+          "Tag":  {
+                      "type":  "cexostring",
+                      "value":  "taxi_terminal"
+                  },
+          "TemplateResRef":  {
+                                 "type":  "resref",
+                                 "value":  "taxi_terminal"
+                             },
+          "TrapDetectable":  {
+                                 "type":  "byte",
+                                 "value":  1
+                             },
+          "TrapDetectDC":  {
+                               "type":  "byte",
+                               "value":  0
+                           },
+          "TrapDisarmable":  {
+                                 "type":  "byte",
+                                 "value":  1
+                             },
+          "TrapFlag":  {
+                           "type":  "byte",
+                           "value":  0
+                       },
+          "TrapOneShot":  {
+                              "type":  "byte",
+                              "value":  1
+                          },
+          "TrapType":  {
+                           "type":  "byte",
+                           "value":  0
+                       },
+          "Type":  {
+                       "type":  "byte",
+                       "value":  0
+                   },
+          "Useable":  {
+                          "type":  "byte",
+                          "value":  1
+                      },
+          "VarTable":  {
+                           "type":  "list",
+                           "value":  [
+                                         {
+                                             "__struct_id":  0,
+                                             "Name":  {
+                                                          "type":  "cexostring",
+                                                          "value":  "TAXI_REGION_ID"
+                                                      },
+                                             "Type":  {
+                                                          "type":  "dword",
+                                                          "value":  1
+                                                      },
+                                             "Value":  {
+                                                           "type":  "int",
+                                                           "value":  1
+                                                       }
+                                         },
+                                         {
+                                             "__struct_id":  0,
+                                             "Name":  {
+                                                          "type":  "cexostring",
+                                                          "value":  "CONVERSATION"
+                                                      },
+                                             "Type":  {
+                                                          "type":  "dword",
+                                                          "value":  3
+                                                      },
+                                             "Value":  {
+                                                           "type":  "cexostring",
+                                                           "value":  "TaxiTerminalDialog"
+                                                       }
+                                         },
+                                         {
+                                             "__struct_id":  0,
+                                             "Name":  {
+                                                          "type":  "cexostring",
+                                                          "value":  "TAXI_DESTINATION_ID"
+                                                      },
+                                             "Type":  {
+                                                          "type":  "dword",
+                                                          "value":  1
+                                                      },
+                                             "Value":  {
+                                                           "type":  "int",
+                                                           "value":  2
+                                                       }
+                                         }
+                                     ]
+                       },
+          "Will":  {
+                       "type":  "byte",
+                       "value":  0
+                   },
+          "X":  {
+                    "type":  "float",
+                    "value":  145.961059570313
+                },
+          "Y":  {
+                    "type":  "float",
+                    "value":  169.506713867188
+                },
+          "Z":  {
+                    "type":  "float",
+                    "value":  0.19999885559082031
+                }
+      },
+      {
+          "__struct_id":  9,
+          "AnimationState":  {
+                                 "type":  "byte",
+                                 "value":  0
+                             },
+          "Appearance":  {
+                             "type":  "dword",
+                             "value":  20627
+                         },
+          "AutoRemoveKey":  {
+                                "type":  "byte",
+                                "value":  0
+                            },
+          "Bearing":  {
+                          "type":  "float",
+                          "value":  1.5707942247390749
+                      },
+          "BodyBag":  {
+                          "type":  "byte",
+                          "value":  0
+                      },
+          "CloseLockDC":  {
+                              "type":  "byte",
+                              "value":  0
+                          },
+          "Conversation":  {
+                               "type":  "resref",
+                               "value":  ""
+                           },
+          "CurrentHP":  {
+                            "type":  "short",
+                            "value":  10
+                        },
+          "Description":  {
+                              "type":  "cexolocstring",
+                              "value":  {
+                                            "0":  ""
+                                        }
+                          },
+          "DisarmDC":  {
+                           "type":  "byte",
+                           "value":  0
+                       },
+          "Faction":  {
+                          "type":  "dword",
+                          "value":  1
+                      },
+          "Fort":  {
+                       "type":  "byte",
+                       "value":  5
+                   },
+          "Hardness":  {
+                           "type":  "byte",
+                           "value":  5
+                       },
+          "HasInventory":  {
+                               "type":  "byte",
+                               "value":  0
+                           },
+          "HP":  {
+                     "type":  "short",
+                     "value":  10
+                 },
+          "Interruptable":  {
+                                "type":  "byte",
+                                "value":  1
+                            },
+          "KeyName":  {
+                          "type":  "cexostring",
+                          "value":  ""
+                      },
+          "KeyRequired":  {
+                              "type":  "byte",
+                              "value":  0
+                          },
+          "Lockable":  {
+                           "type":  "byte",
+                           "value":  0
+                       },
+          "Locked":  {
+                         "type":  "byte",
+                         "value":  0
+                     },
+          "LocName":  {
+                          "type":  "cexolocstring",
+                          "value":  {
+                                        "0":  "Taxi Terminal"
+                                    }
+                      },
+          "OnClick":  {
+                          "type":  "resref",
+                          "value":  ""
+                      },
+          "OnClosed":  {
+                           "type":  "resref",
+                           "value":  ""
+                       },
+          "OnDamaged":  {
+                            "type":  "resref",
+                            "value":  ""
+                        },
+          "OnDeath":  {
+                          "type":  "resref",
+                          "value":  ""
+                      },
+          "OnDisarm":  {
+                           "type":  "resref",
+                           "value":  ""
+                       },
+          "OnHeartbeat":  {
+                              "type":  "resref",
+                              "value":  ""
+                          },
+          "OnInvDisturbed":  {
+                                 "type":  "resref",
+                                 "value":  ""
+                             },
+          "OnLock":  {
+                         "type":  "resref",
+                         "value":  ""
+                     },
+          "OnMeleeAttacked":  {
+                                  "type":  "resref",
+                                  "value":  ""
+                              },
+          "OnOpen":  {
+                         "type":  "resref",
+                         "value":  ""
+                     },
+          "OnSpellCastAt":  {
+                                "type":  "resref",
+                                "value":  ""
+                            },
+          "OnTrapTriggered":  {
+                                  "type":  "resref",
+                                  "value":  ""
+                              },
+          "OnUnlock":  {
+                           "type":  "resref",
+                           "value":  ""
+                       },
+          "OnUsed":  {
+                         "type":  "resref",
+                         "value":  "dialog_start"
+                     },
+          "OnUserDefined":  {
+                                "type":  "resref",
+                                "value":  ""
+                            },
+          "OpenLockDC":  {
+                             "type":  "byte",
+                             "value":  0
+                         },
+          "Plot":  {
+                       "type":  "byte",
+                       "value":  1
+                   },
+          "PortraitId":  {
+                             "type":  "word",
+                             "value":  0
+                         },
+          "Ref":  {
+                      "type":  "byte",
+                      "value":  0
+                  },
+          "Static":  {
+                         "type":  "byte",
+                         "value":  0
+                     },
+          "Tag":  {
+                      "type":  "cexostring",
+                      "value":  "taxi_terminal"
+                  },
+          "TemplateResRef":  {
+                                 "type":  "resref",
+                                 "value":  "taxi_terminal"
+                             },
+          "TrapDetectable":  {
+                                 "type":  "byte",
+                                 "value":  1
+                             },
+          "TrapDetectDC":  {
+                               "type":  "byte",
+                               "value":  0
+                           },
+          "TrapDisarmable":  {
+                                 "type":  "byte",
+                                 "value":  1
+                             },
+          "TrapFlag":  {
+                           "type":  "byte",
+                           "value":  0
+                       },
+          "TrapOneShot":  {
+                              "type":  "byte",
+                              "value":  1
+                          },
+          "TrapType":  {
+                           "type":  "byte",
+                           "value":  0
+                       },
+          "Type":  {
+                       "type":  "byte",
+                       "value":  0
+                   },
+          "Useable":  {
+                          "type":  "byte",
+                          "value":  1
+                      },
+          "VarTable":  {
+                           "type":  "list",
+                           "value":  [
+                                         {
+                                             "__struct_id":  0,
+                                             "Name":  {
+                                                          "type":  "cexostring",
+                                                          "value":  "TAXI_REGION_ID"
+                                                      },
+                                             "Type":  {
+                                                          "type":  "dword",
+                                                          "value":  1
+                                                      },
+                                             "Value":  {
+                                                           "type":  "int",
+                                                           "value":  1
+                                                       }
+                                         },
+                                         {
+                                             "__struct_id":  0,
+                                             "Name":  {
+                                                          "type":  "cexostring",
+                                                          "value":  "CONVERSATION"
+                                                      },
+                                             "Type":  {
+                                                          "type":  "dword",
+                                                          "value":  3
+                                                      },
+                                             "Value":  {
+                                                           "type":  "cexostring",
+                                                           "value":  "TaxiTerminalDialog"
+                                                       }
+                                         },
+                                         {
+                                             "__struct_id":  0,
+                                             "Name":  {
+                                                          "type":  "cexostring",
+                                                          "value":  "TAXI_DESTINATION_ID"
+                                                      },
+                                             "Type":  {
+                                                          "type":  "dword",
+                                                          "value":  1
+                                                      },
+                                             "Value":  {
+                                                           "type":  "int",
+                                                           "value":  3
+                                                       }
+                                         }
+                                     ]
+                       },
+          "Will":  {
+                       "type":  "byte",
+                       "value":  0
+                   },
+          "X":  {
+                    "type":  "float",
+                    "value":  115.003784179688
+                },
+          "Y":  {
+                    "type":  "float",
+                    "value":  183.210739135742
+                },
+          "Z":  {
+                    "type":  "float",
+                    "value":  0.19999885559082031
+                }
+      },
+      {
+          "__struct_id":  9,
+          "AnimationState":  {
+                                 "type":  "byte",
+                                 "value":  0
+                             },
+          "Appearance":  {
+                             "type":  "dword",
+                             "value":  20627
+                         },
+          "AutoRemoveKey":  {
+                                "type":  "byte",
+                                "value":  0
+                            },
+          "Bearing":  {
+                          "type":  "float",
+                          "value":  0
+                      },
+          "BodyBag":  {
+                          "type":  "byte",
+                          "value":  0
+                      },
+          "CloseLockDC":  {
+                              "type":  "byte",
+                              "value":  0
+                          },
+          "Conversation":  {
+                               "type":  "resref",
+                               "value":  ""
+                           },
+          "CurrentHP":  {
+                            "type":  "short",
+                            "value":  10
+                        },
+          "Description":  {
+                              "type":  "cexolocstring",
+                              "value":  {
+                                            "0":  ""
+                                        }
+                          },
+          "DisarmDC":  {
+                           "type":  "byte",
+                           "value":  0
+                       },
+          "Faction":  {
+                          "type":  "dword",
+                          "value":  1
+                      },
+          "Fort":  {
+                       "type":  "byte",
+                       "value":  5
+                   },
+          "Hardness":  {
+                           "type":  "byte",
+                           "value":  5
+                       },
+          "HasInventory":  {
+                               "type":  "byte",
+                               "value":  0
+                           },
+          "HP":  {
+                     "type":  "short",
+                     "value":  10
+                 },
+          "Interruptable":  {
+                                "type":  "byte",
+                                "value":  1
+                            },
+          "KeyName":  {
+                          "type":  "cexostring",
+                          "value":  ""
+                      },
+          "KeyRequired":  {
+                              "type":  "byte",
+                              "value":  0
+                          },
+          "Lockable":  {
+                           "type":  "byte",
+                           "value":  0
+                       },
+          "Locked":  {
+                         "type":  "byte",
+                         "value":  0
+                     },
+          "LocName":  {
+                          "type":  "cexolocstring",
+                          "value":  {
+                                        "0":  "Taxi Terminal"
+                                    }
+                      },
+          "OnClick":  {
+                          "type":  "resref",
+                          "value":  ""
+                      },
+          "OnClosed":  {
+                           "type":  "resref",
+                           "value":  ""
+                       },
+          "OnDamaged":  {
+                            "type":  "resref",
+                            "value":  ""
+                        },
+          "OnDeath":  {
+                          "type":  "resref",
+                          "value":  ""
+                      },
+          "OnDisarm":  {
+                           "type":  "resref",
+                           "value":  ""
+                       },
+          "OnHeartbeat":  {
+                              "type":  "resref",
+                              "value":  ""
+                          },
+          "OnInvDisturbed":  {
+                                 "type":  "resref",
+                                 "value":  ""
+                             },
+          "OnLock":  {
+                         "type":  "resref",
+                         "value":  ""
+                     },
+          "OnMeleeAttacked":  {
+                                  "type":  "resref",
+                                  "value":  ""
+                              },
+          "OnOpen":  {
+                         "type":  "resref",
+                         "value":  ""
+                     },
+          "OnSpellCastAt":  {
+                                "type":  "resref",
+                                "value":  ""
+                            },
+          "OnTrapTriggered":  {
+                                  "type":  "resref",
+                                  "value":  ""
+                              },
+          "OnUnlock":  {
+                           "type":  "resref",
+                           "value":  ""
+                       },
+          "OnUsed":  {
+                         "type":  "resref",
+                         "value":  "dialog_start"
+                     },
+          "OnUserDefined":  {
+                                "type":  "resref",
+                                "value":  ""
+                            },
+          "OpenLockDC":  {
+                             "type":  "byte",
+                             "value":  0
+                         },
+          "Plot":  {
+                       "type":  "byte",
+                       "value":  1
+                   },
+          "PortraitId":  {
+                             "type":  "word",
+                             "value":  0
+                         },
+          "Ref":  {
+                      "type":  "byte",
+                      "value":  0
+                  },
+          "Static":  {
+                         "type":  "byte",
+                         "value":  0
+                     },
+          "Tag":  {
+                      "type":  "cexostring",
+                      "value":  "taxi_terminal"
+                  },
+          "TemplateResRef":  {
+                                 "type":  "resref",
+                                 "value":  "taxi_terminal"
+                             },
+          "TrapDetectable":  {
+                                 "type":  "byte",
+                                 "value":  1
+                             },
+          "TrapDetectDC":  {
+                               "type":  "byte",
+                               "value":  0
+                           },
+          "TrapDisarmable":  {
+                                 "type":  "byte",
+                                 "value":  1
+                             },
+          "TrapFlag":  {
+                           "type":  "byte",
+                           "value":  0
+                       },
+          "TrapOneShot":  {
+                              "type":  "byte",
+                              "value":  1
+                          },
+          "TrapType":  {
+                           "type":  "byte",
+                           "value":  0
+                       },
+          "Type":  {
+                       "type":  "byte",
+                       "value":  0
+                   },
+          "Useable":  {
+                          "type":  "byte",
+                          "value":  1
+                      },
+          "VarTable":  {
+                           "type":  "list",
+                           "value":  [
+                                         {
+                                             "__struct_id":  0,
+                                             "Name":  {
+                                                          "type":  "cexostring",
+                                                          "value":  "TAXI_REGION_ID"
+                                                      },
+                                             "Type":  {
+                                                          "type":  "dword",
+                                                          "value":  1
+                                                      },
+                                             "Value":  {
+                                                           "type":  "int",
+                                                           "value":  1
+                                                       }
+                                         },
+                                         {
+                                             "__struct_id":  0,
+                                             "Name":  {
+                                                          "type":  "cexostring",
+                                                          "value":  "CONVERSATION"
+                                                      },
+                                             "Type":  {
+                                                          "type":  "dword",
+                                                          "value":  3
+                                                      },
+                                             "Value":  {
+                                                           "type":  "cexostring",
+                                                           "value":  "TaxiTerminalDialog"
+                                                       }
+                                         },
+                                         {
+                                             "__struct_id":  0,
+                                             "Name":  {
+                                                          "type":  "cexostring",
+                                                          "value":  "TAXI_DESTINATION_ID"
+                                                      },
+                                             "Type":  {
+                                                          "type":  "dword",
+                                                          "value":  1
+                                                      },
+                                             "Value":  {
+                                                           "type":  "int",
+                                                           "value":  4
+                                                       }
+                                         }
+                                     ]
+                       },
+          "Will":  {
+                       "type":  "byte",
+                       "value":  0
+                   },
+          "X":  {
+                    "type":  "float",
+                    "value":  190.382614135742
+                },
+          "Y":  {
+                    "type":  "float",
+                    "value":  148.731964262324
+                },
+          "Z":  {
+                    "type":  "float",
+                    "value":  0.19999885559082031
+                }
+      },
+      {
+          "__struct_id":  9,
+          "AnimationState":  {
+                                 "type":  "byte",
+                                 "value":  0
+                             },
+          "Appearance":  {
+                             "type":  "dword",
+                             "value":  20627
+                         },
+          "AutoRemoveKey":  {
+                                "type":  "byte",
+                                "value":  0
+                            },
+          "Bearing":  {
+                          "type":  "float",
+                          "value":  0
+                      },
+          "BodyBag":  {
+                          "type":  "byte",
+                          "value":  0
+                      },
+          "CloseLockDC":  {
+                              "type":  "byte",
+                              "value":  0
+                          },
+          "Conversation":  {
+                               "type":  "resref",
+                               "value":  ""
+                           },
+          "CurrentHP":  {
+                            "type":  "short",
+                            "value":  10
+                        },
+          "Description":  {
+                              "type":  "cexolocstring",
+                              "value":  {
+                                            "0":  ""
+                                        }
+                          },
+          "DisarmDC":  {
+                           "type":  "byte",
+                           "value":  0
+                       },
+          "Faction":  {
+                          "type":  "dword",
+                          "value":  1
+                      },
+          "Fort":  {
+                       "type":  "byte",
+                       "value":  5
+                   },
+          "Hardness":  {
+                           "type":  "byte",
+                           "value":  5
+                       },
+          "HasInventory":  {
+                               "type":  "byte",
+                               "value":  0
+                           },
+          "HP":  {
+                     "type":  "short",
+                     "value":  10
+                 },
+          "Interruptable":  {
+                                "type":  "byte",
+                                "value":  1
+                            },
+          "KeyName":  {
+                          "type":  "cexostring",
+                          "value":  ""
+                      },
+          "KeyRequired":  {
+                              "type":  "byte",
+                              "value":  0
+                          },
+          "Lockable":  {
+                           "type":  "byte",
+                           "value":  0
+                       },
+          "Locked":  {
+                         "type":  "byte",
+                         "value":  0
+                     },
+          "LocName":  {
+                          "type":  "cexolocstring",
+                          "value":  {
+                                        "0":  "Taxi Terminal"
+                                    }
+                      },
+          "OnClick":  {
+                          "type":  "resref",
+                          "value":  ""
+                      },
+          "OnClosed":  {
+                           "type":  "resref",
+                           "value":  ""
+                       },
+          "OnDamaged":  {
+                            "type":  "resref",
+                            "value":  ""
+                        },
+          "OnDeath":  {
+                          "type":  "resref",
+                          "value":  ""
+                      },
+          "OnDisarm":  {
+                           "type":  "resref",
+                           "value":  ""
+                       },
+          "OnHeartbeat":  {
+                              "type":  "resref",
+                              "value":  ""
+                          },
+          "OnInvDisturbed":  {
+                                 "type":  "resref",
+                                 "value":  ""
+                             },
+          "OnLock":  {
+                         "type":  "resref",
+                         "value":  ""
+                     },
+          "OnMeleeAttacked":  {
+                                  "type":  "resref",
+                                  "value":  ""
+                              },
+          "OnOpen":  {
+                         "type":  "resref",
+                         "value":  ""
+                     },
+          "OnSpellCastAt":  {
+                                "type":  "resref",
+                                "value":  ""
+                            },
+          "OnTrapTriggered":  {
+                                  "type":  "resref",
+                                  "value":  ""
+                              },
+          "OnUnlock":  {
+                           "type":  "resref",
+                           "value":  ""
+                       },
+          "OnUsed":  {
+                         "type":  "resref",
+                         "value":  "dialog_start"
+                     },
+          "OnUserDefined":  {
+                                "type":  "resref",
+                                "value":  ""
+                            },
+          "OpenLockDC":  {
+                             "type":  "byte",
+                             "value":  0
+                         },
+          "Plot":  {
+                       "type":  "byte",
+                       "value":  1
+                   },
+          "PortraitId":  {
+                             "type":  "word",
+                             "value":  0
+                         },
+          "Ref":  {
+                      "type":  "byte",
+                      "value":  0
+                  },
+          "Static":  {
+                         "type":  "byte",
+                         "value":  0
+                     },
+          "Tag":  {
+                      "type":  "cexostring",
+                      "value":  "taxi_terminal"
+                  },
+          "TemplateResRef":  {
+                                 "type":  "resref",
+                                 "value":  "taxi_terminal"
+                             },
+          "TrapDetectable":  {
+                                 "type":  "byte",
+                                 "value":  1
+                             },
+          "TrapDetectDC":  {
+                               "type":  "byte",
+                               "value":  0
+                           },
+          "TrapDisarmable":  {
+                                 "type":  "byte",
+                                 "value":  1
+                             },
+          "TrapFlag":  {
+                           "type":  "byte",
+                           "value":  0
+                       },
+          "TrapOneShot":  {
+                              "type":  "byte",
+                              "value":  1
+                          },
+          "TrapType":  {
+                           "type":  "byte",
+                           "value":  0
+                       },
+          "Type":  {
+                       "type":  "byte",
+                       "value":  0
+                   },
+          "Useable":  {
+                          "type":  "byte",
+                          "value":  1
+                      },
+          "VarTable":  {
+                           "type":  "list",
+                           "value":  [
+                                         {
+                                             "__struct_id":  0,
+                                             "Name":  {
+                                                          "type":  "cexostring",
+                                                          "value":  "TAXI_REGION_ID"
+                                                      },
+                                             "Type":  {
+                                                          "type":  "dword",
+                                                          "value":  1
+                                                      },
+                                             "Value":  {
+                                                           "type":  "int",
+                                                           "value":  1
+                                                       }
+                                         },
+                                         {
+                                             "__struct_id":  0,
+                                             "Name":  {
+                                                          "type":  "cexostring",
+                                                          "value":  "CONVERSATION"
+                                                      },
+                                             "Type":  {
+                                                          "type":  "dword",
+                                                          "value":  3
+                                                      },
+                                             "Value":  {
+                                                           "type":  "cexostring",
+                                                           "value":  "TaxiTerminalDialog"
+                                                       }
+                                         },
+                                         {
+                                             "__struct_id":  0,
+                                             "Name":  {
+                                                          "type":  "cexostring",
+                                                          "value":  "TAXI_DESTINATION_ID"
+                                                      },
+                                             "Type":  {
+                                                          "type":  "dword",
+                                                          "value":  1
+                                                      },
+                                             "Value":  {
+                                                           "type":  "int",
+                                                           "value":  5
+                                                       }
+                                         }
+                                     ]
+                       },
+          "Will":  {
+                       "type":  "byte",
+                       "value":  0
+                   },
+          "X":  {
+                    "type":  "float",
+                    "value":  186.592620849609
+                },
+          "Y":  {
+                    "type":  "float",
+                    "value":  42.4022561629587
+                },
+          "Z":  {
+                    "type":  "float",
+                    "value":  0.19999885559082031
+                }
+      },
+      {
+          "__struct_id":  9,
+          "AnimationState":  {
+                                 "type":  "byte",
+                                 "value":  0
+                             },
+          "Appearance":  {
+                             "type":  "dword",
+                             "value":  20627
+                         },
+          "AutoRemoveKey":  {
+                                "type":  "byte",
+                                "value":  0
+                            },
+          "Bearing":  {
+                          "type":  "float",
+                          "value":  0
+                      },
+          "BodyBag":  {
+                          "type":  "byte",
+                          "value":  0
+                      },
+          "CloseLockDC":  {
+                              "type":  "byte",
+                              "value":  0
+                          },
+          "Conversation":  {
+                               "type":  "resref",
+                               "value":  ""
+                           },
+          "CurrentHP":  {
+                            "type":  "short",
+                            "value":  10
+                        },
+          "Description":  {
+                              "type":  "cexolocstring",
+                              "value":  {
+                                            "0":  ""
+                                        }
+                          },
+          "DisarmDC":  {
+                           "type":  "byte",
+                           "value":  0
+                       },
+          "Faction":  {
+                          "type":  "dword",
+                          "value":  1
+                      },
+          "Fort":  {
+                       "type":  "byte",
+                       "value":  5
+                   },
+          "Hardness":  {
+                           "type":  "byte",
+                           "value":  5
+                       },
+          "HasInventory":  {
+                               "type":  "byte",
+                               "value":  0
+                           },
+          "HP":  {
+                     "type":  "short",
+                     "value":  10
+                 },
+          "Interruptable":  {
+                                "type":  "byte",
+                                "value":  1
+                            },
+          "KeyName":  {
+                          "type":  "cexostring",
+                          "value":  ""
+                      },
+          "KeyRequired":  {
+                              "type":  "byte",
+                              "value":  0
+                          },
+          "Lockable":  {
+                           "type":  "byte",
+                           "value":  0
+                       },
+          "Locked":  {
+                         "type":  "byte",
+                         "value":  0
+                     },
+          "LocName":  {
+                          "type":  "cexolocstring",
+                          "value":  {
+                                        "0":  "Taxi Terminal"
+                                    }
+                      },
+          "OnClick":  {
+                          "type":  "resref",
+                          "value":  ""
+                      },
+          "OnClosed":  {
+                           "type":  "resref",
+                           "value":  ""
+                       },
+          "OnDamaged":  {
+                            "type":  "resref",
+                            "value":  ""
+                        },
+          "OnDeath":  {
+                          "type":  "resref",
+                          "value":  ""
+                      },
+          "OnDisarm":  {
+                           "type":  "resref",
+                           "value":  ""
+                       },
+          "OnHeartbeat":  {
+                              "type":  "resref",
+                              "value":  ""
+                          },
+          "OnInvDisturbed":  {
+                                 "type":  "resref",
+                                 "value":  ""
+                             },
+          "OnLock":  {
+                         "type":  "resref",
+                         "value":  ""
+                     },
+          "OnMeleeAttacked":  {
+                                  "type":  "resref",
+                                  "value":  ""
+                              },
+          "OnOpen":  {
+                         "type":  "resref",
+                         "value":  ""
+                     },
+          "OnSpellCastAt":  {
+                                "type":  "resref",
+                                "value":  ""
+                            },
+          "OnTrapTriggered":  {
+                                  "type":  "resref",
+                                  "value":  ""
+                              },
+          "OnUnlock":  {
+                           "type":  "resref",
+                           "value":  ""
+                       },
+          "OnUsed":  {
+                         "type":  "resref",
+                         "value":  "dialog_start"
+                     },
+          "OnUserDefined":  {
+                                "type":  "resref",
+                                "value":  ""
+                            },
+          "OpenLockDC":  {
+                             "type":  "byte",
+                             "value":  0
+                         },
+          "Plot":  {
+                       "type":  "byte",
+                       "value":  1
+                   },
+          "PortraitId":  {
+                             "type":  "word",
+                             "value":  0
+                         },
+          "Ref":  {
+                      "type":  "byte",
+                      "value":  0
+                  },
+          "Static":  {
+                         "type":  "byte",
+                         "value":  0
+                     },
+          "Tag":  {
+                      "type":  "cexostring",
+                      "value":  "taxi_terminal"
+                  },
+          "TemplateResRef":  {
+                                 "type":  "resref",
+                                 "value":  "taxi_terminal"
+                             },
+          "TrapDetectable":  {
+                                 "type":  "byte",
+                                 "value":  1
+                             },
+          "TrapDetectDC":  {
+                               "type":  "byte",
+                               "value":  0
+                           },
+          "TrapDisarmable":  {
+                                 "type":  "byte",
+                                 "value":  1
+                             },
+          "TrapFlag":  {
+                           "type":  "byte",
+                           "value":  0
+                       },
+          "TrapOneShot":  {
+                              "type":  "byte",
+                              "value":  1
+                          },
+          "TrapType":  {
+                           "type":  "byte",
+                           "value":  0
+                       },
+          "Type":  {
+                       "type":  "byte",
+                       "value":  0
+                   },
+          "Useable":  {
+                          "type":  "byte",
+                          "value":  1
+                      },
+          "VarTable":  {
+                           "type":  "list",
+                           "value":  [
+                                         {
+                                             "__struct_id":  0,
+                                             "Name":  {
+                                                          "type":  "cexostring",
+                                                          "value":  "TAXI_REGION_ID"
+                                                      },
+                                             "Type":  {
+                                                          "type":  "dword",
+                                                          "value":  1
+                                                      },
+                                             "Value":  {
+                                                           "type":  "int",
+                                                           "value":  1
+                                                       }
+                                         },
+                                         {
+                                             "__struct_id":  0,
+                                             "Name":  {
+                                                          "type":  "cexostring",
+                                                          "value":  "CONVERSATION"
+                                                      },
+                                             "Type":  {
+                                                          "type":  "dword",
+                                                          "value":  3
+                                                      },
+                                             "Value":  {
+                                                           "type":  "cexostring",
+                                                           "value":  "TaxiTerminalDialog"
+                                                       }
+                                         },
+                                         {
+                                             "__struct_id":  0,
+                                             "Name":  {
+                                                          "type":  "cexostring",
+                                                          "value":  "TAXI_DESTINATION_ID"
+                                                      },
+                                             "Type":  {
+                                                          "type":  "dword",
+                                                          "value":  1
+                                                      },
+                                             "Value":  {
+                                                           "type":  "int",
+                                                           "value":  6
+                                                       }
+                                         }
+                                     ]
+                       },
+          "Will":  {
+                       "type":  "byte",
+                       "value":  0
+                   },
+          "X":  {
+                    "type":  "float",
+                    "value":  157.672409057617
+                },
+          "Y":  {
+                    "type":  "float",
+                    "value":  101.410179138184
+                },
+          "Z":  {
+                    "type":  "float",
+                    "value":  0.29999160766601563
+                }
+      },
+      {
+          "__struct_id":  9,
+          "AnimationState":  {
+                                 "type":  "byte",
+                                 "value":  0
+                             },
+          "Appearance":  {
+                             "type":  "dword",
+                             "value":  20627
+                         },
+          "AutoRemoveKey":  {
+                                "type":  "byte",
+                                "value":  0
+                            },
+          "Bearing":  {
+                          "type":  "float",
+                          "value":  0
+                      },
+          "BodyBag":  {
+                          "type":  "byte",
+                          "value":  0
+                      },
+          "CloseLockDC":  {
+                              "type":  "byte",
+                              "value":  0
+                          },
+          "Conversation":  {
+                               "type":  "resref",
+                               "value":  ""
+                           },
+          "CurrentHP":  {
+                            "type":  "short",
+                            "value":  10
+                        },
+          "Description":  {
+                              "type":  "cexolocstring",
+                              "value":  {
+                                            "0":  ""
+                                        }
+                          },
+          "DisarmDC":  {
+                           "type":  "byte",
+                           "value":  0
+                       },
+          "Faction":  {
+                          "type":  "dword",
+                          "value":  1
+                      },
+          "Fort":  {
+                       "type":  "byte",
+                       "value":  5
+                   },
+          "Hardness":  {
+                           "type":  "byte",
+                           "value":  5
+                       },
+          "HasInventory":  {
+                               "type":  "byte",
+                               "value":  0
+                           },
+          "HP":  {
+                     "type":  "short",
+                     "value":  10
+                 },
+          "Interruptable":  {
+                                "type":  "byte",
+                                "value":  1
+                            },
+          "KeyName":  {
+                          "type":  "cexostring",
+                          "value":  ""
+                      },
+          "KeyRequired":  {
+                              "type":  "byte",
+                              "value":  0
+                          },
+          "Lockable":  {
+                           "type":  "byte",
+                           "value":  0
+                       },
+          "Locked":  {
+                         "type":  "byte",
+                         "value":  0
+                     },
+          "LocName":  {
+                          "type":  "cexolocstring",
+                          "value":  {
+                                        "0":  "Taxi Terminal"
+                                    }
+                      },
+          "OnClick":  {
+                          "type":  "resref",
+                          "value":  ""
+                      },
+          "OnClosed":  {
+                           "type":  "resref",
+                           "value":  ""
+                       },
+          "OnDamaged":  {
+                            "type":  "resref",
+                            "value":  ""
+                        },
+          "OnDeath":  {
+                          "type":  "resref",
+                          "value":  ""
+                      },
+          "OnDisarm":  {
+                           "type":  "resref",
+                           "value":  ""
+                       },
+          "OnHeartbeat":  {
+                              "type":  "resref",
+                              "value":  ""
+                          },
+          "OnInvDisturbed":  {
+                                 "type":  "resref",
+                                 "value":  ""
+                             },
+          "OnLock":  {
+                         "type":  "resref",
+                         "value":  ""
+                     },
+          "OnMeleeAttacked":  {
+                                  "type":  "resref",
+                                  "value":  ""
+                              },
+          "OnOpen":  {
+                         "type":  "resref",
+                         "value":  ""
+                     },
+          "OnSpellCastAt":  {
+                                "type":  "resref",
+                                "value":  ""
+                            },
+          "OnTrapTriggered":  {
+                                  "type":  "resref",
+                                  "value":  ""
+                              },
+          "OnUnlock":  {
+                           "type":  "resref",
+                           "value":  ""
+                       },
+          "OnUsed":  {
+                         "type":  "resref",
+                         "value":  "dialog_start"
+                     },
+          "OnUserDefined":  {
+                                "type":  "resref",
+                                "value":  ""
+                            },
+          "OpenLockDC":  {
+                             "type":  "byte",
+                             "value":  0
+                         },
+          "Plot":  {
+                       "type":  "byte",
+                       "value":  1
+                   },
+          "PortraitId":  {
+                             "type":  "word",
+                             "value":  0
+                         },
+          "Ref":  {
+                      "type":  "byte",
+                      "value":  0
+                  },
+          "Static":  {
+                         "type":  "byte",
+                         "value":  0
+                     },
+          "Tag":  {
+                      "type":  "cexostring",
+                      "value":  "taxi_terminal"
+                  },
+          "TemplateResRef":  {
+                                 "type":  "resref",
+                                 "value":  "taxi_terminal"
+                             },
+          "TrapDetectable":  {
+                                 "type":  "byte",
+                                 "value":  1
+                             },
+          "TrapDetectDC":  {
+                               "type":  "byte",
+                               "value":  0
+                           },
+          "TrapDisarmable":  {
+                                 "type":  "byte",
+                                 "value":  1
+                             },
+          "TrapFlag":  {
+                           "type":  "byte",
+                           "value":  0
+                       },
+          "TrapOneShot":  {
+                              "type":  "byte",
+                              "value":  1
+                          },
+          "TrapType":  {
+                           "type":  "byte",
+                           "value":  0
+                       },
+          "Type":  {
+                       "type":  "byte",
+                       "value":  0
+                   },
+          "Useable":  {
+                          "type":  "byte",
+                          "value":  1
+                      },
+          "VarTable":  {
+                           "type":  "list",
+                           "value":  [
+                                         {
+                                             "__struct_id":  0,
+                                             "Name":  {
+                                                          "type":  "cexostring",
+                                                          "value":  "TAXI_REGION_ID"
+                                                      },
+                                             "Type":  {
+                                                          "type":  "dword",
+                                                          "value":  1
+                                                      },
+                                             "Value":  {
+                                                           "type":  "int",
+                                                           "value":  1
+                                                       }
+                                         },
+                                         {
+                                             "__struct_id":  0,
+                                             "Name":  {
+                                                          "type":  "cexostring",
+                                                          "value":  "CONVERSATION"
+                                                      },
+                                             "Type":  {
+                                                          "type":  "dword",
+                                                          "value":  3
+                                                      },
+                                             "Value":  {
+                                                           "type":  "cexostring",
+                                                           "value":  "TaxiTerminalDialog"
+                                                       }
+                                         },
+                                         {
+                                             "__struct_id":  0,
+                                             "Name":  {
+                                                          "type":  "cexostring",
+                                                          "value":  "TAXI_DESTINATION_ID"
+                                                      },
+                                             "Type":  {
+                                                          "type":  "dword",
+                                                          "value":  1
+                                                      },
+                                             "Value":  {
+                                                           "type":  "int",
+                                                           "value":  7
+                                                       }
+                                         }
+                                     ]
+                       },
+          "Will":  {
+                       "type":  "byte",
+                       "value":  0
+                   },
+          "X":  {
+                    "type":  "float",
+                    "value":  36.0421028137207
+                },
+          "Y":  {
+                    "type":  "float",
+                    "value":  177.244781645136
+                },
+          "Z":  {
+                    "type":  "float",
+                    "value":  0.29999199509620672
+                }
+      },
+      {
+          "__struct_id":  9,
+          "AnimationState":  {
+                                 "type":  "byte",
+                                 "value":  0
+                             },
+          "Appearance":  {
+                             "type":  "dword",
+                             "value":  20627
+                         },
+          "AutoRemoveKey":  {
+                                "type":  "byte",
+                                "value":  0
+                            },
+          "Bearing":  {
+                          "type":  "float",
+                          "value":  0
+                      },
+          "BodyBag":  {
+                          "type":  "byte",
+                          "value":  0
+                      },
+          "CloseLockDC":  {
+                              "type":  "byte",
+                              "value":  0
+                          },
+          "Conversation":  {
+                               "type":  "resref",
+                               "value":  ""
+                           },
+          "CurrentHP":  {
+                            "type":  "short",
+                            "value":  10
+                        },
+          "Description":  {
+                              "type":  "cexolocstring",
+                              "value":  {
+                                            "0":  ""
+                                        }
+                          },
+          "DisarmDC":  {
+                           "type":  "byte",
+                           "value":  0
+                       },
+          "Faction":  {
+                          "type":  "dword",
+                          "value":  1
+                      },
+          "Fort":  {
+                       "type":  "byte",
+                       "value":  5
+                   },
+          "Hardness":  {
+                           "type":  "byte",
+                           "value":  5
+                       },
+          "HasInventory":  {
+                               "type":  "byte",
+                               "value":  0
+                           },
+          "HP":  {
+                     "type":  "short",
+                     "value":  10
+                 },
+          "Interruptable":  {
+                                "type":  "byte",
+                                "value":  1
+                            },
+          "KeyName":  {
+                          "type":  "cexostring",
+                          "value":  ""
+                      },
+          "KeyRequired":  {
+                              "type":  "byte",
+                              "value":  0
+                          },
+          "Lockable":  {
+                           "type":  "byte",
+                           "value":  0
+                       },
+          "Locked":  {
+                         "type":  "byte",
+                         "value":  0
+                     },
+          "LocName":  {
+                          "type":  "cexolocstring",
+                          "value":  {
+                                        "0":  "Taxi Terminal"
+                                    }
+                      },
+          "OnClick":  {
+                          "type":  "resref",
+                          "value":  ""
+                      },
+          "OnClosed":  {
+                           "type":  "resref",
+                           "value":  ""
+                       },
+          "OnDamaged":  {
+                            "type":  "resref",
+                            "value":  ""
+                        },
+          "OnDeath":  {
+                          "type":  "resref",
+                          "value":  ""
+                      },
+          "OnDisarm":  {
+                           "type":  "resref",
+                           "value":  ""
+                       },
+          "OnHeartbeat":  {
+                              "type":  "resref",
+                              "value":  ""
+                          },
+          "OnInvDisturbed":  {
+                                 "type":  "resref",
+                                 "value":  ""
+                             },
+          "OnLock":  {
+                         "type":  "resref",
+                         "value":  ""
+                     },
+          "OnMeleeAttacked":  {
+                                  "type":  "resref",
+                                  "value":  ""
+                              },
+          "OnOpen":  {
+                         "type":  "resref",
+                         "value":  ""
+                     },
+          "OnSpellCastAt":  {
+                                "type":  "resref",
+                                "value":  ""
+                            },
+          "OnTrapTriggered":  {
+                                  "type":  "resref",
+                                  "value":  ""
+                              },
+          "OnUnlock":  {
+                           "type":  "resref",
+                           "value":  ""
+                       },
+          "OnUsed":  {
+                         "type":  "resref",
+                         "value":  "dialog_start"
+                     },
+          "OnUserDefined":  {
+                                "type":  "resref",
+                                "value":  ""
+                            },
+          "OpenLockDC":  {
+                             "type":  "byte",
+                             "value":  0
+                         },
+          "Plot":  {
+                       "type":  "byte",
+                       "value":  1
+                   },
+          "PortraitId":  {
+                             "type":  "word",
+                             "value":  0
+                         },
+          "Ref":  {
+                      "type":  "byte",
+                      "value":  0
+                  },
+          "Static":  {
+                         "type":  "byte",
+                         "value":  0
+                     },
+          "Tag":  {
+                      "type":  "cexostring",
+                      "value":  "taxi_terminal"
+                  },
+          "TemplateResRef":  {
+                                 "type":  "resref",
+                                 "value":  "taxi_terminal"
+                             },
+          "TrapDetectable":  {
+                                 "type":  "byte",
+                                 "value":  1
+                             },
+          "TrapDetectDC":  {
+                               "type":  "byte",
+                               "value":  0
+                           },
+          "TrapDisarmable":  {
+                                 "type":  "byte",
+                                 "value":  1
+                             },
+          "TrapFlag":  {
+                           "type":  "byte",
+                           "value":  0
+                       },
+          "TrapOneShot":  {
+                              "type":  "byte",
+                              "value":  1
+                          },
+          "TrapType":  {
+                           "type":  "byte",
+                           "value":  0
+                       },
+          "Type":  {
+                       "type":  "byte",
+                       "value":  0
+                   },
+          "Useable":  {
+                          "type":  "byte",
+                          "value":  1
+                      },
+          "VarTable":  {
+                           "type":  "list",
+                           "value":  [
+                                         {
+                                             "__struct_id":  0,
+                                             "Name":  {
+                                                          "type":  "cexostring",
+                                                          "value":  "TAXI_REGION_ID"
+                                                      },
+                                             "Type":  {
+                                                          "type":  "dword",
+                                                          "value":  1
+                                                      },
+                                             "Value":  {
+                                                           "type":  "int",
+                                                           "value":  1
+                                                       }
+                                         },
+                                         {
+                                             "__struct_id":  0,
+                                             "Name":  {
+                                                          "type":  "cexostring",
+                                                          "value":  "CONVERSATION"
+                                                      },
+                                             "Type":  {
+                                                          "type":  "dword",
+                                                          "value":  3
+                                                      },
+                                             "Value":  {
+                                                           "type":  "cexostring",
+                                                           "value":  "TaxiTerminalDialog"
+                                                       }
+                                         },
+                                         {
+                                             "__struct_id":  0,
+                                             "Name":  {
+                                                          "type":  "cexostring",
+                                                          "value":  "TAXI_DESTINATION_ID"
+                                                      },
+                                             "Type":  {
+                                                          "type":  "dword",
+                                                          "value":  1
+                                                      },
+                                             "Value":  {
+                                                           "type":  "int",
+                                                           "value":  8
+                                                       }
+                                         }
+                                     ]
+                       },
+          "Will":  {
+                       "type":  "byte",
+                       "value":  0
+                   },
+          "X":  {
+                    "type":  "float",
+                    "value":  76.0391693115234
+                },
+          "Y":  {
+                    "type":  "float",
+                    "value":  91.3700942993164
+                },
+          "Z":  {
+                    "type":  "float",
+                    "value":  0.19999885559082031
+                }
+      },
+      {
+          "__struct_id":  9,
+          "AnimationState":  {
+                                 "type":  "byte",
+                                 "value":  0
+                             },
+          "Appearance":  {
+                             "type":  "dword",
+                             "value":  20627
+                         },
+          "AutoRemoveKey":  {
+                                "type":  "byte",
+                                "value":  0
+                            },
+          "Bearing":  {
+                          "type":  "float",
+                          "value":  0
+                      },
+          "BodyBag":  {
+                          "type":  "byte",
+                          "value":  0
+                      },
+          "CloseLockDC":  {
+                              "type":  "byte",
+                              "value":  0
+                          },
+          "Conversation":  {
+                               "type":  "resref",
+                               "value":  ""
+                           },
+          "CurrentHP":  {
+                            "type":  "short",
+                            "value":  10
+                        },
+          "Description":  {
+                              "type":  "cexolocstring",
+                              "value":  {
+                                            "0":  ""
+                                        }
+                          },
+          "DisarmDC":  {
+                           "type":  "byte",
+                           "value":  0
+                       },
+          "Faction":  {
+                          "type":  "dword",
+                          "value":  1
+                      },
+          "Fort":  {
+                       "type":  "byte",
+                       "value":  5
+                   },
+          "Hardness":  {
+                           "type":  "byte",
+                           "value":  5
+                       },
+          "HasInventory":  {
+                               "type":  "byte",
+                               "value":  0
+                           },
+          "HP":  {
+                     "type":  "short",
+                     "value":  10
+                 },
+          "Interruptable":  {
+                                "type":  "byte",
+                                "value":  1
+                            },
+          "KeyName":  {
+                          "type":  "cexostring",
+                          "value":  ""
+                      },
+          "KeyRequired":  {
+                              "type":  "byte",
+                              "value":  0
+                          },
+          "Lockable":  {
+                           "type":  "byte",
+                           "value":  0
+                       },
+          "Locked":  {
+                         "type":  "byte",
+                         "value":  0
+                     },
+          "LocName":  {
+                          "type":  "cexolocstring",
+                          "value":  {
+                                        "0":  "Taxi Terminal"
+                                    }
+                      },
+          "OnClick":  {
+                          "type":  "resref",
+                          "value":  ""
+                      },
+          "OnClosed":  {
+                           "type":  "resref",
+                           "value":  ""
+                       },
+          "OnDamaged":  {
+                            "type":  "resref",
+                            "value":  ""
+                        },
+          "OnDeath":  {
+                          "type":  "resref",
+                          "value":  ""
+                      },
+          "OnDisarm":  {
+                           "type":  "resref",
+                           "value":  ""
+                       },
+          "OnHeartbeat":  {
+                              "type":  "resref",
+                              "value":  ""
+                          },
+          "OnInvDisturbed":  {
+                                 "type":  "resref",
+                                 "value":  ""
+                             },
+          "OnLock":  {
+                         "type":  "resref",
+                         "value":  ""
+                     },
+          "OnMeleeAttacked":  {
+                                  "type":  "resref",
+                                  "value":  ""
+                              },
+          "OnOpen":  {
+                         "type":  "resref",
+                         "value":  ""
+                     },
+          "OnSpellCastAt":  {
+                                "type":  "resref",
+                                "value":  ""
+                            },
+          "OnTrapTriggered":  {
+                                  "type":  "resref",
+                                  "value":  ""
+                              },
+          "OnUnlock":  {
+                           "type":  "resref",
+                           "value":  ""
+                       },
+          "OnUsed":  {
+                         "type":  "resref",
+                         "value":  "dialog_start"
+                     },
+          "OnUserDefined":  {
+                                "type":  "resref",
+                                "value":  ""
+                            },
+          "OpenLockDC":  {
+                             "type":  "byte",
+                             "value":  0
+                         },
+          "Plot":  {
+                       "type":  "byte",
+                       "value":  1
+                   },
+          "PortraitId":  {
+                             "type":  "word",
+                             "value":  0
+                         },
+          "Ref":  {
+                      "type":  "byte",
+                      "value":  0
+                  },
+          "Static":  {
+                         "type":  "byte",
+                         "value":  0
+                     },
+          "Tag":  {
+                      "type":  "cexostring",
+                      "value":  "taxi_terminal"
+                  },
+          "TemplateResRef":  {
+                                 "type":  "resref",
+                                 "value":  "taxi_terminal"
+                             },
+          "TrapDetectable":  {
+                                 "type":  "byte",
+                                 "value":  1
+                             },
+          "TrapDetectDC":  {
+                               "type":  "byte",
+                               "value":  0
+                           },
+          "TrapDisarmable":  {
+                                 "type":  "byte",
+                                 "value":  1
+                             },
+          "TrapFlag":  {
+                           "type":  "byte",
+                           "value":  0
+                       },
+          "TrapOneShot":  {
+                              "type":  "byte",
+                              "value":  1
+                          },
+          "TrapType":  {
+                           "type":  "byte",
+                           "value":  0
+                       },
+          "Type":  {
+                       "type":  "byte",
+                       "value":  0
+                   },
+          "Useable":  {
+                          "type":  "byte",
+                          "value":  1
+                      },
+          "VarTable":  {
+                           "type":  "list",
+                           "value":  [
+                                         {
+                                             "__struct_id":  0,
+                                             "Name":  {
+                                                          "type":  "cexostring",
+                                                          "value":  "TAXI_REGION_ID"
+                                                      },
+                                             "Type":  {
+                                                          "type":  "dword",
+                                                          "value":  1
+                                                      },
+                                             "Value":  {
+                                                           "type":  "int",
+                                                           "value":  1
+                                                       }
+                                         },
+                                         {
+                                             "__struct_id":  0,
+                                             "Name":  {
+                                                          "type":  "cexostring",
+                                                          "value":  "CONVERSATION"
+                                                      },
+                                             "Type":  {
+                                                          "type":  "dword",
+                                                          "value":  3
+                                                      },
+                                             "Value":  {
+                                                           "type":  "cexostring",
+                                                           "value":  "TaxiTerminalDialog"
+                                                       }
+                                         },
+                                         {
+                                             "__struct_id":  0,
+                                             "Name":  {
+                                                          "type":  "cexostring",
+                                                          "value":  "TAXI_DESTINATION_ID"
+                                                      },
+                                             "Type":  {
+                                                          "type":  "dword",
+                                                          "value":  1
+                                                      },
+                                             "Value":  {
+                                                           "type":  "int",
+                                                           "value":  9
+                                                       }
+                                         }
+                                     ]
+                       },
+          "Will":  {
+                       "type":  "byte",
+                       "value":  0
+                   },
+          "X":  {
+                    "type":  "float",
+                    "value":  160.581620041524
+                },
+          "Y":  {
+                    "type":  "float",
+                    "value":  213.276611328125
+                },
+          "Z":  {
+                    "type":  "float",
+                    "value":  0.19999885559082031
+                }
+      },
+      {
+          "__struct_id":  9,
+          "AnimationState":  {
+                                 "type":  "byte",
+                                 "value":  0
+                             },
+          "Appearance":  {
+                             "type":  "dword",
+                             "value":  20627
+                         },
+          "AutoRemoveKey":  {
+                                "type":  "byte",
+                                "value":  0
+                            },
+          "Bearing":  {
+                          "type":  "float",
+                          "value":  0
+                      },
+          "BodyBag":  {
+                          "type":  "byte",
+                          "value":  0
+                      },
+          "CloseLockDC":  {
+                              "type":  "byte",
+                              "value":  0
+                          },
+          "Conversation":  {
+                               "type":  "resref",
+                               "value":  ""
+                           },
+          "CurrentHP":  {
+                            "type":  "short",
+                            "value":  10
+                        },
+          "Description":  {
+                              "type":  "cexolocstring",
+                              "value":  {
+                                            "0":  ""
+                                        }
+                          },
+          "DisarmDC":  {
+                           "type":  "byte",
+                           "value":  0
+                       },
+          "Faction":  {
+                          "type":  "dword",
+                          "value":  1
+                      },
+          "Fort":  {
+                       "type":  "byte",
+                       "value":  5
+                   },
+          "Hardness":  {
+                           "type":  "byte",
+                           "value":  5
+                       },
+          "HasInventory":  {
+                               "type":  "byte",
+                               "value":  0
+                           },
+          "HP":  {
+                     "type":  "short",
+                     "value":  10
+                 },
+          "Interruptable":  {
+                                "type":  "byte",
+                                "value":  1
+                            },
+          "KeyName":  {
+                          "type":  "cexostring",
+                          "value":  ""
+                      },
+          "KeyRequired":  {
+                              "type":  "byte",
+                              "value":  0
+                          },
+          "Lockable":  {
+                           "type":  "byte",
+                           "value":  0
+                       },
+          "Locked":  {
+                         "type":  "byte",
+                         "value":  0
+                     },
+          "LocName":  {
+                          "type":  "cexolocstring",
+                          "value":  {
+                                        "0":  "Taxi Terminal"
+                                    }
+                      },
+          "OnClick":  {
+                          "type":  "resref",
+                          "value":  ""
+                      },
+          "OnClosed":  {
+                           "type":  "resref",
+                           "value":  ""
+                       },
+          "OnDamaged":  {
+                            "type":  "resref",
+                            "value":  ""
+                        },
+          "OnDeath":  {
+                          "type":  "resref",
+                          "value":  ""
+                      },
+          "OnDisarm":  {
+                           "type":  "resref",
+                           "value":  ""
+                       },
+          "OnHeartbeat":  {
+                              "type":  "resref",
+                              "value":  ""
+                          },
+          "OnInvDisturbed":  {
+                                 "type":  "resref",
+                                 "value":  ""
+                             },
+          "OnLock":  {
+                         "type":  "resref",
+                         "value":  ""
+                     },
+          "OnMeleeAttacked":  {
+                                  "type":  "resref",
+                                  "value":  ""
+                              },
+          "OnOpen":  {
+                         "type":  "resref",
+                         "value":  ""
+                     },
+          "OnSpellCastAt":  {
+                                "type":  "resref",
+                                "value":  ""
+                            },
+          "OnTrapTriggered":  {
+                                  "type":  "resref",
+                                  "value":  ""
+                              },
+          "OnUnlock":  {
+                           "type":  "resref",
+                           "value":  ""
+                       },
+          "OnUsed":  {
+                         "type":  "resref",
+                         "value":  "dialog_start"
+                     },
+          "OnUserDefined":  {
+                                "type":  "resref",
+                                "value":  ""
+                            },
+          "OpenLockDC":  {
+                             "type":  "byte",
+                             "value":  0
+                         },
+          "Plot":  {
+                       "type":  "byte",
+                       "value":  1
+                   },
+          "PortraitId":  {
+                             "type":  "word",
+                             "value":  0
+                         },
+          "Ref":  {
+                      "type":  "byte",
+                      "value":  0
+                  },
+          "Static":  {
+                         "type":  "byte",
+                         "value":  0
+                     },
+          "Tag":  {
+                      "type":  "cexostring",
+                      "value":  "taxi_terminal"
+                  },
+          "TemplateResRef":  {
+                                 "type":  "resref",
+                                 "value":  "taxi_terminal"
+                             },
+          "TrapDetectable":  {
+                                 "type":  "byte",
+                                 "value":  1
+                             },
+          "TrapDetectDC":  {
+                               "type":  "byte",
+                               "value":  0
+                           },
+          "TrapDisarmable":  {
+                                 "type":  "byte",
+                                 "value":  1
+                             },
+          "TrapFlag":  {
+                           "type":  "byte",
+                           "value":  0
+                       },
+          "TrapOneShot":  {
+                              "type":  "byte",
+                              "value":  1
+                          },
+          "TrapType":  {
+                           "type":  "byte",
+                           "value":  0
+                       },
+          "Type":  {
+                       "type":  "byte",
+                       "value":  0
+                   },
+          "Useable":  {
+                          "type":  "byte",
+                          "value":  1
+                      },
+          "VarTable":  {
+                           "type":  "list",
+                           "value":  [
+                                         {
+                                             "__struct_id":  0,
+                                             "Name":  {
+                                                          "type":  "cexostring",
+                                                          "value":  "TAXI_REGION_ID"
+                                                      },
+                                             "Type":  {
+                                                          "type":  "dword",
+                                                          "value":  1
+                                                      },
+                                             "Value":  {
+                                                           "type":  "int",
+                                                           "value":  1
+                                                       }
+                                         },
+                                         {
+                                             "__struct_id":  0,
+                                             "Name":  {
+                                                          "type":  "cexostring",
+                                                          "value":  "CONVERSATION"
+                                                      },
+                                             "Type":  {
+                                                          "type":  "dword",
+                                                          "value":  3
+                                                      },
+                                             "Value":  {
+                                                           "type":  "cexostring",
+                                                           "value":  "TaxiTerminalDialog"
+                                                       }
+                                         },
+                                         {
+                                             "__struct_id":  0,
+                                             "Name":  {
+                                                          "type":  "cexostring",
+                                                          "value":  "TAXI_DESTINATION_ID"
+                                                      },
+                                             "Type":  {
+                                                          "type":  "dword",
+                                                          "value":  1
+                                                      },
+                                             "Value":  {
+                                                           "type":  "int",
+                                                           "value":  10
+                                                       }
+                                         }
+                                     ]
+                       },
+          "Will":  {
+                       "type":  "byte",
+                       "value":  0
+                   },
+          "X":  {
+                    "type":  "float",
+                    "value":  14.0738897323608
+                },
+          "Y":  {
+                    "type":  "float",
+                    "value":  92.8228227217966
+                },
+          "Z":  {
+                    "type":  "float",
+                    "value":  0.19999885559082031
+                }
       }
     ]
   },
@@ -399718,6 +402488,666 @@
           "type": "float",
           "value": 0.1999988555908203
         }
+      },
+      {
+          "__struct_id":  5,
+          "Appearance":  {
+                             "type":  "byte",
+                             "value":  1
+                         },
+          "Description":  {
+                              "type":  "cexolocstring",
+                              "value":  {
+
+                                        }
+                          },
+          "HasMapNote":  {
+                             "type":  "byte",
+                             "value":  0
+                         },
+          "LinkedTo":  {
+                           "type":  "cexostring",
+                           "value":  ""
+                       },
+          "LocalizedName":  {
+                                "id":  14817,
+                                "type":  "cexolocstring",
+                                "value":  {
+
+                                          }
+                            },
+          "MapNote":  {
+                          "type":  "cexolocstring",
+                          "value":  {
+
+                                    }
+                      },
+          "MapNoteEnabled":  {
+                                 "type":  "byte",
+                                 "value":  1
+                             },
+          "Tag":  {
+                      "type":  "cexostring",
+                      "value":  "TAXI_VELES_ENTRANCE"
+                  },
+          "TemplateResRef":  {
+                                 "type":  "resref",
+                                 "value":  "nw_waypoint001"
+                             },
+          "XOrientation":  {
+                               "type":  "float",
+                               "value":  1
+                           },
+          "XPosition":  {
+                            "type":  "float",
+                            "value":  94.910224914550781
+                        },
+          "YOrientation":  {
+                               "type":  "float",
+                               "value":  7.54979012640433E-08
+                           },
+          "YPosition":  {
+                            "type":  "float",
+                            "value":  4.1654882431030273
+                        },
+          "ZPosition":  {
+                            "type":  "float",
+                            "value":  0.19999885559082031
+                        }
+      },
+      {
+          "__struct_id":  5,
+          "Appearance":  {
+                             "type":  "byte",
+                             "value":  1
+                         },
+          "Description":  {
+                              "type":  "cexolocstring",
+                              "value":  {
+
+                                        }
+                          },
+          "HasMapNote":  {
+                             "type":  "byte",
+                             "value":  0
+                         },
+          "LinkedTo":  {
+                           "type":  "cexostring",
+                           "value":  ""
+                       },
+          "LocalizedName":  {
+                                "id":  14817,
+                                "type":  "cexolocstring",
+                                "value":  {
+
+                                          }
+                            },
+          "MapNote":  {
+                          "type":  "cexolocstring",
+                          "value":  {
+
+                                    }
+                      },
+          "MapNoteEnabled":  {
+                                 "type":  "byte",
+                                 "value":  1
+                             },
+          "Tag":  {
+                      "type":  "cexostring",
+                      "value":  "TAXI_VELES_MARKET"
+                  },
+          "TemplateResRef":  {
+                                 "type":  "resref",
+                                 "value":  "nw_waypoint001"
+                             },
+          "XOrientation":  {
+                               "type":  "float",
+                               "value":  1.40129846432482E-45
+                           },
+          "XPosition":  {
+                            "type":  "float",
+                            "value":  145.9610595703125
+                        },
+          "YOrientation":  {
+                               "type":  "float",
+                               "value":  -1
+                           },
+          "YPosition":  {
+                            "type":  "float",
+                            "value":  171.5067138671875
+                        },
+          "ZPosition":  {
+                            "type":  "float",
+                            "value":  0.19999885559082031
+                        }
+      },
+      {
+          "__struct_id":  5,
+          "Appearance":  {
+                             "type":  "byte",
+                             "value":  1
+                         },
+          "Description":  {
+                              "type":  "cexolocstring",
+                              "value":  {
+
+                                        }
+                          },
+          "HasMapNote":  {
+                             "type":  "byte",
+                             "value":  0
+                         },
+          "LinkedTo":  {
+                           "type":  "cexostring",
+                           "value":  ""
+                       },
+          "LocalizedName":  {
+                                "id":  14817,
+                                "type":  "cexolocstring",
+                                "value":  {
+
+                                          }
+                            },
+          "MapNote":  {
+                          "type":  "cexolocstring",
+                          "value":  {
+
+                                    }
+                      },
+          "MapNoteEnabled":  {
+                                 "type":  "byte",
+                                 "value":  1
+                             },
+          "Tag":  {
+                      "type":  "cexostring",
+                      "value":  "TAXI_VELES_CZERKATOWER"
+                  },
+          "TemplateResRef":  {
+                                 "type":  "resref",
+                                 "value":  "nw_waypoint001"
+                             },
+          "XOrientation":  {
+                               "type":  "float",
+                               "value":  1.63531530786706E-42
+                           },
+          "XPosition":  {
+                            "type":  "float",
+                            "value":  115.0037841796875
+                        },
+          "YOrientation":  {
+                               "type":  "float",
+                               "value":  -1
+                           },
+          "YPosition":  {
+                            "type":  "float",
+                            "value":  185.21073913574219
+                        },
+          "ZPosition":  {
+                            "type":  "float",
+                            "value":  0.19999885559082031
+                        }
+      },
+      {
+          "__struct_id":  5,
+          "Appearance":  {
+                             "type":  "byte",
+                             "value":  1
+                         },
+          "Description":  {
+                              "type":  "cexolocstring",
+                              "value":  {
+
+                                        }
+                          },
+          "HasMapNote":  {
+                             "type":  "byte",
+                             "value":  0
+                         },
+          "LinkedTo":  {
+                           "type":  "cexostring",
+                           "value":  ""
+                       },
+          "LocalizedName":  {
+                                "id":  14817,
+                                "type":  "cexolocstring",
+                                "value":  {
+
+                                          }
+                            },
+          "MapNote":  {
+                          "type":  "cexolocstring",
+                          "value":  {
+
+                                    }
+                      },
+          "MapNoteEnabled":  {
+                                 "type":  "byte",
+                                 "value":  1
+                             },
+          "Tag":  {
+                      "type":  "cexostring",
+                      "value":  "TAXI_VELES_COUNCIL"
+                  },
+          "TemplateResRef":  {
+                                 "type":  "resref",
+                                 "value":  "nw_waypoint001"
+                             },
+          "XOrientation":  {
+                               "type":  "float",
+                               "value":  -1
+                           },
+          "XPosition":  {
+                            "type":  "float",
+                            "value":  192.38261413574219
+                        },
+          "YOrientation":  {
+                               "type":  "float",
+                               "value":  7.54979012640433E-08
+                           },
+          "YPosition":  {
+                            "type":  "float",
+                            "value":  148.7319641113281
+                        },
+          "ZPosition":  {
+                            "type":  "float",
+                            "value":  0.19999885559082031
+                        }
+      },
+      {
+          "__struct_id":  5,
+          "Appearance":  {
+                             "type":  "byte",
+                             "value":  1
+                         },
+          "Description":  {
+                              "type":  "cexolocstring",
+                              "value":  {
+
+                                        }
+                          },
+          "HasMapNote":  {
+                             "type":  "byte",
+                             "value":  0
+                         },
+          "LinkedTo":  {
+                           "type":  "cexostring",
+                           "value":  ""
+                       },
+          "LocalizedName":  {
+                                "id":  14817,
+                                "type":  "cexolocstring",
+                                "value":  {
+
+                                          }
+                            },
+          "MapNote":  {
+                          "type":  "cexolocstring",
+                          "value":  {
+
+                                    }
+                      },
+          "MapNoteEnabled":  {
+                                 "type":  "byte",
+                                 "value":  1
+                             },
+          "Tag":  {
+                      "type":  "cexostring",
+                      "value":  "TAXI_VELES_MEDICAL"
+                  },
+          "TemplateResRef":  {
+                                 "type":  "resref",
+                                 "value":  "nw_waypoint001"
+                             },
+          "XOrientation":  {
+                               "type":  "float",
+                               "value":  -1
+                           },
+          "XPosition":  {
+                            "type":  "float",
+                            "value":  188.5926208496094
+                        },
+          "YOrientation":  {
+                               "type":  "float",
+                               "value":  7.54979012640433E-08
+                           },
+          "YPosition":  {
+                            "type":  "float",
+                            "value":  42.402256011962891
+                        },
+          "ZPosition":  {
+                            "type":  "float",
+                            "value":  0.19999885559082031
+                        }
+      },
+      {
+          "__struct_id":  5,
+          "Appearance":  {
+                             "type":  "byte",
+                             "value":  1
+                         },
+          "Description":  {
+                              "type":  "cexolocstring",
+                              "value":  {
+
+                                        }
+                          },
+          "HasMapNote":  {
+                             "type":  "byte",
+                             "value":  0
+                         },
+          "LinkedTo":  {
+                           "type":  "cexostring",
+                           "value":  ""
+                       },
+          "LocalizedName":  {
+                                "id":  14817,
+                                "type":  "cexolocstring",
+                                "value":  {
+
+                                          }
+                            },
+          "MapNote":  {
+                          "type":  "cexolocstring",
+                          "value":  {
+
+                                    }
+                      },
+          "MapNoteEnabled":  {
+                                 "type":  "byte",
+                                 "value":  1
+                             },
+          "Tag":  {
+                      "type":  "cexostring",
+                      "value":  "TAXI_VELES_STARPORT"
+                  },
+          "TemplateResRef":  {
+                                 "type":  "resref",
+                                 "value":  "nw_waypoint001"
+                             },
+          "XOrientation":  {
+                               "type":  "float",
+                               "value":  -1
+                           },
+          "XPosition":  {
+                            "type":  "float",
+                            "value":  159.67240905761719
+                        },
+          "YOrientation":  {
+                               "type":  "float",
+                               "value":  7.07276583790539E-35
+                           },
+          "YPosition":  {
+                            "type":  "float",
+                            "value":  101.41017913818359
+                        },
+          "ZPosition":  {
+                            "type":  "float",
+                            "value":  0.29999160766601563
+                        }
+      },
+      {
+          "__struct_id":  5,
+          "Appearance":  {
+                             "type":  "byte",
+                             "value":  1
+                         },
+          "Description":  {
+                              "type":  "cexolocstring",
+                              "value":  {
+
+                                        }
+                          },
+          "HasMapNote":  {
+                             "type":  "byte",
+                             "value":  0
+                         },
+          "LinkedTo":  {
+                           "type":  "cexostring",
+                           "value":  ""
+                       },
+          "LocalizedName":  {
+                                "id":  14817,
+                                "type":  "cexolocstring",
+                                "value":  {
+
+                                          }
+                            },
+          "MapNote":  {
+                          "type":  "cexolocstring",
+                          "value":  {
+
+                                    }
+                      },
+          "MapNoteEnabled":  {
+                                 "type":  "byte",
+                                 "value":  1
+                             },
+          "Tag":  {
+                      "type":  "cexostring",
+                      "value":  "TAXI_VELES_INDUSTRIAL"
+                  },
+          "TemplateResRef":  {
+                                 "type":  "resref",
+                                 "value":  "nw_waypoint001"
+                             },
+          "XOrientation":  {
+                               "type":  "float",
+                               "value":  1
+                           },
+          "XPosition":  {
+                            "type":  "float",
+                            "value":  34.0421028137207
+                        },
+          "YOrientation":  {
+                               "type":  "float",
+                               "value":  7.54979012640433E-08
+                           },
+          "YPosition":  {
+                            "type":  "float",
+                            "value":  177.2447814941406
+                        },
+          "ZPosition":  {
+                            "type":  "float",
+                            "value":  0.29999199509620672
+                        }
+      },
+      {
+          "__struct_id":  5,
+          "Appearance":  {
+                             "type":  "byte",
+                             "value":  1
+                         },
+          "Description":  {
+                              "type":  "cexolocstring",
+                              "value":  {
+
+                                        }
+                          },
+          "HasMapNote":  {
+                             "type":  "byte",
+                             "value":  0
+                         },
+          "LinkedTo":  {
+                           "type":  "cexostring",
+                           "value":  ""
+                       },
+          "LocalizedName":  {
+                                "id":  14817,
+                                "type":  "cexolocstring",
+                                "value":  {
+
+                                          }
+                            },
+          "MapNote":  {
+                          "type":  "cexolocstring",
+                          "value":  {
+
+                                    }
+                      },
+          "MapNoteEnabled":  {
+                                 "type":  "byte",
+                                 "value":  1
+                             },
+          "Tag":  {
+                      "type":  "cexostring",
+                      "value":  "TAXI_VELES_CANTINA"
+                  },
+          "TemplateResRef":  {
+                                 "type":  "resref",
+                                 "value":  "nw_waypoint001"
+                             },
+          "XOrientation":  {
+                               "type":  "float",
+                               "value":  1.40129846432482E-45
+                           },
+          "XPosition":  {
+                            "type":  "float",
+                            "value":  76.039169311523438
+                        },
+          "YOrientation":  {
+                               "type":  "float",
+                               "value":  1
+                           },
+          "YPosition":  {
+                            "type":  "float",
+                            "value":  89.3700942993164
+                        },
+          "ZPosition":  {
+                            "type":  "float",
+                            "value":  0.19999885559082031
+                        }
+      },
+      {
+          "__struct_id":  5,
+          "Appearance":  {
+                             "type":  "byte",
+                             "value":  1
+                         },
+          "Description":  {
+                              "type":  "cexolocstring",
+                              "value":  {
+
+                                        }
+                          },
+          "HasMapNote":  {
+                             "type":  "byte",
+                             "value":  0
+                         },
+          "LinkedTo":  {
+                           "type":  "cexostring",
+                           "value":  ""
+                       },
+          "LocalizedName":  {
+                                "id":  14817,
+                                "type":  "cexolocstring",
+                                "value":  {
+
+                                          }
+                            },
+          "MapNote":  {
+                          "type":  "cexolocstring",
+                          "value":  {
+
+                                    }
+                      },
+          "MapNoteEnabled":  {
+                                 "type":  "byte",
+                                 "value":  1
+                             },
+          "Tag":  {
+                      "type":  "cexostring",
+                      "value":  "TAXI_VELES_RESIDENTIAL"
+                  },
+          "TemplateResRef":  {
+                                 "type":  "resref",
+                                 "value":  "nw_waypoint001"
+                             },
+          "XOrientation":  {
+                               "type":  "float",
+                               "value":  3.89414367418794E-07
+                           },
+          "XPosition":  {
+                            "type":  "float",
+                            "value":  160.58161926269531
+                        },
+          "YOrientation":  {
+                               "type":  "float",
+                               "value":  -1
+                           },
+          "YPosition":  {
+                            "type":  "float",
+                            "value":  215.276611328125
+                        },
+          "ZPosition":  {
+                            "type":  "float",
+                            "value":  0.19999885559082031
+                        }
+      },
+      {
+          "__struct_id":  5,
+          "Appearance":  {
+                             "type":  "byte",
+                             "value":  1
+                         },
+          "Description":  {
+                              "type":  "cexolocstring",
+                              "value":  {
+
+                                        }
+                          },
+          "HasMapNote":  {
+                             "type":  "byte",
+                             "value":  0
+                         },
+          "LinkedTo":  {
+                           "type":  "cexostring",
+                           "value":  ""
+                       },
+          "LocalizedName":  {
+                                "id":  14817,
+                                "type":  "cexolocstring",
+                                "value":  {
+
+                                          }
+                            },
+          "MapNote":  {
+                          "type":  "cexolocstring",
+                          "value":  {
+
+                                    }
+                      },
+          "MapNoteEnabled":  {
+                                 "type":  "byte",
+                                 "value":  1
+                             },
+          "Tag":  {
+                      "type":  "cexostring",
+                      "value":  "TAXI_VELES_APARTMENT"
+                  },
+          "TemplateResRef":  {
+                                 "type":  "resref",
+                                 "value":  "nw_waypoint001"
+                             },
+          "XOrientation":  {
+                               "type":  "float",
+                               "value":  1
+                           },
+          "XPosition":  {
+                            "type":  "float",
+                            "value":  12.07388973236084
+                        },
+          "YOrientation":  {
+                               "type":  "float",
+                               "value":  7.54979012640433E-08
+                           },
+          "YPosition":  {
+                            "type":  "float",
+                            "value":  92.822822570800781
+                        },
+          "ZPosition":  {
+                            "type":  "float",
+                            "value":  0.19999885559082031
+                        }
       }
     ]
   }

--- a/SWLOR.Game.Server/Feature/DialogDefinition/TaxiTerminalDialog.cs
+++ b/SWLOR.Game.Server/Feature/DialogDefinition/TaxiTerminalDialog.cs
@@ -24,7 +24,7 @@ namespace SWLOR.Game.Server.Feature.DialogDefinition
 
             var player = GetPC();
             var regionId = GetLocalInt(OBJECT_SELF, "TAXI_REGION_ID");
-            var destinations = Taxi.GetDestinationsByRegionId(regionId);
+            var destinations = Taxi.GetAvailableDestinationsByRegionId(regionId);
             var destinationId = GetLocalInt(OBJECT_SELF, "TAXI_DESTINATION_ID");
             var destinationType = (TaxiDestinationType) destinationId;
 
@@ -35,7 +35,9 @@ namespace SWLOR.Game.Server.Feature.DialogDefinition
                 {
                     page.AddResponse(ColorToken.Green($"{destination.Value.Name}"), () =>
                     {
-                        var location = GetLocation(GetWaypointByTag(destination.Value.WaypointTag));
+                        if (!Taxi.TryGetDestinationLocation(destination.Value, out var location))
+                            return;
+
                         AssignCommand(player, () =>
                         {
                             ClearAllActions();
@@ -57,8 +59,9 @@ namespace SWLOR.Game.Server.Feature.DialogDefinition
                 var dbPlayer = DB.Get<Player>(playerId);
 
                 // Register Location option
-                if (!dbPlayer.TaxiDestinations.ContainsKey(regionId) ||
-                    !dbPlayer.TaxiDestinations[regionId].Contains(destinationType))
+                if (destinations.ContainsKey(destinationType) &&
+                    (!dbPlayer.TaxiDestinations.ContainsKey(regionId) ||
+                     !dbPlayer.TaxiDestinations[regionId].Contains(destinationType)))
                 {
                     page.AddResponse(ColorToken.Green("[REGISTER LOCATION]"), () =>
                     {
@@ -84,7 +87,9 @@ namespace SWLOR.Game.Server.Feature.DialogDefinition
                                 return;
                             }
 
-                            var location = GetLocation(GetWaypointByTag(destination.Value.WaypointTag));
+                            if (!Taxi.TryGetDestinationLocation(destination.Value, out var location))
+                                return;
+
                             AssignCommand(player, () =>
                             {
                                 ClearAllActions();

--- a/SWLOR.Game.Server/Feature/PlayerInitialization.cs
+++ b/SWLOR.Game.Server/Feature/PlayerInitialization.cs
@@ -355,12 +355,11 @@ namespace SWLOR.Game.Server.Feature
         /// <param name="dbPlayer">The player's database entity.</param>
         private static void RegisterDefaultRespawnPoint(Player dbPlayer)
         {
-            const string DefaultRespawnWaypointTag = "DTH_DEFAULT_RESPAWN_POINT";
-            var waypoint = GetWaypointByTag(DefaultRespawnWaypointTag);
+            var waypoint = GetWaypointByTag(Death.DefaultRespawnWaypointTag);
 
             if (!GetIsObjectValid(waypoint))
             {
-                Log.Write(LogGroup.Error, $"Default respawn waypoint could not be located. Did you place a waypoint with the tag 'DTH_DEFAULT_RESPAWN_POINT'?");
+                Log.Write(LogGroup.Error, $"Default respawn waypoint could not be located. Did you place a waypoint with the tag '{Death.DefaultRespawnWaypointTag}'?");
                 return;
             }
 

--- a/SWLOR.Game.Server/Service/Death.cs
+++ b/SWLOR.Game.Server/Service/Death.cs
@@ -8,6 +8,8 @@ namespace SWLOR.Game.Server.Service
 {
     public class Death
     {
+        public const string DefaultRespawnWaypointTag = "DTH_DEFAULT_RESPAWN_POINT";
+
         /// <summary>
         /// When a player starts dying, instantly kill them.
         /// </summary>
@@ -98,7 +100,14 @@ namespace SWLOR.Game.Server.Service
             // Already have a respawn point, no need to set the default one.
             if (!string.IsNullOrWhiteSpace(dbPlayer.RespawnAreaResref)) return;
 
-            var waypoint = GetWaypointByTag("DEATH_DEFAULT_RESPAWN_POINT");
+            var waypoint = GetWaypointByTag(DefaultRespawnWaypointTag);
+
+            if (!GetIsObjectValid(waypoint))
+            {
+                Log.Write(LogGroup.Error, $"Default respawn waypoint could not be located. Did you place a waypoint with the tag '{DefaultRespawnWaypointTag}'?");
+                return;
+            }
+
             var position = GetPosition(waypoint);
             var areaResref = GetResRef(GetArea(waypoint));
             var facing = GetFacing(waypoint);
@@ -147,7 +156,7 @@ namespace SWLOR.Game.Server.Service
 
             if (!GetIsObjectValid(area))
             {
-                var defaultLocation = GetLocation(GetWaypointByTag("DTH_DEFAULT_RESPAWN_POINT"));
+                var defaultLocation = GetLocation(GetWaypointByTag(DefaultRespawnWaypointTag));
                 AssignCommand(player, () => ActionJumpToLocation(defaultLocation));
             }
             else

--- a/SWLOR.Game.Server/Service/Log.cs
+++ b/SWLOR.Game.Server/Service/Log.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Serilog;
 using Serilog.Core;
+using Serilog.Events;
 using SWLOR.Game.Server.Core;
 using SWLOR.Game.Server.Enumeration;
 using SWLOR.Game.Server.Extension;
@@ -74,6 +75,22 @@ namespace SWLOR.Game.Server.Service
         /// <param name="printToConsole">If true, the details will be printed to the console.</param>
         public static void Write(LogGroup group, string details, bool printToConsole = false)
         {
+            Write(group, details, LogEventLevel.Information, printToConsole);
+        }
+
+        /// <summary>
+        /// Writes a warning message to the audit log for a given log group.
+        /// </summary>
+        /// <param name="group">The group to audit this log under.</param>
+        /// <param name="details">The details about the entry which will be written to disk.</param>
+        /// <param name="printToConsole">If true, the details will be printed to the console.</param>
+        public static void WriteWarning(LogGroup group, string details, bool printToConsole = false)
+        {
+            Write(group, details, LogEventLevel.Warning, printToConsole);
+        }
+
+        private static void Write(LogGroup group, string details, LogEventLevel level, bool printToConsole)
+        {
             var settings = ApplicationSettings.Get();
             var logDetail = _logGroups[group];
 
@@ -91,7 +108,7 @@ namespace SWLOR.Game.Server.Service
                 Console.WriteLine(details);
             }
 
-            _loggers[group].Information(details);
+            _loggers[group].Write(level, details);
         }
     }
 }

--- a/SWLOR.Game.Server/Service/Taxi.cs
+++ b/SWLOR.Game.Server/Service/Taxi.cs
@@ -4,7 +4,9 @@ using System.Linq;
 using SWLOR.Game.Server.Core;
 using SWLOR.Game.Server.Entity;
 using SWLOR.Game.Server.Extension;
+using SWLOR.Game.Server.Service.LogService;
 using SWLOR.Game.Server.Service.TaxiService;
+using SWLOR.NWN.API.Engine;
 
 namespace SWLOR.Game.Server.Service
 {
@@ -12,6 +14,7 @@ namespace SWLOR.Game.Server.Service
     {
         private static readonly Dictionary<TaxiDestinationType, TaxiDestinationAttribute> _allTaxiDestinations = new Dictionary<TaxiDestinationType, TaxiDestinationAttribute>();
         private static readonly Dictionary<int, Dictionary<TaxiDestinationType, TaxiDestinationAttribute>> _taxiDestinationsByRegionId = new Dictionary<int, Dictionary<TaxiDestinationType, TaxiDestinationAttribute>>();
+        private static bool _hasReportedUnplacedWaypointTags;
 
         /// <summary>
         /// When the module loads, cache all taxi destinations.
@@ -19,16 +22,34 @@ namespace SWLOR.Game.Server.Service
         [NWNEventHandler(ScriptName.OnModuleCacheBefore)]
         public static void LoadTaxiDestinations()
         {
+            _allTaxiDestinations.Clear();
+            _taxiDestinationsByRegionId.Clear();
+
+            var unplacedWaypointTags = new List<string>();
             var taxiDestinationTypes = Enum.GetValues(typeof(TaxiDestinationType)).Cast<TaxiDestinationType>();
             foreach (var destination in taxiDestinationTypes)
             {
                 var detail = destination.GetAttribute<TaxiDestinationType, TaxiDestinationAttribute>();
-                
+
                 if(!_taxiDestinationsByRegionId.ContainsKey(detail.RegionId))
                     _taxiDestinationsByRegionId[detail.RegionId] = new Dictionary<TaxiDestinationType, TaxiDestinationAttribute>();
 
                 _taxiDestinationsByRegionId[detail.RegionId][destination] = detail;
                 _allTaxiDestinations[destination] = detail;
+
+                if (destination != TaxiDestinationType.Invalid && !IsDestinationAvailable(detail))
+                {
+                    unplacedWaypointTags.Add(detail.WaypointTag);
+                }
+            }
+
+            if (!_hasReportedUnplacedWaypointTags && unplacedWaypointTags.Count > 0)
+            {
+                Log.WriteWarning(
+                    LogGroup.Server,
+                    $"Taxi destinations have no placed waypoint and will not be offered: {string.Join(", ", unplacedWaypointTags)}",
+                    true);
+                _hasReportedUnplacedWaypointTags = true;
             }
         }
 
@@ -73,6 +94,42 @@ namespace SWLOR.Game.Server.Service
         public static Dictionary<TaxiDestinationType, TaxiDestinationAttribute> GetDestinationsByRegionId(int regionId)
         {
             return _taxiDestinationsByRegionId[regionId].ToDictionary(x => x.Key, y => y.Value);
+        }
+
+        /// <summary>
+        /// Retrieves the taxi destinations in a region whose waypoints are currently available.
+        /// </summary>
+        /// <param name="regionId">The region Id to search by.</param>
+        /// <returns>A dictionary of available destination types and attributes.</returns>
+        public static Dictionary<TaxiDestinationType, TaxiDestinationAttribute> GetAvailableDestinationsByRegionId(int regionId)
+        {
+            return GetDestinationsByRegionId(regionId)
+                .Where(x => IsDestinationAvailable(x.Value))
+                .ToDictionary(x => x.Key, y => y.Value);
+        }
+
+        /// <summary>
+        /// Attempts to resolve a taxi destination to a valid location.
+        /// </summary>
+        /// <param name="destination">The destination to resolve.</param>
+        /// <param name="location">The destination's location when available.</param>
+        /// <returns>True if the destination has a valid waypoint; otherwise false.</returns>
+        public static bool TryGetDestinationLocation(TaxiDestinationAttribute destination, out Location location)
+        {
+            var waypoint = GetWaypointByTag(destination.WaypointTag);
+            if (!GetIsObjectValid(waypoint))
+            {
+                location = default;
+                return false;
+            }
+
+            location = GetLocation(waypoint);
+            return true;
+        }
+
+        private static bool IsDestinationAvailable(TaxiDestinationAttribute destination)
+        {
+            return GetIsObjectValid(GetWaypointByTag(destination.WaypointTag));
         }
     }
 }


### PR DESCRIPTION
## Summary

- centralize the placed default respawn waypoint tag as `DTH_DEFAULT_RESPAWN_POINT`
- refuse to persist a default respawn record when that waypoint cannot be resolved, and log the missing waypoint
- place all ten declared Veles taxi destination waypoints in `veles_exterior`
- place one configured region-1 taxi terminal at every Veles stop, covering destination IDs 1–10
- retain defensive filtering, selection-time waypoint validation, and a once-per-process warning for future declared-but-unplaced taxi stops

## Root cause and impact

The default respawn waypoint was looked up under both `DEATH_DEFAULT_RESPAWN_POINT` and `DTH_DEFAULT_RESPAWN_POINT`, but only the latter exists in the module. Players without a respawn record could therefore have an invalid `(0,0,0)`/empty-area record written on every module enter.

The Veles taxi network was declared in code but had never been placed in the module. It now uses the city’s existing district landmarks and sewer-access arrival points, with terminals positioned on nearby clear walkable space.

## Veles taxi stops added

- `TAXI_VELES_ENTRANCE`
- `TAXI_VELES_MARKET`
- `TAXI_VELES_CZERKATOWER`
- `TAXI_VELES_COUNCIL`
- `TAXI_VELES_MEDICAL`
- `TAXI_VELES_STARPORT`
- `TAXI_VELES_INDUSTRIAL`
- `TAXI_VELES_CANTINA`
- `TAXI_VELES_RESIDENTIAL`
- `TAXI_VELES_APARTMENT`

## Validation

- parsed the updated `veles_exterior.git.json` successfully
- verified all 14 declared taxi waypoint tags occur exactly once in module GIT data
- verified ten Veles terminals use region `1`, `TaxiTerminalDialog`, and unique destination IDs `1` through `10`
- verified every new waypoint and terminal matches the existing Dantooine templates outside the intended tag, placement, and local-variable overrides
- verified all waypoint coordinates are within the `veles_exterior` area bounds
- `git diff --check`: passed
- deploy-disabled `SWLOR.Game.Server` build: passed with 0 errors and 8 pre-existing nullable warnings
- requested filtered tests remain unavailable because `SWLOR.Game.Server.Tests/SWLOR.Game.Server.Tests.csproj` does not exist on `origin/master` (`MSB1009`)