### PR TITLE
Improve Toolset area editor workflows

### DIFF
--- a/SWLOR.Toolset.Domain/Editing/DocumentSession.cs
+++ b/SWLOR.Toolset.Domain/Editing/DocumentSession.cs
@@ -26,13 +26,19 @@ namespace SWLOR.Toolset.Domain.Editing
 
         /// <summary>Binds an already-parsed document to a path, recording the file's current mtime (if it exists) for HasExternalChange().</summary>
         public DocumentSession(string filePath, JsonGffDocument document)
+            : this(filePath, document, loadedContent: null)
+        {
+        }
+
+        private DocumentSession(string filePath, JsonGffDocument document, byte[]? loadedContent)
         {
             FilePath = filePath ?? throw new ArgumentNullException(nameof(filePath));
             Document = document ?? throw new ArgumentNullException(nameof(document));
             UndoStack = new UndoStack();
             _loadedMTimeUtc = File.Exists(filePath) ? File.GetLastWriteTimeUtc(filePath) : null;
             _loadedContentHash = _loadedMTimeUtc != null
-                ? System.Security.Cryptography.SHA256.HashData(File.ReadAllBytes(filePath))
+                ? System.Security.Cryptography.SHA256.HashData(
+                    loadedContent ?? File.ReadAllBytes(filePath))
                 : null;
             _guard = EditScope.EnterGuard();
         }
@@ -41,8 +47,22 @@ namespace SWLOR.Toolset.Domain.Editing
         public static DocumentSession Open(string filePath)
         {
             var content = File.ReadAllBytes(filePath);
-            var session = new DocumentSession(filePath, JsonGffDocument.Parse(content));
-            session.RecordCurrentFileState(content);
+            return FromLoadedContent(filePath, JsonGffDocument.Parse(content), content);
+        }
+
+        /// <summary>
+        /// Binds bytes and a document already parsed on a worker thread. The session itself is
+        /// created on the caller's context so its ambient edit guard belongs to the editor, while
+        /// the expensive file read and JSON parse stay off the UI thread.
+        /// </summary>
+        public static DocumentSession FromLoadedContent(
+            string filePath,
+            JsonGffDocument document,
+            byte[] loadedContent)
+        {
+            ArgumentNullException.ThrowIfNull(loadedContent);
+            var session = new DocumentSession(filePath, document, loadedContent);
+            session.RecordCurrentFileState(loadedContent);
             return session;
         }
 

--- a/SWLOR.Toolset.Domain/Editing/DocumentSession.cs
+++ b/SWLOR.Toolset.Domain/Editing/DocumentSession.cs
@@ -61,9 +61,7 @@ namespace SWLOR.Toolset.Domain.Editing
             byte[] loadedContent)
         {
             ArgumentNullException.ThrowIfNull(loadedContent);
-            var session = new DocumentSession(filePath, document, loadedContent);
-            session.RecordCurrentFileState(loadedContent);
-            return session;
+            return new DocumentSession(filePath, document, loadedContent);
         }
 
         /// <summary>Begins a transaction on this session's undo stack.</summary>

--- a/SWLOR.Toolset.Domain/Editing/DocumentSession.cs
+++ b/SWLOR.Toolset.Domain/Editing/DocumentSession.cs
@@ -35,11 +35,17 @@ namespace SWLOR.Toolset.Domain.Editing
             FilePath = filePath ?? throw new ArgumentNullException(nameof(filePath));
             Document = document ?? throw new ArgumentNullException(nameof(document));
             UndoStack = new UndoStack();
-            _loadedMTimeUtc = File.Exists(filePath) ? File.GetLastWriteTimeUtc(filePath) : null;
-            _loadedContentHash = _loadedMTimeUtc != null
-                ? System.Security.Cryptography.SHA256.HashData(
-                    loadedContent ?? File.ReadAllBytes(filePath))
-                : null;
+            var fileExists = File.Exists(filePath);
+            _loadedMTimeUtc = fileExists
+                ? File.GetLastWriteTimeUtc(filePath)
+                : loadedContent != null
+                    ? DateTime.MinValue
+                    : null;
+            _loadedContentHash = loadedContent != null
+                ? System.Security.Cryptography.SHA256.HashData(loadedContent)
+                : fileExists
+                    ? System.Security.Cryptography.SHA256.HashData(File.ReadAllBytes(filePath))
+                    : null;
             _guard = EditScope.EnterGuard();
         }
 

--- a/SWLOR.Toolset.Domain/GameData/Lookups/CloakModelService.cs
+++ b/SWLOR.Toolset.Domain/GameData/Lookups/CloakModelService.cs
@@ -2,38 +2,56 @@ using SWLOR.Toolset.Domain.GameData.TwoDa;
 
 namespace SWLOR.Toolset.Domain.GameData.Lookups
 {
+    /// <summary>The geometry and surface rows selected by one cloak appearance.</summary>
+    public readonly record struct CloakModelMapping(int Model, int Texture);
+
     /// <summary>
-    /// Resolves a cloak appearance (a UTI's ModelPart1) to the shared geometry number named by
-    /// cloakmodel.2da. Multiple appearances intentionally reuse one model with different textures.
+    /// Resolves a cloak appearance (a UTI's ModelPart1) to the shared geometry and texture numbers
+    /// named by cloakmodel.2da. Multiple appearances intentionally reuse one model with different
+    /// textures, so neither half of the mapping may be discarded.
     /// </summary>
     public sealed class CloakModelService
     {
         private const string TableName = "cloakmodel";
-        private readonly ReloadableLazy<IReadOnlyDictionary<int, int>> _models;
+        private readonly ReloadableLazy<IReadOnlyDictionary<int, CloakModelMapping>> _mappings;
 
         public CloakModelService(TwoDaService twoDa)
         {
             ArgumentNullException.ThrowIfNull(twoDa);
-            _models = new ReloadableLazy<IReadOnlyDictionary<int, int>>(() => Build(twoDa));
-            twoDa.TablesReloaded += _models.Reset;
+            _mappings = new ReloadableLazy<IReadOnlyDictionary<int, CloakModelMapping>>(() => Build(twoDa));
+            twoDa.TablesReloaded += _mappings.Reset;
         }
 
-        public int? GetModelOrNull(int appearance) =>
-            _models.Value.TryGetValue(appearance, out var model) ? model : null;
+        public CloakModelMapping? GetOrNull(int appearance) =>
+            _mappings.Value.TryGetValue(appearance, out var mapping) ? mapping : null;
 
-        private static IReadOnlyDictionary<int, int> Build(TwoDaService twoDa)
+        private static IReadOnlyDictionary<int, CloakModelMapping> Build(TwoDaService twoDa)
         {
             if (!twoDa.TryGetTable(TableName, out var table) || table == null)
-                return new Dictionary<int, int>();
+                return new Dictionary<int, CloakModelMapping>();
 
-            var models = new Dictionary<int, int>();
+            var mappings = new Dictionary<int, CloakModelMapping>();
             for (var row = 0; row < table.RowCount; row++)
             {
                 try
                 {
                     var model = table.GetInt(row, "MODEL");
-                    if (model is > 0)
-                        models[row] = model.Value;
+                    if (model is not > 0)
+                        continue;
+
+                    var texture = row;
+                    try
+                    {
+                        texture = table.GetInt(row, "TEXTURE") is > 0 and var mappedTexture
+                            ? mappedTexture
+                            : row;
+                    }
+                    catch (FormatException)
+                    {
+                        // Keep valid geometry usable; the appearance row is the safest texture fallback.
+                    }
+
+                    mappings[row] = new CloakModelMapping(model.Value, texture);
                 }
                 catch (FormatException)
                 {
@@ -41,7 +59,7 @@ namespace SWLOR.Toolset.Domain.GameData.Lookups
                 }
             }
 
-            return models;
+            return mappings;
         }
     }
 }

--- a/SWLOR.Toolset.Domain/GameData/Lookups/CloakModelService.cs
+++ b/SWLOR.Toolset.Domain/GameData/Lookups/CloakModelService.cs
@@ -1,0 +1,47 @@
+using SWLOR.Toolset.Domain.GameData.TwoDa;
+
+namespace SWLOR.Toolset.Domain.GameData.Lookups
+{
+    /// <summary>
+    /// Resolves a cloak appearance (a UTI's ModelPart1) to the shared geometry number named by
+    /// cloakmodel.2da. Multiple appearances intentionally reuse one model with different textures.
+    /// </summary>
+    public sealed class CloakModelService
+    {
+        private const string TableName = "cloakmodel";
+        private readonly ReloadableLazy<IReadOnlyDictionary<int, int>> _models;
+
+        public CloakModelService(TwoDaService twoDa)
+        {
+            ArgumentNullException.ThrowIfNull(twoDa);
+            _models = new ReloadableLazy<IReadOnlyDictionary<int, int>>(() => Build(twoDa));
+            twoDa.TablesReloaded += _models.Reset;
+        }
+
+        public int? GetModelOrNull(int appearance) =>
+            _models.Value.TryGetValue(appearance, out var model) ? model : null;
+
+        private static IReadOnlyDictionary<int, int> Build(TwoDaService twoDa)
+        {
+            if (!twoDa.TryGetTable(TableName, out var table) || table == null)
+                return new Dictionary<int, int>();
+
+            var models = new Dictionary<int, int>();
+            for (var row = 0; row < table.RowCount; row++)
+            {
+                try
+                {
+                    var model = table.GetInt(row, "MODEL");
+                    if (model is > 0)
+                        models[row] = model.Value;
+                }
+                catch (FormatException)
+                {
+                    // A malformed/reserved row cannot identify wearable geometry.
+                }
+            }
+
+            return models;
+        }
+    }
+}

--- a/SWLOR.Toolset.Domain/GameData/Lookups/CloakModelService.cs
+++ b/SWLOR.Toolset.Domain/GameData/Lookups/CloakModelService.cs
@@ -2,8 +2,14 @@ using SWLOR.Toolset.Domain.GameData.TwoDa;
 
 namespace SWLOR.Toolset.Domain.GameData.Lookups
 {
-    /// <summary>The geometry and surface rows selected by one cloak appearance.</summary>
-    public readonly record struct CloakModelMapping(int Model, int Texture);
+    /// <summary>
+    /// The geometry, surface, and wearer-part visibility selected by one cloak appearance.
+    /// </summary>
+    public readonly record struct CloakModelMapping(
+        int Model,
+        int Texture,
+        bool HideLeftShoulder,
+        bool HideRightShoulder);
 
     /// <summary>
     /// Resolves a cloak appearance (a UTI's ModelPart1) to the shared geometry and texture numbers
@@ -51,7 +57,11 @@ namespace SWLOR.Toolset.Domain.GameData.Lookups
                         // Keep valid geometry usable; the appearance row is the safest texture fallback.
                     }
 
-                    mappings[row] = new CloakModelMapping(model.Value, texture);
+                    mappings[row] = new CloakModelMapping(
+                        model.Value,
+                        texture,
+                        ReadFlag(table, row, "HIDESHOL"),
+                        ReadFlag(table, row, "HIDESHOR"));
                 }
                 catch (FormatException)
                 {
@@ -60,6 +70,19 @@ namespace SWLOR.Toolset.Domain.GameData.Lookups
             }
 
             return mappings;
+        }
+
+        private static bool ReadFlag(TwoDaTable table, int row, string column)
+        {
+            try
+            {
+                return table.GetInt(row, column) == 1;
+            }
+            catch (FormatException)
+            {
+                // A malformed optional flag must not discard otherwise usable cloak geometry.
+                return false;
+            }
         }
     }
 }

--- a/SWLOR.Toolset.Domain/Render/AreaSceneBuilder.cs
+++ b/SWLOR.Toolset.Domain/Render/AreaSceneBuilder.cs
@@ -236,7 +236,12 @@ namespace SWLOR.Toolset.Domain.Render
             AddMarkers(markers, git.Placeables, InstanceMarkerKind.Placeable, ResourceType.Utp,
                 resolveModel: instance => ResolvePlaceableModel(instance, placeableAppearances, modelCache));
             AddMarkers(markers, git.Sounds, InstanceMarkerKind.Sound, ResourceType.Uts);
-            AddMarkers(markers, git.Stores, InstanceMarkerKind.Store, ResourceType.Utm);
+            // Aurora gives stores a fixed yellow waypoint flag. A store carries no Appearance field,
+            // so leaving this unresolved falls through to the generic pyramid: its apex is at the
+            // store while its broad face hangs beside the merchant, and its symmetry loses facing.
+            AddMarkers(markers, git.Stores, InstanceMarkerKind.Store, ResourceType.Utm,
+                resolveModel: _ => modelCache.GetOrBuild(WaypointMarkerModel.MerchantModelResRef),
+                modelCorrection: WaypointMarkerModel.ForwardCorrection);
             AddMarkers(markers, git.Triggers, InstanceMarkerKind.Trigger, ResourceType.Utt, includeGeometry: true,
                 tiles: tiles);
             AddMarkers(markers, git.Waypoints, InstanceMarkerKind.Waypoint, ResourceType.Utw,

--- a/SWLOR.Toolset.Domain/Render/AreaSceneBuilder.cs
+++ b/SWLOR.Toolset.Domain/Render/AreaSceneBuilder.cs
@@ -228,7 +228,8 @@ namespace SWLOR.Toolset.Domain.Render
             // and a dozen part models, which needs the composer that lives in the app layer. The caller
             // supplies it, and without one a creature falls back to its marker as before.
             AddMarkers(markers, git.Creatures, InstanceMarkerKind.Creature, ResourceType.Utc,
-                resolveModel: resolveCreatureModel);
+                resolveModel: resolveCreatureModel,
+                modelCorrection: CreatureModelFacing.ForwardCorrection);
             AddMarkers(markers, git.Doors, InstanceMarkerKind.Door, ResourceType.Utd,
                 resolveModel: instance => ResolveDoorModel(instance, doorTypes, modelCache));
             AddMarkers(markers, git.Items, InstanceMarkerKind.Item, ResourceType.Uti);

--- a/SWLOR.Toolset.Domain/Render/BlueprintModelResolver.cs
+++ b/SWLOR.Toolset.Domain/Render/BlueprintModelResolver.cs
@@ -30,8 +30,15 @@ namespace SWLOR.Toolset.Domain.Render
         ItemComposite
     }
 
-    /// <summary>One resolved body part of a segmented creature: the MdlPartComposer bone-part type and its MDL resref.</summary>
-    public readonly record struct BlueprintModelPart(string PartType, string ModelResRef);
+    /// <summary>
+    /// One resolved body/equipment part: the MdlPartComposer attachment type, its MDL resref, and any
+    /// item-specific PLT palette choices. Equipment palettes live here because a cloak and the chest
+    /// armor beneath it can intentionally use different dye rows.
+    /// </summary>
+    public readonly record struct BlueprintModelPart(
+        string PartType,
+        string ModelResRef,
+        IReadOnlyDictionary<int, int>? LayerColorIndices = null);
 
     /// <summary>
     /// The resolved preview-model description for a blueprint, produced by <see cref="BlueprintModelResolver"/>.
@@ -158,18 +165,20 @@ namespace SWLOR.Toolset.Domain.Render
             Func<string, bool>? partModelExists = null,
             WaypointAppearanceService? waypoints = null,
             Func<int, BaseItemIconRow?>? baseItems = null,
-            bool armorPreviewFemale = false)
+            bool armorPreviewFemale = false,
+            CloakModelService? cloakModels = null)
         {
             ArgumentNullException.ThrowIfNull(root);
 
             return type switch
             {
                 ResourceType.Utc => ResolveCreature(
-                    root, appearances, itemBlueprintLoader, partModelExists, baseItems),
+                    root, appearances, itemBlueprintLoader, partModelExists, baseItems, cloakModels),
                 ResourceType.Utp => ResolvePlaceable(root, placeables),
                 ResourceType.Utd => ResolveDoor(root, doors),
                 ResourceType.Utw => ResolveWaypoint(root, waypoints),
-                ResourceType.Uti => ResolveItem(root, baseItems, partModelExists, armorPreviewFemale),
+                ResourceType.Uti => ResolveItem(
+                    root, baseItems, partModelExists, armorPreviewFemale, cloakModels),
                 _ => BlueprintModelReference.NoneWith("No model preview for this blueprint type.")
             };
         }
@@ -190,7 +199,8 @@ namespace SWLOR.Toolset.Domain.Render
             JsonGffStruct root,
             Func<int, BaseItemIconRow?>? baseItems,
             Func<string, bool>? partModelExists,
-            bool armorPreviewFemale = false)
+            bool armorPreviewFemale = false,
+            CloakModelService? cloakModels = null)
         {
             if (baseItems == null)
                 return BlueprintModelReference.NoneWith("Item preview unavailable (base item data not loaded).");
@@ -238,7 +248,11 @@ namespace SWLOR.Toolset.Domain.Render
                     // by itself it is a flat sheet in mid-air. Worn on the mannequin it hangs where it
                     // is meant to, which is the only way to judge one.
                     if (string.Equals(itemClass, CloakItemClass, StringComparison.OrdinalIgnoreCase))
-                        return ResolveCapeMannequin(root, itemClass, armorPreviewFemale, partModelExists, part1);
+                    {
+                        var cloakModel = cloakModels?.GetModelOrNull(part1) ?? part1;
+                        return ResolveCapeMannequin(
+                            root, itemClass, armorPreviewFemale, partModelExists, cloakModel);
+                    }
 
                     var modelResRef = $"{itemClass}_{part1:D3}";
                     if (partModelExists != null && !partModelExists(modelResRef))
@@ -383,7 +397,8 @@ namespace SWLOR.Toolset.Domain.Render
             AppearanceService? appearances,
             Func<string, JsonGffStruct?>? itemBlueprintLoader,
             Func<string, bool>? partModelExists,
-            Func<int, BaseItemIconRow?>? baseItems)
+            Func<int, BaseItemIconRow?>? baseItems,
+            CloakModelService? cloakModels)
         {
             if (appearances == null)
                 return BlueprintModelReference.NoneWith("Creature preview unavailable (appearance data not loaded).");
@@ -393,13 +408,17 @@ namespace SWLOR.Toolset.Domain.Render
             if (row == null)
                 return BlueprintModelReference.NoneWith($"Unknown appearance id {appearanceId}.");
 
-            var visibleEquipment = ResolveVisibleEquipment(
-                root, itemBlueprintLoader, partModelExists, baseItems);
-
             if (string.Equals(row.ModelType, "P", StringComparison.OrdinalIgnoreCase))
             {
+                var prefix = SegmentedCreaturePrefix(root, row);
+                if (prefix == null)
+                    return BlueprintModelReference.NoneWith(
+                        $"{row.DisplayName}: segmented appearance has no race letter.");
+
+                var visibleEquipment = ResolveVisibleEquipment(
+                    root, itemBlueprintLoader, partModelExists, baseItems, cloakModels, prefix);
                 return ResolveSegmentedCreature(
-                    root, row, itemBlueprintLoader, partModelExists, visibleEquipment);
+                    root, row, prefix, itemBlueprintLoader, partModelExists, visibleEquipment);
             }
 
             var modelResRef = row.Race;
@@ -411,26 +430,31 @@ namespace SWLOR.Toolset.Domain.Render
                 Kind = BlueprintModelKind.Simple,
                 Status = $"{row.DisplayName} ({modelResRef}.mdl)",
                 ModelResRef = modelResRef,
-                Parts = visibleEquipment
+                Parts = ResolveVisibleEquipment(
+                    root, itemBlueprintLoader, partModelExists, baseItems, cloakModels,
+                    wearerPrefix: null)
             };
+        }
+
+        private static string? SegmentedCreaturePrefix(JsonGffStruct root, AppearanceRow row)
+        {
+            if (string.IsNullOrWhiteSpace(row.Race))
+                return null;
+
+            // NWN player-body prefix: p{gender}{race}{phenotype}, e.g. "pmh0".
+            var gender = (root.GetIntOrNull("Gender") ?? 0) == 1 ? 'f' : 'm';
+            var phenotype = root.GetIntOrNull("Phenotype") ?? 0;
+            return $"p{gender}{char.ToLowerInvariant(row.Race[0])}{phenotype}";
         }
 
         private static BlueprintModelReference ResolveSegmentedCreature(
             JsonGffStruct root,
             AppearanceRow row,
+            string prefix,
             Func<string, JsonGffStruct?>? itemBlueprintLoader,
             Func<string, bool>? partModelExists,
             IReadOnlyList<BlueprintModelPart> visibleEquipment)
         {
-            var raceLetter = row.Race;
-            if (string.IsNullOrWhiteSpace(raceLetter))
-                return BlueprintModelReference.NoneWith($"{row.DisplayName}: segmented appearance has no race letter.");
-
-            // NWN player-body prefix: p{gender}{race}{phenotype}, e.g. "pmh0" (player, male, human, phenotype 0).
-            var gender = (root.GetIntOrNull("Gender") ?? 0) == 1 ? 'f' : 'm';
-            var phenotype = root.GetIntOrNull("Phenotype") ?? 0;
-            var prefix = $"p{gender}{char.ToLowerInvariant(raceLetter[0])}{phenotype}";
-
             var armor = LoadEquippedChestArmor(root, itemBlueprintLoader);
             var parts = new List<BlueprintModelPart>();
 
@@ -527,7 +551,9 @@ namespace SWLOR.Toolset.Domain.Render
             JsonGffStruct root,
             Func<string, JsonGffStruct?>? itemBlueprintLoader,
             Func<string, bool>? partModelExists,
-            Func<int, BaseItemIconRow?>? baseItems)
+            Func<int, BaseItemIconRow?>? baseItems,
+            CloakModelService? cloakModels,
+            string? wearerPrefix)
         {
             if (baseItems == null)
                 return Array.Empty<BlueprintModelPart>();
@@ -535,16 +561,16 @@ namespace SWLOR.Toolset.Domain.Render
             var parts = new List<BlueprintModelPart>();
             AddVisibleEquipmentPart(
                 parts, root, HeadSlotStructId, "helmet",
-                itemBlueprintLoader, partModelExists, baseItems);
+                itemBlueprintLoader, partModelExists, baseItems, cloakModels, wearerPrefix);
             AddVisibleEquipmentPart(
                 parts, root, CloakSlotStructId, "cloak",
-                itemBlueprintLoader, partModelExists, baseItems);
+                itemBlueprintLoader, partModelExists, baseItems, cloakModels, wearerPrefix);
             AddVisibleEquipmentPart(
                 parts, root, RightHandSlotStructId, "weaponr",
-                itemBlueprintLoader, partModelExists, baseItems);
+                itemBlueprintLoader, partModelExists, baseItems, cloakModels, wearerPrefix);
             AddVisibleEquipmentPart(
                 parts, root, LeftHandSlotStructId, "weaponl",
-                itemBlueprintLoader, partModelExists, baseItems);
+                itemBlueprintLoader, partModelExists, baseItems, cloakModels, wearerPrefix);
             return parts;
         }
 
@@ -555,19 +581,35 @@ namespace SWLOR.Toolset.Domain.Render
             string attachmentType,
             Func<string, JsonGffStruct?>? itemBlueprintLoader,
             Func<string, bool>? partModelExists,
-            Func<int, BaseItemIconRow?> baseItems)
+            Func<int, BaseItemIconRow?> baseItems,
+            CloakModelService? cloakModels,
+            string? wearerPrefix)
         {
             var item = LoadEquippedItem(creature, slot, itemBlueprintLoader);
             if (item == null)
                 return;
 
-            var reference = ResolveItem(item, baseItems, partModelExists, armorPreviewFemale: false);
+            var reference = ResolveItem(
+                item, baseItems, partModelExists, armorPreviewFemale: false,
+                cloakModels: cloakModels);
             if (attachmentType == "cloak")
             {
                 foreach (var part in reference.Parts.Where(
                              part => part.PartType.Equals("cloak", StringComparison.OrdinalIgnoreCase)))
                 {
-                    destination.Add(new BlueprintModelPart(attachmentType, part.ModelResRef));
+                    var modelResRef = part.ModelResRef;
+                    if (!string.IsNullOrWhiteSpace(wearerPrefix))
+                    {
+                        var cloakSuffix = modelResRef.IndexOf("_cloak_", StringComparison.OrdinalIgnoreCase);
+                        if (cloakSuffix >= 0)
+                            modelResRef = wearerPrefix + modelResRef[cloakSuffix..];
+                    }
+
+                    if (partModelExists?.Invoke(modelResRef) ?? true)
+                    {
+                        destination.Add(new BlueprintModelPart(
+                            attachmentType, modelResRef, reference.LayerColorIndices));
+                    }
                 }
 
                 return;
@@ -576,7 +618,10 @@ namespace SWLOR.Toolset.Domain.Render
             if (reference.Kind == BlueprintModelKind.ItemComposite)
             {
                 foreach (var part in reference.Parts)
-                    destination.Add(new BlueprintModelPart(attachmentType, part.ModelResRef));
+                {
+                    destination.Add(new BlueprintModelPart(
+                        attachmentType, part.ModelResRef, reference.LayerColorIndices));
+                }
                 return;
             }
 
@@ -584,7 +629,8 @@ namespace SWLOR.Toolset.Domain.Render
                 !string.IsNullOrWhiteSpace(reference.ModelResRef) &&
                 !reference.ModelResRef.Equals("it_bag", StringComparison.OrdinalIgnoreCase))
             {
-                destination.Add(new BlueprintModelPart(attachmentType, reference.ModelResRef));
+                destination.Add(new BlueprintModelPart(
+                    attachmentType, reference.ModelResRef, reference.LayerColorIndices));
             }
         }
 
@@ -633,6 +679,32 @@ namespace SWLOR.Toolset.Domain.Render
             var chest = root.GetListOrEmpty("Equip_ItemList")
                 .FirstOrDefault(item => ParseStructId(item.RawStructId) == ChestSlotStructId);
             return chest == null ? null : GetEquippedItemResRef(chest);
+        }
+
+        /// <summary>
+        /// Every equipped item blueprint that can change a creature preview: chest armor, helmet,
+        /// cloak, and both held items. Thumbnail dependency tracking uses the same slot set as model
+        /// resolution so editing any visible item invalidates every creature wearing it.
+        /// </summary>
+        public static IReadOnlyList<string> GetVisibleEquippedItemResRefs(JsonGffStruct root)
+        {
+            ArgumentNullException.ThrowIfNull(root);
+            var visibleSlots = new HashSet<int>
+            {
+                HeadSlotStructId,
+                ChestSlotStructId,
+                RightHandSlotStructId,
+                LeftHandSlotStructId,
+                CloakSlotStructId
+            };
+
+            return root.GetListOrEmpty("Equip_ItemList")
+                .Where(item => visibleSlots.Contains(ParseStructId(item.RawStructId)))
+                .Select(GetEquippedItemResRef)
+                .Where(resRef => !string.IsNullOrWhiteSpace(resRef))
+                .Select(resRef => resRef!)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
         }
 
         private static string? GetEquippedItemResRef(JsonGffStruct item) =>

--- a/SWLOR.Toolset.Domain/Render/BlueprintModelResolver.cs
+++ b/SWLOR.Toolset.Domain/Render/BlueprintModelResolver.cs
@@ -31,14 +31,17 @@ namespace SWLOR.Toolset.Domain.Render
     }
 
     /// <summary>
-    /// One resolved body/equipment part: the MdlPartComposer attachment type, its MDL resref, and any
-    /// item-specific PLT palette choices. Equipment palettes live here because a cloak and the chest
-    /// armor beneath it can intentionally use different dye rows.
+    /// One resolved body/equipment part: the MdlPartComposer attachment type, its MDL resref, any
+    /// item-specific PLT palette choices, and an optional texture selected independently of geometry.
+    /// Equipment palettes live here because a cloak and the chest armor beneath it can intentionally
+    /// use different dye rows; cloakmodel.2da similarly lets multiple appearances share geometry while
+    /// selecting different surfaces.
     /// </summary>
     public readonly record struct BlueprintModelPart(
         string PartType,
         string ModelResRef,
-        IReadOnlyDictionary<int, int>? LayerColorIndices = null);
+        IReadOnlyDictionary<int, int>? LayerColorIndices = null,
+        string? TextureResRef = null);
 
     /// <summary>
     /// The resolved preview-model description for a blueprint, produced by <see cref="BlueprintModelResolver"/>.
@@ -249,9 +252,12 @@ namespace SWLOR.Toolset.Domain.Render
                     // is meant to, which is the only way to judge one.
                     if (string.Equals(itemClass, CloakItemClass, StringComparison.OrdinalIgnoreCase))
                     {
-                        var cloakModel = cloakModels?.GetModelOrNull(part1) ?? part1;
+                        var cloakMapping = cloakModels?.GetOrNull(part1);
+                        var cloakModel = cloakMapping?.Model ?? part1;
+                        var cloakTexture = cloakMapping?.Texture ?? part1;
                         return ResolveCapeMannequin(
-                            root, itemClass, armorPreviewFemale, partModelExists, cloakModel);
+                            root, itemClass, armorPreviewFemale, partModelExists,
+                            cloakModel, cloakTexture);
                     }
 
                     var modelResRef = $"{itemClass}_{part1:D3}";
@@ -262,7 +268,8 @@ namespace SWLOR.Toolset.Domain.Render
                     {
                         Kind = BlueprintModelKind.Simple,
                         Status = $"{modelResRef}.mdl",
-                        ModelResRef = modelResRef
+                        ModelResRef = modelResRef,
+                        LayerColorIndices = ResolveLayerColors(root, root)
                     };
                 }
 
@@ -363,14 +370,19 @@ namespace SWLOR.Toolset.Domain.Render
             string itemClass,
             bool female,
             Func<string, bool>? partModelExists,
-            int cloakNumber)
+            int cloakNumber,
+            int cloakTextureNumber)
         {
             var prefix = female ? "pfh0" : "pmh0";
             var cloakResRef = $"{prefix}_cloak_{cloakNumber:D3}";
+            var cloakTextureResRef = $"{prefix}_cloak_{cloakTextureNumber:D3}";
             if (partModelExists != null && !partModelExists(cloakResRef))
                 return LootBagFallback(itemClass, partModelExists, $"no cloak model '{cloakResRef}'");
 
-            var parts = new List<BlueprintModelPart> { new("cloak", cloakResRef) };
+            var parts = new List<BlueprintModelPart>
+            {
+                new("cloak", cloakResRef, TextureResRef: cloakTextureResRef)
+            };
             parts.Add(new BlueprintModelPart("head", BuildPartName(prefix, "head", 1)));
             foreach (var (_, _, partType) in BodyPartFields)
             {
@@ -598,17 +610,23 @@ namespace SWLOR.Toolset.Domain.Render
                              part => part.PartType.Equals("cloak", StringComparison.OrdinalIgnoreCase)))
                 {
                     var modelResRef = part.ModelResRef;
+                    var textureResRef = part.TextureResRef;
                     if (!string.IsNullOrWhiteSpace(wearerPrefix))
                     {
                         var cloakSuffix = modelResRef.IndexOf("_cloak_", StringComparison.OrdinalIgnoreCase);
                         if (cloakSuffix >= 0)
                             modelResRef = wearerPrefix + modelResRef[cloakSuffix..];
+
+                        var textureSuffix = textureResRef?.IndexOf(
+                            "_cloak_", StringComparison.OrdinalIgnoreCase) ?? -1;
+                        if (textureSuffix >= 0)
+                            textureResRef = wearerPrefix + textureResRef![textureSuffix..];
                     }
 
                     if (partModelExists?.Invoke(modelResRef) ?? true)
                     {
                         destination.Add(new BlueprintModelPart(
-                            attachmentType, modelResRef, reference.LayerColorIndices));
+                            attachmentType, modelResRef, reference.LayerColorIndices, textureResRef));
                     }
                 }
 

--- a/SWLOR.Toolset.Domain/Render/BlueprintModelResolver.cs
+++ b/SWLOR.Toolset.Domain/Render/BlueprintModelResolver.cs
@@ -444,7 +444,7 @@ namespace SWLOR.Toolset.Domain.Render
                 ModelResRef = modelResRef,
                 Parts = ResolveVisibleEquipment(
                     root, itemBlueprintLoader, partModelExists, baseItems, cloakModels,
-                    wearerPrefix: null)
+                    wearerPrefix: null).Parts
             };
         }
 
@@ -465,7 +465,7 @@ namespace SWLOR.Toolset.Domain.Render
             string prefix,
             Func<string, JsonGffStruct?>? itemBlueprintLoader,
             Func<string, bool>? partModelExists,
-            IReadOnlyList<BlueprintModelPart> visibleEquipment)
+            VisibleEquipment visibleEquipment)
         {
             var armor = LoadEquippedChestArmor(root, itemBlueprintLoader);
             var parts = new List<BlueprintModelPart>();
@@ -490,6 +490,9 @@ namespace SWLOR.Toolset.Domain.Render
 
             foreach (var (creatureField, armorKey, partType) in BodyPartFields)
             {
+                if (visibleEquipment.HiddenBodyParts.Contains(partType))
+                    continue;
+
                 var number = ResolvePartNumber(
                     root.GetIntOrNull(creatureField) ?? 0,
                     armor == null
@@ -499,7 +502,7 @@ namespace SWLOR.Toolset.Domain.Render
                     parts.Add(new BlueprintModelPart(partType, BuildPartName(prefix, partType, number)));
             }
 
-            parts.AddRange(visibleEquipment);
+            parts.AddRange(visibleEquipment.Parts);
 
             if (parts.Count == 0)
                 return BlueprintModelReference.NoneWith($"{row.DisplayName}: segmented creature has no body parts.");
@@ -559,7 +562,11 @@ namespace SWLOR.Toolset.Domain.Render
         /// Resolves the models for equipment the game draws on a creature. Ordinary right- and
         /// left-hand items are held props; creature natural-weapon/stat slots are deliberately not.
         /// </summary>
-        private static IReadOnlyList<BlueprintModelPart> ResolveVisibleEquipment(
+        private readonly record struct VisibleEquipment(
+            IReadOnlyList<BlueprintModelPart> Parts,
+            IReadOnlySet<string> HiddenBodyParts);
+
+        private static VisibleEquipment ResolveVisibleEquipment(
             JsonGffStruct root,
             Func<string, JsonGffStruct?>? itemBlueprintLoader,
             Func<string, bool>? partModelExists,
@@ -568,7 +575,11 @@ namespace SWLOR.Toolset.Domain.Render
             string? wearerPrefix)
         {
             if (baseItems == null)
-                return Array.Empty<BlueprintModelPart>();
+            {
+                return new VisibleEquipment(
+                    Array.Empty<BlueprintModelPart>(),
+                    new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+            }
 
             var parts = new List<BlueprintModelPart>();
             AddVisibleEquipmentPart(
@@ -583,7 +594,27 @@ namespace SWLOR.Toolset.Domain.Render
             AddVisibleEquipmentPart(
                 parts, root, LeftHandSlotStructId, "weaponl",
                 itemBlueprintLoader, partModelExists, baseItems, cloakModels, wearerPrefix);
-            return parts;
+            return new VisibleEquipment(
+                parts,
+                ResolveCloakHiddenBodyParts(root, itemBlueprintLoader, cloakModels));
+        }
+
+        private static IReadOnlySet<string> ResolveCloakHiddenBodyParts(
+            JsonGffStruct creature,
+            Func<string, JsonGffStruct?>? itemBlueprintLoader,
+            CloakModelService? cloakModels)
+        {
+            var hidden = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var cloak = LoadEquippedItem(creature, CloakSlotStructId, itemBlueprintLoader);
+            var appearance = cloak == null
+                ? null
+                : ItemAppearanceValues.Read(cloak, "ModelPart1");
+            var mapping = appearance is { } value ? cloakModels?.GetOrNull(value) : null;
+            if (mapping?.HideLeftShoulder == true)
+                hidden.Add("shol");
+            if (mapping?.HideRightShoulder == true)
+                hidden.Add("shor");
+            return hidden;
         }
 
         private static void AddVisibleEquipmentPart(

--- a/SWLOR.Toolset.Domain/Render/BlueprintModelResolver.cs
+++ b/SWLOR.Toolset.Domain/Render/BlueprintModelResolver.cs
@@ -51,7 +51,10 @@ namespace SWLOR.Toolset.Domain.Render
         /// <summary>The skeleton/supermodel resref for <see cref="BlueprintModelKind.Segmented"/>; null otherwise.</summary>
         public string? SkeletonResRef { get; init; }
 
-        /// <summary>The body parts (MdlPartComposer part type → resref) for <see cref="BlueprintModelKind.Segmented"/>.</summary>
+        /// <summary>
+        /// Body parts for <see cref="BlueprintModelKind.Segmented"/>, or visible equipment attached
+        /// to a <see cref="BlueprintModelKind.Simple"/> creature (MdlPartComposer part type → resref).
+        /// </summary>
         public IReadOnlyList<BlueprintModelPart> Parts { get; init; } = Array.Empty<BlueprintModelPart>();
 
         /// <summary>
@@ -119,8 +122,12 @@ namespace SWLOR.Toolset.Domain.Render
             "forel", "forer", "handl", "handr", "shinl", "shinr",
         };
 
-        /// <summary>Equip_ItemList struct id for the chest slot (bit flags per the Aurora UTC format).</summary>
+        /// <summary>Visible Equip_ItemList struct ids (bit flags per the Aurora UTC/GIT format).</summary>
+        private const int HeadSlotStructId = 1;
         private const int ChestSlotStructId = 2;
+        private const int RightHandSlotStructId = 16;
+        private const int LeftHandSlotStructId = 32;
+        private const int CloakSlotStructId = 64;
 
         /// <summary>
         /// Resolves the preview model for a blueprint. Returns a <see cref="BlueprintModelKind.None"/>
@@ -138,8 +145,8 @@ namespace SWLOR.Toolset.Domain.Render
         /// ModelType 0/1 item's single ground model. Null = assume exists.
         /// </param>
         /// <param name="baseItems">
-        /// baseitems.2da row lookup by BaseItem id, for <see cref="ResourceType.Uti"/>. Null = no item
-        /// preview (the caller has no 2DA layer loaded).
+        /// baseitems.2da row lookup by BaseItem id, for <see cref="ResourceType.Uti"/> and visible
+        /// creature equipment. Null = item models cannot be resolved (the caller has no 2DA layer loaded).
         /// </param>
         public static BlueprintModelReference Resolve(
             ResourceType type,
@@ -157,7 +164,8 @@ namespace SWLOR.Toolset.Domain.Render
 
             return type switch
             {
-                ResourceType.Utc => ResolveCreature(root, appearances, itemBlueprintLoader, partModelExists),
+                ResourceType.Utc => ResolveCreature(
+                    root, appearances, itemBlueprintLoader, partModelExists, baseItems),
                 ResourceType.Utp => ResolvePlaceable(root, placeables),
                 ResourceType.Utd => ResolveDoor(root, doors),
                 ResourceType.Utw => ResolveWaypoint(root, waypoints),
@@ -374,7 +382,8 @@ namespace SWLOR.Toolset.Domain.Render
             JsonGffStruct root,
             AppearanceService? appearances,
             Func<string, JsonGffStruct?>? itemBlueprintLoader,
-            Func<string, bool>? partModelExists)
+            Func<string, bool>? partModelExists,
+            Func<int, BaseItemIconRow?>? baseItems)
         {
             if (appearances == null)
                 return BlueprintModelReference.NoneWith("Creature preview unavailable (appearance data not loaded).");
@@ -384,8 +393,14 @@ namespace SWLOR.Toolset.Domain.Render
             if (row == null)
                 return BlueprintModelReference.NoneWith($"Unknown appearance id {appearanceId}.");
 
+            var visibleEquipment = ResolveVisibleEquipment(
+                root, itemBlueprintLoader, partModelExists, baseItems);
+
             if (string.Equals(row.ModelType, "P", StringComparison.OrdinalIgnoreCase))
-                return ResolveSegmentedCreature(root, row, itemBlueprintLoader, partModelExists);
+            {
+                return ResolveSegmentedCreature(
+                    root, row, itemBlueprintLoader, partModelExists, visibleEquipment);
+            }
 
             var modelResRef = row.Race;
             if (string.IsNullOrWhiteSpace(modelResRef))
@@ -395,7 +410,8 @@ namespace SWLOR.Toolset.Domain.Render
             {
                 Kind = BlueprintModelKind.Simple,
                 Status = $"{row.DisplayName} ({modelResRef}.mdl)",
-                ModelResRef = modelResRef
+                ModelResRef = modelResRef,
+                Parts = visibleEquipment
             };
         }
 
@@ -403,7 +419,8 @@ namespace SWLOR.Toolset.Domain.Render
             JsonGffStruct root,
             AppearanceRow row,
             Func<string, JsonGffStruct?>? itemBlueprintLoader,
-            Func<string, bool>? partModelExists)
+            Func<string, bool>? partModelExists,
+            IReadOnlyList<BlueprintModelPart> visibleEquipment)
         {
             var raceLetter = row.Race;
             if (string.IsNullOrWhiteSpace(raceLetter))
@@ -445,6 +462,8 @@ namespace SWLOR.Toolset.Domain.Render
                 if (number > 0)
                     parts.Add(new BlueprintModelPart(partType, BuildPartName(prefix, partType, number)));
             }
+
+            parts.AddRange(visibleEquipment);
 
             if (parts.Count == 0)
                 return BlueprintModelReference.NoneWith($"{row.DisplayName}: segmented creature has no body parts.");
@@ -500,16 +519,108 @@ namespace SWLOR.Toolset.Domain.Render
             return armorValue > 0 ? armorValue : creatureValue;
         }
 
-        /// <summary>Loads the equipped chest-slot armor's root struct from Equip_ItemList, if any.</summary>
+        /// <summary>
+        /// Resolves the models for equipment the game draws on a creature. Ordinary right- and
+        /// left-hand items are held props; creature natural-weapon/stat slots are deliberately not.
+        /// </summary>
+        private static IReadOnlyList<BlueprintModelPart> ResolveVisibleEquipment(
+            JsonGffStruct root,
+            Func<string, JsonGffStruct?>? itemBlueprintLoader,
+            Func<string, bool>? partModelExists,
+            Func<int, BaseItemIconRow?>? baseItems)
+        {
+            if (baseItems == null)
+                return Array.Empty<BlueprintModelPart>();
+
+            var parts = new List<BlueprintModelPart>();
+            AddVisibleEquipmentPart(
+                parts, root, HeadSlotStructId, "helmet",
+                itemBlueprintLoader, partModelExists, baseItems);
+            AddVisibleEquipmentPart(
+                parts, root, CloakSlotStructId, "cloak",
+                itemBlueprintLoader, partModelExists, baseItems);
+            AddVisibleEquipmentPart(
+                parts, root, RightHandSlotStructId, "weaponr",
+                itemBlueprintLoader, partModelExists, baseItems);
+            AddVisibleEquipmentPart(
+                parts, root, LeftHandSlotStructId, "weaponl",
+                itemBlueprintLoader, partModelExists, baseItems);
+            return parts;
+        }
+
+        private static void AddVisibleEquipmentPart(
+            ICollection<BlueprintModelPart> destination,
+            JsonGffStruct creature,
+            int slot,
+            string attachmentType,
+            Func<string, JsonGffStruct?>? itemBlueprintLoader,
+            Func<string, bool>? partModelExists,
+            Func<int, BaseItemIconRow?> baseItems)
+        {
+            var item = LoadEquippedItem(creature, slot, itemBlueprintLoader);
+            if (item == null)
+                return;
+
+            var reference = ResolveItem(item, baseItems, partModelExists, armorPreviewFemale: false);
+            if (attachmentType == "cloak")
+            {
+                foreach (var part in reference.Parts.Where(
+                             part => part.PartType.Equals("cloak", StringComparison.OrdinalIgnoreCase)))
+                {
+                    destination.Add(new BlueprintModelPart(attachmentType, part.ModelResRef));
+                }
+
+                return;
+            }
+
+            if (reference.Kind == BlueprintModelKind.ItemComposite)
+            {
+                foreach (var part in reference.Parts)
+                    destination.Add(new BlueprintModelPart(attachmentType, part.ModelResRef));
+                return;
+            }
+
+            if (reference.Kind == BlueprintModelKind.Simple &&
+                !string.IsNullOrWhiteSpace(reference.ModelResRef) &&
+                !reference.ModelResRef.Equals("it_bag", StringComparison.OrdinalIgnoreCase))
+            {
+                destination.Add(new BlueprintModelPart(attachmentType, reference.ModelResRef));
+            }
+        }
+
+        /// <summary>Loads the equipped chest-slot armor's embedded item or referenced blueprint.</summary>
         private static JsonGffStruct? LoadEquippedChestArmor(
             JsonGffStruct root, Func<string, JsonGffStruct?>? itemBlueprintLoader)
         {
-            if (itemBlueprintLoader == null)
+            return LoadEquippedItem(root, ChestSlotStructId, itemBlueprintLoader);
+        }
+
+        /// <summary>
+        /// GIT creatures embed the complete equipped UTI struct; UTC blueprints usually store only
+        /// an EquippedRes reference. Prefer the embedded copy because it carries per-instance part
+        /// and dye overrides, then fall back to loading either supported resref spelling.
+        /// </summary>
+        private static JsonGffStruct? LoadEquippedItem(
+            JsonGffStruct root,
+            int slot,
+            Func<string, JsonGffStruct?>? itemBlueprintLoader)
+        {
+            var equipped = root.GetListOrEmpty("Equip_ItemList")
+                .FirstOrDefault(item => ParseStructId(item.RawStructId) == slot);
+            if (equipped == null)
                 return null;
 
-            var resRef = GetEquippedChestArmorResRef(root);
+            if (equipped.GetIntOrNull("BaseItem").HasValue ||
+                equipped.GetIntOrNull("ArmorPart_Torso").HasValue ||
+                equipped.GetIntOrNull("ModelPart1").HasValue)
+            {
+                return equipped;
+            }
 
-            return string.IsNullOrWhiteSpace(resRef) ? null : itemBlueprintLoader(resRef);
+            var resRef = GetEquippedItemResRef(equipped);
+            return string.IsNullOrWhiteSpace(resRef) || itemBlueprintLoader == null
+                ? null
+                : itemBlueprintLoader(resRef);
         }
 
         /// <summary>
@@ -521,8 +632,11 @@ namespace SWLOR.Toolset.Domain.Render
             ArgumentNullException.ThrowIfNull(root);
             var chest = root.GetListOrEmpty("Equip_ItemList")
                 .FirstOrDefault(item => ParseStructId(item.RawStructId) == ChestSlotStructId);
-            return chest?.GetStringOrNull("EquippedRes");
+            return chest == null ? null : GetEquippedItemResRef(chest);
         }
+
+        private static string? GetEquippedItemResRef(JsonGffStruct item) =>
+            item.GetStringOrNull("EquippedRes") ?? item.GetStringOrNull("TemplateResRef");
 
         private static int ParseStructId(byte[]? raw)
         {

--- a/SWLOR.Toolset.Domain/Render/CreatureModelFacing.cs
+++ b/SWLOR.Toolset.Domain/Render/CreatureModelFacing.cs
@@ -1,0 +1,20 @@
+using System.Numerics;
+
+namespace SWLOR.Toolset.Domain.Render
+{
+    /// <summary>
+    /// Corrects NWN creature artwork from its authored forward axis to the area's shared instance
+    /// heading convention.
+    /// </summary>
+    /// <remarks>
+    /// Creature bodies face model <c>+Y</c>, while a GIT creature's
+    /// <c>XOrientation</c>/<c>YOrientation</c> vector is its world-space facing. The area transform
+    /// applies that heading as though model <c>+X</c> were forward, so an uncorrected creature is
+    /// displayed a quarter turn anticlockwise from Aurora. This model-space turn maps the body's
+    /// <c>+Y</c> front onto <c>+X</c> before the stored heading is applied.
+    /// </remarks>
+    public static class CreatureModelFacing
+    {
+        public static readonly Matrix4x4 ForwardCorrection = Matrix4x4.CreateRotationZ(-MathF.PI / 2f);
+    }
+}

--- a/SWLOR.Toolset.Domain/Render/MdlMeshBuilder.cs
+++ b/SWLOR.Toolset.Domain/Render/MdlMeshBuilder.cs
@@ -98,6 +98,13 @@ namespace SWLOR.Toolset.Domain.Render
         public IReadOnlyDictionary<string, IReadOnlyList<float[]>> AnimationNormals { get; init; } =
             new Dictionary<string, IReadOnlyList<float[]>>(StringComparer.OrdinalIgnoreCase);
 
+        /// <summary>
+        /// Item-specific PLT palette rows for this mesh. Usually empty, in which case the owning
+        /// creature/model palette applies; weighted equipment such as a cloak carries its own dyes.
+        /// </summary>
+        public IReadOnlyDictionary<int, int> LayerColorIndices { get; set; } =
+            new Dictionary<int, int>();
+
         public int VertexCount => Positions.Length / 3;
         public int TriangleCount => Indices.Length / 3;
     }

--- a/SWLOR.Toolset.Domain/Render/MdlMeshBuilder.cs
+++ b/SWLOR.Toolset.Domain/Render/MdlMeshBuilder.cs
@@ -360,7 +360,7 @@ namespace SWLOR.Toolset.Domain.Render
                 // arrives at the default of true, and it carries no bitmap - which drew it as a flat
                 // grey slab across the ground of every tile that had one. The area view gets its
                 // walkmesh from the tile's .wok (see TileWalkmeshCache), never from here.
-                if (mesh.IsWalkmesh || !mesh.Render || PlaceholderNames.Contains(mesh.Name))
+                if (!IsRenderableMesh(mesh))
                     continue;
 
                 var built = BuildMesh(
@@ -414,6 +414,27 @@ namespace SWLOR.Toolset.Domain.Render
                 Emitters = renderEmitters,
                 DefaultAnimationName = defaultAnimationName
             };
+        }
+
+        /// <summary>
+        /// Whether a source trimesh produces one <see cref="RenderMesh"/> in <see cref="Build"/>.
+        /// Consumers that retain metadata parallel to the built mesh list must use this predicate
+        /// rather than approximating the builder's filtering by node name or geometry counts.
+        /// </summary>
+        public static bool IsRenderableMesh(MdlTrimeshNode mesh)
+        {
+            ArgumentNullException.ThrowIfNull(mesh);
+            if (mesh.IsWalkmesh || !mesh.Render || PlaceholderNames.Contains(mesh.Name) ||
+                mesh.Vertices.Length == 0 || mesh.Faces.Length == 0)
+            {
+                return false;
+            }
+
+            var vertexCount = mesh.Vertices.Length;
+            return mesh.Faces.Any(face =>
+                face.VertexIndex0 < vertexCount &&
+                face.VertexIndex1 < vertexCount &&
+                face.VertexIndex2 < vertexCount);
         }
 
         private static RenderMesh? BuildMesh(

--- a/SWLOR.Toolset.Domain/Render/MdlPartBoneMap.cs
+++ b/SWLOR.Toolset.Domain/Render/MdlPartBoneMap.cs
@@ -36,6 +36,13 @@ namespace SWLOR.Toolset.Domain.Render
                 ["footr"] = ["rfoot_g", "rfoot"],
                 ["robe"] = ["torso_g", "pelvis_g", "torso", "pelvis"],
 
+                // Equipped item models use their own authored origin and hang directly from the
+                // creature skeleton's visible attachment bones. Distinct part names keep robe
+                // coverage from mistaking a held weapon for the hand body part beneath it.
+                ["helmet"] = ["head_g", "head"],
+                ["weaponl"] = ["lhand_g", "lhand"],
+                ["weaponr"] = ["rhand_g", "rhand"],
+
                 // A cloak hangs from the skeleton's own Cloak_g, which sits under torso_g and carries
                 // the CL*/CM*/CR* chain the cloak's skinmesh is weighted to. Verified against pmh0.
                 ["cloak"] = ["Cloak_g", "cloak_g", "torso_g"],

--- a/SWLOR.Toolset.Domain/Render/ThumbnailRenderer.cs
+++ b/SWLOR.Toolset.Domain/Render/ThumbnailRenderer.cs
@@ -192,7 +192,7 @@ namespace SWLOR.Toolset.Domain.Render
                 string.IsNullOrWhiteSpace(mesh.TextureName))
                 return null;
 
-            var paletteKey = mesh.LayerColorIndices.Count == 0
+            var paletteKey = resolveLayeredTexture == null || mesh.LayerColorIndices.Count == 0
                 ? string.Empty
                 : "|" + string.Join(
                     ",",

--- a/SWLOR.Toolset.Domain/Render/ThumbnailRenderer.cs
+++ b/SWLOR.Toolset.Domain/Render/ThumbnailRenderer.cs
@@ -90,18 +90,24 @@ namespace SWLOR.Toolset.Domain.Render
         /// the palette's flat tone, which is how the pipeline behaves when no resource index is loaded.
         /// The callback is invoked at most once per distinct texture per render.
         /// </param>
+        /// <param name="resolveLayeredTexture">
+        /// Resolves a texture with the palette carried by its individual mesh. When supplied it
+        /// takes precedence over <paramref name="resolveTexture"/> and lets equipped garments keep
+        /// dyes that differ from the creature's chest armor.
+        /// </param>
         public static byte[]? Render(
             RenderModel? model,
             int size,
             ThumbnailPalette? palette = null,
-            Func<string, TextureImage?>? resolveTexture = null)
+            Func<string, TextureImage?>? resolveTexture = null,
+            Func<string, IReadOnlyDictionary<int, int>?, TextureImage?>? resolveLayeredTexture = null)
         {
             if (model == null || size <= 0)
                 return null;
 
             palette ??= ThumbnailPalette.Default;
 
-            var triangles = CollectTriangles(model, resolveTexture);
+            var triangles = CollectTriangles(model, resolveTexture, resolveLayeredTexture);
             if (triangles.Count == 0)
                 return null;
 
@@ -123,7 +129,9 @@ namespace SWLOR.Toolset.Domain.Render
         }
 
         private static List<SourceTriangle> CollectTriangles(
-            RenderModel model, Func<string, TextureImage?>? resolveTexture)
+            RenderModel model,
+            Func<string, TextureImage?>? resolveTexture,
+            Func<string, IReadOnlyDictionary<int, int>?, TextureImage?>? resolveLayeredTexture)
         {
             var triangles = new List<SourceTriangle>();
 
@@ -135,7 +143,8 @@ namespace SWLOR.Toolset.Domain.Render
                 if (mesh.Indices.Length < 3 || mesh.Positions.Length < 9)
                     continue;
 
-                var texture = ResolveMeshTexture(mesh, resolveTexture, decoded);
+                var texture = ResolveMeshTexture(
+                    mesh, resolveTexture, resolveLayeredTexture, decoded);
                 var hasUvs = texture != null && mesh.TexCoords.Length * 3 >= mesh.Positions.Length * 2;
 
                 for (var i = 0; i + 2 < mesh.Indices.Length; i += 3)
@@ -176,18 +185,29 @@ namespace SWLOR.Toolset.Domain.Render
         private static TextureImage? ResolveMeshTexture(
             RenderMesh mesh,
             Func<string, TextureImage?>? resolveTexture,
+            Func<string, IReadOnlyDictionary<int, int>?, TextureImage?>? resolveLayeredTexture,
             Dictionary<string, TextureImage?> decoded)
         {
-            if (resolveTexture == null || string.IsNullOrWhiteSpace(mesh.TextureName))
+            if ((resolveTexture == null && resolveLayeredTexture == null) ||
+                string.IsNullOrWhiteSpace(mesh.TextureName))
                 return null;
 
-            if (decoded.TryGetValue(mesh.TextureName, out var cached))
+            var paletteKey = mesh.LayerColorIndices.Count == 0
+                ? string.Empty
+                : "|" + string.Join(
+                    ",",
+                    mesh.LayerColorIndices.OrderBy(pair => pair.Key)
+                        .Select(pair => $"{pair.Key}:{pair.Value}"));
+            var cacheKey = mesh.TextureName + paletteKey;
+            if (decoded.TryGetValue(cacheKey, out var cached))
                 return cached;
 
             TextureImage? texture = null;
             try
             {
-                texture = resolveTexture(mesh.TextureName);
+                texture = resolveLayeredTexture != null
+                    ? resolveLayeredTexture(mesh.TextureName, mesh.LayerColorIndices)
+                    : resolveTexture!(mesh.TextureName);
             }
             catch (Exception)
             {
@@ -197,7 +217,7 @@ namespace SWLOR.Toolset.Domain.Render
             if (texture != null && texture.Pixels.Length < texture.Width * texture.Height * 4)
                 texture = null;
 
-            decoded[mesh.TextureName] = texture;
+            decoded[cacheKey] = texture;
             return texture;
         }
 

--- a/SWLOR.Toolset.Domain/Render/WaypointMarkerModel.cs
+++ b/SWLOR.Toolset.Domain/Render/WaypointMarkerModel.cs
@@ -6,8 +6,8 @@ namespace SWLOR.Toolset.Domain.Render
     /// Corrects the axis the toolset's waypoint flag artwork is authored along.
     /// </summary>
     /// <remarks>
-    /// Every other placed object follows one convention: the model's forward is <c>+X</c>, and the
-    /// instance's heading is applied as a plain rotation about Z. That is not a guess - across the
+    /// The area transform treats model <c>+X</c> as forward and applies the instance's heading as a
+    /// plain rotation about Z. That is the correct convention for doors: across the
     /// corpus, 515 doors that sit in a doorway their tile declares carry a Bearing equal to that
     /// doorway's orientation to within 0 or 180 degrees, never 90. Since a door's leaf spans model
     /// +X (TTR_UDoor_01 measures 3.32m across X against 0.44m across Y), rotating it by its bearing
@@ -17,7 +17,7 @@ namespace SWLOR.Toolset.Domain.Render
     /// put their ground direction arrow at model <c>+Y</c>: the arrow tip measures (0.00, 1.20) with
     /// the flag above it. Rotated by the heading like everything else, the arrow ends up pointing a
     /// quarter turn anticlockwise of the facing the waypoint actually carries, so a waypoint set to
-    /// face east drew pointing north. This turns the artwork onto the shared convention first, and
+    /// face east drew pointing north. This turns the artwork onto the transform's convention first, and
     /// leaves everything downstream - rendering, picking, the gizmo - unchanged.
     /// </para>
     /// <para>
@@ -30,8 +30,8 @@ namespace SWLOR.Toolset.Domain.Render
     public static class WaypointMarkerModel
     {
         /// <summary>
-        /// Turns the flag artwork's <c>+Y</c> arrow onto the <c>+X</c> forward every other model
-        /// uses. Composed in model space, before the instance's own heading.
+        /// Turns the flag artwork's <c>+Y</c> arrow onto the transform's <c>+X</c> forward.
+        /// Composed in model space, before the instance's own heading.
         /// </summary>
         public static readonly Matrix4x4 ForwardCorrection = Matrix4x4.CreateRotationZ(-MathF.PI / 2f);
     }

--- a/SWLOR.Toolset.Domain/Render/WaypointMarkerModel.cs
+++ b/SWLOR.Toolset.Domain/Render/WaypointMarkerModel.cs
@@ -30,6 +30,13 @@ namespace SWLOR.Toolset.Domain.Render
     public static class WaypointMarkerModel
     {
         /// <summary>
+        /// Aurora draws placed stores with the yellow waypoint flag rather than with a generic
+        /// object marker. Stores have no appearance field of their own, so this is their fixed
+        /// editor-only model.
+        /// </summary>
+        public const string MerchantModelResRef = "gi_waypoint04";
+
+        /// <summary>
         /// Turns the flag artwork's <c>+Y</c> arrow onto the transform's <c>+X</c> forward.
         /// Composed in model space, before the instance's own heading.
         /// </summary>

--- a/SWLOR.Toolset.Domain/Workspace/ModulePlacementIndex.cs
+++ b/SWLOR.Toolset.Domain/Workspace/ModulePlacementIndex.cs
@@ -45,6 +45,7 @@ namespace SWLOR.Toolset.Domain.Workspace
         private readonly ModuleWorkspace _workspace;
         private readonly object _syncRoot = new();
         private Task<IReadOnlyDictionary<string, IReadOnlyList<ObjectPlacement>>>? _buildTask;
+        private CancellationTokenSource? _buildCancellation;
         private int _generation;
 
         public ModulePlacementIndex(ModuleWorkspace workspace) =>
@@ -78,7 +79,16 @@ namespace SWLOR.Toolset.Domain.Workspace
                 lock (_syncRoot)
                 {
                     generation = _generation;
-                    task = _buildTask ??= Task.Run(Build);
+                    if (_buildTask == null)
+                    {
+                        _buildCancellation = new CancellationTokenSource();
+                        var cancellationToken = _buildCancellation.Token;
+                        _buildTask = Task.Run(
+                            () => Build(cancellationToken),
+                            CancellationToken.None);
+                    }
+
+                    task = _buildTask;
                 }
 
                 IReadOnlyDictionary<string, IReadOnlyList<ObjectPlacement>> index;
@@ -88,20 +98,38 @@ namespace SWLOR.Toolset.Domain.Workspace
                 }
                 catch
                 {
+                    CancellationTokenSource? completedCancellation = null;
                     lock (_syncRoot)
                     {
                         if (ReferenceEquals(_buildTask, task))
+                        {
                             _buildTask = null;
+                            completedCancellation = _buildCancellation;
+                            _buildCancellation = null;
+                        }
                     }
 
+                    completedCancellation?.Dispose();
                     throw;
                 }
 
+                CancellationTokenSource? successfulCancellation = null;
+                var retry = false;
                 lock (_syncRoot)
                 {
+                    if (ReferenceEquals(_buildTask, task))
+                    {
+                        successfulCancellation = _buildCancellation;
+                        _buildCancellation = null;
+                    }
+
                     if (generation != _generation)
-                        continue;
+                        retry = true;
                 }
+
+                successfulCancellation?.Dispose();
+                if (retry)
+                    continue;
 
                 return index;
             }
@@ -109,15 +137,38 @@ namespace SWLOR.Toolset.Domain.Workspace
 
         public void Invalidate()
         {
+            Task<IReadOnlyDictionary<string, IReadOnlyList<ObjectPlacement>>>? obsoleteTask;
+            CancellationTokenSource? obsoleteCancellation;
             lock (_syncRoot)
             {
                 _generation++;
+                obsoleteTask = _buildTask;
                 _buildTask = null;
+                obsoleteCancellation = _buildCancellation;
+                _buildCancellation = null;
             }
+
+            if (obsoleteCancellation == null)
+                return;
+
+            obsoleteCancellation.Cancel();
+            if (obsoleteTask == null || obsoleteTask.IsCompleted)
+            {
+                obsoleteCancellation.Dispose();
+                return;
+            }
+
+            _ = obsoleteTask.ContinueWith(
+                _ => obsoleteCancellation.Dispose(),
+                CancellationToken.None,
+                TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
         }
 
-        private IReadOnlyDictionary<string, IReadOnlyList<ObjectPlacement>> Build()
+        private IReadOnlyDictionary<string, IReadOnlyList<ObjectPlacement>> Build(
+            CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var areas = _workspace.EnumerateAreaResRefs();
             var perArea = new List<ObjectPlacement>?[areas.Count];
             var failures = new (string AreaResRef, Exception Error)?[areas.Count];
@@ -126,10 +177,12 @@ namespace SWLOR.Toolset.Domain.Workspace
                 areas.Count,
                 new ParallelOptions
                 {
-                    MaxDegreeOfParallelism = Math.Max(1, Math.Min(Environment.ProcessorCount, 4))
+                    MaxDegreeOfParallelism = Math.Max(1, Math.Min(Environment.ProcessorCount, 4)),
+                    CancellationToken = cancellationToken
                 },
                 index =>
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
                     try
                     {
                         perArea[index] = ReadArea(areas[index]);
@@ -139,8 +192,11 @@ namespace SWLOR.Toolset.Domain.Workspace
                         failures[index] = (areas[index], ex);
                         AreaReadFailed?.Invoke(areas[index], ex);
                     }
+
+                    cancellationToken.ThrowIfCancellationRequested();
                 });
 
+            cancellationToken.ThrowIfCancellationRequested();
             var failedAreas = failures
                 .Where(failure => failure.HasValue)
                 .Select(failure => failure!.Value)

--- a/SWLOR.Toolset.Domain/Workspace/ModulePlacementIndex.cs
+++ b/SWLOR.Toolset.Domain/Workspace/ModulePlacementIndex.cs
@@ -1,9 +1,28 @@
-using System.Text;
 using System.Text.Json;
-using System.Text.Unicode;
 
 namespace SWLOR.Toolset.Domain.Workspace
 {
+    /// <summary>
+    /// The module placement scan could not read every area, so its results would be incomplete.
+    /// The failed areas are retained for diagnostics and a later query retries the complete scan.
+    /// </summary>
+    public sealed class PlacementIndexIncompleteException : IOException
+    {
+        public IReadOnlyList<string> AreaResRefs { get; }
+
+        internal PlacementIndexIncompleteException(
+            IReadOnlyList<(string AreaResRef, Exception Error)> failures)
+            : base(
+                $"Could not scan placements in {failures.Count} " +
+                $"area{(failures.Count == 1 ? string.Empty : "s")}: " +
+                $"{string.Join(", ", failures.Select(failure => failure.AreaResRef))}. " +
+                "Refresh to retry.",
+                new AggregateException(failures.Select(failure => failure.Error)))
+        {
+            AreaResRefs = failures.Select(failure => failure.AreaResRef).ToList();
+        }
+    }
+
     /// <summary>
     /// Module-wide map from a blueprint to every area instance placed from it. The first query builds
     /// all supported kinds together on a bounded worker pool; subsequent Source tabs are lookups.
@@ -31,6 +50,12 @@ namespace SWLOR.Toolset.Domain.Workspace
         public ModulePlacementIndex(ModuleWorkspace workspace) =>
             _workspace = workspace ?? throw new ArgumentNullException(nameof(workspace));
 
+        /// <summary>Raised on the scanning worker when one area's GIT cannot be indexed.</summary>
+        public event Action<string, Exception>? AreaReadFailed;
+
+        /// <summary>Starts or joins the shared module-wide scan without requesting a specific blueprint.</summary>
+        public async Task WarmAsync() => _ = await GetIndexAsync().ConfigureAwait(false);
+
         public async Task<IReadOnlyList<ObjectPlacement>> FindAsync(
             ResourceType type,
             string blueprintResRef)
@@ -38,6 +63,14 @@ namespace SWLOR.Toolset.Domain.Workspace
             if (string.IsNullOrWhiteSpace(blueprintResRef))
                 return Array.Empty<ObjectPlacement>();
 
+            var index = await GetIndexAsync().ConfigureAwait(false);
+            return index.TryGetValue(Key(type, blueprintResRef), out var placements)
+                ? placements
+                : Array.Empty<ObjectPlacement>();
+        }
+
+        private async Task<IReadOnlyDictionary<string, IReadOnlyList<ObjectPlacement>>> GetIndexAsync()
+        {
             while (true)
             {
                 Task<IReadOnlyDictionary<string, IReadOnlyList<ObjectPlacement>>> task;
@@ -48,16 +81,29 @@ namespace SWLOR.Toolset.Domain.Workspace
                     task = _buildTask ??= Task.Run(Build);
                 }
 
-                var index = await task.ConfigureAwait(false);
+                IReadOnlyDictionary<string, IReadOnlyList<ObjectPlacement>> index;
+                try
+                {
+                    index = await task.ConfigureAwait(false);
+                }
+                catch
+                {
+                    lock (_syncRoot)
+                    {
+                        if (ReferenceEquals(_buildTask, task))
+                            _buildTask = null;
+                    }
+
+                    throw;
+                }
+
                 lock (_syncRoot)
                 {
                     if (generation != _generation)
                         continue;
                 }
 
-                return index.TryGetValue(Key(type, blueprintResRef), out var placements)
-                    ? placements
-                    : Array.Empty<ObjectPlacement>();
+                return index;
             }
         }
 
@@ -74,6 +120,7 @@ namespace SWLOR.Toolset.Domain.Workspace
         {
             var areas = _workspace.EnumerateAreaResRefs();
             var perArea = new List<ObjectPlacement>?[areas.Count];
+            var failures = new (string AreaResRef, Exception Error)?[areas.Count];
             Parallel.For(
                 0,
                 areas.Count,
@@ -87,11 +134,19 @@ namespace SWLOR.Toolset.Domain.Workspace
                     {
                         perArea[index] = ReadArea(areas[index]);
                     }
-                    catch
+                    catch (Exception ex)
                     {
-                        // One malformed GIT must not hide valid placements in every other area.
+                        failures[index] = (areas[index], ex);
+                        AreaReadFailed?.Invoke(areas[index], ex);
                     }
                 });
+
+            var failedAreas = failures
+                .Where(failure => failure.HasValue)
+                .Select(failure => failure!.Value)
+                .ToList();
+            if (failedAreas.Count > 0)
+                throw new PlacementIndexIncompleteException(failedAreas);
 
             var result = new Dictionary<string, List<ObjectPlacement>>(StringComparer.OrdinalIgnoreCase);
             foreach (var placements in perArea)
@@ -119,7 +174,7 @@ namespace SWLOR.Toolset.Domain.Workspace
         private List<ObjectPlacement> ReadArea(string areaResRef)
         {
             var path = Path.Combine(_workspace.ModuleRoot, "git", areaResRef + ".git.json");
-            using var document = JsonDocument.Parse(ReadAsUtf8(path));
+            using var document = JsonDocument.Parse(NwnJsonEncoding.ReadFileAsUtf8(path));
             var root = document.RootElement;
             var placements = new List<ObjectPlacement>();
 
@@ -171,18 +226,5 @@ namespace SWLOR.Toolset.Domain.Workspace
                 ? result
                 : 0f;
 
-        private static byte[] ReadAsUtf8(string path)
-        {
-            var raw = File.ReadAllBytes(path);
-            return Utf8.IsValid(raw) ? raw : Encoding.UTF8.GetBytes(NwnText.GetString(raw));
-        }
-
-        private static readonly Encoding NwnText = CreateNwnTextEncoding();
-
-        private static Encoding CreateNwnTextEncoding()
-        {
-            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
-            return Encoding.GetEncoding(1252);
-        }
     }
 }

--- a/SWLOR.Toolset.Domain/Workspace/ModulePlacementIndex.cs
+++ b/SWLOR.Toolset.Domain/Workspace/ModulePlacementIndex.cs
@@ -1,0 +1,188 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Unicode;
+
+namespace SWLOR.Toolset.Domain.Workspace
+{
+    /// <summary>
+    /// Module-wide map from a blueprint to every area instance placed from it. The first query builds
+    /// all supported kinds together on a bounded worker pool; subsequent Source tabs are lookups.
+    /// </summary>
+    public sealed class ModulePlacementIndex
+    {
+        private static readonly (ResourceType Type, string List, string Template, string X, string Y, string Z)[]
+            Lists =
+            {
+                (ResourceType.Utc, "Creature List", "TemplateResRef", "XPosition", "YPosition", "ZPosition"),
+                (ResourceType.Utp, "Placeable List", "TemplateResRef", "X", "Y", "Z"),
+                (ResourceType.Utd, "Door List", "TemplateResRef", "X", "Y", "Z"),
+                (ResourceType.Utw, "WaypointList", "TemplateResRef", "XPosition", "YPosition", "ZPosition"),
+                (ResourceType.Utm, "StoreList", "ResRef", "XPosition", "YPosition", "ZPosition"),
+                (ResourceType.Uts, "SoundList", "TemplateResRef", "XPosition", "YPosition", "ZPosition"),
+                (ResourceType.Utt, "TriggerList", "TemplateResRef", "XPosition", "YPosition", "ZPosition"),
+                (ResourceType.Uti, "List", "TemplateResRef", "XPosition", "YPosition", "ZPosition")
+            };
+
+        private readonly ModuleWorkspace _workspace;
+        private readonly object _syncRoot = new();
+        private Task<IReadOnlyDictionary<string, IReadOnlyList<ObjectPlacement>>>? _buildTask;
+        private int _generation;
+
+        public ModulePlacementIndex(ModuleWorkspace workspace) =>
+            _workspace = workspace ?? throw new ArgumentNullException(nameof(workspace));
+
+        public async Task<IReadOnlyList<ObjectPlacement>> FindAsync(
+            ResourceType type,
+            string blueprintResRef)
+        {
+            if (string.IsNullOrWhiteSpace(blueprintResRef))
+                return Array.Empty<ObjectPlacement>();
+
+            while (true)
+            {
+                Task<IReadOnlyDictionary<string, IReadOnlyList<ObjectPlacement>>> task;
+                int generation;
+                lock (_syncRoot)
+                {
+                    generation = _generation;
+                    task = _buildTask ??= Task.Run(Build);
+                }
+
+                var index = await task.ConfigureAwait(false);
+                lock (_syncRoot)
+                {
+                    if (generation != _generation)
+                        continue;
+                }
+
+                return index.TryGetValue(Key(type, blueprintResRef), out var placements)
+                    ? placements
+                    : Array.Empty<ObjectPlacement>();
+            }
+        }
+
+        public void Invalidate()
+        {
+            lock (_syncRoot)
+            {
+                _generation++;
+                _buildTask = null;
+            }
+        }
+
+        private IReadOnlyDictionary<string, IReadOnlyList<ObjectPlacement>> Build()
+        {
+            var areas = _workspace.EnumerateAreaResRefs();
+            var perArea = new List<ObjectPlacement>?[areas.Count];
+            Parallel.For(
+                0,
+                areas.Count,
+                new ParallelOptions
+                {
+                    MaxDegreeOfParallelism = Math.Max(1, Math.Min(Environment.ProcessorCount, 4))
+                },
+                index =>
+                {
+                    try
+                    {
+                        perArea[index] = ReadArea(areas[index]);
+                    }
+                    catch
+                    {
+                        // One malformed GIT must not hide valid placements in every other area.
+                    }
+                });
+
+            var result = new Dictionary<string, List<ObjectPlacement>>(StringComparer.OrdinalIgnoreCase);
+            foreach (var placements in perArea)
+            foreach (var placement in placements ?? Enumerable.Empty<ObjectPlacement>())
+            {
+                var key = Key(placement.BlueprintType, placement.BlueprintResRef);
+                if (!result.TryGetValue(key, out var values))
+                {
+                    values = new List<ObjectPlacement>();
+                    result.Add(key, values);
+                }
+
+                values.Add(placement);
+            }
+
+            return result.ToDictionary(
+                pair => pair.Key,
+                pair => (IReadOnlyList<ObjectPlacement>)pair.Value
+                    .OrderBy(value => value.AreaResRef, StringComparer.OrdinalIgnoreCase)
+                    .ThenBy(value => value.InstanceIndex)
+                    .ToList(),
+                StringComparer.OrdinalIgnoreCase);
+        }
+
+        private List<ObjectPlacement> ReadArea(string areaResRef)
+        {
+            var path = Path.Combine(_workspace.ModuleRoot, "git", areaResRef + ".git.json");
+            using var document = JsonDocument.Parse(ReadAsUtf8(path));
+            var root = document.RootElement;
+            var placements = new List<ObjectPlacement>();
+
+            foreach (var config in Lists)
+            {
+                if (!root.TryGetProperty(config.List, out var field) ||
+                    !field.TryGetProperty("value", out var values) ||
+                    values.ValueKind != JsonValueKind.Array)
+                    continue;
+
+                var instanceIndex = 0;
+                foreach (var instance in values.EnumerateArray())
+                {
+                    var resRef = FieldString(instance, config.Template);
+                    if (!string.IsNullOrWhiteSpace(resRef))
+                    {
+                        placements.Add(new ObjectPlacement(
+                            config.Type,
+                            resRef,
+                            areaResRef,
+                            instanceIndex,
+                            FieldString(instance, "Tag") ?? string.Empty,
+                            FieldSingle(instance, config.X),
+                            FieldSingle(instance, config.Y),
+                            FieldSingle(instance, config.Z)));
+                    }
+
+                    instanceIndex++;
+                }
+            }
+
+            return placements;
+        }
+
+        private static string Key(ResourceType type, string resRef) => $"{(int)type}:{resRef}";
+
+        private static string? FieldString(JsonElement instance, string name) =>
+            instance.TryGetProperty(name, out var field) &&
+            field.TryGetProperty("value", out var value) &&
+            value.ValueKind == JsonValueKind.String
+                ? value.GetString()
+                : null;
+
+        private static float FieldSingle(JsonElement instance, string name) =>
+            instance.TryGetProperty(name, out var field) &&
+            field.TryGetProperty("value", out var value) &&
+            value.ValueKind == JsonValueKind.Number &&
+            value.TryGetSingle(out var result)
+                ? result
+                : 0f;
+
+        private static byte[] ReadAsUtf8(string path)
+        {
+            var raw = File.ReadAllBytes(path);
+            return Utf8.IsValid(raw) ? raw : Encoding.UTF8.GetBytes(NwnText.GetString(raw));
+        }
+
+        private static readonly Encoding NwnText = CreateNwnTextEncoding();
+
+        private static Encoding CreateNwnTextEncoding()
+        {
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+            return Encoding.GetEncoding(1252);
+        }
+    }
+}

--- a/SWLOR.Toolset.Domain/Workspace/ModuleTagIndex.cs
+++ b/SWLOR.Toolset.Domain/Workspace/ModuleTagIndex.cs
@@ -1,6 +1,4 @@
-using System.Text;
 using System.Text.Json;
-using System.Text.Unicode;
 using SWLOR.Toolset.Domain.Documents;
 
 namespace SWLOR.Toolset.Domain.Workspace
@@ -225,41 +223,6 @@ namespace SWLOR.Toolset.Domain.Workspace
             }
         }
 
-        /// <summary>
-        /// A module JSON file as UTF-8 bytes, whatever it is stored as.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// Both scans below are UTF-8 readers, and the module is not uniformly UTF-8. nwn_gff writes
-        /// NWN text as raw Windows-1252, so a file carrying an em-dash holds the single byte 0x97 -
-        /// which is not valid UTF-8 at all. <c>coolship.git.json</c> is one such file, and there are
-        /// a dozen more; a Python pass over the module leaves the rest as real UTF-8, so the corpus
-        /// genuinely contains both.
-        /// </para>
-        /// <para>
-        /// The reader threw on the Windows-1252 ones, and the enclosing catch turned that into
-        /// silence: every waypoint and door tag in that area simply disappeared from tag resolution
-        /// and from transition destinations. A door pointing at one of them then read as pointing at
-        /// nothing. Valid UTF-8 is passed through untouched; anything else is transcoded.
-        /// </para>
-        /// </remarks>
-        private static byte[] ReadAsUtf8(string path)
-        {
-            var raw = File.ReadAllBytes(path);
-            return Utf8.IsValid(raw)
-                ? raw
-                : Encoding.UTF8.GetBytes(NwnText.GetString(raw));
-        }
-
-        /// <summary>Windows-1252: what nwn_gff writes, and a single-byte encoding that never throws.</summary>
-        private static readonly Encoding NwnText = CreateNwnTextEncoding();
-
-        private static Encoding CreateNwnTextEncoding()
-        {
-            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
-            return Encoding.GetEncoding(1252);
-        }
-
         private Dictionary<string, string> Index()
         {
             lock (_syncRoot)
@@ -310,7 +273,7 @@ namespace SWLOR.Toolset.Domain.Workspace
             string areaResRef)
         {
             var path = Path.Combine(_workspace.ModuleRoot, "git", areaResRef + ".git.json");
-            using var document = JsonDocument.Parse(ReadAsUtf8(path));
+            using var document = JsonDocument.Parse(NwnJsonEncoding.ReadFileAsUtf8(path));
             var root = document.RootElement;
 
             // A GIT can contain tens of thousands of fields, but this index needs only two lists
@@ -369,7 +332,7 @@ namespace SWLOR.Toolset.Domain.Workspace
         private HashSet<string> ReadTransitionDestinations(string areaResRef)
         {
             var path = Path.Combine(_workspace.ModuleRoot, "git", areaResRef + ".git.json");
-            var reader = new Utf8JsonReader(ReadAsUtf8(path));
+            var reader = new Utf8JsonReader(NwnJsonEncoding.ReadFileAsUtf8(path));
             var destinations = new HashSet<string>(StringComparer.Ordinal);
 
             while (reader.Read())

--- a/SWLOR.Toolset.Domain/Workspace/ModuleWorkspace.cs
+++ b/SWLOR.Toolset.Domain/Workspace/ModuleWorkspace.cs
@@ -49,6 +49,7 @@ namespace SWLOR.Toolset.Domain.Workspace
             ModuleRoot = fullPath;
             ResourceIndex = resourceIndex;
             _tagIndex = new Lazy<ModuleTagIndex>(() => new ModuleTagIndex(this));
+            _placementIndex = new Lazy<ModulePlacementIndex>(() => new ModulePlacementIndex(this));
         }
 
         /// <summary>
@@ -69,6 +70,11 @@ namespace SWLOR.Toolset.Domain.Workspace
         public ModuleTagIndex TagIndex => _tagIndex.Value;
 
         private readonly Lazy<ModuleTagIndex> _tagIndex;
+
+        /// <summary>Every blueprint-backed object placement in the module, built lazily in the background.</summary>
+        public ModulePlacementIndex PlacementIndex => _placementIndex.Value;
+
+        private readonly Lazy<ModulePlacementIndex> _placementIndex;
 
         public string GetResourceFolder(ResourceType type) => Path.Combine(ModuleRoot, type.Extension());
 

--- a/SWLOR.Toolset.Domain/Workspace/NwnJsonEncoding.cs
+++ b/SWLOR.Toolset.Domain/Workspace/NwnJsonEncoding.cs
@@ -1,9 +1,10 @@
 using System.Text;
-using System.Text.Unicode;
 
 namespace SWLOR.Toolset.Domain.Workspace
 {
-    /// <summary>Normalizes the mixed UTF-8 and Windows-1252 JSON emitted by NWN tooling.</summary>
+    /// <summary>
+    /// Normalizes canonical Windows-1252 NWN JSON and explicitly BOM-marked UTF-8 JSON.
+    /// </summary>
     internal static class NwnJsonEncoding
     {
         private static readonly Encoding NwnText = CreateNwnTextEncoding();
@@ -11,9 +12,14 @@ namespace SWLOR.Toolset.Domain.Workspace
         public static byte[] ReadFileAsUtf8(string path)
         {
             var raw = File.ReadAllBytes(path);
-            return Utf8.IsValid(raw)
-                ? raw
-                : Encoding.UTF8.GetBytes(NwnText.GetString(raw));
+            if (raw.AsSpan().StartsWith(Encoding.UTF8.Preamble))
+                return raw.AsSpan(Encoding.UTF8.Preamble.Length).ToArray();
+
+            // nwn_gff JSON is canonically Windows-1252. Validity cannot distinguish it from
+            // UTF-8: the Windows-1252 bytes C2 A9, for example, are also valid UTF-8 but mean a
+            // different string. A UTF-8 BOM is the explicit provenance that opts a file into
+            // UTF-8; unmarked module JSON keeps the NWN encoding.
+            return Encoding.UTF8.GetBytes(NwnText.GetString(raw));
         }
 
         private static Encoding CreateNwnTextEncoding()

--- a/SWLOR.Toolset.Domain/Workspace/NwnJsonEncoding.cs
+++ b/SWLOR.Toolset.Domain/Workspace/NwnJsonEncoding.cs
@@ -1,9 +1,10 @@
 using System.Text;
+using System.Text.Unicode;
 
 namespace SWLOR.Toolset.Domain.Workspace
 {
     /// <summary>
-    /// Normalizes canonical Windows-1252 NWN JSON and explicitly BOM-marked UTF-8 JSON.
+    /// Normalizes NWN JSON that may be Windows-1252 or UTF-8.
     /// </summary>
     internal static class NwnJsonEncoding
     {
@@ -15,10 +16,13 @@ namespace SWLOR.Toolset.Domain.Workspace
             if (raw.AsSpan().StartsWith(Encoding.UTF8.Preamble))
                 return raw.AsSpan(Encoding.UTF8.Preamble.Length).ToArray();
 
-            // nwn_gff JSON is canonically Windows-1252. Validity cannot distinguish it from
-            // UTF-8: the Windows-1252 bytes C2 A9, for example, are also valid UTF-8 but mean a
-            // different string. A UTF-8 BOM is the explicit provenance that opts a file into
-            // UTF-8; unmarked module JSON keeps the NWN encoding.
+            // Modern tools also emit BOM-less UTF-8. Treat a valid unmarked byte stream as UTF-8;
+            // otherwise fall back to the legacy NWN Windows-1252 encoding. An unmarked stream that
+            // is valid in both encodings is inherently ambiguous, and choosing UTF-8 avoids
+            // corrupting contemporary module exports.
+            if (Utf8.IsValid(raw))
+                return raw;
+
             return Encoding.UTF8.GetBytes(NwnText.GetString(raw));
         }
 

--- a/SWLOR.Toolset.Domain/Workspace/NwnJsonEncoding.cs
+++ b/SWLOR.Toolset.Domain/Workspace/NwnJsonEncoding.cs
@@ -1,0 +1,25 @@
+using System.Text;
+using System.Text.Unicode;
+
+namespace SWLOR.Toolset.Domain.Workspace
+{
+    /// <summary>Normalizes the mixed UTF-8 and Windows-1252 JSON emitted by NWN tooling.</summary>
+    internal static class NwnJsonEncoding
+    {
+        private static readonly Encoding NwnText = CreateNwnTextEncoding();
+
+        public static byte[] ReadFileAsUtf8(string path)
+        {
+            var raw = File.ReadAllBytes(path);
+            return Utf8.IsValid(raw)
+                ? raw
+                : Encoding.UTF8.GetBytes(NwnText.GetString(raw));
+        }
+
+        private static Encoding CreateNwnTextEncoding()
+        {
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+            return Encoding.GetEncoding(1252);
+        }
+    }
+}

--- a/SWLOR.Toolset.Domain/Workspace/NwnJsonEncoding.cs
+++ b/SWLOR.Toolset.Domain/Workspace/NwnJsonEncoding.cs
@@ -1,5 +1,6 @@
+using System.Buffers;
 using System.Text;
-using System.Text.Unicode;
+using SWLOR.Toolset.Domain.Gff;
 
 namespace SWLOR.Toolset.Domain.Workspace
 {
@@ -8,28 +9,71 @@ namespace SWLOR.Toolset.Domain.Workspace
     /// </summary>
     internal static class NwnJsonEncoding
     {
-        private static readonly Encoding NwnText = CreateNwnTextEncoding();
-
         public static byte[] ReadFileAsUtf8(string path)
         {
             var raw = File.ReadAllBytes(path);
-            if (raw.AsSpan().StartsWith(Encoding.UTF8.Preamble))
-                return raw.AsSpan(Encoding.UTF8.Preamble.Length).ToArray();
-
-            // Modern tools also emit BOM-less UTF-8. Treat a valid unmarked byte stream as UTF-8;
-            // otherwise fall back to the legacy NWN Windows-1252 encoding. An unmarked stream that
-            // is valid in both encodings is inherently ambiguous, and choosing UTF-8 avoids
-            // corrupting contemporary module exports.
-            if (Utf8.IsValid(raw))
-                return raw;
-
-            return Encoding.UTF8.GetBytes(NwnText.GetString(raw));
+            var contentOffset = raw.AsSpan().StartsWith(Encoding.UTF8.Preamble)
+                ? Encoding.UTF8.Preamble.Length
+                : 0;
+            return NormalizeStringTokens(raw, contentOffset);
         }
 
-        private static Encoding CreateNwnTextEncoding()
+        /// <summary>
+        /// Converts each JSON string independently through the same encoding-aware token codec as
+        /// the editable GFF reader. GIT files can contain legacy Windows-1252 and imported UTF-8
+        /// strings together; choosing one encoding for the entire byte stream corrupts one side of
+        /// that mix. Syntax, whitespace, and numeric values remain byte-for-byte unchanged.
+        /// </summary>
+        private static byte[] NormalizeStringTokens(byte[] raw, int contentOffset)
         {
-            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
-            return Encoding.GetEncoding(1252);
+            var content = raw.AsSpan(contentOffset);
+            ArrayBufferWriter<byte>? output = null;
+            var position = 0;
+            var copyStart = 0;
+            while (position < content.Length)
+            {
+                var relativeStart = content[position..].IndexOf((byte)'"');
+                if (relativeStart < 0)
+                    break;
+
+                var tokenStart = position + relativeStart;
+                var tokenEnd = FindStringTokenEnd(content, tokenStart);
+                var token = content[tokenStart..tokenEnd];
+                if (!JsonStringCodec.IsUtf8Content(token[1..^1]))
+                {
+                    output ??= new ArrayBufferWriter<byte>(content.Length);
+                    output.Write(content[copyStart..tokenStart]);
+                    output.Write(JsonStringCodec.Encode(JsonStringCodec.Decode(token), useUtf8: true));
+                    copyStart = tokenEnd;
+                }
+
+                position = tokenEnd;
+            }
+
+            if (output == null)
+                return contentOffset == 0 ? raw : content.ToArray();
+
+            output.Write(content[copyStart..]);
+            return output.WrittenSpan.ToArray();
+        }
+
+        private static int FindStringTokenEnd(ReadOnlySpan<byte> content, int tokenStart)
+        {
+            for (var position = tokenStart + 1; position < content.Length; position++)
+            {
+                if (content[position] == (byte)'\\')
+                {
+                    position++;
+                    if (position >= content.Length)
+                        break;
+                    continue;
+                }
+
+                if (content[position] == (byte)'"')
+                    return position + 1;
+            }
+
+            throw new FormatException($"Unterminated JSON string token at offset {tokenStart}.");
         }
     }
 }

--- a/SWLOR.Toolset.Domain/Workspace/ObjectPlacement.cs
+++ b/SWLOR.Toolset.Domain/Workspace/ObjectPlacement.cs
@@ -1,0 +1,13 @@
+namespace SWLOR.Toolset.Domain.Workspace
+{
+    /// <summary>One blueprint-backed object placed in an area's GIT instance list.</summary>
+    public sealed record ObjectPlacement(
+        ResourceType BlueprintType,
+        string BlueprintResRef,
+        string AreaResRef,
+        int InstanceIndex,
+        string Tag,
+        float X,
+        float Y,
+        float Z);
+}

--- a/SWLOR.Toolset.Tests/AreaContentsContextMenuTests.cs
+++ b/SWLOR.Toolset.Tests/AreaContentsContextMenuTests.cs
@@ -17,19 +17,19 @@ namespace SWLOR.Toolset.Tests
     {
         [AvaloniaTest]
         public void RightClickingAnInstanceRowOpensItsPropertiesMenu() =>
-            RightClickingAPlacementRowOpensItsPropertiesMenu(
+            RightClickingARowMatchesItsPropertiesMenu(
                 AreaContentsNodeKind.Instance, "Open properties...");
 
         [AvaloniaTest]
         public void RightClickingAGroupRowOpensItsFirstInstancePropertiesMenu() =>
-            RightClickingAPlacementRowOpensItsPropertiesMenu(
+            RightClickingARowMatchesItsPropertiesMenu(
                 AreaContentsNodeKind.Group, "Open first instance properties...");
 
         [AvaloniaTest]
         public void RightClickingAKindHeadingDoesNotOpenAStalePropertiesMenu() =>
-            RightClickingAPlacementRowOpensItsPropertiesMenu(AreaContentsNodeKind.Kind, null);
+            RightClickingARowMatchesItsPropertiesMenu(AreaContentsNodeKind.Kind, null);
 
-        private static void RightClickingAPlacementRowOpensItsPropertiesMenu(
+        private static void RightClickingARowMatchesItsPropertiesMenu(
             AreaContentsNodeKind kind,
             string? expectedLabel)
         {

--- a/SWLOR.Toolset.Tests/AreaContentsContextMenuTests.cs
+++ b/SWLOR.Toolset.Tests/AreaContentsContextMenuTests.cs
@@ -1,0 +1,80 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.NUnit;
+using Avalonia.Input;
+using Avalonia.VisualTree;
+using FluentAssertions;
+using NUnit.Framework;
+using SWLOR.Toolset.Domain.Workspace;
+using SWLOR.Toolset.Shell.Panels;
+using SWLOR.Toolset.Shell.Views;
+
+namespace SWLOR.Toolset.Tests
+{
+    /// <summary>Exercises the real pointer-to-popup path for Area Contents rows.</summary>
+    public sealed class AreaContentsContextMenuTests
+    {
+        [AvaloniaTest]
+        public void RightClickingAnInstanceRowOpensItsPropertiesMenu() =>
+            RightClickingAPlacementRowOpensItsPropertiesMenu(
+                AreaContentsNodeKind.Instance, "Open properties...");
+
+        [AvaloniaTest]
+        public void RightClickingAGroupRowOpensItsFirstInstancePropertiesMenu() =>
+            RightClickingAPlacementRowOpensItsPropertiesMenu(
+                AreaContentsNodeKind.Group, "Open first instance properties...");
+
+        [AvaloniaTest]
+        public void RightClickingAKindHeadingDoesNotOpenAStalePropertiesMenu() =>
+            RightClickingAPlacementRowOpensItsPropertiesMenu(AreaContentsNodeKind.Kind, null);
+
+        private static void RightClickingAPlacementRowOpensItsPropertiesMenu(
+            AreaContentsNodeKind kind,
+            string? expectedLabel)
+        {
+            var row = new AreaContentsNodeViewModel(
+                kind,
+                ResourceType.Utc,
+                "Test creature",
+                depth: 1)
+            {
+                Indices = kind == AreaContentsNodeKind.Group ? new[] { 0, 1 } : new[] { 0 }
+            };
+            var viewModel = new AreaContentsViewModel();
+            viewModel.Rows.Add(row);
+
+            var view = new AreaContentsView { DataContext = viewModel };
+            var window = new Window { Content = view, Width = 400, Height = 300 };
+            window.Show();
+
+            try
+            {
+                var rowSurface = view.GetVisualDescendants()
+                    .OfType<Grid>()
+                    .Single(control => ReferenceEquals(control.DataContext, row) && control.ContextMenu != null);
+                var rowContainer = rowSurface.FindAncestorOfType<ListBoxItem>()!;
+                var point = rowContainer.TranslatePoint(
+                    new Point(rowContainer.Bounds.Width - 2, rowContainer.Bounds.Height / 2),
+                    window)!.Value;
+
+                window.MouseMove(point, RawInputModifiers.None);
+                window.MouseDown(point, MouseButton.Right, RawInputModifiers.RightMouseButton);
+                window.MouseUp(point, MouseButton.Right, RawInputModifiers.None);
+
+                rowSurface.ContextMenu!.IsOpen.Should().Be(expectedLabel != null,
+                    "only placement-bearing rows may expose the properties action");
+                if (expectedLabel != null)
+                {
+                    rowSurface.ContextMenu.Items
+                        .OfType<MenuItem>()
+                        .Should().ContainSingle(item => Equals(item.Header, expectedLabel));
+                }
+            }
+            finally
+            {
+                window.Close();
+            }
+        }
+    }
+}

--- a/SWLOR.Toolset.Tests/AreaContentsTests.cs
+++ b/SWLOR.Toolset.Tests/AreaContentsTests.cs
@@ -258,6 +258,23 @@ namespace SWLOR.Toolset.Tests
         }
 
         [Test]
+        public void OpeningProperties_FromAGroup_OpensItsFirstPlacement()
+        {
+            var editor = CreateEditor();
+            var panel = CreatePanel(editor, AreaContentsGrouping.Blueprint);
+            var group = KindNode(panel, "Placeables").Children
+                .First(child => child.Kind == AreaContentsNodeKind.Group);
+            var section = editor.SectionFor(ResourceType.Utp)!;
+            InstanceListSectionViewModel? requestedSection = null;
+            editor.InstancePropertiesRequested += value => requestedSection = value;
+
+            panel.OpenPropertiesCommand.Execute(group);
+
+            section.SelectedRow.Should().BeSameAs(section.Rows[group.Indices[0]]);
+            requestedSection.Should().BeSameAs(section);
+        }
+
+        [Test]
         public void RevealingPlacement_VerifiesIdentityBeforeTrustingAStaleIndex()
         {
             var editor = CreateEditor();

--- a/SWLOR.Toolset.Tests/AreaContentsTests.cs
+++ b/SWLOR.Toolset.Tests/AreaContentsTests.cs
@@ -237,6 +237,21 @@ namespace SWLOR.Toolset.Tests
                 "a single click picks the object out; flying the camera on every arrow-key step would be unusable");
         }
 
+        [Test]
+        public void OpeningProperties_FromContents_RetainsTheSelectedKindAndPropertiesPage()
+        {
+            var editor = CreateEditor();
+            var panel = CreatePanel(editor);
+            var row = FirstInstanceUnder(KindNode(panel, "Creatures"));
+            var section = editor.SectionFor(ResourceType.Utc)!;
+
+            panel.OpenPropertiesCommand.Execute(row);
+
+            editor.SelectedRootTabIndex.Should().Be(1);
+            section.IsExpanded.Should().BeTrue();
+            section.SelectedRow.Should().BeSameAs(section.Rows[row.Indices[0]]);
+        }
+
         // ----- deleting -----
 
         [Test]

--- a/SWLOR.Toolset.Tests/AreaContentsTests.cs
+++ b/SWLOR.Toolset.Tests/AreaContentsTests.cs
@@ -421,17 +421,42 @@ namespace SWLOR.Toolset.Tests
             var section = editor.SectionFor(ResourceType.Utp)!;
             section.SelectedRow = section.Rows[0];
             var notifications = 0;
+            var placementNotifications = 0;
             editor.CatalogEntryChanged += () => notifications++;
+            editor.PlacementsChanged += () => placementNotifications++;
 
             section.DetailTag = "git_only_catalog_refresh";
 
             (await editor.TrySaveAsync()).Should().BeTrue();
             notifications.Should().Be(1,
                 "placed-instance tags and script slots are indexed from GIT, not ARE");
+            placementNotifications.Should().Be(1,
+                "a saved GIT changes the module placement index");
             new GitDocument(JsonGffDocument.Load(
                     Path.Combine(_moduleRoot, "git", $"{AreaResRef}.git.json")))
                 .Placeables[0].GetStringOrNull("Tag")
                 .Should().Be("git_only_catalog_refresh");
+        }
+
+        [Test]
+        public async Task SavingAnAreOnlyEditDoesNotPublishAPlacementChange()
+        {
+            var editor = CreateEditor();
+            var comments = editor.AreaPropertyGroups
+                .SelectMany(group => group.Fields)
+                .OfType<TextFieldViewModel>()
+                .Single(field => field.Descriptor.FieldName == "Comments");
+            var catalogNotifications = 0;
+            var placementNotifications = 0;
+            editor.CatalogEntryChanged += () => catalogNotifications++;
+            editor.PlacementsChanged += () => placementNotifications++;
+
+            comments.Text = "ARE metadata only";
+
+            (await editor.TrySaveAsync()).Should().BeTrue();
+            catalogNotifications.Should().Be(1);
+            placementNotifications.Should().Be(0,
+                "ARE metadata is not part of the GIT placement index");
         }
 
         [Test]
@@ -449,11 +474,15 @@ namespace SWLOR.Toolset.Tests
                 File.GetLastWriteTimeUtc(gitPath).AddSeconds(2));
 
             var notifications = 0;
+            var placementNotifications = 0;
             editor.CatalogEntryChanged += () => notifications++;
+            editor.PlacementsChanged += () => placementNotifications++;
 
             (await editor.TrySaveAsync()).Should().BeTrue();
 
             notifications.Should().Be(1);
+            placementNotifications.Should().Be(1,
+                "reloading the paired GIT changes the placement snapshot");
             editor.SectionFor(ResourceType.Utp)!.Rows[0].Tag.Should().Be(diskTag);
         }
 

--- a/SWLOR.Toolset.Tests/AreaContentsTests.cs
+++ b/SWLOR.Toolset.Tests/AreaContentsTests.cs
@@ -284,6 +284,38 @@ namespace SWLOR.Toolset.Tests
             section.SelectedRow.Should().BeSameAs(expected);
         }
 
+        [Test]
+        public void RevealingPlacement_DoesNotSelectAnotherInstanceWhenTheSourceWasDeleted()
+        {
+            var editor = CreateEditor();
+            var section = editor.SectionFor(ResourceType.Utp)!;
+            var sameBlueprint = section.Rows
+                .Where(row => row.TemplateResRef == ReusedBlueprint)
+                .Take(2)
+                .ToList();
+            sameBlueprint.Should().HaveCount(2);
+            var deleted = sameBlueprint[0];
+            var placement = new ObjectPlacement(
+                ResourceType.Utp,
+                deleted.TemplateResRef,
+                AreaResRef,
+                deleted.Index,
+                deleted.Tag,
+                deleted.X,
+                deleted.Y,
+                deleted.Z);
+            section.DeleteInstances(new[] { deleted.Index }).Should().BeTrue();
+            section.SelectedRow = null;
+            var cameraMoved = false;
+            editor.CameraFocusRequested += _ => cameraMoved = true;
+
+            editor.RevealPlacement(placement);
+
+            section.SelectedRow.Should().BeNull();
+            cameraMoved.Should().BeFalse(
+                "a stale Source row must not silently navigate to another copy of the blueprint");
+        }
+
         // ----- deleting -----
 
         [Test]

--- a/SWLOR.Toolset.Tests/AreaContentsTests.cs
+++ b/SWLOR.Toolset.Tests/AreaContentsTests.cs
@@ -244,12 +244,44 @@ namespace SWLOR.Toolset.Tests
             var panel = CreatePanel(editor);
             var row = FirstInstanceUnder(KindNode(panel, "Creatures"));
             var section = editor.SectionFor(ResourceType.Utc)!;
+            InstanceListSectionViewModel? requestedSection = null;
+            editor.InstancePropertiesRequested += value => requestedSection = value;
 
             panel.OpenPropertiesCommand.Execute(row);
 
             editor.SelectedRootTabIndex.Should().Be(1);
             section.IsExpanded.Should().BeTrue();
             section.SelectedRow.Should().BeSameAs(section.Rows[row.Indices[0]]);
+            requestedSection.Should().BeSameAs(
+                section,
+                "the view must bring the requested editor into view after switching pages");
+        }
+
+        [Test]
+        public void RevealingPlacement_VerifiesIdentityBeforeTrustingAStaleIndex()
+        {
+            var editor = CreateEditor();
+            var section = editor.SectionFor(ResourceType.Utp)!;
+            var sameBlueprint = section.Rows
+                .Where(row => row.TemplateResRef == ReusedBlueprint)
+                .Take(2)
+                .ToList();
+            sameBlueprint.Should().HaveCount(2);
+            var staleIndexRow = sameBlueprint[0];
+            var expected = sameBlueprint[1];
+            var placement = new ObjectPlacement(
+                ResourceType.Utp,
+                expected.TemplateResRef,
+                AreaResRef,
+                staleIndexRow.Index,
+                expected.Tag,
+                expected.X,
+                expected.Y,
+                expected.Z);
+
+            editor.RevealPlacement(placement);
+
+            section.SelectedRow.Should().BeSameAs(expected);
         }
 
         // ----- deleting -----

--- a/SWLOR.Toolset.Tests/AreaViewportStateTests.cs
+++ b/SWLOR.Toolset.Tests/AreaViewportStateTests.cs
@@ -1,0 +1,26 @@
+using System.Numerics;
+using Avalonia.Headless.NUnit;
+using FluentAssertions;
+using SWLOR.Toolset.Viewport;
+
+namespace SWLOR.Toolset.Tests
+{
+    public sealed class AreaViewportStateTests
+    {
+        [AvaloniaTest]
+        public void ViewportState_RoundTripsAcrossControlRecreation()
+        {
+            var expected = new AreaViewportState(
+                new Vector3(12.5f, -4f, 8f),
+                Distance: 30f,
+                InitialDistance: 50f,
+                Azimuth: 1.25f,
+                Elevation: 0.45f);
+            var replacementControl = new GlAreaControl();
+
+            replacementControl.RestoreViewportState(expected);
+
+            replacementControl.CaptureViewportState().Should().Be(expected);
+        }
+    }
+}

--- a/SWLOR.Toolset.Tests/AreaViewportStateTests.cs
+++ b/SWLOR.Toolset.Tests/AreaViewportStateTests.cs
@@ -1,6 +1,8 @@
 using System.Numerics;
+using System.Reflection;
 using Avalonia.Headless.NUnit;
 using FluentAssertions;
+using NUnit.Framework;
 using SWLOR.Toolset.Domain.Render;
 using SWLOR.Toolset.Viewport;
 
@@ -8,6 +10,20 @@ namespace SWLOR.Toolset.Tests
 {
     public sealed class AreaViewportStateTests
     {
+        [Test]
+        public void CreatureModelsDrawTwoSidedWithoutDisablingPropCulling()
+        {
+            var policy = typeof(GlAreaControl).GetMethod(
+                "CullInstanceModelFaces",
+                BindingFlags.NonPublic | BindingFlags.Static)!;
+
+            policy.Invoke(null, [InstanceMarkerKind.Creature]).Should().Be(false,
+                "segmented creature equipment has mixed winding and otherwise disappears in the area view");
+            policy.Invoke(null, [InstanceMarkerKind.Placeable]).Should().Be(true,
+                "dense areas still need ordinary prop face culling");
+            policy.Invoke(null, [InstanceMarkerKind.Door]).Should().Be(true);
+        }
+
         [AvaloniaTest]
         public void ViewportState_RoundTripsAcrossControlRecreation()
         {

--- a/SWLOR.Toolset.Tests/AreaViewportStateTests.cs
+++ b/SWLOR.Toolset.Tests/AreaViewportStateTests.cs
@@ -45,5 +45,34 @@ namespace SWLOR.Toolset.Tests
                 expectedTarget,
                 "the first scene's default framing must not overwrite a Go To request made while it loaded");
         }
+
+        [AvaloniaTest]
+        public void DeferredGoToFocusAppliedAfterViewportRestore_Wins()
+        {
+            var expectedTarget = new Vector3(17f, 29f, 3f);
+            var control = new GlAreaControl
+            {
+                Scene = new AreaScene
+                {
+                    Tileset = "tcn01",
+                    Width = 8,
+                    Height = 8,
+                    Tiles = Array.Empty<TilePlacement>(),
+                    Instances = Array.Empty<InstanceMarker>(),
+                    Diagnostics = new AreaSceneDiagnostics()
+                }
+            };
+
+            control.RestoreViewportState(new AreaViewportState(
+                new Vector3(-40f, -50f, 1f),
+                Distance: 22f,
+                InitialDistance: 33f,
+                Azimuth: 0.5f,
+                Elevation: 0.7f));
+            control.FocusOn(expectedTarget);
+
+            control.CaptureViewportState()!.Value.Target.Should().Be(expectedTarget,
+                "the retained viewport must be restored before a queued Source-tab Go To is applied");
+        }
     }
 }

--- a/SWLOR.Toolset.Tests/AreaViewportStateTests.cs
+++ b/SWLOR.Toolset.Tests/AreaViewportStateTests.cs
@@ -50,8 +50,18 @@ namespace SWLOR.Toolset.Tests
             var replacementControl = new GlAreaControl();
 
             replacementControl.RestoreViewportState(expected);
+            replacementControl.Scene = new AreaScene
+            {
+                Tileset = "tcn01",
+                Width = 8,
+                Height = 8,
+                Tiles = Array.Empty<TilePlacement>(),
+                Instances = Array.Empty<InstanceMarker>(),
+                Diagnostics = new AreaSceneDiagnostics()
+            };
 
-            replacementControl.CaptureViewportState().Should().Be(expected);
+            replacementControl.CaptureViewportState().Should().Be(expected,
+                "the first scene must establish a rebuild baseline without replacing restored camera state");
         }
 
         [AvaloniaTest]

--- a/SWLOR.Toolset.Tests/AreaViewportStateTests.cs
+++ b/SWLOR.Toolset.Tests/AreaViewportStateTests.cs
@@ -24,6 +24,20 @@ namespace SWLOR.Toolset.Tests
             policy.Invoke(null, [InstanceMarkerKind.Door]).Should().Be(true);
         }
 
+        [Test]
+        public void StoreMarkersUseAurorasWaypointYellow()
+        {
+            var markerColor = typeof(GlAreaControl).GetMethod(
+                "MarkerColor",
+                BindingFlags.NonPublic | BindingFlags.Static)!;
+
+            var store = (Vector3)markerColor.Invoke(null, [InstanceMarkerKind.Store])!;
+            var waypoint = (Vector3)markerColor.Invoke(null, [InstanceMarkerKind.Waypoint])!;
+
+            store.Should().Be(new Vector3(0.98f, 0.80f, 0.10f));
+            store.Should().Be(waypoint, "Aurora draws merchants as yellow waypoint markers");
+        }
+
         [AvaloniaTest]
         public void ViewportState_RoundTripsAcrossControlRecreation()
         {

--- a/SWLOR.Toolset.Tests/AreaViewportStateTests.cs
+++ b/SWLOR.Toolset.Tests/AreaViewportStateTests.cs
@@ -1,6 +1,7 @@
 using System.Numerics;
 using Avalonia.Headless.NUnit;
 using FluentAssertions;
+using SWLOR.Toolset.Domain.Render;
 using SWLOR.Toolset.Viewport;
 
 namespace SWLOR.Toolset.Tests
@@ -21,6 +22,28 @@ namespace SWLOR.Toolset.Tests
             replacementControl.RestoreViewportState(expected);
 
             replacementControl.CaptureViewportState().Should().Be(expected);
+        }
+
+        [AvaloniaTest]
+        public void FocusRequestedBeforeInitialScene_IsAppliedAfterSceneFraming()
+        {
+            var expectedTarget = new Vector3(73f, 41f, 2.5f);
+            var control = new GlAreaControl();
+
+            control.FocusOn(expectedTarget);
+            control.Scene = new AreaScene
+            {
+                Tileset = "tcn01",
+                Width = 8,
+                Height = 8,
+                Tiles = Array.Empty<TilePlacement>(),
+                Instances = Array.Empty<InstanceMarker>(),
+                Diagnostics = new AreaSceneDiagnostics()
+            };
+
+            control.CaptureViewportState()!.Value.Target.Should().Be(
+                expectedTarget,
+                "the first scene's default framing must not overwrite a Go To request made while it loaded");
         }
     }
 }

--- a/SWLOR.Toolset.Tests/BlueprintModelResolverTests.cs
+++ b/SWLOR.Toolset.Tests/BlueprintModelResolverTests.cs
@@ -236,10 +236,31 @@ namespace SWLOR.Toolset.Tests
             var cloak = result.Parts.Single(part => part.PartType == "cloak");
             cloak.ModelResRef.Should().Be("pfe0_cloak_007",
                 "cloak appearance 10 maps to geometry 7 through cloakmodel.2da");
+            cloak.TextureResRef.Should().Be("pfe0_cloak_014",
+                "cloak appearance 10 selects texture 14 independently of its shared geometry");
             cloak.LayerColorIndices.Should().NotBeNull();
             cloak.LayerColorIndices![PltLayers.Cloth1].Should().Be(45);
             result.LayerColorIndices[PltLayers.Cloth1].Should().Be(97,
                 "the chest robe and cloak intentionally use independent palettes");
+        }
+
+        [Test]
+        public void Resolve_EquippedHelmet_UsesTheItemsOwnDyes()
+        {
+            var root = BlueprintRoot(ResourceType.Utc, "sith_commando");
+
+            var result = BlueprintModelResolver.Resolve(
+                ResourceType.Utc, root, Appearances(), null, null,
+                resRef => BlueprintRoot(ResourceType.Uti, resRef),
+                _ => true, baseItems: BaseItems().GetOrNull,
+                cloakModels: CloakModels());
+
+            var helmet = result.Parts.Single(part => part.PartType == "helmet");
+            helmet.ModelResRef.Should().Be("helm_120");
+            helmet.LayerColorIndices.Should().NotBeNull();
+            helmet.LayerColorIndices![PltLayers.Metal1].Should().Be(17);
+            helmet.LayerColorIndices[PltLayers.Metal2].Should().Be(0);
+            helmet.LayerColorIndices[PltLayers.Cloth1].Should().Be(63);
         }
 
         [Test]

--- a/SWLOR.Toolset.Tests/BlueprintModelResolverTests.cs
+++ b/SWLOR.Toolset.Tests/BlueprintModelResolverTests.cs
@@ -225,7 +225,9 @@ namespace SWLOR.Toolset.Tests
             // when its model resolves.
             var root = BlueprintRoot(ResourceType.Utc, "agr_guildmaster");
             var robeArmor = BlueprintRoot(ResourceType.Uti, "noble_gr");
+            // This corpus item carries the EE word companion, which is authoritative over the byte.
             robeArmor.Get("ArmorPart_Robe").SetInteger(7);
+            robeArmor.Get("xArmorPart_Robe").SetInteger(7);
 
             var withRobe = BlueprintModelResolver.Resolve(
                 ResourceType.Utc, root, Appearances(), null, null, _ => robeArmor, _ => true);

--- a/SWLOR.Toolset.Tests/BlueprintModelResolverTests.cs
+++ b/SWLOR.Toolset.Tests/BlueprintModelResolverTests.cs
@@ -193,8 +193,9 @@ namespace SWLOR.Toolset.Tests
         [Test]
         public void Resolve_PlacedCreature_AttachesEveryCompositeRightHandWeaponPart()
         {
-            // The first Anchorhead creature embeds a three-part rifle in slot 16. Item parts retain
-            // their shared item-space coordinates and all attach to the right-hand skeleton hook.
+            // Find the first Anchorhead creature carrying an item in slot 16. Its embedded
+            // three-part rifle retains shared item-space coordinates and every part attaches to the
+            // right-hand skeleton hook.
             var workspace = new ModuleWorkspace(CorpusLocator.ModuleDirectory);
             var (_, git, _) = workspace.LoadArea("anchor_entreenor");
             var root = git.Creatures.First(creature => creature.GetListOrEmpty("Equip_ItemList")
@@ -225,6 +226,8 @@ namespace SWLOR.Toolset.Tests
             // generic pmh0 mannequin, but the equipped garment must use the wearer's skeleton and
             // retain Cloth1 45 instead of inheriting the robe's Cloth1 97.
             var root = BlueprintRoot(ResourceType.Utc, "darthgravius");
+            root.SetInt("BodyPart_LShoul", GffFieldType.Byte, 1);
+            root.SetInt("BodyPart_RShoul", GffFieldType.Byte, 1);
             JsonGffStruct? LoadItem(string resRef) => BlueprintRoot(ResourceType.Uti, resRef);
 
             var result = BlueprintModelResolver.Resolve(
@@ -242,6 +245,9 @@ namespace SWLOR.Toolset.Tests
             cloak.LayerColorIndices![PltLayers.Cloth1].Should().Be(45);
             result.LayerColorIndices[PltLayers.Cloth1].Should().Be(97,
                 "the chest robe and cloak intentionally use independent palettes");
+            result.Parts.Should().NotContain(
+                part => part.PartType == "shol" || part.PartType == "shor",
+                "cloak appearance 10 hides both wearer shoulder parts in cloakmodel.2da");
         }
 
         [Test]

--- a/SWLOR.Toolset.Tests/BlueprintModelResolverTests.cs
+++ b/SWLOR.Toolset.Tests/BlueprintModelResolverTests.cs
@@ -64,6 +64,9 @@ namespace SWLOR.Toolset.Tests
             return new DoorTypeService(twoDa, tlk);
         }
 
+        private static BaseItemIconService BaseItems() =>
+            new(new TwoDaService(Sw2DaDirectory));
+
         private static Domain.Gff.JsonGffStruct BlueprintRoot(ResourceType type, string resRef)
         {
             var workspace = new ModuleWorkspace(CorpusLocator.ModuleDirectory);
@@ -156,6 +159,60 @@ namespace SWLOR.Toolset.Tests
                 .Should().Be((int)armor.Get("Cloth2Color").GetInteger());
             result.LayerColorIndices[PltLayers.Leather1]
                 .Should().Be((int)armor.Get("Leather1Color").GetInteger());
+        }
+
+        [Test]
+        public void Resolve_PlacedCreature_UsesItsEmbeddedArmorPartsAndDyes()
+        {
+            // Placed GIT creatures contain the complete equipped UTI struct rather than the
+            // EquippedRes-only entry stored in a UTC. Bruenor's embedded Czerka uniform is torso
+            // 189 / Cloth1 107; ignoring that struct produced the naked part-1 body in the area view.
+            var workspace = new ModuleWorkspace(CorpusLocator.ModuleDirectory);
+            var (_, git, _) = workspace.LoadArea("czs220_hangar");
+            var root = git.Creatures.First();
+
+            var result = BlueprintModelResolver.Resolve(
+                ResourceType.Utc,
+                root,
+                Appearances(),
+                null,
+                null,
+                _ => throw new InvalidOperationException("embedded armor must not reload its source UTI"),
+                _ => true,
+                baseItems: BaseItems().GetOrNull);
+
+            result.Parts.Should().Contain(
+                part => part.PartType == "chest" && part.ModelResRef == "pmh0_chest189");
+            result.LayerColorIndices[PltLayers.Cloth1].Should().Be(107);
+            BlueprintModelResolver.GetEquippedChestArmorResRef(root).Should().Be("czerkauniform");
+        }
+
+        [Test]
+        public void Resolve_PlacedCreature_AttachesEveryCompositeRightHandWeaponPart()
+        {
+            // The first Anchorhead creature embeds a three-part rifle in slot 16. Item parts retain
+            // their shared item-space coordinates and all attach to the right-hand skeleton hook.
+            var workspace = new ModuleWorkspace(CorpusLocator.ModuleDirectory);
+            var (_, git, _) = workspace.LoadArea("anchor_entreenor");
+            var root = git.Creatures.First(creature => creature.GetListOrEmpty("Equip_ItemList")
+                .Any(item => System.Text.Encoding.ASCII.GetString(item.RawStructId ?? []) == "16"));
+
+            var result = BlueprintModelResolver.Resolve(
+                ResourceType.Utc,
+                root,
+                Appearances(),
+                null,
+                null,
+                _ => throw new InvalidOperationException("embedded weapon must not reload its source UTI"),
+                _ => true,
+                baseItems: BaseItems().GetOrNull);
+
+            var weaponParts = result.Parts.Where(part => part.PartType == "weaponr").ToList();
+            weaponParts.Should().HaveCount(3);
+            weaponParts.Select(part => part.ModelResRef).Should()
+                .Contain(model => model.EndsWith("_b_011", StringComparison.OrdinalIgnoreCase))
+                .And.Contain(model => model.EndsWith("_m_121", StringComparison.OrdinalIgnoreCase))
+                .And.Contain(model => model.EndsWith("_t_011", StringComparison.OrdinalIgnoreCase));
         }
 
         [Test]

--- a/SWLOR.Toolset.Tests/BlueprintModelResolverTests.cs
+++ b/SWLOR.Toolset.Tests/BlueprintModelResolverTests.cs
@@ -67,6 +67,9 @@ namespace SWLOR.Toolset.Tests
         private static BaseItemIconService BaseItems() =>
             new(new TwoDaService(Sw2DaDirectory));
 
+        private static CloakModelService CloakModels() =>
+            new(new TwoDaService(Sw2DaDirectory));
+
         private static Domain.Gff.JsonGffStruct BlueprintRoot(ResourceType type, string resRef)
         {
             var workspace = new ModuleWorkspace(CorpusLocator.ModuleDirectory);
@@ -213,6 +216,39 @@ namespace SWLOR.Toolset.Tests
                 .Contain(model => model.EndsWith("_b_011", StringComparison.OrdinalIgnoreCase))
                 .And.Contain(model => model.EndsWith("_m_121", StringComparison.OrdinalIgnoreCase))
                 .And.Contain(model => model.EndsWith("_t_011", StringComparison.OrdinalIgnoreCase));
+        }
+
+        [Test]
+        public void Resolve_EquippedCloak_UsesTheWearersBodyPrefixAndItsOwnDyes()
+        {
+            // Darth Gravius is a female dynamic elf (pfe0). The cloak item preview itself uses a
+            // generic pmh0 mannequin, but the equipped garment must use the wearer's skeleton and
+            // retain Cloth1 45 instead of inheriting the robe's Cloth1 97.
+            var root = BlueprintRoot(ResourceType.Utc, "darthgravius");
+            JsonGffStruct? LoadItem(string resRef) => BlueprintRoot(ResourceType.Uti, resRef);
+
+            var result = BlueprintModelResolver.Resolve(
+                ResourceType.Utc, root, Appearances(), null, null,
+                LoadItem, _ => true, baseItems: BaseItems().GetOrNull,
+                cloakModels: CloakModels());
+
+            result.SkeletonResRef.Should().Be("pfe0");
+            var cloak = result.Parts.Single(part => part.PartType == "cloak");
+            cloak.ModelResRef.Should().Be("pfe0_cloak_007",
+                "cloak appearance 10 maps to geometry 7 through cloakmodel.2da");
+            cloak.LayerColorIndices.Should().NotBeNull();
+            cloak.LayerColorIndices![PltLayers.Cloth1].Should().Be(45);
+            result.LayerColorIndices[PltLayers.Cloth1].Should().Be(97,
+                "the chest robe and cloak intentionally use independent palettes");
+        }
+
+        [Test]
+        public void VisibleEquipmentDependenciesIncludeArmorCloakAndHeldItems()
+        {
+            var root = BlueprintRoot(ResourceType.Utc, "darthgravius");
+
+            BlueprintModelResolver.GetVisibleEquippedItemResRefs(root).Should().BeEquivalentTo(
+                new[] { "graviusrobe001", "d_gravius_saber", "jeweled_cloak" });
         }
 
         [Test]

--- a/SWLOR.Toolset.Tests/CreatureEquipmentRenderTests.cs
+++ b/SWLOR.Toolset.Tests/CreatureEquipmentRenderTests.cs
@@ -72,6 +72,20 @@ namespace SWLOR.Toolset.Tests
             dressed.Meshes.Should().Contain(
                 mesh => mesh.TextureName.Equals("pmh0_chest189", StringComparison.OrdinalIgnoreCase),
                 "the embedded Czerka uniform's torso geometry must replace the naked chest");
+            dressed.Meshes.Should().NotContain(
+                mesh => mesh.TextureName.Equals("pmh0_chest001", StringComparison.OrdinalIgnoreCase),
+                "the equipped torso must not coexist with the naked torso");
+
+            var dockhandRoot = hangarGit.Creatures.First(creature =>
+                creature.GetListOrEmpty("Equip_ItemList").Any(item =>
+                    System.Text.Encoding.ASCII.GetString(item.RawStructId ?? []) == "2" &&
+                    item.GetIntOrNull("ArmorPart_Torso") == 102));
+            var dockhand = renderer.BuildModel(ResourceType.Utc, dockhandRoot);
+            dockhand.Should().NotBeNull();
+            dockhand!.Meshes.Should().Contain(
+                mesh => mesh.TextureName.Equals("pmh0_chest102", StringComparison.OrdinalIgnoreCase));
+            dockhand.Meshes.Should().NotContain(
+                mesh => mesh.TextureName.Equals("pmh0_chest001", StringComparison.OrdinalIgnoreCase));
 
             var (_, anchorGit, _) = workspace.LoadArea("anchor_entreenor");
             var armedRoot = anchorGit.Creatures.First(creature => creature.GetListOrEmpty("Equip_ItemList")

--- a/SWLOR.Toolset.Tests/CreatureEquipmentRenderTests.cs
+++ b/SWLOR.Toolset.Tests/CreatureEquipmentRenderTests.cs
@@ -103,6 +103,38 @@ namespace SWLOR.Toolset.Tests
             armed!.Meshes.Sum(mesh => mesh.VertexCount).Should().BeGreaterThan(
                 unarmed!.Meshes.Sum(mesh => mesh.VertexCount),
                 "the embedded rifle parts must add geometry to the right-hand skeleton bone");
+
+            var gravius = renderer.BuildModel(
+                ResourceType.Utc,
+                workspace.LoadBlueprint(ResourceType.Utc, "darthgravius").Fields);
+            gravius.Should().NotBeNull();
+            gravius!.LayerColorIndices[SWLOR.NWN.Formats.Plt.PltLayers.Cloth1].Should().Be(97);
+            var cloakMeshes = gravius.Meshes.Where(mesh =>
+                mesh.TextureName.Contains("cloak", StringComparison.OrdinalIgnoreCase)).ToList();
+            cloakMeshes.Should().NotBeEmpty(
+                "the female elf must wear the cloak model authored for her own skeleton");
+            cloakMeshes.Should().OnlyContain(mesh => mesh.LayerColorIndices.ContainsKey(
+                SWLOR.NWN.Formats.Plt.PltLayers.Cloth1));
+            cloakMeshes.Select(mesh =>
+                    mesh.LayerColorIndices[SWLOR.NWN.Formats.Plt.PltLayers.Cloth1])
+                .Should().OnlyContain(cloth => cloth == 45,
+                    "the cloak's dyes must not be replaced by the equipped chest robe's palette");
+
+            // Fixed-model creatures still need their attachments composed. This is also the model
+            // path shared by software thumbnails, which previously rendered only the bare base MDL.
+            var fixedCreature = workspace.LoadBlueprint(ResourceType.Utc, "bf_butcher").Fields;
+            var armedFixed = renderer.BuildModel(ResourceType.Utc, fixedCreature);
+            var fixedEquipment = fixedCreature.GetOrNull("Equip_ItemList")!;
+            var fixedRightHand = fixedEquipment.Elements!.FindIndex(item =>
+                System.Text.Encoding.ASCII.GetString(item.RawStructId ?? []) == "16");
+            fixedEquipment.Elements.RemoveAt(fixedRightHand);
+            var unarmedFixed = renderer.BuildModel(ResourceType.Utc, fixedCreature);
+
+            armedFixed.Should().NotBeNull();
+            unarmedFixed.Should().NotBeNull();
+            armedFixed!.Meshes.Sum(mesh => mesh.VertexCount).Should().BeGreaterThan(
+                unarmedFixed!.Meshes.Sum(mesh => mesh.VertexCount),
+                "a simple creature's held item must be composed with its base model");
         }
     }
 }

--- a/SWLOR.Toolset.Tests/CreatureEquipmentRenderTests.cs
+++ b/SWLOR.Toolset.Tests/CreatureEquipmentRenderTests.cs
@@ -18,6 +18,11 @@ namespace SWLOR.Toolset.Tests
     [NonParallelizable]
     public sealed class CreatureEquipmentRenderTests
     {
+        private BlueprintPreviewRenderer _renderer = null!;
+        private ModuleWorkspace _workspace = null!;
+        private GitDocument _hangarGit = null!;
+        private GitDocument _anchorGit = null!;
+
         private static string RepoRoot
         {
             get
@@ -37,13 +42,17 @@ namespace SWLOR.Toolset.Tests
             }
         }
 
-        [Test]
-        public void PlacedArmorAndHeldWeaponBecomeCreatureGeometry()
+        [OneTimeSetUp]
+        public async Task OneTimeSetUp()
         {
             var installRoot = NwnInstallLocator.Locate();
-            installRoot.Should().NotBeNull("the licensed rendering corpus requires NWN:EE");
+            if (installRoot == null)
+            {
+                Assert.Ignore("the licensed rendering corpus requires NWN:EE");
+                return;
+            }
 
-            var baseLayer = KeyBifCatalog.Load(Path.Combine(installRoot!, "data"));
+            var baseLayer = KeyBifCatalog.Load(Path.Combine(installRoot, "data"));
             var index = ResourceIndex.FromHakBuilderConfig(
                 Path.Combine(RepoRoot, "Build", "hakbuilder.json"),
                 Path.Combine(RepoRoot, "SWLOR_Haks"),
@@ -55,7 +64,8 @@ namespace SWLOR.Toolset.Tests
             var log = new OutputLogService();
             var context = new WorkspaceContext(path => new ModuleWorkspace(path, index), log);
             context.Open(CorpusLocator.ModuleDirectory);
-            var renderer = new BlueprintPreviewRenderer(
+            await context.Catalog!.BuildTask;
+            _renderer = new BlueprintPreviewRenderer(
                 context,
                 index,
                 appearances: new AppearanceService(twoDa, tlk),
@@ -63,9 +73,15 @@ namespace SWLOR.Toolset.Tests
                 twoDa: twoDa,
                 tlk: tlk);
 
-            var workspace = context.Workspace!;
-            var (_, hangarGit, _) = workspace.LoadArea("czs220_hangar");
-            var dressed = renderer.BuildModel(ResourceType.Utc, hangarGit.Creatures.First());
+            _workspace = context.Workspace!;
+            (_, _hangarGit, _) = _workspace.LoadArea("czs220_hangar");
+            (_, _anchorGit, _) = _workspace.LoadArea("anchor_entreenor");
+        }
+
+        [Test]
+        public void PlacedChestArmorReplacesNakedTorsoAndKeepsArmorDyes()
+        {
+            var dressed = _renderer.BuildModel(ResourceType.Utc, _hangarGit.Creatures.First());
 
             dressed.Should().NotBeNull();
             dressed!.LayerColorIndices[SWLOR.NWN.Formats.Plt.PltLayers.Cloth1].Should().Be(107);
@@ -76,37 +92,39 @@ namespace SWLOR.Toolset.Tests
                 mesh => mesh.TextureName.Equals("pmh0_chest001", StringComparison.OrdinalIgnoreCase),
                 "the equipped torso must not coexist with the naked torso");
 
-            var dockhandRoot = hangarGit.Creatures.First(creature =>
+            var dockhandRoot = _hangarGit.Creatures.First(creature =>
                 creature.GetListOrEmpty("Equip_ItemList").Any(item =>
                     System.Text.Encoding.ASCII.GetString(item.RawStructId ?? []) == "2" &&
                     item.GetIntOrNull("ArmorPart_Torso") == 102));
-            var dockhand = renderer.BuildModel(ResourceType.Utc, dockhandRoot);
+            var dockhand = _renderer.BuildModel(ResourceType.Utc, dockhandRoot);
             dockhand.Should().NotBeNull();
             dockhand!.Meshes.Should().Contain(
                 mesh => mesh.TextureName.Equals("pmh0_chest102", StringComparison.OrdinalIgnoreCase));
             dockhand.Meshes.Should().NotContain(
                 mesh => mesh.TextureName.Equals("pmh0_chest001", StringComparison.OrdinalIgnoreCase));
+        }
 
-            var (_, anchorGit, _) = workspace.LoadArea("anchor_entreenor");
-            var armedRoot = anchorGit.Creatures.First(creature => creature.GetListOrEmpty("Equip_ItemList")
+        [Test]
+        public void EmbeddedRightHandWeaponAddsCreatureGeometry()
+        {
+            var armedRoot = _anchorGit.Creatures.First(creature => creature.GetListOrEmpty("Equip_ItemList")
                 .Any(item => System.Text.Encoding.ASCII.GetString(item.RawStructId ?? []) == "16"));
-            var armed = renderer.BuildModel(ResourceType.Utc, armedRoot);
-
-            var equipment = armedRoot.GetOrNull("Equip_ItemList")!;
-            var rightHandIndex = equipment.Elements!.FindIndex(
-                item => System.Text.Encoding.ASCII.GetString(item.RawStructId ?? []) == "16");
-            equipment.Elements.RemoveAt(rightHandIndex);
-            var unarmed = renderer.BuildModel(ResourceType.Utc, armedRoot);
+            var armed = _renderer.BuildModel(ResourceType.Utc, armedRoot);
+            var unarmed = _renderer.BuildModel(ResourceType.Utc, WithoutEquippedSlot(armedRoot, 16));
 
             armed.Should().NotBeNull();
             unarmed.Should().NotBeNull();
             armed!.Meshes.Sum(mesh => mesh.VertexCount).Should().BeGreaterThan(
                 unarmed!.Meshes.Sum(mesh => mesh.VertexCount),
                 "the embedded rifle parts must add geometry to the right-hand skeleton bone");
+        }
 
-            var gravius = renderer.BuildModel(
+        [Test]
+        public void EquippedCloakUsesWearerGeometryTextureAndOwnDyes()
+        {
+            var gravius = _renderer.BuildModel(
                 ResourceType.Utc,
-                workspace.LoadBlueprint(ResourceType.Utc, "darthgravius").Fields);
+                _workspace.LoadBlueprint(ResourceType.Utc, "darthgravius").Fields);
             gravius.Should().NotBeNull();
             gravius!.LayerColorIndices[SWLOR.NWN.Formats.Plt.PltLayers.Cloth1].Should().Be(97);
             var cloakMeshes = gravius.Meshes.Where(mesh =>
@@ -122,10 +140,14 @@ namespace SWLOR.Toolset.Tests
                     mesh.LayerColorIndices[SWLOR.NWN.Formats.Plt.PltLayers.Cloth1])
                 .Should().OnlyContain(cloth => cloth == 45,
                     "the cloak's dyes must not be replaced by the equipped chest robe's palette");
+        }
 
-            var commando = renderer.BuildModel(
+        [Test]
+        public void EquippedHelmetKeepsItsOwnDyes()
+        {
+            var commando = _renderer.BuildModel(
                 ResourceType.Utc,
-                workspace.LoadBlueprint(ResourceType.Utc, "sith_commando").Fields);
+                _workspace.LoadBlueprint(ResourceType.Utc, "sith_commando").Fields);
             commando.Should().NotBeNull();
             var helmetMeshes = commando!.Meshes.Where(mesh =>
                 mesh.LayerColorIndices.ContainsKey(SWLOR.NWN.Formats.Plt.PltLayers.Cloth1) &&
@@ -134,22 +156,34 @@ namespace SWLOR.Toolset.Tests
                 mesh.LayerColorIndices[SWLOR.NWN.Formats.Plt.PltLayers.Metal2] == 0).ToList();
             helmetMeshes.Should().NotBeEmpty(
                 "the helmet's Cloth1 63 / Metal2 0 UTI palette must not inherit the armor's 23 / 17 dyes");
+        }
 
+        [Test]
+        public void FixedModelCreatureComposesHeldWeapon()
+        {
             // Fixed-model creatures still need their attachments composed. This is also the model
             // path shared by software thumbnails, which previously rendered only the bare base MDL.
-            var fixedCreature = workspace.LoadBlueprint(ResourceType.Utc, "bf_butcher").Fields;
-            var armedFixed = renderer.BuildModel(ResourceType.Utc, fixedCreature);
-            var fixedEquipment = fixedCreature.GetOrNull("Equip_ItemList")!;
-            var fixedRightHand = fixedEquipment.Elements!.FindIndex(item =>
-                System.Text.Encoding.ASCII.GetString(item.RawStructId ?? []) == "16");
-            fixedEquipment.Elements.RemoveAt(fixedRightHand);
-            var unarmedFixed = renderer.BuildModel(ResourceType.Utc, fixedCreature);
+            var fixedCreature = _workspace.LoadBlueprint(ResourceType.Utc, "bf_butcher").Fields;
+            var armedFixed = _renderer.BuildModel(ResourceType.Utc, fixedCreature);
+            var unarmedFixed = _renderer.BuildModel(
+                ResourceType.Utc, WithoutEquippedSlot(fixedCreature, 16));
 
             armedFixed.Should().NotBeNull();
             unarmedFixed.Should().NotBeNull();
             armedFixed!.Meshes.Sum(mesh => mesh.VertexCount).Should().BeGreaterThan(
                 unarmedFixed!.Meshes.Sum(mesh => mesh.VertexCount),
                 "a simple creature's held item must be composed with its base model");
+        }
+
+        private static JsonGffStruct WithoutEquippedSlot(JsonGffStruct source, int slot)
+        {
+            var clone = InstanceFieldMap.Duplicate(source);
+            var equipment = clone.GetOrNull("Equip_ItemList")!;
+            var index = equipment.Elements!.FindIndex(item =>
+                System.Text.Encoding.ASCII.GetString(item.RawStructId ?? []) == slot.ToString());
+            index.Should().BeGreaterThanOrEqualTo(0);
+            equipment.Elements.RemoveAt(index);
+            return clone;
         }
     }
 }

--- a/SWLOR.Toolset.Tests/CreatureEquipmentRenderTests.cs
+++ b/SWLOR.Toolset.Tests/CreatureEquipmentRenderTests.cs
@@ -115,10 +115,25 @@ namespace SWLOR.Toolset.Tests
                 "the female elf must wear the cloak model authored for her own skeleton");
             cloakMeshes.Should().OnlyContain(mesh => mesh.LayerColorIndices.ContainsKey(
                 SWLOR.NWN.Formats.Plt.PltLayers.Cloth1));
+            cloakMeshes.Should().OnlyContain(mesh =>
+                mesh.TextureName.Equals("pfe0_cloak_014", StringComparison.OrdinalIgnoreCase),
+                "cloak appearance 10 reuses geometry 7 but selects texture 14");
             cloakMeshes.Select(mesh =>
                     mesh.LayerColorIndices[SWLOR.NWN.Formats.Plt.PltLayers.Cloth1])
                 .Should().OnlyContain(cloth => cloth == 45,
                     "the cloak's dyes must not be replaced by the equipped chest robe's palette");
+
+            var commando = renderer.BuildModel(
+                ResourceType.Utc,
+                workspace.LoadBlueprint(ResourceType.Utc, "sith_commando").Fields);
+            commando.Should().NotBeNull();
+            var helmetMeshes = commando!.Meshes.Where(mesh =>
+                mesh.LayerColorIndices.ContainsKey(SWLOR.NWN.Formats.Plt.PltLayers.Cloth1) &&
+                mesh.LayerColorIndices[SWLOR.NWN.Formats.Plt.PltLayers.Cloth1] == 63 &&
+                mesh.LayerColorIndices.ContainsKey(SWLOR.NWN.Formats.Plt.PltLayers.Metal2) &&
+                mesh.LayerColorIndices[SWLOR.NWN.Formats.Plt.PltLayers.Metal2] == 0).ToList();
+            helmetMeshes.Should().NotBeEmpty(
+                "the helmet's Cloth1 63 / Metal2 0 UTI palette must not inherit the armor's 23 / 17 dyes");
 
             // Fixed-model creatures still need their attachments composed. This is also the model
             // path shared by software thumbnails, which previously rendered only the bare base MDL.

--- a/SWLOR.Toolset.Tests/CreatureEquipmentRenderTests.cs
+++ b/SWLOR.Toolset.Tests/CreatureEquipmentRenderTests.cs
@@ -1,0 +1,94 @@
+using FluentAssertions;
+using NUnit.Framework;
+using SWLOR.Toolset.Domain.Documents;
+using SWLOR.Toolset.Domain.GameData.Lookups;
+using SWLOR.Toolset.Domain.GameData.Resources;
+using SWLOR.Toolset.Domain.GameData.Tlk;
+using SWLOR.Toolset.Domain.GameData.TwoDa;
+using SWLOR.Toolset.Domain.Gff;
+using SWLOR.Toolset.Domain.Render;
+using SWLOR.Toolset.Domain.Workspace;
+using SWLOR.Toolset.Workspace;
+
+namespace SWLOR.Toolset.Tests
+{
+    /// <summary>End-to-end coverage for visible equipment on placed creature geometry.</summary>
+    [TestFixture]
+    [Category("LicensedCorpus")]
+    [NonParallelizable]
+    public sealed class CreatureEquipmentRenderTests
+    {
+        private static string RepoRoot
+        {
+            get
+            {
+                for (var current = new DirectoryInfo(AppContext.BaseDirectory);
+                     current != null;
+                     current = current.Parent)
+                {
+                    if (File.Exists(Path.Combine(current.FullName, "Build", "hakbuilder.json")) &&
+                        Directory.Exists(Path.Combine(current.FullName, "SWLOR_Haks", "sw_2da")))
+                    {
+                        return current.FullName;
+                    }
+                }
+
+                throw new DirectoryNotFoundException("Could not locate the repository rendering corpus.");
+            }
+        }
+
+        [Test]
+        public void PlacedArmorAndHeldWeaponBecomeCreatureGeometry()
+        {
+            var installRoot = NwnInstallLocator.Locate();
+            installRoot.Should().NotBeNull("the licensed rendering corpus requires NWN:EE");
+
+            var baseLayer = KeyBifCatalog.Load(Path.Combine(installRoot!, "data"));
+            var index = ResourceIndex.FromHakBuilderConfig(
+                Path.Combine(RepoRoot, "Build", "hakbuilder.json"),
+                Path.Combine(RepoRoot, "SWLOR_Haks"),
+                baseLayer);
+            index.EnsureInitialized();
+
+            var twoDa = new TwoDaService(index);
+            var tlk = TlkService.Load(Path.Combine(RepoRoot, "SWLOR_Haks", "sw_tlk", "sw_tlk.tlk.json"));
+            var log = new OutputLogService();
+            var context = new WorkspaceContext(path => new ModuleWorkspace(path, index), log);
+            context.Open(CorpusLocator.ModuleDirectory);
+            var renderer = new BlueprintPreviewRenderer(
+                context,
+                index,
+                appearances: new AppearanceService(twoDa, tlk),
+                baseItems: new BaseItemIconService(twoDa),
+                twoDa: twoDa,
+                tlk: tlk);
+
+            var workspace = context.Workspace!;
+            var (_, hangarGit, _) = workspace.LoadArea("czs220_hangar");
+            var dressed = renderer.BuildModel(ResourceType.Utc, hangarGit.Creatures.First());
+
+            dressed.Should().NotBeNull();
+            dressed!.LayerColorIndices[SWLOR.NWN.Formats.Plt.PltLayers.Cloth1].Should().Be(107);
+            dressed.Meshes.Should().Contain(
+                mesh => mesh.TextureName.Equals("pmh0_chest189", StringComparison.OrdinalIgnoreCase),
+                "the embedded Czerka uniform's torso geometry must replace the naked chest");
+
+            var (_, anchorGit, _) = workspace.LoadArea("anchor_entreenor");
+            var armedRoot = anchorGit.Creatures.First(creature => creature.GetListOrEmpty("Equip_ItemList")
+                .Any(item => System.Text.Encoding.ASCII.GetString(item.RawStructId ?? []) == "16"));
+            var armed = renderer.BuildModel(ResourceType.Utc, armedRoot);
+
+            var equipment = armedRoot.GetOrNull("Equip_ItemList")!;
+            var rightHandIndex = equipment.Elements!.FindIndex(
+                item => System.Text.Encoding.ASCII.GetString(item.RawStructId ?? []) == "16");
+            equipment.Elements.RemoveAt(rightHandIndex);
+            var unarmed = renderer.BuildModel(ResourceType.Utc, armedRoot);
+
+            armed.Should().NotBeNull();
+            unarmed.Should().NotBeNull();
+            armed!.Meshes.Sum(mesh => mesh.VertexCount).Should().BeGreaterThan(
+                unarmed!.Meshes.Sum(mesh => mesh.VertexCount),
+                "the embedded rifle parts must add geometry to the right-hand skeleton bone");
+        }
+    }
+}

--- a/SWLOR.Toolset.Tests/DocumentSessionExternalChangeTests.cs
+++ b/SWLOR.Toolset.Tests/DocumentSessionExternalChangeTests.cs
@@ -49,6 +49,19 @@ namespace SWLOR.Toolset.Tests
         }
 
         [Test]
+        public void FromLoadedContent_FileDeletedAfterRead_IsAnExternalChange()
+        {
+            var content = File.ReadAllBytes(_path);
+            var document = JsonGffDocument.Parse(content);
+            File.Delete(_path);
+
+            using var session = DocumentSession.FromLoadedContent(_path, document, content);
+
+            session.HasExternalChange().Should().BeTrue(
+                "bytes loaded from an existing file must retain a baseline when that file disappears before binding");
+        }
+
+        [Test]
         public void RevertAfterTheSavedHistoryWasDiscarded_ReloadsTheDiskState()
         {
             using var session = DocumentSession.Open(_path);

--- a/SWLOR.Toolset.Tests/EditorServiceIndexTests.cs
+++ b/SWLOR.Toolset.Tests/EditorServiceIndexTests.cs
@@ -222,6 +222,69 @@ namespace SWLOR.Toolset.Tests
         }
 
         [Test]
+        public async Task ReplacingAWorkspaceDuringAreaDocumentLoadingDoesNotOpenTheObsoleteArea()
+        {
+            const string areaResRef = "bank";
+            var firstRoot = NewModuleRoot();
+            var secondRoot = NewModuleRoot();
+            foreach (var extension in new[] { "are", "git", "gic" })
+            {
+                File.Copy(
+                    Path.Combine(
+                        CorpusLocator.ModuleDirectory,
+                        extension,
+                        $"{areaResRef}.{extension}.json"),
+                    Path.Combine(firstRoot, extension, $"{areaResRef}.{extension}.json"));
+            }
+
+            var firstWorkspace = new ModuleWorkspace(firstRoot);
+            var secondWorkspace = new ModuleWorkspace(secondRoot);
+            var log = new OutputLogService();
+            var workspace = new WorkspaceContext(
+                root => root == firstRoot ? firstWorkspace : secondWorkspace,
+                log);
+            using var loadStarted = new ManualResetEventSlim();
+            using var releaseLoad = new ManualResetEventSlim();
+            var editors = new EditorService(
+                workspace,
+                new LookupOptionProvider(workspace),
+                log,
+                factory: null!,
+                prompts: null!,
+                areaDocumentsLoader: (arePath, gitPath, gicPath) =>
+                {
+                    loadStarted.Set();
+                    if (!releaseLoad.Wait(TimeSpan.FromSeconds(5)))
+                        throw new TimeoutException("The area-load race test was not released.");
+
+                    return AreaEditorDocumentLoad.Load(arePath, gitPath, gicPath);
+                });
+
+            workspace.Open(firstRoot);
+            var firstCatalog = workspace.Catalog!.BuildTask;
+            await firstWorkspace.TagIndex.GetTransitionDestinationTagsAsync();
+            editors.TryOpenEditor(ResourceType.Area, areaResRef);
+            loadStarted.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+
+            workspace.Open(secondRoot);
+            var secondCatalog = workspace.Catalog!.BuildTask;
+            releaseLoad.Set();
+
+            var openingAreas = (HashSet<string>)typeof(EditorService)
+                .GetField("_openingAreaEditors", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .GetValue(editors)!;
+            await WaitUntilAsync(() => !openingAreas.Contains(areaResRef));
+            await Task.WhenAll(firstCatalog, secondCatalog);
+
+            var openAreas = (Dictionary<string, AreaEditorViewModel>)typeof(EditorService)
+                .GetField("_openAreaEditors", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .GetValue(editors)!;
+            openAreas.Should().NotContainKey(areaResRef,
+                "an area parsed for the previous module must not be published into the replacement workspace");
+            log.Lines.Should().NotContain(line => line.Contains("Failed to open area editor"));
+        }
+
+        [Test]
         public async Task PlacementInvalidationReloadsAnOpenObjectSource()
         {
             var moduleRoot = NewModuleRoot();
@@ -373,7 +436,7 @@ namespace SWLOR.Toolset.Tests
         private string NewModuleRoot()
         {
             var root = Path.Combine(Path.GetTempPath(), $"swlor_editor_index_{Guid.NewGuid():N}");
-            foreach (var folder in new[] { "are", "git", "utc" })
+            foreach (var folder in new[] { "are", "git", "gic", "utc" })
                 Directory.CreateDirectory(Path.Combine(root, folder));
             _roots.Add(root);
             return root;

--- a/SWLOR.Toolset.Tests/EditorServiceIndexTests.cs
+++ b/SWLOR.Toolset.Tests/EditorServiceIndexTests.cs
@@ -1,10 +1,13 @@
 using System.Reflection;
 using FluentAssertions;
 using NUnit.Framework;
+using SWLOR.Toolset.Domain.Documents;
 using SWLOR.Toolset.Domain.GameData.Lookups;
 using SWLOR.Toolset.Domain.Workspace;
 using SWLOR.Toolset.Editors;
+using SWLOR.Toolset.Editors.Merchants;
 using SWLOR.Toolset.Editors.Sources;
+using SWLOR.Toolset.Services;
 using SWLOR.Toolset.Workspace;
 
 namespace SWLOR.Toolset.Tests
@@ -260,6 +263,57 @@ namespace SWLOR.Toolset.Tests
         }
 
         [Test]
+        public void PlacementInvalidationClearsAnOpenMerchantSourceSnapshot()
+        {
+            var moduleRoot = NewModuleRoot();
+            var merchantFolder = Path.Combine(moduleRoot, "utm");
+            Directory.CreateDirectory(merchantFolder);
+            var merchantPath = Path.Combine(merchantFolder, "probe_store.utm.json");
+            File.WriteAllBytes(
+                merchantPath,
+                BlueprintTemplateFactory.CreateFileContent(
+                    ResourceType.Utm, "probe_store", "Probe Store"));
+            var log = new OutputLogService();
+            var workspace = new WorkspaceContext(root => new ModuleWorkspace(root), log);
+            var editors = new EditorService(
+                workspace,
+                new LookupOptionProvider(workspace),
+                log,
+                factory: null!,
+                prompts: null!);
+            workspace.Open(moduleRoot);
+            Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+            var merchant = new MerchantDocumentViewModel(
+                merchantPath,
+                "probe_store",
+                log,
+                new StubPrompts());
+
+            try
+            {
+                var openEditors = (Dictionary<string, MerchantDocumentViewModel>)typeof(EditorService)
+                    .GetField("_openMerchantEditors", BindingFlags.Instance | BindingFlags.NonPublic)!
+                    .GetValue(editors)!;
+                openEditors[merchantPath] = merchant;
+                merchant.Editor.ArePlacedInstancesLoaded = true;
+                merchant.Editor.PlacedInstances.Add(new MerchantInstancePlacement(
+                    "Old Area", "old_area", "OLD_STORE", 0, 0, 0));
+
+                workspace.InvalidatePlacementIndex();
+                Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+
+                merchant.Editor.ArePlacedInstancesLoaded.Should().BeFalse();
+                merchant.Editor.PlacedInstancesNeedRefresh.Should().BeTrue();
+                merchant.Editor.PlacedInstances.Should().BeEmpty(
+                    "stale merchant coordinates must not remain available to Go To");
+            }
+            finally
+            {
+                merchant.OnClose();
+            }
+        }
+
+        [Test]
         public async Task ReplacingAWorkspaceCancelsItsObsoletePlacementWarmup()
         {
             var firstRoot = NewModuleRoot();
@@ -323,6 +377,28 @@ namespace SWLOR.Toolset.Tests
                 Directory.CreateDirectory(Path.Combine(root, folder));
             _roots.Add(root);
             return root;
+        }
+
+        private sealed class StubPrompts : IEditorPromptService
+        {
+            public Task<ExternalChangeChoice> ConfirmExternalChangeAsync(string filePath) =>
+                Task.FromResult(ExternalChangeChoice.Cancel);
+
+            public Task<UnsavedChangesChoice> ConfirmCloseAsync(string documentTitle) =>
+                Task.FromResult(UnsavedChangesChoice.Cancel);
+
+            public Task<bool> ConfirmDestructiveAsync(
+                string headline,
+                string message,
+                string confirmLabel) =>
+                Task.FromResult(false);
+
+            public Task<string?> PromptForTextAsync(
+                string headline,
+                string message,
+                string initialValue,
+                string confirmLabel) =>
+                Task.FromResult<string?>(null);
         }
     }
 }

--- a/SWLOR.Toolset.Tests/EditorServiceIndexTests.cs
+++ b/SWLOR.Toolset.Tests/EditorServiceIndexTests.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 using SWLOR.Toolset.Domain.GameData.Lookups;
 using SWLOR.Toolset.Domain.Workspace;
 using SWLOR.Toolset.Editors;
+using SWLOR.Toolset.Editors.Sources;
 using SWLOR.Toolset.Workspace;
 
 namespace SWLOR.Toolset.Tests
@@ -215,6 +216,104 @@ namespace SWLOR.Toolset.Tests
             placements.Should().ContainSingle().Which.Should().BeSameAs(expected);
             queriedRoots.Should().Equal(firstRoot, secondRoot);
             log.Lines.Should().Contain(line => line.Contains("Retrying placement scan"));
+        }
+
+        [Test]
+        public async Task PlacementInvalidationReloadsAnOpenObjectSource()
+        {
+            var moduleRoot = NewModuleRoot();
+            var log = new OutputLogService();
+            var workspace = new WorkspaceContext(root => new ModuleWorkspace(root), log);
+            var first = new ObjectPlacement(
+                ResourceType.Utw, "arrival_wp", "old_area", 0, "OLD", 1f, 2f, 3f);
+            var replacement = new ObjectPlacement(
+                ResourceType.Utw, "arrival_wp", "new_area", 1, "NEW", 4f, 5f, 6f);
+            IReadOnlyList<ObjectPlacement> current = new[] { first };
+            var editors = new EditorService(
+                workspace,
+                new LookupOptionProvider(workspace),
+                log,
+                factory: null!,
+                prompts: null!,
+                objectPlacementsFinder: (_, _, _) => Task.FromResult(current));
+            workspace.Open(moduleRoot);
+            var createSource = typeof(EditorService).GetMethod(
+                "CreateObjectSource",
+                BindingFlags.Instance | BindingFlags.NonPublic)!;
+            var source = (ObjectSourceSectionViewModel)createSource.Invoke(
+                editors,
+                new object[] { ResourceType.Utw, "arrival_wp" })!;
+            await WaitUntilAsync(() =>
+                !source.IsLoading &&
+                source.Placements.Count == 1 &&
+                ReferenceEquals(source.Placements[0].Placement, first));
+
+            current = new[] { replacement };
+            workspace.InvalidatePlacementIndex();
+            await WaitUntilAsync(() =>
+                !source.IsLoading &&
+                source.Placements.Count == 1 &&
+                ReferenceEquals(source.Placements[0].Placement, replacement));
+
+            source.Placements.Should().ContainSingle()
+                .Which.Placement.Should().BeSameAs(replacement);
+        }
+
+        [Test]
+        public async Task ReplacingAWorkspaceCancelsItsObsoletePlacementWarmup()
+        {
+            var firstRoot = NewModuleRoot();
+            var secondRoot = NewModuleRoot();
+            File.WriteAllText(Path.Combine(firstRoot, "are", "broken.are.json"), "{}");
+            File.WriteAllText(Path.Combine(firstRoot, "git", "broken.git.json"), "{");
+            var firstWorkspace = new ModuleWorkspace(firstRoot);
+            using var readFailed = new ManualResetEventSlim();
+            using var releaseFailure = new ManualResetEventSlim();
+            firstWorkspace.PlacementIndex.AreaReadFailed += (area, _) =>
+            {
+                if (area != "broken")
+                    return;
+
+                readFailed.Set();
+                releaseFailure.Wait(TimeSpan.FromSeconds(5));
+            };
+            var log = new OutputLogService();
+            var cancellationLogged = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            log.Lines.CollectionChanged += (_, args) =>
+            {
+                if (args.NewItems?.Cast<string>().Any(line => line.Contains(
+                        "Placement index warm-up canceled because its snapshot was invalidated")) == true)
+                {
+                    cancellationLogged.TrySetResult();
+                }
+            };
+            var workspace = new WorkspaceContext(
+                root => root == firstRoot ? firstWorkspace : new ModuleWorkspace(root),
+                log);
+
+            workspace.Open(firstRoot);
+            var firstCatalog = workspace.Catalog!.BuildTask;
+            readFailed.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+            workspace.Open(secondRoot);
+            var secondCatalog = workspace.Catalog!.BuildTask;
+            releaseFailure.Set();
+
+            await cancellationLogged.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await Task.WhenAll(firstCatalog, secondCatalog);
+        }
+
+        private static async Task WaitUntilAsync(Func<bool> condition)
+        {
+            var timeout = DateTime.UtcNow.AddSeconds(5);
+            while (!condition() && DateTime.UtcNow < timeout)
+            {
+                Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+                await Task.Delay(10);
+            }
+
+            Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+            condition().Should().BeTrue();
         }
 
         private string NewModuleRoot()

--- a/SWLOR.Toolset.Tests/EditorServiceIndexTests.cs
+++ b/SWLOR.Toolset.Tests/EditorServiceIndexTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using FluentAssertions;
 using NUnit.Framework;
 using SWLOR.Toolset.Domain.GameData.Lookups;
@@ -156,6 +157,64 @@ namespace SWLOR.Toolset.Tests
 
             await Task.Delay(750);
             attempts.Should().Be(4);
+        }
+
+        [Test]
+        public async Task ReplacingAWorkspaceDuringPlacementLookupRetriesAgainstTheReplacement()
+        {
+            var firstRoot = NewModuleRoot();
+            var secondRoot = NewModuleRoot();
+            var log = new OutputLogService();
+            var workspace = new WorkspaceContext(root => new ModuleWorkspace(root), log);
+            var firstStarted = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var releaseFirst = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var expected = new ObjectPlacement(
+                ResourceType.Utw,
+                "arrival_wp",
+                "replacement_area",
+                0,
+                "ARRIVAL",
+                1f,
+                2f,
+                3f);
+            var queriedRoots = new List<string>();
+            var editors = new EditorService(
+                workspace,
+                new LookupOptionProvider(workspace),
+                log,
+                factory: null!,
+                prompts: null!,
+                objectPlacementsFinder: async (module, _, _) =>
+                {
+                    queriedRoots.Add(module.ModuleRoot);
+                    if (module.ModuleRoot == firstRoot)
+                    {
+                        firstStarted.SetResult();
+                        await releaseFirst.Task;
+                        return Array.Empty<ObjectPlacement>();
+                    }
+
+                    return new[] { expected };
+                });
+            workspace.Open(firstRoot);
+
+            var method = typeof(EditorService).GetMethod(
+                "FindObjectPlacementsAsync",
+                BindingFlags.Instance | BindingFlags.NonPublic)!;
+            var lookup = (Task<IReadOnlyList<ObjectPlacement>>)method.Invoke(
+                editors,
+                new object[] { ResourceType.Utw, "arrival_wp" })!;
+            await firstStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            workspace.Open(secondRoot);
+            releaseFirst.SetResult();
+
+            var placements = await lookup.WaitAsync(TimeSpan.FromSeconds(5));
+
+            placements.Should().ContainSingle().Which.Should().BeSameAs(expected);
+            queriedRoots.Should().Equal(firstRoot, secondRoot);
+            log.Lines.Should().Contain(line => line.Contains("Retrying placement scan"));
         }
 
         private string NewModuleRoot()

--- a/SWLOR.Toolset.Tests/InstanceFacingTests.cs
+++ b/SWLOR.Toolset.Tests/InstanceFacingTests.cs
@@ -20,6 +20,8 @@ namespace SWLOR.Toolset.Tests
     /// </remarks>
     public class InstanceFacingTests
     {
+        private static readonly Lazy<AreaScene> HangarScene = new(BuildHangarScene);
+
         private static string RepoRoot
         {
             get
@@ -142,11 +144,7 @@ namespace SWLOR.Toolset.Tests
         [Test]
         public void CreatureAndWaypointMarkers_CarryTheirForwardCorrection()
         {
-            var index = BuildIndex();
-            var area = LoadArea("czs220_hangar");
-            var scene = AreaSceneBuilder.Build(
-                area.Are, area.Git,
-                new TilesetCatalog(index), new TileModelCache(index));
+            var scene = HangarScene.Value;
 
             var waypoints = scene.Instances.Where(i => i.Kind == InstanceMarkerKind.Waypoint).ToList();
             waypoints.Should().NotBeEmpty("czs220_hangar should carry waypoints");
@@ -174,10 +172,7 @@ namespace SWLOR.Toolset.Tests
         [Test]
         public void PlacedCreature_DrawsItsFrontAlongTheStoredHeading()
         {
-            var index = BuildIndex();
-            var area = LoadArea("czs220_hangar");
-            var scene = AreaSceneBuilder.Build(
-                area.Are, area.Git, new TilesetCatalog(index), new TileModelCache(index));
+            var scene = HangarScene.Value;
             var maureen = scene.Instances.Single(i =>
                 i.Kind == InstanceMarkerKind.Creature && i.TemplateResRef == "maureenliagri");
 
@@ -187,6 +182,14 @@ namespace SWLOR.Toolset.Tests
 
             drawnFront.X.Should().BeApproximately(storedHeading.X, 0.001f);
             drawnFront.Y.Should().BeApproximately(storedHeading.Y, 0.001f);
+        }
+
+        private static AreaScene BuildHangarScene()
+        {
+            var index = BuildIndex();
+            var area = LoadArea("czs220_hangar");
+            return AreaSceneBuilder.Build(
+                area.Are, area.Git, new TilesetCatalog(index), new TileModelCache(index));
         }
 
         private static (Domain.Documents.AreDocument Are, Domain.Documents.GitDocument Git) LoadArea(string resRef)

--- a/SWLOR.Toolset.Tests/InstanceFacingTests.cs
+++ b/SWLOR.Toolset.Tests/InstanceFacingTests.cs
@@ -13,11 +13,10 @@ namespace SWLOR.Toolset.Tests
     /// Guards that a placed instance is drawn facing the heading its data carries.
     /// </summary>
     /// <remarks>
-    /// Everything shares one convention - model forward is +X, and the heading is a plain rotation
-    /// about Z - except the toolset's waypoint flag artwork, which is authored pointing +Y and is
-    /// turned onto the convention by <see cref="WaypointMarkerModel.ForwardCorrection"/>. These tests
-    /// assert both halves: that the correction lands the flag's arrow on the stored heading, and that
-    /// no other kind is quietly turned with it.
+    /// The area transform uses model +X as its forward axis. Creature bodies and the toolset's
+    /// waypoint flag artwork are authored pointing +Y, so each is turned onto that convention before
+    /// the stored heading is applied. These tests guard both corrections and keep them away from
+    /// objects such as doors whose artwork already follows the transform's convention.
     /// </remarks>
     public class InstanceFacingTests
     {
@@ -135,35 +134,59 @@ namespace SWLOR.Toolset.Tests
         }
 
         /// <summary>
-        /// The correction is scoped to waypoints. Doors are the proof it must not spread: across the
-        /// corpus a door's Bearing matches its doorway's orientation to 0 or 180 degrees and never 90,
-        /// so a door model - whose leaf spans +X - is already laid along its wall by a plain rotation.
+        /// The correction is scoped to creatures and waypoints. Doors are the proof it must not
+        /// spread: across the corpus a door's Bearing matches its doorway's orientation to 0 or 180
+        /// degrees and never 90, so a door model - whose leaf spans +X - is already laid along its
+        /// wall by a plain rotation.
         /// </summary>
         [Test]
-        public void OnlyWaypointMarkers_CarryTheForwardCorrection()
+        public void CreatureAndWaypointMarkers_CarryTheirForwardCorrection()
         {
             var index = BuildIndex();
+            var area = LoadArea("czs220_hangar");
             var scene = AreaSceneBuilder.Build(
-                LoadArea("cz220shipbreakin").Are, LoadArea("cz220shipbreakin").Git,
+                area.Are, area.Git,
                 new TilesetCatalog(index), new TileModelCache(index));
 
             var waypoints = scene.Instances.Where(i => i.Kind == InstanceMarkerKind.Waypoint).ToList();
-            waypoints.Should().NotBeEmpty("cz220shipbreakin should carry waypoints");
+            waypoints.Should().NotBeEmpty("czs220_hangar should carry waypoints");
 
-            foreach (var waypoint in waypoints)
+            var creatures = scene.Instances.Where(i => i.Kind == InstanceMarkerKind.Creature).ToList();
+            creatures.Should().NotBeEmpty("czs220_hangar should carry creatures");
+
+            foreach (var corrected in creatures.Concat(waypoints))
             {
-                // The correction turns model +Y onto +X; check it by where it sends the Y axis.
-                var turned = Vector3.TransformNormal(Vector3.UnitY, waypoint.VisualTransform);
+                // Both corrections turn model +Y onto +X; check where they send the Y axis.
+                var turned = Vector3.TransformNormal(Vector3.UnitY, corrected.VisualTransform);
                 turned.X.Should().BeApproximately(1f, 0.001f);
                 turned.Y.Should().BeApproximately(0f, 0.001f);
             }
 
-            foreach (var other in scene.Instances.Where(i => i.Kind != InstanceMarkerKind.Waypoint))
+            foreach (var other in scene.Instances.Where(i =>
+                         i.Kind != InstanceMarkerKind.Creature && i.Kind != InstanceMarkerKind.Waypoint))
             {
                 var turned = Vector3.TransformNormal(Vector3.UnitY, other.VisualTransform);
                 turned.X.Should().BeApproximately(0f, 0.001f,
-                    $"a {other.Kind} must keep the shared convention, not the waypoint artwork's");
+                    $"a {other.Kind} must keep the transform's native convention");
             }
+        }
+
+        [Test]
+        public void PlacedCreature_DrawsItsFrontAlongTheStoredHeading()
+        {
+            var index = BuildIndex();
+            var area = LoadArea("czs220_hangar");
+            var scene = AreaSceneBuilder.Build(
+                area.Are, area.Git, new TilesetCatalog(index), new TileModelCache(index));
+            var maureen = scene.Instances.Single(i =>
+                i.Kind == InstanceMarkerKind.Creature && i.TemplateResRef == "maureenliagri");
+
+            var drawnFront = Vector3.Normalize(Vector3.TransformNormal(
+                Vector3.UnitY, AreaPicking.ComputeInstanceTransform(maureen)));
+            var storedHeading = Vector2.Normalize(maureen.Orientation);
+
+            drawnFront.X.Should().BeApproximately(storedHeading.X, 0.001f);
+            drawnFront.Y.Should().BeApproximately(storedHeading.Y, 0.001f);
         }
 
         private static (Domain.Documents.AreDocument Are, Domain.Documents.GitDocument Git) LoadArea(string resRef)

--- a/SWLOR.Toolset.Tests/InstanceFacingTests.cs
+++ b/SWLOR.Toolset.Tests/InstanceFacingTests.cs
@@ -15,8 +15,9 @@ namespace SWLOR.Toolset.Tests
     /// <remarks>
     /// The area transform uses model +X as its forward axis. Creature bodies and the toolset's
     /// waypoint flag artwork are authored pointing +Y, so each is turned onto that convention before
-    /// the stored heading is applied. These tests guard both corrections and keep them away from
-    /// objects such as doors whose artwork already follows the transform's convention.
+    /// the stored heading is applied. Stores use that same flag artwork. These tests guard the
+    /// corrections and keep them away from objects such as doors whose artwork already follows the
+    /// transform's convention.
     /// </remarks>
     public class InstanceFacingTests
     {
@@ -136,13 +137,13 @@ namespace SWLOR.Toolset.Tests
         }
 
         /// <summary>
-        /// The correction is scoped to creatures and waypoints. Doors are the proof it must not
-        /// spread: across the corpus a door's Bearing matches its doorway's orientation to 0 or 180
-        /// degrees and never 90, so a door model - whose leaf spans +X - is already laid along its
-        /// wall by a plain rotation.
+        /// The correction is scoped to creatures and waypoint artwork (including stores). Doors are
+        /// the proof it must not spread: across the corpus a door's Bearing matches its doorway's
+        /// orientation to 0 or 180 degrees and never 90, so a door model - whose leaf spans +X - is
+        /// already laid along its wall by a plain rotation.
         /// </summary>
         [Test]
-        public void CreatureAndWaypointMarkers_CarryTheirForwardCorrection()
+        public void CreatureWaypointAndStoreMarkers_CarryTheirForwardCorrection()
         {
             var scene = HangarScene.Value;
 
@@ -152,7 +153,10 @@ namespace SWLOR.Toolset.Tests
             var creatures = scene.Instances.Where(i => i.Kind == InstanceMarkerKind.Creature).ToList();
             creatures.Should().NotBeEmpty("czs220_hangar should carry creatures");
 
-            foreach (var corrected in creatures.Concat(waypoints))
+            var stores = scene.Instances.Where(i => i.Kind == InstanceMarkerKind.Store).ToList();
+            stores.Should().NotBeEmpty("czs220_hangar should carry a merchant store");
+
+            foreach (var corrected in creatures.Concat(waypoints).Concat(stores))
             {
                 // Both corrections turn model +Y onto +X; check where they send the Y axis.
                 var turned = Vector3.TransformNormal(Vector3.UnitY, corrected.VisualTransform);
@@ -161,12 +165,43 @@ namespace SWLOR.Toolset.Tests
             }
 
             foreach (var other in scene.Instances.Where(i =>
-                         i.Kind != InstanceMarkerKind.Creature && i.Kind != InstanceMarkerKind.Waypoint))
+                         i.Kind != InstanceMarkerKind.Creature && i.Kind != InstanceMarkerKind.Store &&
+                         i.Kind != InstanceMarkerKind.Waypoint))
             {
                 var turned = Vector3.TransformNormal(Vector3.UnitY, other.VisualTransform);
                 turned.X.Should().BeApproximately(0f, 0.001f,
                     $"a {other.Kind} must keep the transform's native convention");
             }
+        }
+
+        [Test]
+        public void PlacedStore_UsesYellowWaypointArtworkCenteredOnItsStoredPositionAndFacing()
+        {
+            var index = BuildIndexWithBaseGame();
+            if (index == null)
+            {
+                Assert.Ignore("No local NWN:EE installation found; merchant marker artwork is a base-game resource.");
+                return;
+            }
+
+            var area = LoadArea("czs220_hangar");
+            var scene = AreaSceneBuilder.Build(
+                area.Are, area.Git, new TilesetCatalog(index), new TileModelCache(index));
+            var store = scene.Instances.Single(i => i.Kind == InstanceMarkerKind.Store);
+
+            store.Model.Should().NotBeNull("Aurora represents a merchant with the yellow waypoint model");
+            store.Model!.Name.Should().BeEquivalentTo(WaypointMarkerModel.MerchantModelResRef);
+
+            var transform = AreaPicking.ComputeInstanceTransform(store);
+            Vector3.Transform(Vector3.Zero, transform).Should().Be(store.Position,
+                "the waypoint pole's origin belongs at the store instead of a pyramid face beside it");
+
+            var tip = ArrowTip(index, WaypointMarkerModel.MerchantModelResRef);
+            tip.Should().NotBeNull();
+            var drawn = Vector3.Normalize(Vector3.Transform(tip!.Value, transform) - store.Position);
+            var heading = Vector2.Normalize(store.Orientation);
+            drawn.X.Should().BeApproximately(heading.X, 0.02f);
+            drawn.Y.Should().BeApproximately(heading.Y, 0.02f);
         }
 
         [Test]
@@ -205,6 +240,11 @@ namespace SWLOR.Toolset.Tests
             if (index == null)
                 return null;
 
+            return ArrowTip(index, resRef);
+        }
+
+        private static Vector3? ArrowTip(ResourceIndex index, string resRef)
+        {
             var identity = new ResourceIdentity(resRef, ResourceIdentity.TypeFromExtension("mdl"));
             if (!index.TryLookup(identity, out var handle))
                 return null;

--- a/SWLOR.Toolset.Tests/MdlMeshBuilderPlaceholderTests.cs
+++ b/SWLOR.Toolset.Tests/MdlMeshBuilderPlaceholderTests.cs
@@ -96,6 +96,19 @@ namespace SWLOR.Toolset.Tests
                 .Which.NodeName.Should().Be("ground");
         }
 
+        [Test]
+        public void AMeshWhoseFacesAllReferenceMissingVertices_IsNotBuilt()
+        {
+            var malformed = Trimesh("malformed");
+            malformed.Faces =
+            [
+                new MdlFace { VertexIndex0 = 0, VertexIndex1 = 1, VertexIndex2 = 99 }
+            ];
+
+            MdlMeshBuilder.IsRenderableMesh(malformed).Should().BeFalse();
+            MdlMeshBuilder.Build(ModelOf(malformed)).Meshes.Should().BeEmpty();
+        }
+
         /// <summary>
         /// The Aurora "no texture" literal must resolve the same way whether it came from an ASCII
         /// MDL (already lowercased/blanked by <see cref="AsciiMdlReader"/>) or a binary MDL (which

--- a/SWLOR.Toolset.Tests/MerchantEditorTests.cs
+++ b/SWLOR.Toolset.Tests/MerchantEditorTests.cs
@@ -1033,6 +1033,64 @@ namespace SWLOR.Toolset.Tests
         }
 
         [Test]
+        public async Task InstanceUpdatePreservesDisplayedRowsAcrossPlacementInvalidation()
+        {
+            var moduleRoot = Path.Combine(
+                Path.GetTempPath(),
+                "swlor-merchant-update-invalidation-" + Guid.NewGuid().ToString("N"),
+                "Module");
+            Directory.CreateDirectory(Path.Combine(moduleRoot, "are"));
+            Directory.CreateDirectory(Path.Combine(moduleRoot, "git"));
+            Directory.CreateDirectory(Path.Combine(moduleRoot, "utm"));
+            Directory.CreateDirectory(Path.Combine(moduleRoot, "utc"));
+
+            var merchant = JsonGffDocument.Parse(
+                BlueprintTemplateFactory.CreateFileContent(
+                    ResourceType.Utm, "probe_store", "Probe Store"));
+            WritePlacedMerchantArea(moduleRoot, "area_a", merchant);
+            merchant.Root.SetInt("MarkUp", GffFieldType.Int, 175);
+            File.WriteAllBytes(
+                Path.Combine(moduleRoot, "utm", "probe_store.utm.json"),
+                merchant.ToBytes());
+
+            var log = new OutputLogService();
+            var workspace = new WorkspaceContext(path => new ModuleWorkspace(path), log);
+            workspace.Open(moduleRoot);
+            var service = new MerchantInstanceService(workspace, log);
+            using var editor = new MerchantEditorViewModel(
+                merchant.Root,
+                "probe_store",
+                (_, mutation) =>
+                {
+                    mutation();
+                    return true;
+                },
+                instances: service);
+            workspace.PlacementIndexInvalidated += editor.InvalidatePlacedInstances;
+
+            try
+            {
+                await editor.RefreshPlacedInstancesAsync();
+                editor.PlacedInstances.Should().ContainSingle()
+                    .Which.IsCurrent.Should().BeFalse();
+
+                await editor.UpdateOutOfDateInstancesCommand.ExecuteAsync(null);
+
+                editor.PlacedInstances.Should().ContainSingle()
+                    .Which.IsCurrent.Should().BeTrue(
+                        "the command must restore its displayed snapshot after its own invalidation");
+                editor.ArePlacedInstancesLoaded.Should().BeTrue();
+                editor.PlacedInstancesNeedRefresh.Should().BeFalse();
+            }
+            finally
+            {
+                workspace.PlacementIndexInvalidated -= editor.InvalidatePlacedInstances;
+                await workspace.Catalog!.BuildTask;
+                Directory.Delete(Directory.GetParent(moduleRoot)!.FullName, recursive: true);
+            }
+        }
+
+        [Test]
         public void InstanceSummaryReportsOutOfDateMerchantAndItemRecordCounts()
         {
             using var editor = new MerchantEditorViewModel(

--- a/SWLOR.Toolset.Tests/MerchantEditorTests.cs
+++ b/SWLOR.Toolset.Tests/MerchantEditorTests.cs
@@ -995,6 +995,14 @@ namespace SWLOR.Toolset.Tests
 
             try
             {
+                var placements = await service.FindAsync("probe_store");
+                placements.Should().HaveCount(2);
+                placements.Should().OnlyContain(placement =>
+                    Math.Abs(placement.XPosition - 1f) < 0.001f &&
+                    Math.Abs(placement.YPosition - 2f) < 0.001f &&
+                    Math.Abs(placement.ZPosition - 3f) < 0.001f,
+                    "merchant Go To needs the scanned coordinates when a saved index becomes stale");
+
                 var updated = await service.UpdateOutOfDateAsync(
                     "probe_store",
                     new[] { "area_a" });
@@ -1050,6 +1058,39 @@ namespace SWLOR.Toolset.Tests
                 "1 merchant record, 2 item records out of date");
             editor.PlacedInstances[0].SyncState.Should().Be("Out of date");
             editor.PlacedInstances[2].SyncState.Should().Be("Up to date");
+        }
+
+        [Test]
+        public void GoToInstance_UsesSavedSourceResRefAndRequiresNavigationCallback()
+        {
+            string? navigatedResRef = null;
+            var placement = new MerchantInstancePlacement(
+                "Area A", "area_a", "store_a", 0, 0, 0, 1f, 2f, 3f);
+            using var editor = new MerchantEditorViewModel(
+                NewMerchant(),
+                "probe_store",
+                (_, mutation) =>
+                {
+                    mutation();
+                    return true;
+                },
+                goToInstance: (resRef, _) => navigatedResRef = resRef);
+
+            editor.DetailRows.Single(row => row.Definition.Name == "ResRef").Text = "unsaved_name";
+
+            editor.GoToInstanceCommand.CanExecute(placement).Should().BeTrue();
+            editor.GoToInstanceCommand.Execute(placement);
+            navigatedResRef.Should().Be(
+                "probe_store",
+                "the displayed placement was loaded for the saved source, not the unsaved field value");
+
+            using var withoutNavigation = new MerchantEditorViewModel(
+                NewMerchant(), "probe_store", (_, mutation) =>
+                {
+                    mutation();
+                    return true;
+                });
+            withoutNavigation.GoToInstanceCommand.CanExecute(placement).Should().BeFalse();
         }
 
         private static JsonGffStruct NewMerchant() =>

--- a/SWLOR.Toolset.Tests/ModelPreviewCameraInputTests.cs
+++ b/SWLOR.Toolset.Tests/ModelPreviewCameraInputTests.cs
@@ -42,22 +42,6 @@ namespace SWLOR.Toolset.Tests
             longTurn.Should().BeApproximately(shortTurn * 2f, 0.0001f);
         }
 
-        [AvaloniaTest]
-        public void ViewportState_RoundTripsAcrossControlRecreation()
-        {
-            var expected = new AreaViewportState(
-                new Vector3(12.5f, -4f, 8f),
-                Distance: 30f,
-                InitialDistance: 50f,
-                Azimuth: 1.25f,
-                Elevation: 0.45f);
-            var replacementControl = new GlAreaControl();
-
-            replacementControl.RestoreViewportState(expected);
-
-            replacementControl.CaptureViewportState().Should().Be(expected);
-        }
-
         private static GlAreaControl PreviewControl()
         {
             var control = new GlAreaControl();

--- a/SWLOR.Toolset.Tests/ModelPreviewCameraInputTests.cs
+++ b/SWLOR.Toolset.Tests/ModelPreviewCameraInputTests.cs
@@ -42,6 +42,22 @@ namespace SWLOR.Toolset.Tests
             longTurn.Should().BeApproximately(shortTurn * 2f, 0.0001f);
         }
 
+        [AvaloniaTest]
+        public void ViewportState_RoundTripsAcrossControlRecreation()
+        {
+            var expected = new AreaViewportState(
+                new Vector3(12.5f, -4f, 8f),
+                Distance: 30f,
+                InitialDistance: 50f,
+                Azimuth: 1.25f,
+                Elevation: 0.45f);
+            var replacementControl = new GlAreaControl();
+
+            replacementControl.RestoreViewportState(expected);
+
+            replacementControl.CaptureViewportState().Should().Be(expected);
+        }
+
         private static GlAreaControl PreviewControl()
         {
             var control = new GlAreaControl();

--- a/SWLOR.Toolset.Tests/ModuleExplorerDragDropTests.cs
+++ b/SWLOR.Toolset.Tests/ModuleExplorerDragDropTests.cs
@@ -66,6 +66,16 @@ namespace SWLOR.Toolset.Tests
             first.Members.Should().NotContain("resource_one");
             second.Members.Should().Contain("resource_one");
 
+            explorer.UndoResourceMoveCommand.CanExecute(null).Should().BeTrue();
+            explorer.UndoResourceMoveCommand.Execute(null);
+            first.Members.Should().Contain("resource_one");
+            second.Members.Should().NotContain("resource_one");
+            explorer.RedoResourceMoveCommand.CanExecute(null).Should().BeTrue();
+
+            explorer.RedoResourceMoveCommand.Execute(null);
+            first.Members.Should().NotContain("resource_one");
+            second.Members.Should().Contain("resource_one");
+
             source = explorer.Rows.Single(row => row.Folder == second).Children
                 .Single(row => row.ResRef == "resource_one");
             var unsorted = explorer.Rows.Single(row =>
@@ -76,6 +86,51 @@ namespace SWLOR.Toolset.Tests
             section.FoldersContaining("resource_one").Should().BeEmpty();
             explorer.Rows.Single(row => row.Name == "Unsorted").Children
                 .Should().ContainSingle(row => row.ResRef == "resource_one");
+
+            explorer.UndoResourceMoveCommand.Execute(null);
+            second.Members.Should().Contain("resource_one");
+            explorer.RedoResourceMoveCommand.Execute(null);
+            section.FoldersContaining("resource_one").Should().BeEmpty();
+        }
+
+        [Test]
+        public void UndoRestoresEveryPreviousFolderMembership()
+        {
+            File.WriteAllText(Path.Combine(_module, "nss", "resource_one.nss"), "void main() {}");
+
+            var log = new OutputLogService();
+            var workspace = new WorkspaceContext(root => new ModuleWorkspace(root), log);
+            workspace.Open(_module);
+            var categories = new CategoryService(workspace, log);
+            var section = categories.Section(ResourceType.Nss)!;
+            section.IsSeeded = true;
+            var first = section.AddFolder("First");
+            var second = section.AddFolder("Second");
+            var third = section.AddFolder("Third");
+            first.AddMember("resource_one");
+            third.AddMember("resource_one");
+            categories.SaveChanges().Saved.Should().BeTrue();
+
+            var explorer = new ModuleExplorerViewModel(
+                workspace,
+                new PropertiesViewModel(workspace, log),
+                categories,
+                log)
+            {
+                SelectedType = ResourceType.Nss
+            };
+            explorer.Initialize();
+
+            var source = explorer.Rows.Single(row => row.Folder == first).Children
+                .Single(row => row.ResRef == "resource_one");
+            var target = explorer.Rows.Single(row => row.Folder == second);
+            explorer.DropResource(source, target).Should().BeTrue();
+
+            explorer.UndoResourceMoveCommand.Execute(null);
+
+            first.Members.Should().Contain("resource_one");
+            second.Members.Should().NotContain("resource_one");
+            third.Members.Should().Contain("resource_one");
         }
 
         [Test]

--- a/SWLOR.Toolset.Tests/ModuleExplorerDragDropTests.cs
+++ b/SWLOR.Toolset.Tests/ModuleExplorerDragDropTests.cs
@@ -134,6 +134,52 @@ namespace SWLOR.Toolset.Tests
         }
 
         [Test]
+        public void RenamingAMovedResourceInvalidatesItsUndoHistory()
+        {
+            var oldPath = Path.Combine(_module, "nss", "resource_one.nss");
+            var newPath = Path.Combine(_module, "nss", "resource_renamed.nss");
+            File.WriteAllText(oldPath, "void main() {}");
+
+            var log = new OutputLogService();
+            var workspace = new WorkspaceContext(root => new ModuleWorkspace(root), log);
+            workspace.Open(_module);
+            var categories = new CategoryService(workspace, log);
+            var section = categories.Section(ResourceType.Nss)!;
+            section.IsSeeded = true;
+            var first = section.AddFolder("First");
+            var second = section.AddFolder("Second");
+            first.AddMember("resource_one");
+            categories.SaveChanges().Saved.Should().BeTrue();
+
+            var explorer = new ModuleExplorerViewModel(
+                workspace,
+                new PropertiesViewModel(workspace, log),
+                categories,
+                log)
+            {
+                SelectedType = ResourceType.Nss
+            };
+            explorer.Initialize();
+
+            var source = explorer.Rows.Single(row => row.Folder == first).Children
+                .Single(row => row.ResRef == "resource_one");
+            var target = explorer.Rows.Single(row => row.Folder == second);
+            explorer.DropResource(source, target).Should().BeTrue();
+            explorer.UndoResourceMoveCommand.CanExecute(null).Should().BeTrue();
+
+            File.Move(oldPath, newPath);
+            second.RemoveMember("resource_one").Should().BeTrue();
+            second.AddMember("resource_renamed").Should().BeTrue();
+            categories.SaveChanges().Saved.Should().BeTrue();
+            workspace.RemoveCatalogEntry(ResourceType.Nss, "resource_one");
+            workspace.RefreshCatalogEntry(ResourceType.Nss, "resource_renamed");
+
+            explorer.UndoResourceMoveCommand.CanExecute(null).Should().BeFalse();
+            section.AllFolders().Should().NotContain(folder => folder.Members.Contains("resource_one"));
+            second.Members.Should().Contain("resource_renamed");
+        }
+
+        [Test]
         public void EmptyUnsortedRemainsVisibleAsADragOutTarget()
         {
             File.WriteAllText(Path.Combine(_module, "nss", "filed.nss"), "void main() {}");

--- a/SWLOR.Toolset.Tests/ModuleExplorerDragDropTests.cs
+++ b/SWLOR.Toolset.Tests/ModuleExplorerDragDropTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using NUnit.Framework;
+using SWLOR.Toolset.Domain.Categories;
 using SWLOR.Toolset.Domain.Workspace;
 using SWLOR.Toolset.Shell.Panels;
 using SWLOR.Toolset.Workspace;
@@ -131,6 +132,52 @@ namespace SWLOR.Toolset.Tests
             first.Members.Should().Contain("resource_one");
             second.Members.Should().NotContain("resource_one");
             third.Members.Should().Contain("resource_one");
+        }
+
+        [Test]
+        public void UndoPersistsWhenTheInMemoryMembershipAlreadyMatchesItsDestination()
+        {
+            File.WriteAllText(Path.Combine(_module, "nss", "resource_one.nss"), "void main() {}");
+
+            var log = new OutputLogService();
+            var workspace = new WorkspaceContext(root => new ModuleWorkspace(root), log);
+            workspace.Open(_module);
+            var categories = new CategoryService(workspace, log);
+            var section = categories.Section(ResourceType.Nss)!;
+            section.IsSeeded = true;
+            var first = section.AddFolder("First");
+            var second = section.AddFolder("Second");
+            first.AddMember("resource_one");
+            categories.SaveChanges().Saved.Should().BeTrue();
+
+            var explorer = new ModuleExplorerViewModel(
+                workspace,
+                new PropertiesViewModel(workspace, log),
+                categories,
+                log)
+            {
+                SelectedType = ResourceType.Nss
+            };
+            explorer.Initialize();
+
+            var source = explorer.Rows.Single(row => row.Folder == first).Children
+                .Single(row => row.ResRef == "resource_one");
+            var target = explorer.Rows.Single(row => row.Folder == second);
+            explorer.DropResource(source, target).Should().BeTrue();
+
+            // Reproduce the state left by a failed persistence implementation: memory already has
+            // the undo destination, while the sidecar still contains the completed move.
+            second.RemoveMember("resource_one").Should().BeTrue();
+            first.AddMember("resource_one").Should().BeTrue();
+
+            explorer.UndoResourceMoveCommand.Execute(null);
+
+            var persisted = CategoryCatalog.Load(
+                CategoryCatalog.DefaultPathFor(_module), out var warning);
+            warning.Should().BeNull();
+            persisted.Section(ResourceType.Nss).FoldersContaining("resource_one")
+                .Select(folder => folder.Name).Should().Equal("First");
+            explorer.RedoResourceMoveCommand.CanExecute(null).Should().BeTrue();
         }
 
         [Test]

--- a/SWLOR.Toolset.Tests/ModuleFileWatcherTests.cs
+++ b/SWLOR.Toolset.Tests/ModuleFileWatcherTests.cs
@@ -66,6 +66,16 @@ namespace SWLOR.Toolset.Tests
             ModuleFileWatcher.AffectsTagIndex(path).Should().BeFalse();
         }
 
+        [TestCase(@"C:\module\git\area.git.json", true)]
+        [TestCase(@"C:\module\are\area.are.json", false)]
+        [TestCase(@"C:\module\utd\door.utd.json", false)]
+        [TestCase(@"C:\module\uti\door_key.uti.json", false)]
+        [TestCase(@"C:\module\utw\waypoint.utw.json", false)]
+        public void OnlyPairedGitResourcesInvalidateThePlacementIndex(string path, bool expected)
+        {
+            ModuleFileWatcher.AffectsPlacementIndex(path).Should().Be(expected);
+        }
+
         [TestCase(@"C:\module\git\area.git.json")]
         [TestCase(@"C:\module\utc\creature.utc.json")]
         [TestCase(@"C:\module\dlg\conversation.dlg.json")]

--- a/SWLOR.Toolset.Tests/ModuleIndexFreshnessTests.cs
+++ b/SWLOR.Toolset.Tests/ModuleIndexFreshnessTests.cs
@@ -70,6 +70,26 @@ namespace SWLOR.Toolset.Tests
             index.Tags.Should().Contain("WP_DETRITUS");
         }
 
+        [Test]
+        public void AnAreaWithMixedUtf8AndWindows1252TokensPreservesItsUtf8Tag()
+        {
+            const string expectedTag = "WP_D\u00C9TRITUS";
+            WriteArea("anchor", waypointTag: expectedTag, displayName: "LEGACY_X", asUtf8: true);
+            var path = Path.Combine(_root, "git", "anchor.git.json");
+            var bytes = File.ReadAllBytes(path);
+            var legacyMarker = Encoding.ASCII.GetBytes("LEGACY_X");
+            var markerOffset = bytes.AsSpan().IndexOf(legacyMarker);
+            markerOffset.Should().BeGreaterThanOrEqualTo(0);
+            bytes[markerOffset + legacyMarker.Length - 1] = 0x97;
+            File.WriteAllBytes(path, bytes);
+
+            var index = new ModuleTagIndex(new ModuleWorkspace(_root));
+
+            index.Tags.Should().Contain(
+                expectedTag,
+                "a legacy display-name token must not change the encoding of a genuine UTF-8 tag token");
+        }
+
         /// <summary>
         /// Every dictionary here used to be built once and held for the life of the workspace, which
         /// is right for a module nobody is editing and wrong for the one open in the toolset.

--- a/SWLOR.Toolset.Tests/ModulePlacementIndexTests.cs
+++ b/SWLOR.Toolset.Tests/ModulePlacementIndexTests.cs
@@ -136,6 +136,37 @@ namespace SWLOR.Toolset.Tests
                 "a failed build must be discarded so Refresh can retry it");
         }
 
+        [Test]
+        public async Task Invalidate_CancelsAnObsoleteBuildAndAllowsANewQuery()
+        {
+            File.WriteAllText(Path.Combine(_moduleRoot, "are", "broken.are.json"), "{}");
+            var brokenGit = Path.Combine(_moduleRoot, "git", "broken.git.json");
+            File.WriteAllText(brokenGit, "{");
+            var index = new ModuleWorkspace(_moduleRoot).PlacementIndex;
+            using var readFailed = new ManualResetEventSlim();
+            using var releaseFailure = new ManualResetEventSlim();
+            index.AreaReadFailed += (area, _) =>
+            {
+                if (area != "broken")
+                    return;
+
+                readFailed.Set();
+                releaseFailure.Wait(TimeSpan.FromSeconds(5));
+            };
+
+            var obsoleteWarmup = index.WarmAsync();
+            readFailed.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+            index.Invalidate();
+            releaseFailure.Set();
+
+            var awaitObsoleteWarmup = async () => await obsoleteWarmup;
+            await awaitObsoleteWarmup.Should().ThrowAsync<OperationCanceledException>();
+
+            File.WriteAllText(brokenGit, "{}");
+            (await index.FindAsync(ResourceType.Utc, "guard_a")).Should().ContainSingle(
+                "the canceled generation must not poison the next placement query");
+        }
+
         private void WriteGit(string creatureResRef)
         {
             File.WriteAllText(_gitPath, $$"""

--- a/SWLOR.Toolset.Tests/ModulePlacementIndexTests.cs
+++ b/SWLOR.Toolset.Tests/ModulePlacementIndexTests.cs
@@ -78,12 +78,14 @@ namespace SWLOR.Toolset.Tests
         }
 
         [Test]
-        public async Task FindAsync_PreservesWindows1252ThatAlsoLooksLikeValidUtf8()
+        public async Task FindAsync_DecodesUnmarkedUtf8Git()
         {
-            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
-            var expectedTag = "GUARD_\u00C2\u00A9";
+            var expectedTag = "GUARD_\u6771\u4EAC";
             var json = File.ReadAllText(_gitPath).Replace("GUARD_TAG", expectedTag);
-            File.WriteAllBytes(_gitPath, Encoding.GetEncoding(1252).GetBytes(json));
+            File.WriteAllText(
+                _gitPath,
+                json,
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
             var index = new ModuleWorkspace(_moduleRoot).PlacementIndex;
 
             var placement = (await index.FindAsync(ResourceType.Utc, "guard_a"))

--- a/SWLOR.Toolset.Tests/ModulePlacementIndexTests.cs
+++ b/SWLOR.Toolset.Tests/ModulePlacementIndexTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using FluentAssertions;
 using NUnit.Framework;
 using SWLOR.Toolset.Domain.Workspace;
@@ -60,6 +61,47 @@ namespace SWLOR.Toolset.Tests
 
             (await index.FindAsync(ResourceType.Utc, "guard_a")).Should().BeEmpty();
             (await index.FindAsync(ResourceType.Utc, "guard_b")).Should().ContainSingle();
+        }
+
+        [Test]
+        public async Task FindAsync_DecodesWindows1252Git()
+        {
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+            var json = File.ReadAllText(_gitPath).Replace("GUARD_TAG", "GUARD_CAFÉ");
+            File.WriteAllBytes(_gitPath, Encoding.GetEncoding(1252).GetBytes(json));
+            var index = new ModuleWorkspace(_moduleRoot).PlacementIndex;
+
+            var placement = (await index.FindAsync(ResourceType.Utc, "guard_a"))
+                .Should().ContainSingle().Subject;
+
+            placement.Tag.Should().Be("GUARD_CAFÉ");
+        }
+
+        [Test]
+        public async Task IncompleteScan_NamesLogsAndRetriesFailedArea()
+        {
+            File.WriteAllText(Path.Combine(_moduleRoot, "are", "broken.are.json"), "{}");
+            var brokenGit = Path.Combine(_moduleRoot, "git", "broken.git.json");
+            File.WriteAllText(brokenGit, "{");
+            var index = new ModuleWorkspace(_moduleRoot).PlacementIndex;
+            string? loggedArea = null;
+            Exception? loggedError = null;
+            index.AreaReadFailed += (area, error) =>
+            {
+                loggedArea = area;
+                loggedError = error;
+            };
+
+            var act = async () => await index.FindAsync(ResourceType.Utc, "guard_a");
+
+            var failure = await act.Should().ThrowAsync<PlacementIndexIncompleteException>();
+            failure.Which.AreaResRefs.Should().Equal("broken");
+            loggedArea.Should().Be("broken");
+            loggedError.Should().NotBeNull();
+
+            File.WriteAllText(brokenGit, "{}");
+            (await index.FindAsync(ResourceType.Utc, "guard_a")).Should().ContainSingle(
+                "a failed build must be discarded so Refresh can retry it");
         }
 
         private void WriteGit(string creatureResRef)

--- a/SWLOR.Toolset.Tests/ModulePlacementIndexTests.cs
+++ b/SWLOR.Toolset.Tests/ModulePlacementIndexTests.cs
@@ -95,6 +95,29 @@ namespace SWLOR.Toolset.Tests
         }
 
         [Test]
+        public async Task FindAsync_DecodesUtf8AndWindows1252TokensInTheSameGit()
+        {
+            var expectedTag = "GUARD_\u6771\u4EAC";
+            var json = File.ReadAllText(_gitPath)
+                .Replace("GUARD_TAG", expectedTag)
+                .Replace("CRATE_TAG", "CRATE_X");
+            var bytes = Encoding.UTF8.GetBytes(json);
+            var legacyMarker = Encoding.ASCII.GetBytes("CRATE_X");
+            var markerOffset = bytes.AsSpan().IndexOf(legacyMarker);
+            markerOffset.Should().BeGreaterThanOrEqualTo(0);
+            bytes[markerOffset + legacyMarker.Length - 1] = 0x97;
+            File.WriteAllBytes(_gitPath, bytes);
+            var index = new ModuleWorkspace(_moduleRoot).PlacementIndex;
+
+            var placement = (await index.FindAsync(ResourceType.Utc, "guard_a"))
+                .Should().ContainSingle().Subject;
+
+            placement.Tag.Should().Be(
+                expectedTag,
+                "a legacy token elsewhere in the GIT must not force genuine UTF-8 tags through Windows-1252");
+        }
+
+        [Test]
         public async Task FindAsync_DecodesBomMarkedUtf8Git()
         {
             var expectedTag = "GUARD_\u6771\u4EAC";

--- a/SWLOR.Toolset.Tests/ModulePlacementIndexTests.cs
+++ b/SWLOR.Toolset.Tests/ModulePlacementIndexTests.cs
@@ -78,6 +78,38 @@ namespace SWLOR.Toolset.Tests
         }
 
         [Test]
+        public async Task FindAsync_PreservesWindows1252ThatAlsoLooksLikeValidUtf8()
+        {
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+            var expectedTag = "GUARD_\u00C2\u00A9";
+            var json = File.ReadAllText(_gitPath).Replace("GUARD_TAG", expectedTag);
+            File.WriteAllBytes(_gitPath, Encoding.GetEncoding(1252).GetBytes(json));
+            var index = new ModuleWorkspace(_moduleRoot).PlacementIndex;
+
+            var placement = (await index.FindAsync(ResourceType.Utc, "guard_a"))
+                .Should().ContainSingle().Subject;
+
+            placement.Tag.Should().Be(expectedTag);
+        }
+
+        [Test]
+        public async Task FindAsync_DecodesBomMarkedUtf8Git()
+        {
+            var expectedTag = "GUARD_\u6771\u4EAC";
+            var json = File.ReadAllText(_gitPath).Replace("GUARD_TAG", expectedTag);
+            File.WriteAllText(
+                _gitPath,
+                json,
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: true));
+            var index = new ModuleWorkspace(_moduleRoot).PlacementIndex;
+
+            var placement = (await index.FindAsync(ResourceType.Utc, "guard_a"))
+                .Should().ContainSingle().Subject;
+
+            placement.Tag.Should().Be(expectedTag);
+        }
+
+        [Test]
         public async Task IncompleteScan_NamesLogsAndRetriesFailedArea()
         {
             File.WriteAllText(Path.Combine(_moduleRoot, "are", "broken.are.json"), "{}");

--- a/SWLOR.Toolset.Tests/ModulePlacementIndexTests.cs
+++ b/SWLOR.Toolset.Tests/ModulePlacementIndexTests.cs
@@ -1,0 +1,97 @@
+using FluentAssertions;
+using NUnit.Framework;
+using SWLOR.Toolset.Domain.Workspace;
+
+namespace SWLOR.Toolset.Tests
+{
+    public class ModulePlacementIndexTests
+    {
+        private string _moduleRoot = string.Empty;
+        private string _gitPath = string.Empty;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _moduleRoot = Path.Combine(
+                Path.GetTempPath(), "swlor-placement-index-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path.Combine(_moduleRoot, "are"));
+            Directory.CreateDirectory(Path.Combine(_moduleRoot, "utc"));
+            Directory.CreateDirectory(Path.Combine(_moduleRoot, "git"));
+            File.WriteAllText(Path.Combine(_moduleRoot, "are", "test_area.are.json"), "{}");
+            _gitPath = Path.Combine(_moduleRoot, "git", "test_area.git.json");
+            WriteGit("guard_a");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (Directory.Exists(_moduleRoot))
+                Directory.Delete(_moduleRoot, recursive: true);
+        }
+
+        [Test]
+        public async Task FindAsync_IndexesKindAreaListIndexTagAndPosition()
+        {
+            var index = new ModuleWorkspace(_moduleRoot).PlacementIndex;
+
+            var creature = (await index.FindAsync(ResourceType.Utc, "guard_a")).Should().ContainSingle().Subject;
+            creature.AreaResRef.Should().Be("test_area");
+            creature.InstanceIndex.Should().Be(0);
+            creature.Tag.Should().Be("GUARD_TAG");
+            creature.X.Should().BeApproximately(12.5f, 0.001f);
+            creature.Y.Should().BeApproximately(8.25f, 0.001f);
+            creature.Z.Should().BeApproximately(1.5f, 0.001f);
+
+            var placeable = (await index.FindAsync(ResourceType.Utp, "crate_a")).Should().ContainSingle().Subject;
+            placeable.InstanceIndex.Should().Be(0, "indices are within each kind's GIT list");
+            placeable.X.Should().BeApproximately(3f, 0.001f);
+            placeable.Y.Should().BeApproximately(4f, 0.001f);
+            placeable.Z.Should().BeApproximately(5f, 0.001f);
+        }
+
+        [Test]
+        public async Task Invalidate_RebuildsAgainstChangedGit()
+        {
+            var index = new ModuleWorkspace(_moduleRoot).PlacementIndex;
+            (await index.FindAsync(ResourceType.Utc, "guard_a")).Should().ContainSingle();
+
+            WriteGit("guard_b");
+            index.Invalidate();
+
+            (await index.FindAsync(ResourceType.Utc, "guard_a")).Should().BeEmpty();
+            (await index.FindAsync(ResourceType.Utc, "guard_b")).Should().ContainSingle();
+        }
+
+        private void WriteGit(string creatureResRef)
+        {
+            File.WriteAllText(_gitPath, $$"""
+            {
+              "Creature List": {
+                "type": "list",
+                "value": [
+                  {
+                    "TemplateResRef": { "type": "resref", "value": "{{creatureResRef}}" },
+                    "Tag": { "type": "cexostring", "value": "GUARD_TAG" },
+                    "XPosition": { "type": "float", "value": 12.5 },
+                    "YPosition": { "type": "float", "value": 8.25 },
+                    "ZPosition": { "type": "float", "value": 1.5 }
+                  }
+                ]
+              },
+              "Placeable List": {
+                "type": "list",
+                "value": [
+                  {
+                    "TemplateResRef": { "type": "resref", "value": "crate_a" },
+                    "Tag": { "type": "cexostring", "value": "CRATE_TAG" },
+                    "X": { "type": "float", "value": 3.0 },
+                    "Y": { "type": "float", "value": 4.0 },
+                    "Z": { "type": "float", "value": 5.0 }
+                  }
+                ]
+              }
+            }
+            """);
+        }
+    }
+}

--- a/SWLOR.Toolset.Tests/ObjectSourceSectionTests.cs
+++ b/SWLOR.Toolset.Tests/ObjectSourceSectionTests.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using NUnit.Framework;
 using SWLOR.Toolset.Domain.Workspace;
 using SWLOR.Toolset.Editors.Sources;
+using SWLOR.Toolset.Workspace;
 
 namespace SWLOR.Toolset.Tests
 {
@@ -107,6 +108,28 @@ namespace SWLOR.Toolset.Tests
             source.Placements.Should().BeEmpty();
             source.LoadError.Should().Contain("broken GIT");
             source.Status.Should().Be(source.LoadError);
+        }
+
+        [Test]
+        public async Task FailedLoad_WritesTheFullFailureAndBlueprintIdentityToOutput()
+        {
+            var log = new OutputLogService();
+            var source = new ObjectSourceSectionViewModel(
+                ResourceType.Utw,
+                "broken_wp",
+                (_, _) => Task.FromException<IReadOnlyList<ObjectPlacement>>(
+                    new IOException("broken GIT", new InvalidDataException("bad token"))),
+                area => area,
+                _ => { },
+                log: log);
+
+            await WaitUntilAsync(() => !source.IsLoading);
+
+            log.Lines.Should().Contain(line =>
+                line.Contains("Utw") &&
+                line.Contains("broken_wp") &&
+                line.Contains("InvalidDataException") &&
+                line.Contains("bad token"));
         }
 
         private static async Task WaitUntilAsync(Func<bool> condition)

--- a/SWLOR.Toolset.Tests/ObjectSourceSectionTests.cs
+++ b/SWLOR.Toolset.Tests/ObjectSourceSectionTests.cs
@@ -31,6 +31,55 @@ namespace SWLOR.Toolset.Tests
             navigated.Should().BeSameAs(placement);
         }
 
+        [Test]
+        public async Task RefreshAreaNames_ReplacesCatalogFallbacksAfterTheCatalogBuilds()
+        {
+            var placement = new ObjectPlacement(
+                ResourceType.Utw, "arrival_wp", "dan_enclave", 7, "ARRIVAL", 1f, 2f, 3f);
+            var resolvedName = "dan_enclave";
+            var source = new ObjectSourceSectionViewModel(
+                ResourceType.Utw,
+                "arrival_wp",
+                (_, _) => Task.FromResult<IReadOnlyList<ObjectPlacement>>(new[] { placement }),
+                _ => resolvedName,
+                _ => { });
+            await WaitUntilAsync(() => !source.IsLoading);
+            source.Placements.Should().ContainSingle().Which.AreaName.Should().Be("dan_enclave");
+
+            resolvedName = "Dantooine Jedi Enclave";
+            source.RefreshAreaNames();
+
+            source.Placements.Should().ContainSingle()
+                .Which.AreaName.Should().Be("Dantooine Jedi Enclave");
+        }
+
+        [Test]
+        public async Task Reload_ReplacesAStalePlacementSnapshot()
+        {
+            var oldPlacement = new ObjectPlacement(
+                ResourceType.Utw, "arrival_wp", "old_area", 0, "OLD", 1f, 2f, 3f);
+            var newPlacement = new ObjectPlacement(
+                ResourceType.Utw, "arrival_wp", "new_area", 1, "NEW", 4f, 5f, 6f);
+            IReadOnlyList<ObjectPlacement> current = new[] { oldPlacement };
+            var source = new ObjectSourceSectionViewModel(
+                ResourceType.Utw,
+                "arrival_wp",
+                (_, _) => Task.FromResult(current),
+                area => area,
+                _ => { });
+            await WaitUntilAsync(() => !source.IsLoading);
+
+            current = new[] { newPlacement };
+            source.Reload();
+            await WaitUntilAsync(() =>
+                !source.IsLoading &&
+                source.Placements.Count == 1 &&
+                ReferenceEquals(source.Placements[0].Placement, newPlacement));
+
+            source.Placements.Should().ContainSingle()
+                .Which.Placement.Should().BeSameAs(newPlacement);
+        }
+
         [Test, NonParallelizable]
         public void Position_UsesInvariantFormattingUnderCommaDecimalCulture()
         {

--- a/SWLOR.Toolset.Tests/ObjectSourceSectionTests.cs
+++ b/SWLOR.Toolset.Tests/ObjectSourceSectionTests.cs
@@ -1,0 +1,40 @@
+using FluentAssertions;
+using NUnit.Framework;
+using SWLOR.Toolset.Domain.Workspace;
+using SWLOR.Toolset.Editors.Sources;
+
+namespace SWLOR.Toolset.Tests
+{
+    public class ObjectSourceSectionTests
+    {
+        [Test]
+        public async Task LoadedPlacement_UsesAreaNameAndGoToCallback()
+        {
+            var placement = new ObjectPlacement(
+                ResourceType.Utw, "arrival_wp", "dan_enclave", 7, "ARRIVAL", 1f, 2f, 3f);
+            ObjectPlacement? navigated = null;
+            var source = new ObjectSourceSectionViewModel(
+                ResourceType.Utw,
+                "arrival_wp",
+                (_, _) => Task.FromResult<IReadOnlyList<ObjectPlacement>>(new[] { placement }),
+                area => area == "dan_enclave" ? "Dantooine Jedi Enclave" : area,
+                value => navigated = value);
+
+            await WaitUntilAsync(() => !source.IsLoading);
+
+            var row = source.Placements.Should().ContainSingle().Subject;
+            row.AreaName.Should().Be("Dantooine Jedi Enclave");
+            row.Detail.Should().Contain("ARRIVAL").And.Contain("1.0, 2.0, 3.0");
+            source.GoToCommand.Execute(row);
+            navigated.Should().BeSameAs(placement);
+        }
+
+        private static async Task WaitUntilAsync(Func<bool> condition)
+        {
+            var timeout = DateTime.UtcNow.AddSeconds(2);
+            while (!condition() && DateTime.UtcNow < timeout)
+                await Task.Delay(10);
+            condition().Should().BeTrue();
+        }
+    }
+}

--- a/SWLOR.Toolset.Tests/ObjectSourceSectionTests.cs
+++ b/SWLOR.Toolset.Tests/ObjectSourceSectionTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using FluentAssertions;
 using NUnit.Framework;
 using SWLOR.Toolset.Domain.Workspace;
@@ -27,6 +28,85 @@ namespace SWLOR.Toolset.Tests
             row.Detail.Should().Contain("ARRIVAL").And.Contain("1.0, 2.0, 3.0");
             source.GoToCommand.Execute(row);
             navigated.Should().BeSameAs(placement);
+        }
+
+        [Test, NonParallelizable]
+        public void Position_UsesInvariantFormattingUnderCommaDecimalCulture()
+        {
+            var previous = CultureInfo.CurrentCulture;
+            try
+            {
+                CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
+                var row = new ObjectPlacementRowViewModel(
+                    new ObjectPlacement(
+                        ResourceType.Utw, "arrival_wp", "dan_enclave", 7, "", 1f, 2f, 3f),
+                    "Dantooine Jedi Enclave");
+
+                row.Position.Should().Be("1.0, 2.0, 3.0");
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = previous;
+            }
+        }
+
+        [Test]
+        public async Task SetResRef_InvalidatesBeforeLoadingAndIgnoresStaleResults()
+        {
+            var oldPlacement = new ObjectPlacement(
+                ResourceType.Utw, "old_wp", "old_area", 0, "OLD", 1f, 2f, 3f);
+            var newPlacement = new ObjectPlacement(
+                ResourceType.Utw, "new_wp", "new_area", 0, "NEW", 4f, 5f, 6f);
+            var oldLoad = new TaskCompletionSource<IReadOnlyList<ObjectPlacement>>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var calls = new List<string>();
+            var source = new ObjectSourceSectionViewModel(
+                ResourceType.Utw,
+                "old_wp",
+                (_, resRef) =>
+                {
+                    calls.Add("find:" + resRef);
+                    return resRef == "old_wp"
+                        ? oldLoad.Task
+                        : Task.FromResult<IReadOnlyList<ObjectPlacement>>(new[] { newPlacement });
+                },
+                area => area,
+                _ => { },
+                () => calls.Add("invalidate"));
+
+            source.SetResRef("new_wp");
+            await WaitUntilAsync(() => !source.IsLoading);
+            oldLoad.SetResult(new[] { oldPlacement });
+            await Task.Delay(20);
+
+            calls.Should().StartWith("find:old_wp", "invalidate", "find:new_wp");
+            source.Placements.Should().ContainSingle()
+                .Which.Placement.Should().BeSameAs(newPlacement);
+        }
+
+        [Test]
+        public async Task FailedLoad_ClearsStaleRowsAndReportsTheError()
+        {
+            var placement = new ObjectPlacement(
+                ResourceType.Utw, "old_wp", "old_area", 0, "OLD", 1f, 2f, 3f);
+            var fail = false;
+            var source = new ObjectSourceSectionViewModel(
+                ResourceType.Utw,
+                "old_wp",
+                (_, _) => fail
+                    ? Task.FromException<IReadOnlyList<ObjectPlacement>>(new IOException("broken GIT"))
+                    : Task.FromResult<IReadOnlyList<ObjectPlacement>>(new[] { placement }),
+                area => area,
+                _ => { });
+            await WaitUntilAsync(() => !source.IsLoading);
+            source.Placements.Should().ContainSingle();
+
+            fail = true;
+            await source.RefreshCommand.ExecuteAsync(null);
+
+            source.Placements.Should().BeEmpty();
+            source.LoadError.Should().Contain("broken GIT");
+            source.Status.Should().Be(source.LoadError);
         }
 
         private static async Task WaitUntilAsync(Func<bool> condition)

--- a/SWLOR.Toolset.Tests/ThumbnailRendererTests.cs
+++ b/SWLOR.Toolset.Tests/ThumbnailRendererTests.cs
@@ -318,6 +318,33 @@ namespace SWLOR.Toolset.Tests
         }
 
         [Test]
+        public void TheSameTextureWithDifferentEquipmentPalettesIsResolvedPerMesh()
+        {
+            var first = TexturedQuad("shared_plt").Meshes[0];
+            first.LayerColorIndices = new Dictionary<int, int> { [2] = 45 };
+            var second = TexturedQuad("shared_plt").Meshes[0];
+            second.LayerColorIndices = new Dictionary<int, int> { [2] = 97 };
+            var seen = new List<int>();
+            var model = new RenderModel
+            {
+                Name = "independent-dyes",
+                Meshes = new[] { first, second }
+            };
+
+            ThumbnailRenderer.Render(
+                model,
+                Size,
+                resolveLayeredTexture: (_, colors) =>
+                {
+                    seen.Add(colors![2]);
+                    return SolidTexture(10, 10, 10);
+                });
+
+            seen.Should().BeEquivalentTo(new[] { 45, 97 },
+                "a cloak and chest can share a PLT name while selecting different palette rows");
+        }
+
+        [Test]
         public void Fully_Transparent_Texels_Are_Cut_Out_Rather_Than_Drawn()
         {
             var opaque = ThumbnailRenderer.Render(

--- a/SWLOR.Toolset.Tests/ThumbnailRendererTests.cs
+++ b/SWLOR.Toolset.Tests/ThumbnailRendererTests.cs
@@ -345,6 +345,28 @@ namespace SWLOR.Toolset.Tests
         }
 
         [Test]
+        public void APlainTextureResolverIgnoresUnusedMeshPalettesInItsCacheKey()
+        {
+            var first = TexturedQuad("shared").Meshes[0];
+            first.LayerColorIndices = new Dictionary<int, int> { [2] = 45 };
+            var second = TexturedQuad("shared").Meshes[0];
+            second.LayerColorIndices = new Dictionary<int, int> { [2] = 97 };
+            var lookups = 0;
+
+            ThumbnailRenderer.Render(
+                new RenderModel { Name = "plain-texture", Meshes = [first, second] },
+                Size,
+                resolveTexture: _ =>
+                {
+                    lookups++;
+                    return SolidTexture(10, 10, 10);
+                });
+
+            lookups.Should().Be(1,
+                "the plain resolver cannot use layer colors and should share one decoded texture");
+        }
+
+        [Test]
         public void Fully_Transparent_Texels_Are_Cut_Out_Rather_Than_Drawn()
         {
             var opaque = ThumbnailRenderer.Render(

--- a/SWLOR.Toolset.Tests/ThumbnailServiceTests.cs
+++ b/SWLOR.Toolset.Tests/ThumbnailServiceTests.cs
@@ -192,7 +192,7 @@ namespace SWLOR.Toolset.Tests
         }
 
         [AvaloniaTest]
-        public void EditingACloakInvalidatesEveryCreatureThumbnailThatWearsIt()
+        public async Task EditingACloakInvalidatesEveryCreatureThumbnailThatWearsIt()
         {
             var moduleRoot = Path.Combine(
                 Path.GetTempPath(), "swlor-thumbnail-equipment-" + Guid.NewGuid().ToString("N"));
@@ -208,6 +208,7 @@ namespace SWLOR.Toolset.Tests
                 var context = new WorkspaceContext(
                     path => new ModuleWorkspace(path), new OutputLogService());
                 context.Open(moduleRoot);
+                await context.Catalog!.BuildTask;
                 var service = new ThumbnailService(context, new CountingSource());
                 var invalidated = new List<(ResourceType Type, string ResRef)>();
                 service.InvalidatedForResRef += (type, resRef) => invalidated.Add((type, resRef));

--- a/SWLOR.Toolset.Tests/ThumbnailServiceTests.cs
+++ b/SWLOR.Toolset.Tests/ThumbnailServiceTests.cs
@@ -192,6 +192,44 @@ namespace SWLOR.Toolset.Tests
         }
 
         [AvaloniaTest]
+        public void EditingACloakInvalidatesEveryCreatureThumbnailThatWearsIt()
+        {
+            var moduleRoot = Path.Combine(
+                Path.GetTempPath(), "swlor-thumbnail-equipment-" + Guid.NewGuid().ToString("N"));
+            try
+            {
+                var utcDirectory = Path.Combine(moduleRoot, "utc");
+                Directory.CreateDirectory(utcDirectory);
+                Directory.CreateDirectory(Path.Combine(moduleRoot, "are"));
+                File.Copy(
+                    Path.Combine(CorpusLocator.ModuleDirectory, "utc", "darthgravius.utc.json"),
+                    Path.Combine(utcDirectory, "darthgravius.utc.json"));
+
+                var context = new WorkspaceContext(
+                    path => new ModuleWorkspace(path), new OutputLogService());
+                context.Open(moduleRoot);
+                var service = new ThumbnailService(context, new CountingSource());
+                var invalidated = new List<(ResourceType Type, string ResRef)>();
+                service.InvalidatedForResRef += (type, resRef) => invalidated.Add((type, resRef));
+
+                service.RequestAsync(ResourceType.Utc, "darthgravius", _ => { });
+                Drain();
+                service.Cached(ResourceType.Utc, "darthgravius").Should().NotBeNull();
+
+                service.Invalidate(ResourceType.Uti, "jeweled_cloak");
+
+                service.Cached(ResourceType.Utc, "darthgravius").Should().BeNull();
+                invalidated.Should().Contain((ResourceType.Utc, "darthgravius"),
+                    "cloak, helmet, and held-item edits must invalidate wearers just like chest armor");
+            }
+            finally
+            {
+                if (Directory.Exists(moduleRoot))
+                    Directory.Delete(moduleRoot, recursive: true);
+            }
+        }
+
+        [AvaloniaTest]
         public void ARenderInvalidatedWhileItWasRunningIsNotPublished()
         {
             // The whole point of the epoch: a render that started before the cache was cleared is

--- a/SWLOR.Toolset.Tests/ThumbnailServiceTests.cs
+++ b/SWLOR.Toolset.Tests/ThumbnailServiceTests.cs
@@ -1,5 +1,6 @@
 using Avalonia.Headless.NUnit;
 using System.Collections.Concurrent;
+using System.Reflection;
 using Avalonia.Threading;
 using FluentAssertions;
 using NUnit.Framework;
@@ -137,7 +138,6 @@ namespace SWLOR.Toolset.Tests
 
             source.AppearanceOrder.Should().BeEquivalentTo(
                 new[] { 0, 1, 2, 3, 4, 5, 6 },
-                options => options.WithStrictOrdering(),
                 "every stock dynamic race needs a representative model");
             Enumerable.Range(0, 7).Should().OnlyContain(id => service.CachedAppearance(id) != null);
 
@@ -222,6 +222,51 @@ namespace SWLOR.Toolset.Tests
                 service.Cached(ResourceType.Utc, "darthgravius").Should().BeNull();
                 invalidated.Should().Contain((ResourceType.Utc, "darthgravius"),
                     "cloak, helmet, and held-item edits must invalidate wearers just like chest armor");
+            }
+            finally
+            {
+                if (Directory.Exists(moduleRoot))
+                    Directory.Delete(moduleRoot, recursive: true);
+            }
+        }
+
+        [Test]
+        public async Task CreatureDiskDependenciesIncludeOnlyLooseEquippedItems()
+        {
+            var moduleRoot = Path.Combine(
+                Path.GetTempPath(), "swlor-thumbnail-dependencies-" + Guid.NewGuid().ToString("N"));
+            try
+            {
+                var utcDirectory = Path.Combine(moduleRoot, "utc");
+                var utiDirectory = Path.Combine(moduleRoot, "uti");
+                Directory.CreateDirectory(utcDirectory);
+                Directory.CreateDirectory(utiDirectory);
+                Directory.CreateDirectory(Path.Combine(moduleRoot, "are"));
+                File.Copy(
+                    Path.Combine(CorpusLocator.ModuleDirectory, "utc", "darthgravius.utc.json"),
+                    Path.Combine(utcDirectory, "darthgravius.utc.json"));
+                var looseCloakPath = Path.Combine(utiDirectory, "jeweled_cloak.uti.json");
+                File.Copy(
+                    Path.Combine(CorpusLocator.ModuleDirectory, "uti", "jeweled_cloak.uti.json"),
+                    looseCloakPath);
+
+                var context = new WorkspaceContext(
+                    path => new ModuleWorkspace(path), new OutputLogService());
+                context.Open(moduleRoot);
+                await context.Catalog!.BuildTask;
+                var service = new ThumbnailService(context, new CountingSource());
+                var method = typeof(ThumbnailService).GetMethod(
+                    "DependencyPaths",
+                    BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+                var paths = (IReadOnlyList<string>)method.Invoke(
+                    service,
+                    new object[] { ResourceType.Utc, "darthgravius", false })!;
+
+                paths.Should().ContainSingle()
+                    .Which.Should().Be(
+                        looseCloakPath,
+                        "indexed or HAK equipment has no loose timestamp and is covered by the content version");
             }
             finally
             {

--- a/SWLOR.Toolset.Tests/WorkspaceContextCatalogTests.cs
+++ b/SWLOR.Toolset.Tests/WorkspaceContextCatalogTests.cs
@@ -105,5 +105,33 @@ namespace SWLOR.Toolset.Tests
         {
             WorkspaceContext.IsCatalogIndexedType(type).Should().Be(expected);
         }
+
+        [Test]
+        public async Task SuccessfulCatalogBuildPublishesCompletionForLateNameResolution()
+        {
+            var log = new OutputLogService();
+            var workspace = new WorkspaceContext(root => new ModuleWorkspace(root), log);
+            var completed = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            workspace.CatalogBuildCompleted += () => completed.TrySetResult();
+
+            workspace.Open(_root);
+
+            await completed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+
+        [Test]
+        public void PlacementInvalidationPublishesARefreshNotification()
+        {
+            var log = new OutputLogService();
+            var workspace = new WorkspaceContext(root => new ModuleWorkspace(root), log);
+            workspace.Open(_root);
+            var notifications = 0;
+            workspace.PlacementIndexInvalidated += () => notifications++;
+
+            workspace.InvalidatePlacementIndex();
+
+            notifications.Should().Be(1);
+        }
     }
 }

--- a/SWLOR.Toolset.Tests/WorkspaceContextCatalogTests.cs
+++ b/SWLOR.Toolset.Tests/WorkspaceContextCatalogTests.cs
@@ -133,5 +133,39 @@ namespace SWLOR.Toolset.Tests
 
             notifications.Should().Be(1);
         }
+
+        [TestCase(ResourceType.Utc)]
+        [TestCase(ResourceType.Uti)]
+        [TestCase(ResourceType.Utp)]
+        public void OrdinaryBlueprintCatalogRefreshDoesNotInvalidatePlacements(ResourceType type)
+        {
+            var workspace = new WorkspaceContext(
+                root => new ModuleWorkspace(root),
+                new OutputLogService());
+            workspace.Open(_root);
+            var notifications = 0;
+            workspace.PlacementIndexInvalidated += () => notifications++;
+
+            workspace.RefreshCatalogEntry(type, "ordinary_save");
+
+            notifications.Should().Be(0,
+                "blueprint contents are not inputs to the module-wide GIT placement index");
+        }
+
+        [Test]
+        public void AreaCatalogRefreshInvalidatesPlacements()
+        {
+            var workspace = new WorkspaceContext(
+                root => new ModuleWorkspace(root),
+                new OutputLogService());
+            workspace.Open(_root);
+            var notifications = 0;
+            workspace.PlacementIndexInvalidated += () => notifications++;
+
+            workspace.RefreshCatalogEntry(ResourceType.Area, "changed_area");
+
+            notifications.Should().Be(1,
+                "an area save includes its GIT placement data");
+        }
     }
 }

--- a/SWLOR.Toolset.Tests/WorkspaceContextCatalogTests.cs
+++ b/SWLOR.Toolset.Tests/WorkspaceContextCatalogTests.cs
@@ -23,20 +23,35 @@ namespace SWLOR.Toolset.Tests
     public class WorkspaceContextCatalogTests
     {
         private string _root = string.Empty;
+        private readonly List<Task> _catalogBuildTasks = new();
 
         [SetUp]
         public void SetUp()
         {
+            _catalogBuildTasks.Clear();
             _root = Path.Combine(Path.GetTempPath(), $"swlor_wscatalog_{Guid.NewGuid():N}");
             foreach (var folder in new[] { "are", "utc", "git", "gic", "dlg", "nss" })
                 Directory.CreateDirectory(Path.Combine(_root, folder));
         }
 
         [TearDown]
-        public void TearDown()
+        public async Task TearDown()
         {
-            if (Directory.Exists(_root))
-                Directory.Delete(_root, recursive: true);
+            try
+            {
+                await Task.WhenAll(_catalogBuildTasks);
+            }
+            finally
+            {
+                if (Directory.Exists(_root))
+                    Directory.Delete(_root, recursive: true);
+            }
+        }
+
+        private void OpenWorkspace(WorkspaceContext workspace)
+        {
+            workspace.Open(_root);
+            _catalogBuildTasks.Add(workspace.Catalog!.BuildTask);
         }
 
         [TestCase(ResourceType.Dlg)]
@@ -45,7 +60,7 @@ namespace SWLOR.Toolset.Tests
         {
             var log = new OutputLogService();
             var workspace = new WorkspaceContext(root => new ModuleWorkspace(root), log);
-            workspace.Open(_root);
+            OpenWorkspace(workspace);
             workspace.Catalog!.BuildTask.GetAwaiter().GetResult();
 
             var notified = new List<(ResourceType Type, string ResRef)>();
@@ -65,7 +80,7 @@ namespace SWLOR.Toolset.Tests
         {
             var log = new OutputLogService();
             var workspace = new WorkspaceContext(root => new ModuleWorkspace(root), log);
-            workspace.Open(_root);
+            OpenWorkspace(workspace);
             workspace.Catalog!.BuildTask.GetAwaiter().GetResult();
 
             var notified = new List<(ResourceType Type, string ResRef)>();
@@ -83,7 +98,7 @@ namespace SWLOR.Toolset.Tests
         {
             var log = new OutputLogService();
             var workspace = new WorkspaceContext(root => new ModuleWorkspace(root), log);
-            workspace.Open(_root);
+            OpenWorkspace(workspace);
             workspace.Catalog!.BuildTask.GetAwaiter().GetResult();
 
             File.WriteAllText(
@@ -115,7 +130,7 @@ namespace SWLOR.Toolset.Tests
                 TaskCreationOptions.RunContinuationsAsynchronously);
             workspace.CatalogBuildCompleted += () => completed.TrySetResult();
 
-            workspace.Open(_root);
+            OpenWorkspace(workspace);
 
             await completed.Task.WaitAsync(TimeSpan.FromSeconds(5));
         }
@@ -125,7 +140,7 @@ namespace SWLOR.Toolset.Tests
         {
             var log = new OutputLogService();
             var workspace = new WorkspaceContext(root => new ModuleWorkspace(root), log);
-            workspace.Open(_root);
+            OpenWorkspace(workspace);
             var notifications = 0;
             workspace.PlacementIndexInvalidated += () => notifications++;
 
@@ -142,7 +157,7 @@ namespace SWLOR.Toolset.Tests
             var workspace = new WorkspaceContext(
                 root => new ModuleWorkspace(root),
                 new OutputLogService());
-            workspace.Open(_root);
+            OpenWorkspace(workspace);
             var notifications = 0;
             workspace.PlacementIndexInvalidated += () => notifications++;
 
@@ -158,7 +173,7 @@ namespace SWLOR.Toolset.Tests
             var workspace = new WorkspaceContext(
                 root => new ModuleWorkspace(root),
                 new OutputLogService());
-            workspace.Open(_root);
+            OpenWorkspace(workspace);
             var notifications = 0;
             workspace.PlacementIndexInvalidated += () => notifications++;
 
@@ -174,7 +189,7 @@ namespace SWLOR.Toolset.Tests
             var workspace = new WorkspaceContext(
                 root => new ModuleWorkspace(root),
                 new OutputLogService());
-            workspace.Open(_root);
+            OpenWorkspace(workspace);
             var notifications = 0;
             workspace.PlacementIndexInvalidated += () => notifications++;
 

--- a/SWLOR.Toolset.Tests/WorkspaceContextCatalogTests.cs
+++ b/SWLOR.Toolset.Tests/WorkspaceContextCatalogTests.cs
@@ -153,7 +153,7 @@ namespace SWLOR.Toolset.Tests
         }
 
         [Test]
-        public void AreaCatalogRefreshInvalidatesPlacements()
+        public void AreaCatalogRefreshDoesNotInvalidatePlacements()
         {
             var workspace = new WorkspaceContext(
                 root => new ModuleWorkspace(root),
@@ -164,8 +164,24 @@ namespace SWLOR.Toolset.Tests
 
             workspace.RefreshCatalogEntry(ResourceType.Area, "changed_area");
 
+            notifications.Should().Be(0,
+                "ARE metadata is not an input to the module-wide GIT placement index");
+        }
+
+        [Test]
+        public void AreaCatalogRemovalInvalidatesPlacements()
+        {
+            var workspace = new WorkspaceContext(
+                root => new ModuleWorkspace(root),
+                new OutputLogService());
+            workspace.Open(_root);
+            var notifications = 0;
+            workspace.PlacementIndexInvalidated += () => notifications++;
+
+            workspace.RemoveCatalogEntry(ResourceType.Area, "deleted_area");
+
             notifications.Should().Be(1,
-                "an area save includes its GIT placement data");
+                "removing an area removes all placements from its paired GIT");
         }
     }
 }

--- a/SWLOR.Toolset.Tests/WorkspaceContextCatalogTests.cs
+++ b/SWLOR.Toolset.Tests/WorkspaceContextCatalogTests.cs
@@ -149,6 +149,43 @@ namespace SWLOR.Toolset.Tests
             notifications.Should().Be(1);
         }
 
+        [Test]
+        public void PairedGitInvalidationPublishesTagAndPlacementRefreshNotifications()
+        {
+            var workspace = new WorkspaceContext(
+                root => new ModuleWorkspace(root),
+                new OutputLogService());
+            OpenWorkspace(workspace);
+            var tagNotifications = 0;
+            var placementNotifications = 0;
+            workspace.TagIndexInvalidated += () => tagNotifications++;
+            workspace.PlacementIndexInvalidated += () => placementNotifications++;
+
+            workspace.InvalidateGitIndexes();
+
+            tagNotifications.Should().Be(1);
+            placementNotifications.Should().Be(1);
+        }
+
+        [Test]
+        public void TagOnlyInvalidationDoesNotPublishAPlacementRefreshNotification()
+        {
+            var workspace = new WorkspaceContext(
+                root => new ModuleWorkspace(root),
+                new OutputLogService());
+            OpenWorkspace(workspace);
+            var tagNotifications = 0;
+            var placementNotifications = 0;
+            workspace.TagIndexInvalidated += () => tagNotifications++;
+            workspace.PlacementIndexInvalidated += () => placementNotifications++;
+
+            workspace.InvalidateTagIndex();
+
+            tagNotifications.Should().Be(1);
+            placementNotifications.Should().Be(0,
+                "ARE and blueprint tag changes do not change any GIT placement row");
+        }
+
         [TestCase(ResourceType.Utc)]
         [TestCase(ResourceType.Uti)]
         [TestCase(ResourceType.Utp)]

--- a/SWLOR.Toolset/Editors/AreaEditorDocumentLoad.cs
+++ b/SWLOR.Toolset/Editors/AreaEditorDocumentLoad.cs
@@ -1,0 +1,54 @@
+using SWLOR.Toolset.Domain.Editing;
+using SWLOR.Toolset.Domain.Gff;
+
+namespace SWLOR.Toolset.Editors
+{
+    /// <summary>
+    /// Immutable area-file input read and parsed away from Avalonia's UI thread. DocumentSession is
+    /// deliberately created later, on the editor's context, so only I/O and JSON work move to the
+    /// worker and the undo guard retains its normal lifetime.
+    /// </summary>
+    public sealed class AreaEditorDocumentLoad
+    {
+        private AreaEditorDocumentLoad(
+            byte[] areBytes,
+            JsonGffDocument are,
+            byte[] gitBytes,
+            JsonGffDocument git,
+            byte[] gicBytes,
+            JsonGffDocument gic)
+        {
+            AreBytes = areBytes;
+            Are = are;
+            GitBytes = gitBytes;
+            Git = git;
+            GicBytes = gicBytes;
+            Gic = gic;
+        }
+
+        public byte[] AreBytes { get; }
+        public JsonGffDocument Are { get; }
+        public byte[] GitBytes { get; }
+        public JsonGffDocument Git { get; }
+        public byte[] GicBytes { get; }
+        public JsonGffDocument Gic { get; }
+
+        public static AreaEditorDocumentLoad Load(string arePath, string gitPath, string gicPath)
+        {
+            var areBytes = File.ReadAllBytes(arePath);
+            var gitBytes = File.ReadAllBytes(gitPath);
+            var gicBytes = File.ReadAllBytes(gicPath);
+
+            // Task.Run inherits the UI execution context, including any open editor's ambient
+            // mutation guard. These are brand-new parse graphs, not edits to an open document.
+            using var construction = EditScope.EnterConstruction();
+            return new AreaEditorDocumentLoad(
+                areBytes,
+                JsonGffDocument.Parse(areBytes),
+                gitBytes,
+                JsonGffDocument.Parse(gitBytes),
+                gicBytes,
+                JsonGffDocument.Parse(gicBytes));
+        }
+    }
+}

--- a/SWLOR.Toolset/Editors/AreaEditorViewModel.cs
+++ b/SWLOR.Toolset/Editors/AreaEditorViewModel.cs
@@ -1222,11 +1222,14 @@ namespace SWLOR.Toolset.Editors
                 Tag = resRef,
                 Position = Vector3.Zero,
                 Orientation = new Vector2(1f, 0f),
-                // The ghost has to be turned the same way the placed marker will be, or a waypoint
-                // would swing a quarter turn the instant it was committed.
-                VisualTransform = kind.Value == InstanceMarkerKind.Waypoint
-                    ? WaypointMarkerModel.ForwardCorrection
-                    : Matrix4x4.Identity,
+                // The ghost has to be turned the same way the placed model will be, or creature and
+                // waypoint artwork would swing a quarter turn the instant it was committed.
+                VisualTransform = kind.Value switch
+                {
+                    InstanceMarkerKind.Creature => CreatureModelFacing.ForwardCorrection,
+                    InstanceMarkerKind.Waypoint => WaypointMarkerModel.ForwardCorrection,
+                    _ => Matrix4x4.Identity
+                },
                 Model = model
             };
         }

--- a/SWLOR.Toolset/Editors/AreaEditorViewModel.cs
+++ b/SWLOR.Toolset/Editors/AreaEditorViewModel.cs
@@ -108,6 +108,20 @@ namespace SWLOR.Toolset.Editors
 
         public ObservableCollection<InstanceListSectionViewModel> Sections { get; } = new();
 
+        /// <summary>
+        /// The front page of this area document (0 = Scene, 1 = Properties). This belongs to the
+        /// document rather than its transient view so changing document tabs returns the builder to
+        /// the page they were using.
+        /// </summary>
+        [ObservableProperty]
+        private int _selectedRootTabIndex;
+
+        /// <summary>The Properties page's retained scroll position, stored without an Avalonia dependency.</summary>
+        public Vector2 PropertiesScrollOffset { get; set; }
+
+        /// <summary>The last camera owned by this open area tab, restored when its view is recreated.</summary>
+        public Viewport.AreaViewportState? ViewportState { get; set; }
+
         public bool IsDirty =>
             _areSession.UndoStack.IsDirty ||
             _gitSession.UndoStack.IsDirty ||
@@ -211,6 +225,7 @@ namespace SWLOR.Toolset.Editors
                 OnPropertyChanged(nameof(SelectionCoordinates));
                 OnPropertyChanged(nameof(IDocumentStatusSource.StatusDetail));
                 EditSelectedBlueprintCommand.NotifyCanExecuteChanged();
+                OpenSelectedInstancePropertiesCommand.NotifyCanExecuteChanged();
             }
         }
 
@@ -1464,7 +1479,8 @@ namespace SWLOR.Toolset.Editors
             Waypoints.WaypointEditorServices? waypointEditorServices = null,
             Func<string, IReadOnlyList<BehaviorChoice>>? resolveSoundChoices = null,
             IReadOnlyList<string>? audioResources = null,
-            Services.SoundPreviewService? soundPreview = null)
+            Services.SoundPreviewService? soundPreview = null,
+            AreaEditorDocumentLoad? loadedDocuments = null)
         {
             _scriptSlotHost = scriptSlotHost;
             _resolveBlueprintModel = resolveBlueprintModel;
@@ -1488,9 +1504,18 @@ namespace SWLOR.Toolset.Editors
             var gitPath = Path.Combine(workspace.ModuleRoot, "git", areResRef + ".git.json");
             var gicPath = Path.Combine(workspace.ModuleRoot, "gic", areResRef + ".gic.json");
 
-            _areSession = DocumentSession.Open(arePath);
-            _gitSession = DocumentSession.Open(gitPath);
-            _gicSession = DocumentSession.Open(gicPath);
+            _areSession = loadedDocuments == null
+                ? DocumentSession.Open(arePath)
+                : DocumentSession.FromLoadedContent(
+                    arePath, loadedDocuments.Are, loadedDocuments.AreBytes);
+            _gitSession = loadedDocuments == null
+                ? DocumentSession.Open(gitPath)
+                : DocumentSession.FromLoadedContent(
+                    gitPath, loadedDocuments.Git, loadedDocuments.GitBytes);
+            _gicSession = loadedDocuments == null
+                ? DocumentSession.Open(gicPath)
+                : DocumentSession.FromLoadedContent(
+                    gicPath, loadedDocuments.Gic, loadedDocuments.GicBytes);
             _savedGicBytes = _gicSession.ToBytes();
 
             var areContext = new EditorFieldContext(
@@ -1606,6 +1631,66 @@ namespace SWLOR.Toolset.Editors
 
             if (frameCamera)
                 CameraFocusRequested?.Invoke(new Vector3(row.X, row.Y, row.Z));
+        }
+
+        /// <summary>
+        /// Opens the placed instance's own editable details, rather than the blueprint it was copied
+        /// from. Used by both Area Contents and the scene's right-click menu.
+        /// </summary>
+        public void OpenInstanceProperties(ResourceType type, int index)
+        {
+            if (SectionFor(type) is not { } section || index < 0 || index >= section.Rows.Count)
+                return;
+
+            RevealInstance(type, index, frameCamera: false);
+            section.IsExpanded = true;
+            SelectedRootTabIndex = 1;
+        }
+
+        /// <summary>
+        /// Reveals an indexed source placement. The saved list index is preferred, then a
+        /// resref-and-position match protects navigation when an already-open area has unsaved
+        /// insertions or deletions that shifted its indices.
+        /// </summary>
+        public void RevealPlacement(ObjectPlacement placement)
+        {
+            if (SectionFor(placement.BlueprintType) is not { } section)
+                return;
+
+            var index = placement.InstanceIndex;
+            if (index < 0 || index >= section.Rows.Count ||
+                !string.Equals(
+                    section.Rows[index].TemplateResRef,
+                    placement.BlueprintResRef,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                index = section.Rows
+                    .Where(row => string.Equals(
+                        row.TemplateResRef,
+                        placement.BlueprintResRef,
+                        StringComparison.OrdinalIgnoreCase))
+                    .OrderBy(row =>
+                        MathF.Abs(row.X - placement.X) +
+                        MathF.Abs(row.Y - placement.Y) +
+                        MathF.Abs(row.Z - placement.Z))
+                    .Select(row => row.Index)
+                    .FirstOrDefault(-1);
+            }
+
+            if (index >= 0)
+                RevealInstance(placement.BlueprintType, index, frameCamera: true);
+        }
+
+        [RelayCommand(CanExecute = nameof(HasSceneSelection))]
+        private void OpenSelectedInstanceProperties()
+        {
+            if (SelectedSceneInstance is not { } instance ||
+                MapKindToSectionType(instance.Kind) is not { } type)
+                return;
+
+            var index = IndexWithinKind(instance);
+            if (index >= 0)
+                OpenInstanceProperties(type, index);
         }
 
         /// <summary>Deletes placements of one kind as a single undo entry.</summary>

--- a/SWLOR.Toolset/Editors/AreaEditorViewModel.cs
+++ b/SWLOR.Toolset/Editors/AreaEditorViewModel.cs
@@ -1666,18 +1666,7 @@ namespace SWLOR.Toolset.Editors
                 !MatchesPlacementIdentity(section.Rows[index], placement))
             {
                 index = section.Rows
-                    .Where(row => string.Equals(
-                        row.TemplateResRef,
-                        placement.BlueprintResRef,
-                        StringComparison.OrdinalIgnoreCase))
-                    .OrderByDescending(row => string.Equals(
-                        row.Tag,
-                        placement.Tag,
-                        StringComparison.OrdinalIgnoreCase))
-                    .ThenBy(row =>
-                        MathF.Abs(row.X - placement.X) +
-                        MathF.Abs(row.Y - placement.Y) +
-                        MathF.Abs(row.Z - placement.Z))
+                    .Where(row => MatchesPlacementIdentity(row, placement))
                     .Select(row => row.Index)
                     .FirstOrDefault(-1);
             }

--- a/SWLOR.Toolset/Editors/AreaEditorViewModel.cs
+++ b/SWLOR.Toolset/Editors/AreaEditorViewModel.cs
@@ -1203,12 +1203,14 @@ namespace SWLOR.Toolset.Editors
             RenderModel? model = null;
             try
             {
-                // Built through the same path as the palette thumbnail the builder just clicked, so
-                // the two agree - including for segmented creatures, whose body parts have to be
-                // composed and which an earlier local resolve could not produce at all (it passed no
-                // appearance service and handled only the single-resref case, so every creature
-                // ghosted as a bare marker).
-                model = _resolveBlueprintModel?.Invoke(type, resRef, useIndexedBlueprint);
+                // A store has no appearance of its own. Aurora always previews it as the yellow
+                // waypoint flag, which must be the same model the completed scene build uses.
+                model = kind == InstanceMarkerKind.Store
+                    ? _tileModelCache?.GetOrBuild(WaypointMarkerModel.MerchantModelResRef)
+                    // Everything else is built through the same path as the palette thumbnail the
+                    // builder just clicked, including segmented creatures whose body parts have to
+                    // be composed.
+                    : _resolveBlueprintModel?.Invoke(type, resRef, useIndexedBlueprint);
             }
             catch (Exception ex)
             {
@@ -1223,10 +1225,12 @@ namespace SWLOR.Toolset.Editors
                 Position = Vector3.Zero,
                 Orientation = new Vector2(1f, 0f),
                 // The ghost has to be turned the same way the placed model will be, or creature and
-                // waypoint artwork would swing a quarter turn the instant it was committed.
+                // waypoint artwork would swing a quarter turn the instant it was committed. Stores
+                // use waypoint artwork too.
                 VisualTransform = kind.Value switch
                 {
                     InstanceMarkerKind.Creature => CreatureModelFacing.ForwardCorrection,
+                    InstanceMarkerKind.Store => WaypointMarkerModel.ForwardCorrection,
                     InstanceMarkerKind.Waypoint => WaypointMarkerModel.ForwardCorrection,
                     _ => Matrix4x4.Identity
                 },

--- a/SWLOR.Toolset/Editors/AreaEditorViewModel.cs
+++ b/SWLOR.Toolset/Editors/AreaEditorViewModel.cs
@@ -116,6 +116,10 @@ namespace SWLOR.Toolset.Editors
         [ObservableProperty]
         private int _selectedRootTabIndex;
 
+        /// <summary>Whether the top-level Area Properties card is expanded in this open document.</summary>
+        [ObservableProperty]
+        private bool _areaPropertiesExpanded;
+
         /// <summary>The Properties page's retained scroll position, stored without an Avalonia dependency.</summary>
         public Vector2 PropertiesScrollOffset { get; set; }
 
@@ -2052,6 +2056,7 @@ namespace SWLOR.Toolset.Editors
             var catalogEntryChanged =
                 _areSession.UndoStack.IsDirty ||
                 _gitSession.UndoStack.IsDirty;
+            var placementsChanged = _gitSession.UndoStack.IsDirty;
             var instancePairReloaded = false;
             var tilesetBefore = TilesetResRef;
 
@@ -2168,6 +2173,8 @@ namespace SWLOR.Toolset.Editors
             {
                 CatalogEntryChanged?.Invoke();
             }
+            if (placementsChanged || gitResult.Reloaded || instancePairReloaded)
+                PlacementsChanged?.Invoke();
             return true;
         }
 
@@ -2529,8 +2536,11 @@ namespace SWLOR.Toolset.Editors
         /// <summary>Raised after an async close prompt approves closing this tab.</summary>
         public event Action<AreaEditorViewModel>? CloseRequested;
 
-        /// <summary>Raised after the ARE resource is saved or reloaded so catalog views can re-index it.</summary>
+        /// <summary>Raised after ARE or GIT data is saved/reloaded so area-backed catalog indexes can refresh.</summary>
         public event Action? CatalogEntryChanged;
+
+        /// <summary>Raised after the paired GIT is saved or reloaded so object-source indexes can refresh.</summary>
+        public event Action? PlacementsChanged;
 
         /// <summary>Suppresses a second tab-level prompt after the window-level discard decision.</summary>
         internal void ApproveApplicationClose() => _closeApproved = true;

--- a/SWLOR.Toolset/Editors/AreaEditorViewModel.cs
+++ b/SWLOR.Toolset/Editors/AreaEditorViewModel.cs
@@ -1584,6 +1584,9 @@ namespace SWLOR.Toolset.Editors
         /// </summary>
         public event Action<Vector3>? CameraFocusRequested;
 
+        /// <summary>Asks the view to scroll the requested instance editor into view.</summary>
+        public event Action<InstanceListSectionViewModel>? InstancePropertiesRequested;
+
         /// <summary>
         /// The name to show for one placement: its own if it has one, then its blueprint's, then its
         /// tag, and the resref last. Never blank, so no row in the contents tree is nameless.
@@ -1645,6 +1648,7 @@ namespace SWLOR.Toolset.Editors
             RevealInstance(type, index, frameCamera: false);
             section.IsExpanded = true;
             SelectedRootTabIndex = 1;
+            InstancePropertiesRequested?.Invoke(section);
         }
 
         /// <summary>
@@ -1659,17 +1663,18 @@ namespace SWLOR.Toolset.Editors
 
             var index = placement.InstanceIndex;
             if (index < 0 || index >= section.Rows.Count ||
-                !string.Equals(
-                    section.Rows[index].TemplateResRef,
-                    placement.BlueprintResRef,
-                    StringComparison.OrdinalIgnoreCase))
+                !MatchesPlacementIdentity(section.Rows[index], placement))
             {
                 index = section.Rows
                     .Where(row => string.Equals(
                         row.TemplateResRef,
                         placement.BlueprintResRef,
                         StringComparison.OrdinalIgnoreCase))
-                    .OrderBy(row =>
+                    .OrderByDescending(row => string.Equals(
+                        row.Tag,
+                        placement.Tag,
+                        StringComparison.OrdinalIgnoreCase))
+                    .ThenBy(row =>
                         MathF.Abs(row.X - placement.X) +
                         MathF.Abs(row.Y - placement.Y) +
                         MathF.Abs(row.Z - placement.Z))
@@ -1680,6 +1685,16 @@ namespace SWLOR.Toolset.Editors
             if (index >= 0)
                 RevealInstance(placement.BlueprintType, index, frameCamera: true);
         }
+
+        private static bool MatchesPlacementIdentity(InstanceRow row, ObjectPlacement placement) =>
+            string.Equals(
+                row.TemplateResRef,
+                placement.BlueprintResRef,
+                StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(row.Tag, placement.Tag, StringComparison.OrdinalIgnoreCase) &&
+            MathF.Abs(row.X - placement.X) < 0.001f &&
+            MathF.Abs(row.Y - placement.Y) < 0.001f &&
+            MathF.Abs(row.Z - placement.Z) < 0.001f;
 
         [RelayCommand(CanExecute = nameof(HasSceneSelection))]
         private void OpenSelectedInstanceProperties()

--- a/SWLOR.Toolset/Editors/BlueprintEditorViewModel.cs
+++ b/SWLOR.Toolset/Editors/BlueprintEditorViewModel.cs
@@ -97,6 +97,8 @@ namespace SWLOR.Toolset.Editors
         /// </summary>
         public Appearance.AppearanceGallerySectionViewModel? AppearanceGallery { get; }
 
+        public Sources.ObjectSourceSectionViewModel? Source { get; }
+
         /// <summary>
         /// The generic blueprint view hosts the placeable editor too; only that editor shows the
         /// Waypoint-style Save/Revert footer requested for its multi-tab authoring workflow.
@@ -135,7 +137,8 @@ namespace SWLOR.Toolset.Editors
             Func<Domain.Workspace.ModuleWorkspace?>? resourceLister = null,
             Func<EditorFieldContext, Func<string, Action, bool>,
                 Appearance.AppearanceGallerySectionViewModel?>? appearanceGallery = null,
-            BlueprintSaveCoordinator? saveCoordinator = null)
+            BlueprintSaveCoordinator? saveCoordinator = null,
+            Sources.ObjectSourceSectionViewModel? source = null)
         {
             _scriptSlotHost = scriptSlotHost;
             _resourceLister = resourceLister;
@@ -143,6 +146,7 @@ namespace SWLOR.Toolset.Editors
             _prompts = prompts;
             _gameCodeIndex = gameCodeIndex;
             _saveCoordinator = saveCoordinator;
+            Source = source;
             _resRef = resRef;
             BlueprintType = type;
             Id = $"editor:{filePath}";
@@ -228,6 +232,9 @@ namespace SWLOR.Toolset.Editors
             if (VarTableSection != null && ShouldShowVariablesTab())
                 Tabs.Add(new EditorTabViewModel("Variables", VarTableSection));
 
+            if (Source != null)
+                Tabs.Add(new EditorTabViewModel("Source", Source));
+
             NotifyTabsChanged();
         }
 
@@ -275,7 +282,9 @@ namespace SWLOR.Toolset.Editors
             var wanted = VarTableSection != null && ShouldShowVariablesTab();
 
             if (wanted && existing == null)
-                Tabs.Add(new EditorTabViewModel("Variables", VarTableSection!));
+                Tabs.Insert(
+                    Source == null ? Tabs.Count : Math.Max(0, Tabs.Count - 1),
+                    new EditorTabViewModel("Variables", VarTableSection!));
             else if (wanted && !ReferenceEquals(existing!.Content, VarTableSection))
                 Tabs[Tabs.IndexOf(existing)] = new EditorTabViewModel("Variables", VarTableSection!);
             else if (!wanted && existing != null)
@@ -448,6 +457,7 @@ namespace SWLOR.Toolset.Editors
                 {
                     _resRef = targetResRef;
                     Id = $"editor:{_session.FilePath}";
+                    Source?.SetResRef(targetResRef);
                 }
 
                 _session.UndoStack.MarkSaved();

--- a/SWLOR.Toolset/Editors/BlueprintEditorViewModel.cs
+++ b/SWLOR.Toolset/Editors/BlueprintEditorViewModel.cs
@@ -282,9 +282,11 @@ namespace SWLOR.Toolset.Editors
             var wanted = VarTableSection != null && ShouldShowVariablesTab();
 
             if (wanted && existing == null)
-                Tabs.Insert(
-                    Source == null ? Tabs.Count : Math.Max(0, Tabs.Count - 1),
-                    new EditorTabViewModel("Variables", VarTableSection!));
+            {
+                var sourceTab = Tabs.FirstOrDefault(tab => ReferenceEquals(tab.Content, Source));
+                var index = sourceTab == null ? Tabs.Count : Tabs.IndexOf(sourceTab);
+                Tabs.Insert(index, new EditorTabViewModel("Variables", VarTableSection!));
+            }
             else if (wanted && !ReferenceEquals(existing!.Content, VarTableSection))
                 Tabs[Tabs.IndexOf(existing)] = new EditorTabViewModel("Variables", VarTableSection!);
             else if (!wanted && existing != null)

--- a/SWLOR.Toolset/Editors/Creatures/CreatureDocumentViewModel.cs
+++ b/SWLOR.Toolset/Editors/Creatures/CreatureDocumentViewModel.cs
@@ -23,6 +23,7 @@ namespace SWLOR.Toolset.Editors.Creatures
         private bool _closeApproved;
         private bool _closePromptOpen;
         private bool _disposed;
+        private int _selectedTabIndex;
 
         public CreatureEditorViewModel Editor { get; }
         public Sources.ObjectSourceSectionViewModel? Source { get; }
@@ -31,6 +32,17 @@ namespace SWLOR.Toolset.Editors.Creatures
         public bool CanRedo => _session.UndoStack.CanRedo;
         public string FilePath => _session.FilePath;
         public string ResRef { get; }
+        public int SelectedTabIndex
+        {
+            get => _selectedTabIndex;
+            set
+            {
+                if (_selectedTabIndex == value)
+                    return;
+                _selectedTabIndex = value;
+                OnPropertyChanged();
+            }
+        }
 
         public event Action<CreatureDocumentViewModel>? Closed;
         public event Action<CreatureDocumentViewModel>? CloseRequested;

--- a/SWLOR.Toolset/Editors/Creatures/CreatureDocumentViewModel.cs
+++ b/SWLOR.Toolset/Editors/Creatures/CreatureDocumentViewModel.cs
@@ -25,6 +25,7 @@ namespace SWLOR.Toolset.Editors.Creatures
         private bool _disposed;
 
         public CreatureEditorViewModel Editor { get; }
+        public Sources.ObjectSourceSectionViewModel? Source { get; }
         public bool IsDirty => _session.UndoStack.IsDirty;
         public bool CanUndo => _session.UndoStack.CanUndo;
         public bool CanRedo => _session.UndoStack.CanRedo;
@@ -58,10 +59,12 @@ namespace SWLOR.Toolset.Editors.Creatures
             Func<string, int, int, int,
                 Task<IReadOnlyList<CreatureEquipmentChoice>>>? equipmentSearch = null,
             Func<IReadOnlyList<AppearanceOption>>? appearanceOptionsLoader = null,
-            Func<int, string?>? abilityIcon = null)
+            Func<int, string?>? abilityIcon = null,
+            Sources.ObjectSourceSectionViewModel? source = null)
         {
             _log = log;
             _prompts = prompts;
+            Source = source;
             ResRef = resRef;
             Id = $"creature:{filePath}";
             _session = DocumentSession.Open(filePath);

--- a/SWLOR.Toolset/Editors/Doors/DoorDocumentViewModel.cs
+++ b/SWLOR.Toolset/Editors/Doors/DoorDocumentViewModel.cs
@@ -28,6 +28,7 @@ namespace SWLOR.Toolset.Editors.Doors
         private bool _disposed;
 
         public DoorEditorViewModel Editor { get; }
+        public Sources.ObjectSourceSectionViewModel? Source { get; }
 
         public bool IsDirty => _session.UndoStack.IsDirty;
 
@@ -57,12 +58,14 @@ namespace SWLOR.Toolset.Editors.Doors
             Func<JsonGffStruct, RenderModel?>? resolveModel = null,
             ThumbnailService? thumbnails = null,
             ChoicePreviewService? choicePreviews = null,
-            BlueprintSaveCoordinator? saveCoordinator = null)
+            BlueprintSaveCoordinator? saveCoordinator = null,
+            Sources.ObjectSourceSectionViewModel? source = null)
         {
             _log = log;
             _prompts = prompts;
             _resRef = resRef;
             _saveCoordinator = saveCoordinator;
+            Source = source;
             Id = $"door:{filePath}";
             _session = DocumentSession.Open(filePath);
 
@@ -173,6 +176,7 @@ namespace SWLOR.Toolset.Editors.Doors
                     _resRef = targetResRef;
                     Id = $"door:{_session.FilePath}";
                     Editor.SetHeaderOwner(targetResRef);
+                    Source?.SetResRef(targetResRef);
                 }
 
                 _session.UndoStack.MarkSaved();

--- a/SWLOR.Toolset/Editors/Doors/DoorDocumentViewModel.cs
+++ b/SWLOR.Toolset/Editors/Doors/DoorDocumentViewModel.cs
@@ -26,6 +26,7 @@ namespace SWLOR.Toolset.Editors.Doors
         private bool _closeApproved;
         private bool _closePromptOpen;
         private bool _disposed;
+        private int _selectedTabIndex;
 
         public DoorEditorViewModel Editor { get; }
         public Sources.ObjectSourceSectionViewModel? Source { get; }
@@ -37,6 +38,17 @@ namespace SWLOR.Toolset.Editors.Doors
         public bool CanRedo => _session.UndoStack.CanRedo;
         public string FilePath => _session.FilePath;
         public string ResRef => _resRef;
+        public int SelectedTabIndex
+        {
+            get => _selectedTabIndex;
+            set
+            {
+                if (_selectedTabIndex == value)
+                    return;
+                _selectedTabIndex = value;
+                OnPropertyChanged();
+            }
+        }
 
         public event Action<DoorDocumentViewModel>? Closed;
 

--- a/SWLOR.Toolset/Editors/EditorService.cs
+++ b/SWLOR.Toolset/Editors/EditorService.cs
@@ -1672,6 +1672,7 @@ namespace SWLOR.Toolset.Editors
             _openItemEditors[editor.FilePath] = editor;
             _workspaceContext.RemoveCatalogEntry(ResourceType.Uti, oldResRef);
             _workspaceContext.RefreshCatalogEntry(ResourceType.Uti, editor.ResRef);
+            _workspaceContext.InvalidatePlacementIndex();
 
             // The membership already moved during the save itself (see RefileItemCategories),
             // before the original was deleted, so there is nothing left to reconcile here beyond
@@ -1980,6 +1981,7 @@ namespace SWLOR.Toolset.Editors
             openEditors[newPath] = editor;
             _workspaceContext.RemoveCatalogEntry(type, oldResRef);
             _workspaceContext.RefreshCatalogEntry(type, newResRef);
+            _workspaceContext.InvalidatePlacementIndex();
         }
 
         private Merchants.MerchantItemDefinition? LoadMerchantItem(string resRef)

--- a/SWLOR.Toolset/Editors/EditorService.cs
+++ b/SWLOR.Toolset/Editors/EditorService.cs
@@ -966,7 +966,8 @@ namespace SWLOR.Toolset.Editors
                 resRef,
                 FindObjectPlacementsAsync,
                 ResolveAreaName,
-                GoToObjectPlacement);
+                GoToObjectPlacement,
+                () => _workspaceContext.Workspace?.PlacementIndex.Invalidate());
 
         private async Task<IReadOnlyList<ObjectPlacement>> FindObjectPlacementsAsync(
             ResourceType type,
@@ -974,12 +975,18 @@ namespace SWLOR.Toolset.Editors
         {
             var workspace = _workspaceContext.Workspace;
             if (workspace == null)
+            {
+                _log.AppendLine("Cannot scan object placements: no module workspace is open.");
                 return Array.Empty<ObjectPlacement>();
+            }
 
             var placements = await workspace.PlacementIndex.FindAsync(type, resRef).ConfigureAwait(true);
-            return ReferenceEquals(workspace, _workspaceContext.Workspace)
-                ? placements
-                : Array.Empty<ObjectPlacement>();
+            if (ReferenceEquals(workspace, _workspaceContext.Workspace))
+                return placements;
+
+            _log.AppendLine(
+                $"Discarded placement results for '{resRef}' because the module workspace changed during the scan.");
+            return Array.Empty<ObjectPlacement>();
         }
 
         private string ResolveAreaName(string areaResRef)
@@ -996,7 +1003,12 @@ namespace SWLOR.Toolset.Editors
         {
             var workspace = _workspaceContext.Workspace;
             if (workspace == null)
+            {
+                _log.AppendLine(
+                    $"Cannot navigate to '{placement.BlueprintResRef}' in '{placement.AreaResRef}': " +
+                    "no module workspace is open.");
                 return;
+            }
 
             _pendingAreaReveals[placement.AreaResRef] = placement;
             OpenAreaEditor(workspace, placement.AreaResRef);
@@ -1575,9 +1587,9 @@ namespace SWLOR.Toolset.Editors
                     placement.AreaResRef,
                     placement.InstanceIndex,
                     placement.Tag,
-                    0f,
-                    0f,
-                    0f)));
+                    placement.XPosition,
+                    placement.YPosition,
+                    placement.ZPosition)));
             editor.Closed += closed => _openMerchantEditors.Remove(closed.FilePath);
             editor.CloseRequested += _ => _factory.CloseDocument(editor);
             editor.CatalogEntryChanged += () =>
@@ -3201,6 +3213,7 @@ namespace SWLOR.Toolset.Editors
                 var transitionTagsTask = GetCurrentTransitionDestinationTagsAsync(workspace);
                 var documentLoadTask = Task.Run(() =>
                     AreaEditorDocumentLoad.Load(arePath, gitPath, gicPath));
+                await Task.WhenAll(transitionTagsTask, documentLoadTask).ConfigureAwait(true);
                 var transitionDestinationTags = await transitionTagsTask.ConfigureAwait(true);
                 var loadedDocuments = await documentLoadTask.ConfigureAwait(true);
                 if (transitionDestinationTags == null)

--- a/SWLOR.Toolset/Editors/EditorService.cs
+++ b/SWLOR.Toolset/Editors/EditorService.cs
@@ -3327,6 +3327,7 @@ namespace SWLOR.Toolset.Editors
                 editor.CloseRequested += _ => _factory.CloseDocument(editor);
                 editor.CatalogEntryChanged += () =>
                     _workspaceContext.RefreshCatalogEntry(ResourceType.Area, resRef);
+                editor.PlacementsChanged += _workspaceContext.InvalidatePlacementIndex;
                 _openAreaEditors[resRef] = editor;
                 _factory.OpenDocument(editor);
                 DispatchPendingAreaReveal(editor);

--- a/SWLOR.Toolset/Editors/EditorService.cs
+++ b/SWLOR.Toolset/Editors/EditorService.cs
@@ -99,6 +99,7 @@ namespace SWLOR.Toolset.Editors
         private readonly HashSet<string> _openingAreaEditors = new(StringComparer.OrdinalIgnoreCase);
         private readonly Dictionary<string, ObjectPlacement> _pendingAreaReveals =
             new(StringComparer.OrdinalIgnoreCase);
+        private readonly List<WeakReference<Sources.ObjectSourceSectionViewModel>> _objectSources = new();
         private readonly Dictionary<string, Triggers.TriggerDocumentViewModel> _openTriggerEditors = new(StringComparer.OrdinalIgnoreCase);
         private readonly Dictionary<string, Waypoints.WaypointDocumentViewModel> _openWaypointEditors = new(StringComparer.OrdinalIgnoreCase);
         private readonly HashSet<string> _openingWaypointEditors = new(StringComparer.OrdinalIgnoreCase);
@@ -344,6 +345,8 @@ namespace SWLOR.Toolset.Editors
             });
             _workspaceContext.ScriptUsagesInvalidated += _scriptUsageIndex.Invalidate;
             _workspaceContext.TagIndexInvalidated += OnTagIndexInvalidated;
+            _workspaceContext.PlacementIndexInvalidated += ReloadObjectSources;
+            _workspaceContext.CatalogBuildCompleted += RefreshObjectSourceAreaNames;
 
             // Opening another module invalidates every module-derived picker; saving a blueprint
             // invalidates only the ones built out of the module's own content.
@@ -363,6 +366,7 @@ namespace SWLOR.Toolset.Editors
                 _itemSourcesGeneration++;
                 _behaviorValues?.InvalidateModuleSources();
                 OnTagIndexInvalidated();
+                ReloadObjectSources();
 
                 // Pay the obtainability scan's cost here, in the background, rather than on
                 // whichever item editor happens to open first.
@@ -371,6 +375,8 @@ namespace SWLOR.Toolset.Editors
             _workspaceContext.CatalogEntryRefreshed += (type, refreshedResRef) =>
             {
                 _behaviorValues?.InvalidateModuleSources();
+                if (type == ResourceType.Area)
+                    RefreshObjectSourceAreaNames();
 
                 // A saved store, item, creature, or placeable can change where items are
                 // obtainable; the index is cheap to rebuild, so it is dropped rather than patched.
@@ -975,15 +981,42 @@ namespace SWLOR.Toolset.Editors
 
         private Sources.ObjectSourceSectionViewModel CreateObjectSource(
             ResourceType type,
-            string resRef) =>
-            new(
+            string resRef)
+        {
+            var source = new Sources.ObjectSourceSectionViewModel(
                 type,
                 resRef,
                 FindObjectPlacementsAsync,
                 ResolveAreaName,
                 GoToObjectPlacement,
-                () => _workspaceContext.Workspace?.PlacementIndex.Invalidate(),
+                _workspaceContext.InvalidatePlacementIndex,
                 _log);
+            _objectSources.Add(new WeakReference<Sources.ObjectSourceSectionViewModel>(source));
+            return source;
+        }
+
+        private void ReloadObjectSources() =>
+            VisitObjectSources(source => source.Reload());
+
+        private void RefreshObjectSourceAreaNames() =>
+            VisitObjectSources(source => source.RefreshAreaNames());
+
+        private void VisitObjectSources(Action<Sources.ObjectSourceSectionViewModel> visit)
+        {
+            if (!Avalonia.Threading.Dispatcher.UIThread.CheckAccess())
+            {
+                Avalonia.Threading.Dispatcher.UIThread.Post(() => VisitObjectSources(visit));
+                return;
+            }
+
+            for (var index = _objectSources.Count - 1; index >= 0; index--)
+            {
+                if (_objectSources[index].TryGetTarget(out var source))
+                    visit(source);
+                else
+                    _objectSources.RemoveAt(index);
+            }
+        }
 
         private async Task<IReadOnlyList<ObjectPlacement>> FindObjectPlacementsAsync(
             ResourceType type,

--- a/SWLOR.Toolset/Editors/EditorService.cs
+++ b/SWLOR.Toolset/Editors/EditorService.cs
@@ -97,6 +97,8 @@ namespace SWLOR.Toolset.Editors
         private readonly Dictionary<string, BlueprintEditorViewModel> _openEditors = new(StringComparer.OrdinalIgnoreCase);
         private readonly Dictionary<string, AreaEditorViewModel> _openAreaEditors = new(StringComparer.OrdinalIgnoreCase);
         private readonly HashSet<string> _openingAreaEditors = new(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, ObjectPlacement> _pendingAreaReveals =
+            new(StringComparer.OrdinalIgnoreCase);
         private readonly Dictionary<string, Triggers.TriggerDocumentViewModel> _openTriggerEditors = new(StringComparer.OrdinalIgnoreCase);
         private readonly Dictionary<string, Waypoints.WaypointDocumentViewModel> _openWaypointEditors = new(StringComparer.OrdinalIgnoreCase);
         private readonly HashSet<string> _openingWaypointEditors = new(StringComparer.OrdinalIgnoreCase);
@@ -932,7 +934,8 @@ namespace SWLOR.Toolset.Editors
                     type == ResourceType.Utp ? CreatePlaceableSections : null,
                     () => _workspaceContext.Workspace,
                     type == ResourceType.Utc ? CreateCreatureAppearanceGallery : null,
-                    _blueprintSaves);
+                    _blueprintSaves,
+                    CreateObjectSource(type, resRef));
                 editor.Closed += closed => _openEditors.Remove(closed.FilePath);
                 editor.CloseRequested += _ => _factory.CloseDocument(editor);
                 editor.CatalogEntryChanged += () =>
@@ -953,6 +956,62 @@ namespace SWLOR.Toolset.Editors
             {
                 _log.AppendLine($"Failed to open editor for {resRef}: {ex.Message}");
             }
+        }
+
+        private Sources.ObjectSourceSectionViewModel CreateObjectSource(
+            ResourceType type,
+            string resRef) =>
+            new(
+                type,
+                resRef,
+                FindObjectPlacementsAsync,
+                ResolveAreaName,
+                GoToObjectPlacement);
+
+        private async Task<IReadOnlyList<ObjectPlacement>> FindObjectPlacementsAsync(
+            ResourceType type,
+            string resRef)
+        {
+            var workspace = _workspaceContext.Workspace;
+            if (workspace == null)
+                return Array.Empty<ObjectPlacement>();
+
+            var placements = await workspace.PlacementIndex.FindAsync(type, resRef).ConfigureAwait(true);
+            return ReferenceEquals(workspace, _workspaceContext.Workspace)
+                ? placements
+                : Array.Empty<ObjectPlacement>();
+        }
+
+        private string ResolveAreaName(string areaResRef)
+        {
+            if (_workspaceContext.Catalog?.TryGetEntry(
+                    ResourceType.Area, areaResRef, out var entry) == true &&
+                !string.IsNullOrWhiteSpace(entry!.Name))
+                return entry.Name!;
+
+            return areaResRef;
+        }
+
+        private void GoToObjectPlacement(ObjectPlacement placement)
+        {
+            var workspace = _workspaceContext.Workspace;
+            if (workspace == null)
+                return;
+
+            _pendingAreaReveals[placement.AreaResRef] = placement;
+            OpenAreaEditor(workspace, placement.AreaResRef);
+        }
+
+        private void DispatchPendingAreaReveal(AreaEditorViewModel editor)
+        {
+            if (!_pendingAreaReveals.Remove(editor.AreaResRef, out var placement))
+                return;
+
+            Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+            {
+                _factory.ActivateDocument(editor);
+                editor.RevealPlacement(placement);
+            });
         }
 
         private async Task<bool> CompileOnSaveAsync(
@@ -1298,7 +1357,8 @@ namespace SWLOR.Toolset.Editors
                 filePath, resRef, _gameCodeIndex, _log, _prompts, ResolveTriggerTagArea,
                 ResolveTriggerChoices,
                 ChoicePreviews(),
-                _blueprintSaves);
+                _blueprintSaves,
+                CreateObjectSource(ResourceType.Utt, resRef));
             editor.Closed += closed => _openTriggerEditors.Remove(closed.FilePath);
             editor.CloseRequested += _ => _factory.CloseDocument(editor);
             editor.CatalogEntryChanged += () =>
@@ -1345,7 +1405,8 @@ namespace SWLOR.Toolset.Editors
                     catalog,
                     ResolveWaypointChoices,
                     ChoicePreviews(),
-                    _blueprintSaves);
+                    _blueprintSaves,
+                    CreateObjectSource(ResourceType.Utw, resRef));
                 editor.Closed += closed => _openWaypointEditors.Remove(closed.FilePath);
                 editor.CloseRequested += _ => _factory.CloseDocument(editor);
                 editor.CatalogEntryChanged += () =>
@@ -1394,7 +1455,8 @@ namespace SWLOR.Toolset.Editors
                 itemResRef => LoadMerchantItem(itemResRef)?.Name ?? itemResRef,
                 SearchCreatureEquipmentItems,
                 _appearances == null ? null : CreatureAppearanceOptions,
-                CreatureAbilityIcon);
+                CreatureAbilityIcon,
+                CreateObjectSource(ResourceType.Utc, resRef));
             editor.Closed += closed => _openCreatureEditors.Remove(closed.FilePath);
             editor.CloseRequested += _ => _factory.CloseDocument(editor);
             editor.CatalogEntryChanged += () =>
@@ -1421,7 +1483,8 @@ namespace SWLOR.Toolset.Editors
                     : null,
                 _thumbnails,
                 ChoicePreviews(),
-                _blueprintSaves);
+                _blueprintSaves,
+                CreateObjectSource(ResourceType.Utd, resRef));
             editor.Closed += closed => _openDoorEditors.Remove(closed.FilePath);
             editor.CloseRequested += _ => _factory.CloseDocument(editor);
             editor.CatalogEntryChanged += () =>
@@ -1462,7 +1525,8 @@ namespace SWLOR.Toolset.Editors
                 findReferences: FindItemReferences,
                 canRefileCategories: CanRefileItemCategories,
                 refileCategories: RefileItemCategories,
-                saveCoordinator: _blueprintSaves);
+                saveCoordinator: _blueprintSaves,
+                placementSource: CreateObjectSource(ResourceType.Uti, resRef));
             editor.Closed += closed => _openItemEditors.Remove(closed.FilePath);
             editor.CloseRequested += _ => _factory.CloseDocument(editor);
             editor.CatalogEntryChanged += () =>
@@ -1504,7 +1568,16 @@ namespace SWLOR.Toolset.Editors
                     ? null
                     : (itemResRef, onReady) =>
                         _thumbnails.RequestAsync(ResourceType.Uti, itemResRef, onReady),
-                itemResRef => TryOpenEditor(ResourceType.Uti, itemResRef));
+                itemResRef => TryOpenEditor(ResourceType.Uti, itemResRef),
+                (merchantResRef, placement) => GoToObjectPlacement(new ObjectPlacement(
+                    ResourceType.Utm,
+                    merchantResRef,
+                    placement.AreaResRef,
+                    placement.InstanceIndex,
+                    placement.Tag,
+                    0f,
+                    0f,
+                    0f)));
             editor.Closed += closed => _openMerchantEditors.Remove(closed.FilePath);
             editor.CloseRequested += _ => _factory.CloseDocument(editor);
             editor.CatalogEntryChanged += () =>
@@ -2778,7 +2851,8 @@ namespace SWLOR.Toolset.Editors
                 ResolveSoundChoices,
                 SoundResources(),
                 SoundPreviews(),
-                _blueprintSaves);
+                _blueprintSaves,
+                CreateObjectSource(ResourceType.Uts, resRef));
             editor.Closed += closed => _openSoundEditors.Remove(closed.FilePath);
             editor.CloseRequested += _ => _factory.CloseDocument(editor);
             editor.CatalogEntryChanged += () =>
@@ -3103,6 +3177,7 @@ namespace SWLOR.Toolset.Editors
             if (_openAreaEditors.TryGetValue(resRef, out var existing))
             {
                 _factory.ActivateDocument(existing);
+                DispatchPendingAreaReveal(existing);
                 return;
             }
 
@@ -3113,17 +3188,21 @@ namespace SWLOR.Toolset.Editors
             {
                 var arePath = workspace.GetResourcePath(ResourceType.Area, resRef);
                 var gitPath = Path.Combine(workspace.ModuleRoot, "git", resRef + ".git.json");
-                if (!File.Exists(arePath) || !File.Exists(gitPath))
+                var gicPath = Path.Combine(workspace.ModuleRoot, "gic", resRef + ".gic.json");
+                if (!File.Exists(arePath) || !File.Exists(gitPath) || !File.Exists(gicPath))
                 {
-                    _log.AppendLine($"Area files not found for '{resRef}' (.are/.git pair required).");
+                    _log.AppendLine($"Area files not found for '{resRef}' (.are/.git/.gic set required).");
                     return;
                 }
 
-                // Placed waypoints use the same transition classifier as blueprint waypoints. Its
-                // module-wide GIT scan is warmed in the background so opening a large area does not
-                // freeze Avalonia's UI thread.
-                var transitionDestinationTags =
-                    await GetCurrentTransitionDestinationTagsAsync(workspace).ConfigureAwait(true);
+                // Both cold operations start together: the module-wide waypoint scan and this
+                // area's file read/JSON parse. Neither owns Avalonia's UI thread, so a large area can
+                // load while the builder keeps working in another document.
+                var transitionTagsTask = GetCurrentTransitionDestinationTagsAsync(workspace);
+                var documentLoadTask = Task.Run(() =>
+                    AreaEditorDocumentLoad.Load(arePath, gitPath, gicPath));
+                var transitionDestinationTags = await transitionTagsTask.ConfigureAwait(true);
+                var loadedDocuments = await documentLoadTask.ConfigureAwait(true);
                 if (transitionDestinationTags == null)
                     return;
 
@@ -3167,7 +3246,8 @@ namespace SWLOR.Toolset.Editors
                         ChoicePreviews()),
                     ResolveSoundChoices,
                     SoundResources(),
-                    SoundPreviews());
+                    SoundPreviews(),
+                    loadedDocuments);
                 editor.Closed += _ => _openAreaEditors.Remove(resRef);
                 editor.TilesetChanged += () => _factory.NotifyActiveAreaChanged();
                 editor.CloseRequested += _ => _factory.CloseDocument(editor);
@@ -3175,6 +3255,7 @@ namespace SWLOR.Toolset.Editors
                     _workspaceContext.RefreshCatalogEntry(ResourceType.Area, resRef);
                 _openAreaEditors[resRef] = editor;
                 _factory.OpenDocument(editor);
+                DispatchPendingAreaReveal(editor);
             }
             catch (Exception ex)
             {
@@ -3183,6 +3264,8 @@ namespace SWLOR.Toolset.Editors
             finally
             {
                 _openingAreaEditors.Remove(resRef);
+                if (!_openAreaEditors.ContainsKey(resRef))
+                    _pendingAreaReveals.Remove(resRef);
             }
         }
 

--- a/SWLOR.Toolset/Editors/EditorService.cs
+++ b/SWLOR.Toolset/Editors/EditorService.cs
@@ -139,6 +139,13 @@ namespace SWLOR.Toolset.Editors
         private readonly Func<Domain.Workspace.ModuleWorkspace, string?, ItemObtainabilityIndex>
             _itemSourcesBuilder;
 
+        /// <summary>The placement lookup implementation; injectable to verify workspace races.</summary>
+        private readonly Func<
+            Domain.Workspace.ModuleWorkspace,
+            ResourceType,
+            string,
+            Task<IReadOnlyList<ObjectPlacement>>> _objectPlacementsFinder;
+
         /// <summary>
         /// Bumped every time <see cref="_itemSources"/> is invalidated (a module opens, or a store,
         /// item, creature, or placeable is saved). <see cref="BuildItemSourcesAsync"/> captures this at
@@ -265,7 +272,12 @@ namespace SWLOR.Toolset.Editors
             Func<Domain.Workspace.ModuleWorkspace, string?, ItemObtainabilityIndex>?
                 itemSourcesBuilder = null,
             Workspace.ModuleCustomContentService? moduleCustomContent = null,
-            IExternalLinkService? externalLinks = null)
+            IExternalLinkService? externalLinks = null,
+            Func<
+                Domain.Workspace.ModuleWorkspace,
+                ResourceType,
+                string,
+                Task<IReadOnlyList<ObjectPlacement>>>? objectPlacementsFinder = null)
         {
             _moduleCustomContent = moduleCustomContent;
             _externalLinks = externalLinks;
@@ -285,6 +297,9 @@ namespace SWLOR.Toolset.Editors
             _itemSourcesBuilder = itemSourcesBuilder ??
                                   ((workspace, gameSourceRoot) =>
                                       ItemObtainabilityIndex.Build(workspace, gameSourceRoot));
+            _objectPlacementsFinder = objectPlacementsFinder ??
+                                      ((workspace, type, resRef) =>
+                                          workspace.PlacementIndex.FindAsync(type, resRef));
             _mutationLock = mutationLock;
             _placeableModels = placeableModels;
             _thumbnails = thumbnails;
@@ -967,26 +982,37 @@ namespace SWLOR.Toolset.Editors
                 FindObjectPlacementsAsync,
                 ResolveAreaName,
                 GoToObjectPlacement,
-                () => _workspaceContext.Workspace?.PlacementIndex.Invalidate());
+                () => _workspaceContext.Workspace?.PlacementIndex.Invalidate(),
+                _log);
 
         private async Task<IReadOnlyList<ObjectPlacement>> FindObjectPlacementsAsync(
             ResourceType type,
             string resRef)
         {
-            var workspace = _workspaceContext.Workspace;
-            if (workspace == null)
+            while (true)
             {
-                _log.AppendLine("Cannot scan object placements: no module workspace is open.");
-                return Array.Empty<ObjectPlacement>();
+                var workspace = _workspaceContext.Workspace;
+                if (workspace == null)
+                    throw new InvalidOperationException(
+                        "Cannot scan object placements because no module workspace is open.");
+
+                try
+                {
+                    var placements = await _objectPlacementsFinder(workspace, type, resRef)
+                        .ConfigureAwait(true);
+                    if (ReferenceEquals(workspace, _workspaceContext.Workspace))
+                        return placements;
+                }
+                catch when (!ReferenceEquals(workspace, _workspaceContext.Workspace))
+                {
+                    // The result belongs to an obsolete workspace generation. Retry below against
+                    // the replacement rather than surfacing an error from a module that is gone.
+                }
+
+                _log.AppendLine(
+                    $"Retrying placement scan for '{resRef}' because the module workspace " +
+                    "changed during the scan.");
             }
-
-            var placements = await workspace.PlacementIndex.FindAsync(type, resRef).ConfigureAwait(true);
-            if (ReferenceEquals(workspace, _workspaceContext.Workspace))
-                return placements;
-
-            _log.AppendLine(
-                $"Discarded placement results for '{resRef}' because the module workspace changed during the scan.");
-            return Array.Empty<ObjectPlacement>();
         }
 
         private string ResolveAreaName(string areaResRef)

--- a/SWLOR.Toolset/Editors/EditorService.cs
+++ b/SWLOR.Toolset/Editors/EditorService.cs
@@ -3293,6 +3293,7 @@ namespace SWLOR.Toolset.Editors
                 if (_openAreaEditors.TryGetValue(resRef, out existing))
                 {
                     _factory.ActivateDocument(existing);
+                    DispatchPendingAreaReveal(existing);
                     return;
                 }
 

--- a/SWLOR.Toolset/Editors/EditorService.cs
+++ b/SWLOR.Toolset/Editors/EditorService.cs
@@ -147,6 +147,9 @@ namespace SWLOR.Toolset.Editors
             string,
             Task<IReadOnlyList<ObjectPlacement>>> _objectPlacementsFinder;
 
+        /// <summary>The area file parser; injectable to verify workspace replacement during a slow load.</summary>
+        private readonly Func<string, string, string, AreaEditorDocumentLoad> _areaDocumentsLoader;
+
         /// <summary>
         /// Bumped every time <see cref="_itemSources"/> is invalidated (a module opens, or a store,
         /// item, creature, or placeable is saved). <see cref="BuildItemSourcesAsync"/> captures this at
@@ -278,7 +281,8 @@ namespace SWLOR.Toolset.Editors
                 Domain.Workspace.ModuleWorkspace,
                 ResourceType,
                 string,
-                Task<IReadOnlyList<ObjectPlacement>>>? objectPlacementsFinder = null)
+                Task<IReadOnlyList<ObjectPlacement>>>? objectPlacementsFinder = null,
+            Func<string, string, string, AreaEditorDocumentLoad>? areaDocumentsLoader = null)
         {
             _moduleCustomContent = moduleCustomContent;
             _externalLinks = externalLinks;
@@ -301,6 +305,7 @@ namespace SWLOR.Toolset.Editors
             _objectPlacementsFinder = objectPlacementsFinder ??
                                       ((workspace, type, resRef) =>
                                           workspace.PlacementIndex.FindAsync(type, resRef));
+            _areaDocumentsLoader = areaDocumentsLoader ?? AreaEditorDocumentLoad.Load;
             _mutationLock = mutationLock;
             _placeableModels = placeableModels;
             _thumbnails = thumbnails;
@@ -3283,11 +3288,12 @@ namespace SWLOR.Toolset.Editors
                 // load while the builder keeps working in another document.
                 var transitionTagsTask = GetCurrentTransitionDestinationTagsAsync(workspace);
                 var documentLoadTask = Task.Run(() =>
-                    AreaEditorDocumentLoad.Load(arePath, gitPath, gicPath));
+                    _areaDocumentsLoader(arePath, gitPath, gicPath));
                 await Task.WhenAll(transitionTagsTask, documentLoadTask).ConfigureAwait(true);
                 var transitionDestinationTags = await transitionTagsTask.ConfigureAwait(true);
                 var loadedDocuments = await documentLoadTask.ConfigureAwait(true);
-                if (transitionDestinationTags == null)
+                if (transitionDestinationTags == null ||
+                    !ReferenceEquals(workspace, _workspaceContext.Workspace))
                     return;
 
                 if (_openAreaEditors.TryGetValue(resRef, out existing))

--- a/SWLOR.Toolset/Editors/EditorService.cs
+++ b/SWLOR.Toolset/Editors/EditorService.cs
@@ -345,7 +345,7 @@ namespace SWLOR.Toolset.Editors
             });
             _workspaceContext.ScriptUsagesInvalidated += _scriptUsageIndex.Invalidate;
             _workspaceContext.TagIndexInvalidated += OnTagIndexInvalidated;
-            _workspaceContext.PlacementIndexInvalidated += ReloadObjectSources;
+            _workspaceContext.PlacementIndexInvalidated += ReloadPlacementSources;
             _workspaceContext.CatalogBuildCompleted += RefreshObjectSourceAreaNames;
 
             // Opening another module invalidates every module-derived picker; saving a blueprint
@@ -366,7 +366,7 @@ namespace SWLOR.Toolset.Editors
                 _itemSourcesGeneration++;
                 _behaviorValues?.InvalidateModuleSources();
                 OnTagIndexInvalidated();
-                ReloadObjectSources();
+                ReloadPlacementSources();
 
                 // Pay the obtainability scan's cost here, in the background, rather than on
                 // whichever item editor happens to open first.
@@ -995,8 +995,18 @@ namespace SWLOR.Toolset.Editors
             return source;
         }
 
-        private void ReloadObjectSources() =>
+        private void ReloadPlacementSources()
+        {
+            if (!Avalonia.Threading.Dispatcher.UIThread.CheckAccess())
+            {
+                Avalonia.Threading.Dispatcher.UIThread.Post(ReloadPlacementSources);
+                return;
+            }
+
             VisitObjectSources(source => source.Reload());
+            foreach (var merchant in _openMerchantEditors.Values)
+                merchant.Editor.InvalidatePlacedInstances();
+        }
 
         private void RefreshObjectSourceAreaNames() =>
             VisitObjectSources(source => source.RefreshAreaNames());

--- a/SWLOR.Toolset/Editors/InstanceListSectionViewModel.cs
+++ b/SWLOR.Toolset/Editors/InstanceListSectionViewModel.cs
@@ -131,6 +131,13 @@ namespace SWLOR.Toolset.Editors
         [ObservableProperty]
         private bool _hasSelection;
 
+        /// <summary>
+        /// Whether this kind's placed-instance details are open on the area's Properties tab.
+        /// Kept on the view model so switching document tabs does not collapse the builder's work.
+        /// </summary>
+        [ObservableProperty]
+        private bool _isExpanded;
+
         [ObservableProperty]
         private string _detailTag = string.Empty;
 

--- a/SWLOR.Toolset/Editors/Items/ItemDocumentViewModel.cs
+++ b/SWLOR.Toolset/Editors/Items/ItemDocumentViewModel.cs
@@ -96,7 +96,8 @@ namespace SWLOR.Toolset.Editors.Items
             Func<string, string, IReadOnlyList<string>>? findReferences = null,
             Func<string, bool>? canRefileCategories = null,
             Func<string, string, CategorySaveResult>? refileCategories = null,
-            BlueprintSaveCoordinator? saveCoordinator = null)
+            BlueprintSaveCoordinator? saveCoordinator = null,
+            Sources.ObjectSourceSectionViewModel? placementSource = null)
         {
             _log = log;
             _prompts = prompts;
@@ -127,7 +128,8 @@ namespace SWLOR.Toolset.Editors.Items
                 resolveModel: resolveModel,
                 resourceIndex: resourceIndex,
                 armorDyeSwatches: armorDyeSwatches,
-                armorPartModels: armorPartModels);
+                armorPartModels: armorPartModels,
+                placementSource: placementSource);
             UpdateTitle();
         }
 

--- a/SWLOR.Toolset/Editors/Items/ItemEditorViewModel.cs
+++ b/SWLOR.Toolset/Editors/Items/ItemEditorViewModel.cs
@@ -77,6 +77,9 @@ namespace SWLOR.Toolset.Editors.Items
         [ObservableProperty]
         private bool _isModelPreviewLoading;
 
+        [ObservableProperty]
+        private int _selectedTabIndex;
+
         /// <summary>Null unless a resolver was supplied and the item's base type has a world model to preview.</summary>
         public AreaScene? PreviewScene { get; private set; }
 

--- a/SWLOR.Toolset/Editors/Items/ItemEditorViewModel.cs
+++ b/SWLOR.Toolset/Editors/Items/ItemEditorViewModel.cs
@@ -58,7 +58,9 @@ namespace SWLOR.Toolset.Editors.Items
 
         public ItemSourceSectionViewModel Source { get; }
 
-        public bool ShowsSourceTab => Source.IsLoaded;
+        public Sources.ObjectSourceSectionViewModel? PlacementSource { get; }
+
+        public bool ShowsSourceTab => Source.IsLoaded || PlacementSource != null;
 
         [ObservableProperty]
         private VarTableSectionViewModel? _variables;
@@ -204,7 +206,8 @@ namespace SWLOR.Toolset.Editors.Items
             Func<JsonGffStruct, bool, RenderModel?>? resolveModel = null,
             ResourceIndex? resourceIndex = null,
             ArmorDyeSwatchService? armorDyeSwatches = null,
-            ArmorPartCatalog? armorPartModels = null)
+            ArmorPartCatalog? armorPartModels = null,
+            Sources.ObjectSourceSectionViewModel? placementSource = null)
         {
             ArgumentNullException.ThrowIfNull(item);
 
@@ -240,6 +243,7 @@ namespace SWLOR.Toolset.Editors.Items
                     armorDyeSwatches, armorPartModels);
             }
             Source = new ItemSourceSectionViewModel(headerOwner, sourceLookup, itemSourcesReady);
+            PlacementSource = placementSource;
             _lastAppearanceBaseItem = CurrentBaseItem();
             RebuildVariablesSection();
             RefreshCompleteness();
@@ -263,6 +267,7 @@ namespace SWLOR.Toolset.Editors.Items
         {
             HeaderOwner = resRef;
             Source.Refresh(resRef);
+            PlacementSource?.SetResRef(resRef);
             OnPropertyChanged(nameof(HeaderOwner));
             OnPropertyChanged(nameof(HeaderName));
             OnPropertyChanged(nameof(Source));

--- a/SWLOR.Toolset/Editors/Merchants/MerchantDocumentViewModel.cs
+++ b/SWLOR.Toolset/Editors/Merchants/MerchantDocumentViewModel.cs
@@ -49,7 +49,8 @@ namespace SWLOR.Toolset.Editors.Merchants
             MerchantInstanceService? instances = null,
             BlueprintSaveCoordinator? saveCoordinator = null,
             Action<string, Action<Bitmap>>? requestItemPreview = null,
-            Action<string>? openItem = null)
+            Action<string>? openItem = null,
+            Action<string, MerchantInstancePlacement>? goToInstance = null)
         {
             _log = log ?? throw new ArgumentNullException(nameof(log));
             _prompts = prompts ?? throw new ArgumentNullException(nameof(prompts));
@@ -67,7 +68,8 @@ namespace SWLOR.Toolset.Editors.Merchants
                 searchItems,
                 instances,
                 requestItemPreview,
-                openItem);
+                openItem,
+                goToInstance);
             Editor.PropertyChanged += OnEditorPropertyChanged;
             UpdateTitle();
         }

--- a/SWLOR.Toolset/Editors/Merchants/MerchantEditorViewModel.cs
+++ b/SWLOR.Toolset/Editors/Merchants/MerchantEditorViewModel.cs
@@ -34,6 +34,7 @@ namespace SWLOR.Toolset.Editors.Merchants
         private readonly List<MerchantBuyingRuleViewModel> _allBuyingRules = new();
         private readonly HashSet<(int PaneIndex, int ItemIndex)> _checkedInventoryItems = new();
         private int _instanceRefreshGeneration;
+        private string? _loadedPlacementResRef;
         private int _inventoryRefreshGeneration;
         private int _itemCandidateRefreshGeneration;
         private int _itemCandidateOffset;
@@ -275,12 +276,15 @@ namespace SWLOR.Toolset.Editors.Merchants
             SelectedInventoryCategory = InventoryCategories[0];
         }
 
-        [RelayCommand]
+        [RelayCommand(CanExecute = nameof(CanGoToInstance))]
         private void GoToInstance(MerchantInstancePlacement? placement)
         {
             if (placement != null)
-                _goToInstance?.Invoke(ResRef, placement);
+                _goToInstance?.Invoke(_loadedPlacementResRef ?? HeaderOwner, placement);
         }
+
+        private bool CanGoToInstance(MerchantInstancePlacement? placement) =>
+            _goToInstance != null && placement != null;
 
         public void ReloadFromDocument()
         {
@@ -531,10 +535,12 @@ namespace SWLOR.Toolset.Editors.Merchants
             InstanceError = null;
             try
             {
-                var found = await _instances.FindAsync(ResRef).ConfigureAwait(true);
+                var sourceResRef = ResRef;
+                var found = await _instances.FindAsync(sourceResRef).ConfigureAwait(true);
                 if (_disposed || generation != _instanceRefreshGeneration)
                     return;
 
+                _loadedPlacementResRef = sourceResRef;
                 PlacedInstances.Clear();
                 foreach (var placement in found)
                     PlacedInstances.Add(placement);
@@ -568,6 +574,7 @@ namespace SWLOR.Toolset.Editors.Merchants
             ArePlacedInstancesLoaded = false;
             PlacedInstancesNeedRefresh = true;
             InstanceError = null;
+            _loadedPlacementResRef = null;
             PlacedInstances.Clear();
             NotifyInstanceShapeChanged();
         }

--- a/SWLOR.Toolset/Editors/Merchants/MerchantEditorViewModel.cs
+++ b/SWLOR.Toolset/Editors/Merchants/MerchantEditorViewModel.cs
@@ -28,6 +28,7 @@ namespace SWLOR.Toolset.Editors.Merchants
             Task<IReadOnlyList<MerchantItemDefinition>>>? _searchItems;
         private readonly Action<string, Action<Bitmap>>? _requestItemPreview;
         private readonly Action<string>? _openItem;
+        private readonly Action<string, MerchantInstancePlacement>? _goToInstance;
         private readonly IReadOnlyList<BehaviorChoice> _baseItems;
         private readonly MerchantInstanceService? _instances;
         private readonly List<MerchantBuyingRuleViewModel> _allBuyingRules = new();
@@ -245,7 +246,8 @@ namespace SWLOR.Toolset.Editors.Merchants
                 Task<IReadOnlyList<MerchantItemDefinition>>>? searchItems = null,
             MerchantInstanceService? instances = null,
             Action<string, Action<Bitmap>>? requestItemPreview = null,
-            Action<string>? openItem = null)
+            Action<string>? openItem = null,
+            Action<string, MerchantInstancePlacement>? goToInstance = null)
         {
             ArgumentNullException.ThrowIfNull(merchant);
             _store = new MerchantValueStore(merchant);
@@ -257,6 +259,7 @@ namespace SWLOR.Toolset.Editors.Merchants
             _instances = instances;
             _requestItemPreview = requestItemPreview;
             _openItem = openItem;
+            _goToInstance = goToInstance;
             HeaderOwner = headerOwner;
 
             BuildRows();
@@ -270,6 +273,13 @@ namespace SWLOR.Toolset.Editors.Merchants
             RefreshBuyingRuleSelections();
 
             SelectedInventoryCategory = InventoryCategories[0];
+        }
+
+        [RelayCommand]
+        private void GoToInstance(MerchantInstancePlacement? placement)
+        {
+            if (placement != null)
+                _goToInstance?.Invoke(ResRef, placement);
         }
 
         public void ReloadFromDocument()

--- a/SWLOR.Toolset/Editors/Merchants/MerchantEditorViewModel.cs
+++ b/SWLOR.Toolset/Editors/Merchants/MerchantEditorViewModel.cs
@@ -589,7 +589,11 @@ namespace SWLOR.Toolset.Editors.Merchants
             InstanceError = null;
             try
             {
-                var targetAreas = PlacedInstances
+                // Updating invalidates the module placement index, which tells every open Source tab
+                // to discard its derived rows. This command deliberately operates on the displayed
+                // snapshot, so retain it across that notification and republish it as current below.
+                var displayedPlacements = PlacedInstances.ToList();
+                var targetAreas = displayedPlacements
                     .Where(placement => !placement.IsCurrent)
                     .Select(placement => placement.AreaResRef)
                     .Distinct(StringComparer.OrdinalIgnoreCase)
@@ -599,17 +603,17 @@ namespace SWLOR.Toolset.Editors.Merchants
                 // The service rebuilds every matching merchant in each target area from the saved
                 // blueprint. Those displayed records are therefore current without a second full-
                 // module discovery scan. Refresh remains available to discover new placements.
-                for (var index = 0; index < PlacedInstances.Count; index++)
+                PlacedInstances.Clear();
+                foreach (var placement in displayedPlacements)
                 {
-                    var placement = PlacedInstances[index];
-                    if (targetAreas.Contains(placement.AreaResRef, StringComparer.OrdinalIgnoreCase))
-                    {
-                        PlacedInstances[index] = placement with
-                        {
-                            OutOfDateMerchantRecords = 0,
-                            OutOfDateItemRecords = 0
-                        };
-                    }
+                    PlacedInstances.Add(
+                        targetAreas.Contains(placement.AreaResRef, StringComparer.OrdinalIgnoreCase)
+                            ? placement with
+                            {
+                                OutOfDateMerchantRecords = 0,
+                                OutOfDateItemRecords = 0
+                            }
+                            : placement);
                 }
 
                 ArePlacedInstancesLoaded = true;

--- a/SWLOR.Toolset/Editors/Merchants/MerchantInstanceService.cs
+++ b/SWLOR.Toolset/Editors/Merchants/MerchantInstanceService.cs
@@ -103,7 +103,7 @@ namespace SWLOR.Toolset.Editors.Merchants
                 _reloadOpenAreaInstances?.Invoke(areaResRef);
             if (result.Count > 0)
             {
-                _workspaceContext.InvalidateTagIndex();
+                _workspaceContext.InvalidateGitIndexes();
                 _workspaceContext.InvalidateScriptUsages();
                 _log.AppendLine(
                     $"Updated {result.Count} placed instance{(result.Count == 1 ? string.Empty : "s")} of merchant " +

--- a/SWLOR.Toolset/Editors/Merchants/MerchantInstanceService.cs
+++ b/SWLOR.Toolset/Editors/Merchants/MerchantInstanceService.cs
@@ -15,7 +15,10 @@ namespace SWLOR.Toolset.Editors.Merchants
         string Tag,
         int InstanceIndex,
         int OutOfDateMerchantRecords,
-        int OutOfDateItemRecords)
+        int OutOfDateItemRecords,
+        float XPosition = 0f,
+        float YPosition = 0f,
+        float ZPosition = 0f)
     {
         public bool IsCurrent => OutOfDateMerchantRecords == 0 && OutOfDateItemRecords == 0;
         public string SyncState => IsCurrent ? "Up to date" : "Out of date";
@@ -159,7 +162,10 @@ namespace SWLOR.Toolset.Editors.Merchants
                         store.GetStringOrNull("Tag") ?? string.Empty,
                         index,
                         status.OutOfDateMerchantRecords,
-                        status.OutOfDateItemRecords));
+                        status.OutOfDateItemRecords,
+                        store.GetOrNull("XPosition")?.GetSingle() ?? 0f,
+                        store.GetOrNull("YPosition")?.GetSingle() ?? 0f,
+                        store.GetOrNull("ZPosition")?.GetSingle() ?? 0f));
                 }
             }
 

--- a/SWLOR.Toolset/Editors/Sounds/SoundDocumentViewModel.cs
+++ b/SWLOR.Toolset/Editors/Sounds/SoundDocumentViewModel.cs
@@ -22,6 +22,7 @@ namespace SWLOR.Toolset.Editors.Sounds
         private bool _disposed;
 
         public SoundEditorViewModel Editor { get; }
+        public Sources.ObjectSourceSectionViewModel? Source { get; }
 
         public bool IsDirty => _session.UndoStack.IsDirty;
 
@@ -47,12 +48,14 @@ namespace SWLOR.Toolset.Editors.Sounds
             Func<string, IReadOnlyList<BehaviorChoice>>? resolveChoices = null,
             IReadOnlyList<string>? audioResources = null,
             Services.SoundPreviewService? preview = null,
-            BlueprintSaveCoordinator? saveCoordinator = null)
+            BlueprintSaveCoordinator? saveCoordinator = null,
+            Sources.ObjectSourceSectionViewModel? source = null)
         {
             _log = log;
             _prompts = prompts;
             _resRef = resRef;
             _saveCoordinator = saveCoordinator;
+            Source = source;
             Id = $"sound:{filePath}";
             _session = DocumentSession.Open(filePath);
 
@@ -158,6 +161,7 @@ namespace SWLOR.Toolset.Editors.Sounds
                     _resRef = targetResRef;
                     Id = $"sound:{_session.FilePath}";
                     Editor.SetHeaderOwner(targetResRef);
+                    Source?.SetResRef(targetResRef);
                 }
 
                 _session.UndoStack.MarkSaved();

--- a/SWLOR.Toolset/Editors/Sounds/SoundDocumentViewModel.cs
+++ b/SWLOR.Toolset/Editors/Sounds/SoundDocumentViewModel.cs
@@ -20,6 +20,7 @@ namespace SWLOR.Toolset.Editors.Sounds
         private bool _closeApproved;
         private bool _closePromptOpen;
         private bool _disposed;
+        private int _selectedTabIndex;
 
         public SoundEditorViewModel Editor { get; }
         public Sources.ObjectSourceSectionViewModel? Source { get; }
@@ -31,6 +32,17 @@ namespace SWLOR.Toolset.Editors.Sounds
         public bool CanRedo => _session.UndoStack.CanRedo;
         public string FilePath => _session.FilePath;
         public string ResRef => _resRef;
+        public int SelectedTabIndex
+        {
+            get => _selectedTabIndex;
+            set
+            {
+                if (_selectedTabIndex == value)
+                    return;
+                _selectedTabIndex = value;
+                OnPropertyChanged();
+            }
+        }
 
         public event Action<SoundDocumentViewModel>? Closed;
 

--- a/SWLOR.Toolset/Editors/Sources/ObjectSourceSectionViewModel.cs
+++ b/SWLOR.Toolset/Editors/Sources/ObjectSourceSectionViewModel.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using SWLOR.Toolset.Domain.Workspace;
+using SWLOR.Toolset.Workspace;
 
 namespace SWLOR.Toolset.Editors.Sources
 {
@@ -27,6 +28,7 @@ namespace SWLOR.Toolset.Editors.Sources
         private readonly Func<string, string> _resolveAreaName;
         private readonly Action<ObjectPlacement> _goTo;
         private readonly Action? _invalidate;
+        private readonly OutputLogService? _log;
         private int _loadGeneration;
         private string _resRef;
 
@@ -36,7 +38,8 @@ namespace SWLOR.Toolset.Editors.Sources
             Func<ResourceType, string, Task<IReadOnlyList<ObjectPlacement>>> find,
             Func<string, string> resolveAreaName,
             Action<ObjectPlacement> goTo,
-            Action? invalidate = null)
+            Action? invalidate = null,
+            OutputLogService? log = null)
         {
             BlueprintType = blueprintType;
             _resRef = resRef;
@@ -44,6 +47,7 @@ namespace SWLOR.Toolset.Editors.Sources
             _resolveAreaName = resolveAreaName ?? throw new ArgumentNullException(nameof(resolveAreaName));
             _goTo = goTo ?? throw new ArgumentNullException(nameof(goTo));
             _invalidate = invalidate;
+            _log = log;
             _ = LoadAsync();
         }
 
@@ -113,6 +117,8 @@ namespace SWLOR.Toolset.Editors.Sources
                 if (generation == _loadGeneration)
                 {
                     Placements.Clear();
+                    _log?.AppendLine(
+                        $"Placement scan failed for {BlueprintType} '{resRef}': {ex}");
                     LoadError = $"Could not scan placements: {ex.Message}";
                 }
             }

--- a/SWLOR.Toolset/Editors/Sources/ObjectSourceSectionViewModel.cs
+++ b/SWLOR.Toolset/Editors/Sources/ObjectSourceSectionViewModel.cs
@@ -87,6 +87,23 @@ namespace SWLOR.Toolset.Editors.Sources
             await LoadAsync().ConfigureAwait(true);
         }
 
+        /// <summary>Reloads placements after the workspace snapshot was invalidated.</summary>
+        public void Reload() => _ = LoadAsync();
+
+        /// <summary>
+        /// Re-resolves area labels after the background catalog has finished indexing names.
+        /// </summary>
+        public void RefreshAreaNames()
+        {
+            for (var index = 0; index < Placements.Count; index++)
+            {
+                var row = Placements[index];
+                var areaName = _resolveAreaName(row.AreaResRef);
+                if (!string.Equals(areaName, row.AreaName, StringComparison.Ordinal))
+                    Placements[index] = row with { AreaName = areaName };
+            }
+        }
+
         [RelayCommand]
         private void GoTo(ObjectPlacementRowViewModel? row)
         {

--- a/SWLOR.Toolset/Editors/Sources/ObjectSourceSectionViewModel.cs
+++ b/SWLOR.Toolset/Editors/Sources/ObjectSourceSectionViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Globalization;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using SWLOR.Toolset.Domain.Workspace;
@@ -11,7 +12,9 @@ namespace SWLOR.Toolset.Editors.Sources
     {
         public string AreaResRef => Placement.AreaResRef;
         public string Tag => Placement.Tag;
-        public string Position => $"{Placement.X:0.0}, {Placement.Y:0.0}, {Placement.Z:0.0}";
+        public string Position => string.Create(
+            CultureInfo.InvariantCulture,
+            $"{Placement.X:0.0}, {Placement.Y:0.0}, {Placement.Z:0.0}");
         public string Detail => string.IsNullOrWhiteSpace(Tag)
             ? $"Position {Position}"
             : $"{Tag} · {Position}";
@@ -23,6 +26,7 @@ namespace SWLOR.Toolset.Editors.Sources
         private readonly Func<ResourceType, string, Task<IReadOnlyList<ObjectPlacement>>> _find;
         private readonly Func<string, string> _resolveAreaName;
         private readonly Action<ObjectPlacement> _goTo;
+        private readonly Action? _invalidate;
         private int _loadGeneration;
         private string _resRef;
 
@@ -31,13 +35,15 @@ namespace SWLOR.Toolset.Editors.Sources
             string resRef,
             Func<ResourceType, string, Task<IReadOnlyList<ObjectPlacement>>> find,
             Func<string, string> resolveAreaName,
-            Action<ObjectPlacement> goTo)
+            Action<ObjectPlacement> goTo,
+            Action? invalidate = null)
         {
             BlueprintType = blueprintType;
             _resRef = resRef;
             _find = find ?? throw new ArgumentNullException(nameof(find));
             _resolveAreaName = resolveAreaName ?? throw new ArgumentNullException(nameof(resolveAreaName));
             _goTo = goTo ?? throw new ArgumentNullException(nameof(goTo));
+            _invalidate = invalidate;
             _ = LoadAsync();
         }
 
@@ -66,11 +72,16 @@ namespace SWLOR.Toolset.Editors.Sources
                 return;
 
             _resRef = resRef;
+            _invalidate?.Invoke();
             _ = LoadAsync();
         }
 
         [RelayCommand]
-        private async Task RefreshAsync() => await LoadAsync().ConfigureAwait(true);
+        private async Task RefreshAsync()
+        {
+            _invalidate?.Invoke();
+            await LoadAsync().ConfigureAwait(true);
+        }
 
         [RelayCommand]
         private void GoTo(ObjectPlacementRowViewModel? row)
@@ -100,7 +111,10 @@ namespace SWLOR.Toolset.Editors.Sources
             catch (Exception ex)
             {
                 if (generation == _loadGeneration)
+                {
+                    Placements.Clear();
                     LoadError = $"Could not scan placements: {ex.Message}";
+                }
             }
             finally
             {

--- a/SWLOR.Toolset/Editors/Sources/ObjectSourceSectionViewModel.cs
+++ b/SWLOR.Toolset/Editors/Sources/ObjectSourceSectionViewModel.cs
@@ -1,0 +1,112 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using SWLOR.Toolset.Domain.Workspace;
+
+namespace SWLOR.Toolset.Editors.Sources
+{
+    public sealed record ObjectPlacementRowViewModel(
+        ObjectPlacement Placement,
+        string AreaName)
+    {
+        public string AreaResRef => Placement.AreaResRef;
+        public string Tag => Placement.Tag;
+        public string Position => $"{Placement.X:0.0}, {Placement.Y:0.0}, {Placement.Z:0.0}";
+        public string Detail => string.IsNullOrWhiteSpace(Tag)
+            ? $"Position {Position}"
+            : $"{Tag} · {Position}";
+    }
+
+    /// <summary>The shared Source tab for blueprint-backed objects.</summary>
+    public sealed partial class ObjectSourceSectionViewModel : ObservableObject
+    {
+        private readonly Func<ResourceType, string, Task<IReadOnlyList<ObjectPlacement>>> _find;
+        private readonly Func<string, string> _resolveAreaName;
+        private readonly Action<ObjectPlacement> _goTo;
+        private int _loadGeneration;
+        private string _resRef;
+
+        public ObjectSourceSectionViewModel(
+            ResourceType blueprintType,
+            string resRef,
+            Func<ResourceType, string, Task<IReadOnlyList<ObjectPlacement>>> find,
+            Func<string, string> resolveAreaName,
+            Action<ObjectPlacement> goTo)
+        {
+            BlueprintType = blueprintType;
+            _resRef = resRef;
+            _find = find ?? throw new ArgumentNullException(nameof(find));
+            _resolveAreaName = resolveAreaName ?? throw new ArgumentNullException(nameof(resolveAreaName));
+            _goTo = goTo ?? throw new ArgumentNullException(nameof(goTo));
+            _ = LoadAsync();
+        }
+
+        public ResourceType BlueprintType { get; }
+        public ObservableCollection<ObjectPlacementRowViewModel> Placements { get; } = new();
+
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(Status))]
+        private bool _isLoading;
+
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(Status))]
+        private string? _loadError;
+
+        public string Status => IsLoading
+            ? "Scanning area placements..."
+            : LoadError != null
+                ? LoadError
+                : Placements.Count == 0
+                    ? "This blueprint is not placed in any area."
+                    : $"{Placements.Count} placed instance{(Placements.Count == 1 ? string.Empty : "s")}";
+
+        public void SetResRef(string resRef)
+        {
+            if (string.Equals(_resRef, resRef, StringComparison.OrdinalIgnoreCase))
+                return;
+
+            _resRef = resRef;
+            _ = LoadAsync();
+        }
+
+        [RelayCommand]
+        private async Task RefreshAsync() => await LoadAsync().ConfigureAwait(true);
+
+        [RelayCommand]
+        private void GoTo(ObjectPlacementRowViewModel? row)
+        {
+            if (row != null)
+                _goTo(row.Placement);
+        }
+
+        private async Task LoadAsync()
+        {
+            var generation = ++_loadGeneration;
+            IsLoading = true;
+            LoadError = null;
+            var resRef = _resRef;
+            try
+            {
+                var placements = await _find(BlueprintType, resRef).ConfigureAwait(true);
+                if (generation != _loadGeneration)
+                    return;
+
+                Placements.Clear();
+                foreach (var placement in placements)
+                    Placements.Add(new ObjectPlacementRowViewModel(
+                        placement, _resolveAreaName(placement.AreaResRef)));
+                OnPropertyChanged(nameof(Status));
+            }
+            catch (Exception ex)
+            {
+                if (generation == _loadGeneration)
+                    LoadError = $"Could not scan placements: {ex.Message}";
+            }
+            finally
+            {
+                if (generation == _loadGeneration)
+                    IsLoading = false;
+            }
+        }
+    }
+}

--- a/SWLOR.Toolset/Editors/Sources/ObjectSourceView.axaml
+++ b/SWLOR.Toolset/Editors/Sources/ObjectSourceView.axaml
@@ -1,0 +1,35 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:sources="using:SWLOR.Toolset.Editors.Sources"
+             x:Class="SWLOR.Toolset.Editors.Sources.ObjectSourceView"
+             x:DataType="sources:ObjectSourceSectionViewModel">
+  <Grid RowDefinitions="Auto,*" Margin="14,10,22,10">
+    <Grid Grid.Row="0" ColumnDefinitions="*,Auto" Margin="0,0,0,8">
+      <TextBlock Grid.Column="0" Text="{Binding Status}" VerticalAlignment="Center" />
+      <Button Grid.Column="1" Content="Refresh" Command="{Binding RefreshCommand}"
+              IsEnabled="{Binding !IsLoading}" />
+    </Grid>
+
+    <ScrollViewer Grid.Row="1">
+      <ItemsControl ItemsSource="{Binding Placements}">
+        <ItemsControl.ItemTemplate>
+          <DataTemplate DataType="sources:ObjectPlacementRowViewModel">
+            <Border Classes="card" Padding="12,9" Margin="0,0,0,8" MaxWidth="620"
+                    HorizontalAlignment="Left">
+              <Grid ColumnDefinitions="*,Auto" ColumnSpacing="18">
+                <StackPanel Grid.Column="0">
+                  <TextBlock Text="{Binding AreaName}" Classes="section" />
+                  <TextBlock Text="{Binding AreaResRef}" Classes="resref" />
+                  <TextBlock Text="{Binding Detail}" Classes="dim" Margin="0,3,0,0" />
+                </StackPanel>
+                <Button Grid.Column="1" Content="Go To"
+                        Command="{Binding $parent[ItemsControl].((sources:ObjectSourceSectionViewModel)DataContext).GoToCommand}"
+                        CommandParameter="{Binding}" VerticalAlignment="Center" />
+              </Grid>
+            </Border>
+          </DataTemplate>
+        </ItemsControl.ItemTemplate>
+      </ItemsControl>
+    </ScrollViewer>
+  </Grid>
+</UserControl>

--- a/SWLOR.Toolset/Editors/Sources/ObjectSourceView.axaml.cs
+++ b/SWLOR.Toolset/Editors/Sources/ObjectSourceView.axaml.cs
@@ -1,0 +1,9 @@
+using Avalonia.Controls;
+
+namespace SWLOR.Toolset.Editors.Sources
+{
+    public partial class ObjectSourceView : UserControl
+    {
+        public ObjectSourceView() => InitializeComponent();
+    }
+}

--- a/SWLOR.Toolset/Editors/Triggers/TriggerDocumentViewModel.cs
+++ b/SWLOR.Toolset/Editors/Triggers/TriggerDocumentViewModel.cs
@@ -27,6 +27,7 @@ namespace SWLOR.Toolset.Editors.Triggers
         private bool _disposed;
 
         public TriggerEditorViewModel Editor { get; }
+        public Sources.ObjectSourceSectionViewModel? Source { get; }
 
         public bool IsDirty => _session.UndoStack.IsDirty;
 
@@ -55,12 +56,14 @@ namespace SWLOR.Toolset.Editors.Triggers
             Func<BehaviorTagScope, string, string?>? resolveTag = null,
             Func<string, IReadOnlyList<BehaviorChoice>>? resolveChoices = null,
             ChoicePreviewService? previews = null,
-            BlueprintSaveCoordinator? saveCoordinator = null)
+            BlueprintSaveCoordinator? saveCoordinator = null,
+            Sources.ObjectSourceSectionViewModel? source = null)
         {
             _log = log;
             _prompts = prompts;
             _resRef = resRef;
             _saveCoordinator = saveCoordinator;
+            Source = source;
             Id = $"trigger:{filePath}";
             _session = DocumentSession.Open(filePath);
 
@@ -162,6 +165,7 @@ namespace SWLOR.Toolset.Editors.Triggers
                     _resRef = targetResRef;
                     Id = $"trigger:{_session.FilePath}";
                     Editor.SetHeaderOwner(targetResRef);
+                    Source?.SetResRef(targetResRef);
                 }
 
                 _session.UndoStack.MarkSaved();

--- a/SWLOR.Toolset/Editors/Triggers/TriggerDocumentViewModel.cs
+++ b/SWLOR.Toolset/Editors/Triggers/TriggerDocumentViewModel.cs
@@ -25,6 +25,7 @@ namespace SWLOR.Toolset.Editors.Triggers
         private bool _closeApproved;
         private bool _closePromptOpen;
         private bool _disposed;
+        private int _selectedTabIndex;
 
         public TriggerEditorViewModel Editor { get; }
         public Sources.ObjectSourceSectionViewModel? Source { get; }
@@ -36,6 +37,17 @@ namespace SWLOR.Toolset.Editors.Triggers
         public bool CanRedo => _session.UndoStack.CanRedo;
         public string FilePath => _session.FilePath;
         public string ResRef => _resRef;
+        public int SelectedTabIndex
+        {
+            get => _selectedTabIndex;
+            set
+            {
+                if (_selectedTabIndex == value)
+                    return;
+                _selectedTabIndex = value;
+                OnPropertyChanged();
+            }
+        }
 
         /// <summary>Raised when the tab closes so the editor registry can forget this instance.</summary>
         public event Action<TriggerDocumentViewModel>? Closed;

--- a/SWLOR.Toolset/Editors/Views/AreaEditorView.axaml
+++ b/SWLOR.Toolset/Editors/Views/AreaEditorView.axaml
@@ -188,7 +188,9 @@
       <TabItem Header="Properties">
     <ScrollViewer x:Name="PropertiesScroll">
       <StackPanel Margin="8" Spacing="6">
-        <Expander Header="Area Properties" IsExpanded="False" HorizontalAlignment="Stretch">
+        <Expander Header="Area Properties"
+                  IsExpanded="{Binding AreaPropertiesExpanded, Mode=TwoWay}"
+                  HorizontalAlignment="Stretch">
           <ItemsControl ItemsSource="{Binding AreaPropertyGroups}" Margin="8,4">
             <ItemsControl.ItemTemplate>
               <DataTemplate DataType="editors:EditorGroup">

--- a/SWLOR.Toolset/Editors/Views/AreaEditorView.axaml
+++ b/SWLOR.Toolset/Editors/Views/AreaEditorView.axaml
@@ -15,7 +15,7 @@
        Undo prefers whichever of this editor's two histories (.git instances / .are properties) was
        touched most recently, falling back to the other. -->
   <DockPanel>
-    <TabControl x:Name="RootTabs">
+    <TabControl x:Name="RootTabs" SelectedIndex="{Binding SelectedRootTabIndex, Mode=TwoWay}">
       <TabItem Header="Scene" x:Name="ViewTab3D">
         <!-- No toolbar at all now. Placement comes from the Palette panel, the scene rebuilds itself
              after every edit, and the view options that were here either had no audience or are simply
@@ -56,7 +56,10 @@
                 <MenuItem Header="{Binding SelectionKindLabel}" IsEnabled="False"
                           ToolTip.Tip="{Binding SelectionResRef}" />
                 <Separator />
-                <MenuItem Header="Edit object..."
+                <MenuItem Header="Open properties..."
+                          Command="{Binding OpenSelectedInstancePropertiesCommand}"
+                          ToolTip.Tip="Edit this placed object's instance properties" />
+                <MenuItem Header="Edit blueprint..."
                           Command="{Binding EditSelectedBlueprintCommand}"
                           ToolTip.Tip="Open the blueprint this was placed from" />
               </ContextMenu>
@@ -183,7 +186,7 @@
         </Grid>
       </TabItem>
       <TabItem Header="Properties">
-    <ScrollViewer>
+    <ScrollViewer x:Name="PropertiesScroll">
       <StackPanel Margin="8" Spacing="6">
         <Expander Header="Area Properties" IsExpanded="False" HorizontalAlignment="Stretch">
           <ItemsControl ItemsSource="{Binding AreaPropertyGroups}" Margin="8,4">
@@ -201,7 +204,8 @@
         <ItemsControl ItemsSource="{Binding Sections}">
           <ItemsControl.ItemTemplate>
             <DataTemplate DataType="editors:InstanceListSectionViewModel">
-              <Expander HorizontalAlignment="Stretch" Margin="0,0,0,6" IsExpanded="False">
+              <Expander HorizontalAlignment="Stretch" Margin="0,0,0,6"
+                        IsExpanded="{Binding IsExpanded, Mode=TwoWay}">
                 <Expander.Header>
                   <StackPanel Orientation="Horizontal" Spacing="8">
                     <TextBlock Text="{Binding Title}" FontWeight="Bold" />

--- a/SWLOR.Toolset/Editors/Views/AreaEditorView.axaml.cs
+++ b/SWLOR.Toolset/Editors/Views/AreaEditorView.axaml.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Numerics;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Threading;
 using SWLOR.Toolset.Domain.Render;
 
 namespace SWLOR.Toolset.Editors
@@ -10,6 +11,7 @@ namespace SWLOR.Toolset.Editors
     public partial class AreaEditorView : UserControl
     {
         private AreaEditorViewModel? _viewModel;
+        private bool _viewportStateRestored;
 
         public AreaEditorView()
         {
@@ -54,6 +56,7 @@ namespace SWLOR.Toolset.Editors
                 _display.PropertyChanged -= OnDisplayPropertyChanged;
             if (_viewModel != null)
             {
+                SaveViewState(_viewModel);
                 _viewModel.PropertyChanged -= OnViewModelPropertyChanged;
                 _viewModel.CameraFocusRequested -= OnCameraFocusRequested;
                 _viewModel.PaintRejected -= OnPaintRejected;
@@ -80,20 +83,28 @@ namespace SWLOR.Toolset.Editors
 
         private void AttachViewModel()
         {
+            var next = DataContext as AreaEditorViewModel;
+            if (ReferenceEquals(next, _viewModel))
+                return;
+
             if (_viewModel != null)
             {
+                SaveViewState(_viewModel);
                 _viewModel.PropertyChanged -= OnViewModelPropertyChanged;
                 _viewModel.CameraFocusRequested -= OnCameraFocusRequested;
                 _viewModel.PaintRejected -= OnPaintRejected;
             }
 
-            _viewModel = DataContext as AreaEditorViewModel;
+            _viewModel = next;
             if (_viewModel == null)
                 return;
+
+            _viewportStateRestored = false;
 
             AreaView.ResourceIndex = _viewModel.ResourceIndex;
             AreaView.InvalidateGameResources();
             AreaView.Scene = _viewModel.AreaScene;
+            RestoreViewportStateWhenReady();
             AreaView.SelectedInstance = _viewModel.SelectedSceneInstance;
             AreaView.IsPlacementActive = _viewModel.IsPlacementPending;
             AreaView.PlacementGhost = _viewModel.PlacementGhost;
@@ -113,6 +124,35 @@ namespace SWLOR.Toolset.Editors
             // (it is the first tab), and reading IsSelected here raced the TabControl's own setup - the
             // case where a second area opened to an empty viewport that never built.
             _viewModel.EnsureSceneBuilt();
+
+            // Layout owns the scrollable extent, so wait until this view has measured before
+            // restoring the document's last offset.
+            Dispatcher.UIThread.Post(() =>
+            {
+                if (_viewModel != null)
+                {
+                    var offset = _viewModel.PropertiesScrollOffset;
+                    PropertiesScroll.Offset = new Avalonia.Vector(offset.X, offset.Y);
+                }
+            });
+        }
+
+        private void SaveViewState(AreaEditorViewModel viewModel)
+        {
+            viewModel.ViewportState = AreaView.CaptureViewportState() ?? viewModel.ViewportState;
+            viewModel.PropertiesScrollOffset = new Vector2(
+                (float)PropertiesScroll.Offset.X,
+                (float)PropertiesScroll.Offset.Y);
+        }
+
+        private void RestoreViewportStateWhenReady()
+        {
+            if (_viewportStateRestored || _viewModel?.AreaScene == null ||
+                _viewModel.ViewportState is not { } state)
+                return;
+
+            AreaView.RestoreViewportState(state);
+            _viewportStateRestored = true;
         }
 
         private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -121,7 +161,10 @@ namespace SWLOR.Toolset.Editors
                 return;
 
             if (e.PropertyName == nameof(AreaEditorViewModel.AreaScene))
+            {
                 AreaView.Scene = _viewModel.AreaScene;
+                RestoreViewportStateWhenReady();
+            }
             else if (e.PropertyName == nameof(AreaEditorViewModel.GameResourceRevision))
                 AreaView.InvalidateGameResources();
             else if (e.PropertyName == nameof(AreaEditorViewModel.SelectedSceneInstance))
@@ -154,7 +197,8 @@ namespace SWLOR.Toolset.Editors
         /// </remarks>
         private void OnCameraFocusRequested(Vector3 position)
         {
-            RootTabs.SelectedItem = ViewTab3D;
+            if (_viewModel != null)
+                _viewModel.SelectedRootTabIndex = 0;
             AreaView.FocusOn(position);
         }
 

--- a/SWLOR.Toolset/Editors/Views/AreaEditorView.axaml.cs
+++ b/SWLOR.Toolset/Editors/Views/AreaEditorView.axaml.cs
@@ -4,6 +4,7 @@ using System.Numerics;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Threading;
+using Avalonia.VisualTree;
 using SWLOR.Toolset.Domain.Render;
 
 namespace SWLOR.Toolset.Editors
@@ -59,6 +60,7 @@ namespace SWLOR.Toolset.Editors
                 SaveViewState(_viewModel);
                 _viewModel.PropertyChanged -= OnViewModelPropertyChanged;
                 _viewModel.CameraFocusRequested -= OnCameraFocusRequested;
+                _viewModel.InstancePropertiesRequested -= OnInstancePropertiesRequested;
                 _viewModel.PaintRejected -= OnPaintRejected;
             }
 
@@ -92,6 +94,7 @@ namespace SWLOR.Toolset.Editors
                 SaveViewState(_viewModel);
                 _viewModel.PropertyChanged -= OnViewModelPropertyChanged;
                 _viewModel.CameraFocusRequested -= OnCameraFocusRequested;
+                _viewModel.InstancePropertiesRequested -= OnInstancePropertiesRequested;
                 _viewModel.PaintRejected -= OnPaintRejected;
             }
 
@@ -118,6 +121,7 @@ namespace SWLOR.Toolset.Editors
             AreaView.SelectedTileCell = _viewModel.SelectedTile;
             _viewModel.PropertyChanged += OnViewModelPropertyChanged;
             _viewModel.CameraFocusRequested += OnCameraFocusRequested;
+            _viewModel.InstancePropertiesRequested += OnInstancePropertiesRequested;
             _viewModel.PaintRejected += OnPaintRejected;
 
             // Opening an area shows its map. Not gated on the 3D View tab being selected: it always is
@@ -143,6 +147,21 @@ namespace SWLOR.Toolset.Editors
             viewModel.PropertiesScrollOffset = new Vector2(
                 (float)PropertiesScroll.Offset.X,
                 (float)PropertiesScroll.Offset.Y);
+        }
+
+        private void OnInstancePropertiesRequested(InstanceListSectionViewModel section)
+        {
+            Dispatcher.UIThread.Post(() =>
+            {
+                if (_viewModel == null)
+                    return;
+
+                PropertiesScroll
+                    .GetVisualDescendants()
+                    .OfType<Expander>()
+                    .FirstOrDefault(expander => ReferenceEquals(expander.DataContext, section))
+                    ?.BringIntoView();
+            }, DispatcherPriority.Render);
         }
 
         private void RestoreViewportStateWhenReady()

--- a/SWLOR.Toolset/Editors/Views/AreaEditorView.axaml.cs
+++ b/SWLOR.Toolset/Editors/Views/AreaEditorView.axaml.cs
@@ -13,6 +13,7 @@ namespace SWLOR.Toolset.Editors
     {
         private AreaEditorViewModel? _viewModel;
         private bool _viewportStateRestored;
+        private Vector3? _pendingCameraFocus;
 
         public AreaEditorView()
         {
@@ -65,6 +66,7 @@ namespace SWLOR.Toolset.Editors
             }
 
             _viewModel = null;
+            _pendingCameraFocus = null;
 
             base.OnDetachedFromVisualTree(e);
         }
@@ -98,6 +100,7 @@ namespace SWLOR.Toolset.Editors
                 _viewModel.PaintRejected -= OnPaintRejected;
             }
 
+            _pendingCameraFocus = null;
             _viewModel = next;
             if (_viewModel == null)
                 return;
@@ -108,6 +111,7 @@ namespace SWLOR.Toolset.Editors
             AreaView.InvalidateGameResources();
             AreaView.Scene = _viewModel.AreaScene;
             RestoreViewportStateWhenReady();
+            ApplyPendingCameraFocus();
             AreaView.SelectedInstance = _viewModel.SelectedSceneInstance;
             AreaView.IsPlacementActive = _viewModel.IsPlacementPending;
             AreaView.PlacementGhost = _viewModel.PlacementGhost;
@@ -183,6 +187,7 @@ namespace SWLOR.Toolset.Editors
             {
                 AreaView.Scene = _viewModel.AreaScene;
                 RestoreViewportStateWhenReady();
+                ApplyPendingCameraFocus();
             }
             else if (e.PropertyName == nameof(AreaEditorViewModel.GameResourceRevision))
                 AreaView.InvalidateGameResources();
@@ -218,6 +223,27 @@ namespace SWLOR.Toolset.Editors
         {
             if (_viewModel != null)
                 _viewModel.SelectedRootTabIndex = 0;
+
+            if (AreaView.Scene == null)
+            {
+                _pendingCameraFocus = position;
+                return;
+            }
+
+            _pendingCameraFocus = null;
+            AreaView.FocusOn(position);
+        }
+
+        /// <summary>
+        /// Applies a Go To request only after the area's retained camera has been restored. Focusing
+        /// from the scene setter would let the later restore overwrite the requested object.
+        /// </summary>
+        private void ApplyPendingCameraFocus()
+        {
+            if (AreaView.Scene == null || _pendingCameraFocus is not { } position)
+                return;
+
+            _pendingCameraFocus = null;
             AreaView.FocusOn(position);
         }
 

--- a/SWLOR.Toolset/Editors/Views/BlueprintEditorView.axaml
+++ b/SWLOR.Toolset/Editors/Views/BlueprintEditorView.axaml
@@ -3,6 +3,7 @@
              xmlns:editors="using:SWLOR.Toolset.Editors"
              xmlns:placeables="using:SWLOR.Toolset.Editors.Placeables"
              xmlns:appearance="using:SWLOR.Toolset.Editors.Appearance"
+             xmlns:sources="using:SWLOR.Toolset.Editors.Sources"
              x:Class="SWLOR.Toolset.Editors.BlueprintEditorView"
              x:DataType="editors:BlueprintEditorViewModel">
 
@@ -10,6 +11,10 @@
        shared app-wide from App.axaml's Application.DataTemplates. The four templates below are tab
        CONTENTS, which only this editor hosts. -->
   <UserControl.DataTemplates>
+
+    <DataTemplate DataType="sources:ObjectSourceSectionViewModel">
+      <sources:ObjectSourceView />
+    </DataTemplate>
 
     <!-- A schema-driven tab: its groups, one after another. Headings rather than expanders - a group
          holds two or three fields, so collapsing one buys a couple of rows in exchange for a page

--- a/SWLOR.Toolset/Editors/Views/CreatureDocumentView.axaml
+++ b/SWLOR.Toolset/Editors/Views/CreatureDocumentView.axaml
@@ -1,6 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:creatures="using:SWLOR.Toolset.Editors.Creatures"
+             xmlns:sources="using:SWLOR.Toolset.Editors.Sources"
              x:Class="SWLOR.Toolset.Editors.Creatures.CreatureDocumentView"
              x:DataType="creatures:CreatureDocumentViewModel">
   <DockPanel>
@@ -36,6 +37,13 @@
         </StackPanel>
       </Grid>
     </Border>
-    <creatures:CreatureEditorView DataContext="{Binding Editor}" />
+    <TabControl>
+      <TabItem Header="Edit">
+        <creatures:CreatureEditorView DataContext="{Binding Editor}" />
+      </TabItem>
+      <TabItem Header="Source" IsVisible="{Binding Source, Converter={x:Static ObjectConverters.IsNotNull}}">
+        <sources:ObjectSourceView DataContext="{Binding Source}" />
+      </TabItem>
+    </TabControl>
   </DockPanel>
 </UserControl>

--- a/SWLOR.Toolset/Editors/Views/CreatureDocumentView.axaml
+++ b/SWLOR.Toolset/Editors/Views/CreatureDocumentView.axaml
@@ -37,7 +37,7 @@
         </StackPanel>
       </Grid>
     </Border>
-    <TabControl>
+    <TabControl SelectedIndex="{Binding SelectedTabIndex, Mode=TwoWay}">
       <TabItem Header="Edit">
         <creatures:CreatureEditorView DataContext="{Binding Editor}" />
       </TabItem>

--- a/SWLOR.Toolset/Editors/Views/DoorDocumentView.axaml
+++ b/SWLOR.Toolset/Editors/Views/DoorDocumentView.axaml
@@ -20,7 +20,7 @@
       </Grid>
     </Border>
 
-    <TabControl>
+    <TabControl SelectedIndex="{Binding SelectedTabIndex, Mode=TwoWay}">
       <TabItem Header="Edit">
         <doors:DoorEditorView DataContext="{Binding Editor}" />
       </TabItem>

--- a/SWLOR.Toolset/Editors/Views/DoorDocumentView.axaml
+++ b/SWLOR.Toolset/Editors/Views/DoorDocumentView.axaml
@@ -1,6 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:doors="using:SWLOR.Toolset.Editors.Doors"
+             xmlns:sources="using:SWLOR.Toolset.Editors.Sources"
              x:Class="SWLOR.Toolset.Editors.Doors.DoorDocumentView"
              x:DataType="doors:DoorDocumentViewModel">
   <DockPanel>
@@ -19,6 +20,13 @@
       </Grid>
     </Border>
 
-    <doors:DoorEditorView DataContext="{Binding Editor}" />
+    <TabControl>
+      <TabItem Header="Edit">
+        <doors:DoorEditorView DataContext="{Binding Editor}" />
+      </TabItem>
+      <TabItem Header="Source" IsVisible="{Binding Source, Converter={x:Static ObjectConverters.IsNotNull}}">
+        <sources:ObjectSourceView DataContext="{Binding Source}" />
+      </TabItem>
+    </TabControl>
   </DockPanel>
 </UserControl>

--- a/SWLOR.Toolset/Editors/Views/ItemEditorView.axaml
+++ b/SWLOR.Toolset/Editors/Views/ItemEditorView.axaml
@@ -473,7 +473,7 @@
         </Grid>
       </Border>
 
-      <TabControl Grid.Column="1">
+      <TabControl Grid.Column="1" SelectedIndex="{Binding SelectedTabIndex, Mode=TwoWay}">
         <TabItem Header="Basic">
           <ScrollViewer>
             <Grid ColumnDefinitions="*,Auto" RowDefinitions="Auto,Auto"

--- a/SWLOR.Toolset/Editors/Views/ItemEditorView.axaml
+++ b/SWLOR.Toolset/Editors/Views/ItemEditorView.axaml
@@ -1,6 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:items="using:SWLOR.Toolset.Editors.Items"
+             xmlns:sources="using:SWLOR.Toolset.Editors.Sources"
              xmlns:behaviors="using:SWLOR.Toolset.Editors.Behaviors"
              xmlns:dworkspace="using:SWLOR.Toolset.Domain.Workspace"
              x:Class="SWLOR.Toolset.Editors.Items.ItemEditorView"
@@ -600,10 +601,16 @@
         </TabItem>
 
         <TabItem Header="Source" IsVisible="{Binding ShowsSourceTab}">
-          <ScrollViewer>
+          <Grid RowDefinitions="Auto,*">
+            <Border Grid.Row="0" Height="260"
+                    IsVisible="{Binding PlacementSource, Converter={x:Static ObjectConverters.IsNotNull}}">
+              <sources:ObjectSourceView DataContext="{Binding PlacementSource}" />
+            </Border>
+          <ScrollViewer Grid.Row="1">
             <StackPanel Margin="14,10,22,10" Spacing="8"
                         DataContext="{Binding Source}"
                         x:DataType="items:ItemSourceSectionViewModel">
+              <TextBlock Text="Player obtainability" Classes="section" Margin="0,2,0,3" />
               <TextBlock Text="{Binding Verdict}" FontSize="12.5"
                          Foreground="{DynamicResource GreenBrush}"
                          IsVisible="{Binding IsObtainable}" />
@@ -645,6 +652,7 @@
               </ItemsControl>
             </StackPanel>
           </ScrollViewer>
+          </Grid>
         </TabItem>
 
         <TabItem Header="Variables" IsVisible="{Binding ShowsVariablesTab}">

--- a/SWLOR.Toolset/Editors/Views/MerchantEditorView.axaml
+++ b/SWLOR.Toolset/Editors/Views/MerchantEditorView.axaml
@@ -288,7 +288,7 @@
       </Grid>
     </TabItem>
 
-    <TabItem Header="Placed instances">
+    <TabItem Header="Source">
       <Grid RowDefinitions="Auto,Auto,*" Margin="16,12,22,16" RowSpacing="10">
         <Grid Grid.Row="0" ColumnDefinitions="*,Auto,Auto" ColumnSpacing="8">
           <StackPanel Grid.Column="0">
@@ -320,6 +320,15 @@
             <DataGridTextColumn Header="Item records"
                                 Binding="{Binding OutOfDateItemRecords}" Width="105" />
             <DataGridTextColumn Header="Status" Binding="{Binding SyncState}" Width="110" />
+            <DataGridTemplateColumn Header="" Width="78">
+              <DataGridTemplateColumn.CellTemplate>
+                <DataTemplate DataType="merchants:MerchantInstancePlacement">
+                  <Button Content="Go To"
+                          Command="{Binding $parent[DataGrid].((merchants:MerchantEditorViewModel)DataContext).GoToInstanceCommand}"
+                          CommandParameter="{Binding}" Margin="4,1" />
+                </DataTemplate>
+              </DataGridTemplateColumn.CellTemplate>
+            </DataGridTemplateColumn>
           </DataGrid.Columns>
         </DataGrid>
       </Grid>

--- a/SWLOR.Toolset/Editors/Views/MerchantEditorView.axaml
+++ b/SWLOR.Toolset/Editors/Views/MerchantEditorView.axaml
@@ -325,7 +325,8 @@
                 <DataTemplate DataType="merchants:MerchantInstancePlacement">
                   <Button Content="Go To"
                           Command="{Binding $parent[DataGrid].((merchants:MerchantEditorViewModel)DataContext).GoToInstanceCommand}"
-                          CommandParameter="{Binding}" Margin="4,1" />
+                          CommandParameter="{Binding}" Margin="4,1"
+                          ToolTip.Tip="Go to instance" />
                 </DataTemplate>
               </DataGridTemplateColumn.CellTemplate>
             </DataGridTemplateColumn>

--- a/SWLOR.Toolset/Editors/Views/SoundDocumentView.axaml
+++ b/SWLOR.Toolset/Editors/Views/SoundDocumentView.axaml
@@ -21,7 +21,7 @@
       </Grid>
     </Border>
 
-    <TabControl>
+    <TabControl SelectedIndex="{Binding SelectedTabIndex, Mode=TwoWay}">
       <TabItem Header="Edit">
         <sounds:SoundEditorView DataContext="{Binding Editor}" />
       </TabItem>

--- a/SWLOR.Toolset/Editors/Views/SoundDocumentView.axaml
+++ b/SWLOR.Toolset/Editors/Views/SoundDocumentView.axaml
@@ -1,6 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:sounds="using:SWLOR.Toolset.Editors.Sounds"
+             xmlns:sources="using:SWLOR.Toolset.Editors.Sources"
              x:Class="SWLOR.Toolset.Editors.Sounds.SoundDocumentView"
              x:DataType="sounds:SoundDocumentViewModel">
   <DockPanel>
@@ -20,6 +21,13 @@
       </Grid>
     </Border>
 
-    <sounds:SoundEditorView DataContext="{Binding Editor}" />
+    <TabControl>
+      <TabItem Header="Edit">
+        <sounds:SoundEditorView DataContext="{Binding Editor}" />
+      </TabItem>
+      <TabItem Header="Source" IsVisible="{Binding Source, Converter={x:Static ObjectConverters.IsNotNull}}">
+        <sources:ObjectSourceView DataContext="{Binding Source}" />
+      </TabItem>
+    </TabControl>
   </DockPanel>
 </UserControl>

--- a/SWLOR.Toolset/Editors/Views/TriggerDocumentView.axaml
+++ b/SWLOR.Toolset/Editors/Views/TriggerDocumentView.axaml
@@ -30,7 +30,8 @@
       </Grid>
     </Border>
 
-    <TabControl DataContext="{Binding Editor}" x:DataType="triggers:TriggerEditorViewModel">
+    <TabControl DataContext="{Binding Editor}" x:DataType="triggers:TriggerEditorViewModel"
+                SelectedIndex="{Binding $parent[UserControl].((triggers:TriggerDocumentViewModel)DataContext).SelectedTabIndex, Mode=TwoWay}">
       <TabItem Header="Basic">
         <ScrollViewer>
           <ItemsControl ItemsSource="{Binding BasicRows}" Margin="14,10" />

--- a/SWLOR.Toolset/Editors/Views/TriggerDocumentView.axaml
+++ b/SWLOR.Toolset/Editors/Views/TriggerDocumentView.axaml
@@ -2,6 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:triggers="using:SWLOR.Toolset.Editors.Triggers"
              xmlns:behaviors="using:SWLOR.Toolset.Editors.Behaviors"
+             xmlns:sources="using:SWLOR.Toolset.Editors.Sources"
              x:Class="SWLOR.Toolset.Editors.Triggers.TriggerDocumentView"
              x:DataType="triggers:TriggerDocumentViewModel">
 
@@ -59,6 +60,12 @@
       <!-- Variables exist only under Custom. -->
       <TabItem Header="Variables" IsVisible="{Binding ShowsVariablesTab}">
         <behaviors:VariablesSectionView DataContext="{Binding Variables}" />
+      </TabItem>
+
+      <TabItem Header="Source"
+               DataContext="{Binding $parent[UserControl].((triggers:TriggerDocumentViewModel)DataContext).Source}"
+               IsVisible="{Binding Converter={x:Static ObjectConverters.IsNotNull}}">
+        <sources:ObjectSourceView />
       </TabItem>
     </TabControl>
   </DockPanel>

--- a/SWLOR.Toolset/Editors/Views/WaypointDocumentView.axaml
+++ b/SWLOR.Toolset/Editors/Views/WaypointDocumentView.axaml
@@ -2,6 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:waypoints="using:SWLOR.Toolset.Editors.Waypoints"
              xmlns:behaviors="using:SWLOR.Toolset.Editors.Behaviors"
+             xmlns:sources="using:SWLOR.Toolset.Editors.Sources"
              x:Class="SWLOR.Toolset.Editors.Waypoints.WaypointDocumentView"
              x:DataType="waypoints:WaypointDocumentViewModel">
 
@@ -26,6 +27,13 @@
       </Grid>
     </Border>
 
-    <waypoints:WaypointEditorView DataContext="{Binding Editor}" />
+    <TabControl>
+      <TabItem Header="Edit">
+        <waypoints:WaypointEditorView DataContext="{Binding Editor}" />
+      </TabItem>
+      <TabItem Header="Source" IsVisible="{Binding Source, Converter={x:Static ObjectConverters.IsNotNull}}">
+        <sources:ObjectSourceView DataContext="{Binding Source}" />
+      </TabItem>
+    </TabControl>
   </DockPanel>
 </UserControl>

--- a/SWLOR.Toolset/Editors/Views/WaypointDocumentView.axaml
+++ b/SWLOR.Toolset/Editors/Views/WaypointDocumentView.axaml
@@ -27,7 +27,7 @@
       </Grid>
     </Border>
 
-    <TabControl>
+    <TabControl SelectedIndex="{Binding SelectedTabIndex, Mode=TwoWay}">
       <TabItem Header="Edit">
         <waypoints:WaypointEditorView DataContext="{Binding Editor}" />
       </TabItem>

--- a/SWLOR.Toolset/Editors/Waypoints/WaypointDocumentViewModel.cs
+++ b/SWLOR.Toolset/Editors/Waypoints/WaypointDocumentViewModel.cs
@@ -20,6 +20,7 @@ namespace SWLOR.Toolset.Editors.Waypoints
         private bool _closeApproved;
         private bool _closePromptOpen;
         private bool _disposed;
+        private int _selectedTabIndex;
 
         public WaypointEditorViewModel Editor { get; }
         public Sources.ObjectSourceSectionViewModel? Source { get; }
@@ -29,6 +30,17 @@ namespace SWLOR.Toolset.Editors.Waypoints
         public bool CanRedo => _session.UndoStack.CanRedo;
         public string FilePath => _session.FilePath;
         public string ResRef => _resRef;
+        public int SelectedTabIndex
+        {
+            get => _selectedTabIndex;
+            set
+            {
+                if (_selectedTabIndex == value)
+                    return;
+                _selectedTabIndex = value;
+                OnPropertyChanged();
+            }
+        }
 
         public event Action<WaypointDocumentViewModel>? Closed;
         public event Action<WaypointDocumentViewModel>? CloseRequested;

--- a/SWLOR.Toolset/Editors/Waypoints/WaypointDocumentViewModel.cs
+++ b/SWLOR.Toolset/Editors/Waypoints/WaypointDocumentViewModel.cs
@@ -22,6 +22,7 @@ namespace SWLOR.Toolset.Editors.Waypoints
         private bool _disposed;
 
         public WaypointEditorViewModel Editor { get; }
+        public Sources.ObjectSourceSectionViewModel? Source { get; }
 
         public bool IsDirty => _session.UndoStack.IsDirty;
         public bool CanUndo => _session.UndoStack.CanUndo;
@@ -43,12 +44,14 @@ namespace SWLOR.Toolset.Editors.Waypoints
             WaypointBehaviorCatalog catalog,
             Func<string, IReadOnlyList<BehaviorChoice>>? resolveChoices = null,
             Behaviors.ChoicePreviewService? previews = null,
-            BlueprintSaveCoordinator? saveCoordinator = null)
+            BlueprintSaveCoordinator? saveCoordinator = null,
+            Sources.ObjectSourceSectionViewModel? source = null)
         {
             _log = log;
             _prompts = prompts;
             _resRef = resRef;
             _saveCoordinator = saveCoordinator;
+            Source = source;
             Id = $"waypoint:{filePath}";
             _session = DocumentSession.Open(filePath);
 
@@ -164,6 +167,7 @@ namespace SWLOR.Toolset.Editors.Waypoints
                     _resRef = targetResRef;
                     Id = $"waypoint:{_session.FilePath}";
                     Editor.SetHeaderOwner(targetResRef);
+                    Source?.SetResRef(targetResRef);
                 }
 
                 _session.UndoStack.MarkSaved();

--- a/SWLOR.Toolset/Program.cs
+++ b/SWLOR.Toolset/Program.cs
@@ -1,4 +1,5 @@
 using Avalonia;
+using Serilog;
 
 namespace SWLOR.Toolset
 {
@@ -17,6 +18,35 @@ namespace SWLOR.Toolset
 
         [STAThread]
         public static void Main(string[] args)
-            => BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+        {
+            var logPath = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "SWLOR Toolset",
+                "Logs",
+                "toolset-.log");
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Information()
+                .Enrich.WithProperty("Application", "SWLOR.Toolset")
+                .WriteTo.File(
+                    logPath,
+                    rollingInterval: RollingInterval.Day,
+                    retainedFileCountLimit: 14,
+                    shared: true)
+                .CreateLogger();
+
+            try
+            {
+                BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+            }
+            catch (Exception ex)
+            {
+                Log.Fatal(ex, "SWLOR Toolset terminated unexpectedly.");
+                throw;
+            }
+            finally
+            {
+                Log.CloseAndFlush();
+            }
+        }
     }
 }

--- a/SWLOR.Toolset/SWLOR.Toolset.csproj
+++ b/SWLOR.Toolset/SWLOR.Toolset.csproj
@@ -47,6 +47,8 @@
     <PackageReference Include="Dock.Model.Mvvm" Version="11.3.12.1" />
     <!-- GlAreaControl uses Silk.NET.OpenGL types directly. -->
     <PackageReference Include="Silk.NET.OpenGL" Version="2.23.0" />
+    <PackageReference Include="Serilog" Version="4.4.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SWLOR.Toolset/Services/ErfArchiveService.cs
+++ b/SWLOR.Toolset/Services/ErfArchiveService.cs
@@ -1922,7 +1922,7 @@ namespace SWLOR.Toolset.Services
 
             if (extension.Equals("git", StringComparison.OrdinalIgnoreCase))
             {
-                _workspaceContext.InvalidateTagIndex();
+                _workspaceContext.InvalidateGitIndexes();
                 _workspaceContext.InvalidateScriptUsages();
             }
             else if (extension.Equals("itp", StringComparison.OrdinalIgnoreCase))

--- a/SWLOR.Toolset/Shell/Panels/AreaContentsNodeViewModel.cs
+++ b/SWLOR.Toolset/Shell/Panels/AreaContentsNodeViewModel.cs
@@ -61,6 +61,17 @@ namespace SWLOR.Toolset.Shell.Panels
 
         public bool IsInstance => Kind == AreaContentsNodeKind.Instance;
 
+        /// <summary>
+        /// True when this row identifies placements whose properties can be opened. A group is an
+        /// object-bearing row too; its action opens the first member and says so explicitly.
+        /// </summary>
+        public bool CanOpenProperties =>
+            (Kind is AreaContentsNodeKind.Instance or AreaContentsNodeKind.Group) && Indices.Count > 0;
+
+        public string OpenPropertiesLabel => Kind == AreaContentsNodeKind.Group
+            ? "Open first instance properties..."
+            : "Open properties...";
+
         /// <summary>True for anything a Delete keypress may act on.</summary>
         public bool IsDeletable => Indices.Count > 0;
 

--- a/SWLOR.Toolset/Shell/Panels/AreaContentsViewModel.cs
+++ b/SWLOR.Toolset/Shell/Panels/AreaContentsViewModel.cs
@@ -405,6 +405,17 @@ namespace SWLOR.Toolset.Shell.Panels
             _editor.RevealInstance(node.BlueprintType, node.Indices[0], frameCamera: true);
         }
 
+        /// <summary>Opens the selected placement's editable details in the owning area tab.</summary>
+        [RelayCommand]
+        private void OpenProperties(AreaContentsNodeViewModel? node)
+        {
+            node ??= SelectedRow;
+            if (_editor == null || node is not { Kind: AreaContentsNodeKind.Instance })
+                return;
+
+            _editor.OpenInstanceProperties(node.BlueprintType, node.Indices[0]);
+        }
+
         /// <summary>
         /// Delete: removes the selected row's objects from the area.
         /// </summary>

--- a/SWLOR.Toolset/Shell/Panels/AreaContentsViewModel.cs
+++ b/SWLOR.Toolset/Shell/Panels/AreaContentsViewModel.cs
@@ -410,7 +410,7 @@ namespace SWLOR.Toolset.Shell.Panels
         private void OpenProperties(AreaContentsNodeViewModel? node)
         {
             node ??= SelectedRow;
-            if (_editor == null || node is not { Kind: AreaContentsNodeKind.Instance })
+            if (_editor == null || node is not { CanOpenProperties: true })
                 return;
 
             _editor.OpenInstanceProperties(node.BlueprintType, node.Indices[0]);

--- a/SWLOR.Toolset/Shell/Panels/ModuleExplorerViewModel.cs
+++ b/SWLOR.Toolset/Shell/Panels/ModuleExplorerViewModel.cs
@@ -817,13 +817,15 @@ namespace SWLOR.Toolset.Shell.Panels
                 destinations.Add(folder);
             }
 
-            var changed = false;
             foreach (var folder in section.AllFolders())
-                changed |= folder.RemoveMember(edit.ResRef);
+                folder.RemoveMember(edit.ResRef);
             foreach (var folder in destinations)
-                changed |= folder.AddMember(edit.ResRef);
+                folder.AddMember(edit.ResRef);
 
-            if (changed && !SaveCategories())
+            // Persist even when the in-memory tree already matches the requested destination. This
+            // can be a retry after a refused write: the history entry is intentionally retained, and
+            // success must mean the sidecar on disk now matches the undo/redo state too.
+            if (!SaveCategories())
             {
                 Refresh();
                 return false;

--- a/SWLOR.Toolset/Shell/Panels/ModuleExplorerViewModel.cs
+++ b/SWLOR.Toolset/Shell/Panels/ModuleExplorerViewModel.cs
@@ -430,6 +430,7 @@ namespace SWLOR.Toolset.Shell.Panels
                     FileNewResource(resRef, targetFolder);
 
                     _workspaceContext.RefreshCatalogEntry(ResourceType.Area, resRef);
+                    _workspaceContext.InvalidatePlacementIndex();
                     Refresh();
                     _editorService?.Invoke().TryOpenEditor(ResourceType.Area, resRef);
                 },

--- a/SWLOR.Toolset/Shell/Panels/ModuleExplorerViewModel.cs
+++ b/SWLOR.Toolset/Shell/Panels/ModuleExplorerViewModel.cs
@@ -122,8 +122,10 @@ namespace SWLOR.Toolset.Shell.Panels
 
             PublishTabs();
 
-            _workspaceContext.CatalogEntryRefreshed += (type, _) =>
+            _workspaceContext.CatalogEntryRefreshed += (type, resRef) =>
             {
+                InvalidateMoveHistoryForMissingResource(type, resRef);
+
                 if (type == ResourceType.Dlg)
                 {
                     _dialogueHitsQuery = null;
@@ -133,6 +135,31 @@ namespace SWLOR.Toolset.Shell.Panels
                 if (_workspaceContext.Catalog is { } catalog)
                     RefreshFromCatalog(catalog);
             };
+        }
+
+        /// <summary>
+        /// Rename and delete notifications name the resource that just disappeared. A move edit for
+        /// that identity can no longer be replayed safely: adding its stale resref back to the
+        /// category sidecar would corrupt membership while leaving the renamed file where it is.
+        /// </summary>
+        private void InvalidateMoveHistoryForMissingResource(ResourceType type, string resRef)
+        {
+            if (!_resourceMoveUndo.Concat(_resourceMoveRedo).Any(edit =>
+                    edit.Type == type &&
+                    edit.ResRef.Equals(resRef, StringComparison.OrdinalIgnoreCase)))
+            {
+                return;
+            }
+
+            var workspace = _workspaceContext.Workspace;
+            if (workspace == null)
+                return;
+
+            var stillExists = type == ResourceType.Dlg
+                ? ConversationResRefs(workspace).Contains(resRef, StringComparer.OrdinalIgnoreCase)
+                : workspace.EnumerateResRefs(type).Contains(resRef, StringComparer.OrdinalIgnoreCase);
+            if (!stillExists)
+                ClearResourceMoveHistory();
         }
 
         /// <summary>

--- a/SWLOR.Toolset/Shell/Panels/ModuleExplorerViewModel.cs
+++ b/SWLOR.Toolset/Shell/Panels/ModuleExplorerViewModel.cs
@@ -53,6 +53,8 @@ namespace SWLOR.Toolset.Shell.Panels
 
         private readonly List<ExplorerNodeViewModel> _roots = new();
         private Dictionary<ResourceType, List<CatalogEntry>>? _catalogByType;
+        private readonly Stack<ResourceMoveEdit> _resourceMoveUndo = new();
+        private readonly Stack<ResourceMoveEdit> _resourceMoveRedo = new();
 
         /// <summary>Types whose sidecar section has already been seeded this session.</summary>
         private readonly HashSet<ResourceType> _seeded = new();
@@ -172,6 +174,7 @@ namespace SWLOR.Toolset.Shell.Panels
         /// <summary>Builds the tree for the selected tab.</summary>
         public void Initialize()
         {
+            ClearResourceMoveHistory();
             _catalogByType = null;
             Refresh();
         }
@@ -556,6 +559,7 @@ namespace SWLOR.Toolset.Shell.Panels
 
 
             SaveCategories();
+            ClearResourceMoveHistory();
             Refresh();
         }
 
@@ -588,6 +592,7 @@ namespace SWLOR.Toolset.Shell.Panels
 
             section.RemoveFolder(folder);
             SaveCategories();
+            ClearResourceMoveHistory();
             SelectedRow = null;
             Refresh();
         }
@@ -685,6 +690,13 @@ namespace SWLOR.Toolset.Shell.Panels
             if (section == null || source.Item is not { } item || source.Type != SelectedType)
                 return false;
 
+            var beforeFolderPaths = section.FoldersContaining(item.ResRef)
+                .Select(section.PathKey)
+                .ToArray();
+            var afterFolderPaths = target == null
+                ? Array.Empty<string>()
+                : new[] { section.PathKey(target) };
+
             // Out of wherever it was first: a resref may legally sit in several folders, but a move the
             // builder asked for means one destination, not an extra one. A null destination is Unsorted.
             var changed = false;
@@ -699,8 +711,123 @@ namespace SWLOR.Toolset.Shell.Panels
 
             var saved = SaveCategories();
             Refresh();
+            if (!saved)
+                return false;
+
+            _resourceMoveUndo.Push(new ResourceMoveEdit(
+                SelectedType,
+                item.ResRef,
+                item.PrimaryText,
+                beforeFolderPaths,
+                afterFolderPaths));
+            _resourceMoveRedo.Clear();
+            NotifyResourceMoveHistoryChanged();
+            StatusMessage = target == null
+                ? $"Moved '{item.PrimaryText}' to Unsorted."
+                : $"Moved '{item.PrimaryText}' to '{string.Join(" / ", section.PathTo(target))}'.";
             return saved;
         }
+
+        private bool CanUndoResourceMove() => _resourceMoveUndo.Count > 0;
+
+        [RelayCommand(CanExecute = nameof(CanUndoResourceMove))]
+        private void UndoResourceMove()
+        {
+            if (!_resourceMoveUndo.TryPeek(out var edit) ||
+                !ApplyResourceMove(edit, edit.BeforeFolderPaths, "undo"))
+            {
+                return;
+            }
+
+            _resourceMoveUndo.Pop();
+            _resourceMoveRedo.Push(edit);
+            NotifyResourceMoveHistoryChanged();
+            StatusMessage = $"Undid move of '{edit.DisplayName}'.";
+        }
+
+        private bool CanRedoResourceMove() => _resourceMoveRedo.Count > 0;
+
+        [RelayCommand(CanExecute = nameof(CanRedoResourceMove))]
+        private void RedoResourceMove()
+        {
+            if (!_resourceMoveRedo.TryPeek(out var edit) ||
+                !ApplyResourceMove(edit, edit.AfterFolderPaths, "redo"))
+            {
+                return;
+            }
+
+            _resourceMoveRedo.Pop();
+            _resourceMoveUndo.Push(edit);
+            NotifyResourceMoveHistoryChanged();
+            StatusMessage = $"Redid move of '{edit.DisplayName}'.";
+        }
+
+        private bool ApplyResourceMove(
+            ResourceMoveEdit edit,
+            IReadOnlyList<string> destinationFolderPaths,
+            string operation)
+        {
+            var section = _categories.Section(edit.Type);
+            if (section == null)
+            {
+                ClearResourceMoveHistory();
+                StatusMessage = $"Cannot {operation} the move because its resource section no longer exists.";
+                return false;
+            }
+
+            var destinations = new List<CategoryFolder>();
+            foreach (var path in destinationFolderPaths)
+            {
+                var folder = section.FindByPathKey(path);
+                if (folder == null)
+                {
+                    ClearResourceMoveHistory();
+                    StatusMessage = $"Cannot {operation} the move because folder '{path}' no longer exists.";
+                    Refresh();
+                    return false;
+                }
+
+                destinations.Add(folder);
+            }
+
+            var changed = false;
+            foreach (var folder in section.AllFolders())
+                changed |= folder.RemoveMember(edit.ResRef);
+            foreach (var folder in destinations)
+                changed |= folder.AddMember(edit.ResRef);
+
+            if (changed && !SaveCategories())
+            {
+                Refresh();
+                return false;
+            }
+
+            Refresh();
+            return true;
+        }
+
+        private void ClearResourceMoveHistory()
+        {
+            if (_resourceMoveUndo.Count == 0 && _resourceMoveRedo.Count == 0)
+                return;
+
+            _resourceMoveUndo.Clear();
+            _resourceMoveRedo.Clear();
+            NotifyResourceMoveHistoryChanged();
+        }
+
+        private void NotifyResourceMoveHistoryChanged()
+        {
+            UndoResourceMoveCommand.NotifyCanExecuteChanged();
+            RedoResourceMoveCommand.NotifyCanExecuteChanged();
+        }
+
+        private sealed record ResourceMoveEdit(
+            ResourceType Type,
+            string ResRef,
+            string DisplayName,
+            IReadOnlyList<string> BeforeFolderPaths,
+            IReadOnlyList<string> AfterFolderPaths);
 
 
         /// <summary>

--- a/SWLOR.Toolset/Shell/Views/AreaContentsView.axaml
+++ b/SWLOR.Toolset/Shell/Views/AreaContentsView.axaml
@@ -36,7 +36,15 @@
          list is where the key lands. -->
     <ListBox Grid.Row="1" Background="Transparent" BorderThickness="0"
              ItemsSource="{Binding Rows}" SelectedItem="{Binding SelectedRow}"
-             DoubleTapped="OnRowDoubleTapped" KeyDown="OnRowKeyDown">
+             DoubleTapped="OnRowDoubleTapped" KeyDown="OnRowKeyDown"
+             ContextRequested="OnRowContextRequested">
+      <ListBox.ContextMenu>
+        <ContextMenu>
+          <MenuItem Header="Open properties..."
+                    Command="{Binding OpenPropertiesCommand}"
+                    CommandParameter="{Binding SelectedRow}" />
+        </ContextMenu>
+      </ListBox.ContextMenu>
       <ListBox.Styles>
         <Style Selector="ListBoxItem">
           <Setter Property="Padding" Value="0,2" />
@@ -44,7 +52,8 @@
       </ListBox.Styles>
       <ListBox.ItemTemplate>
         <DataTemplate DataType="panels:AreaContentsNodeViewModel">
-          <Grid ColumnDefinitions="Auto,*,Auto" Margin="{Binding Indent}" Background="Transparent">
+          <Grid ColumnDefinitions="Auto,*,Auto" Margin="{Binding Indent}" Background="Transparent"
+                PointerPressed="OnRowPointerPressed">
 
             <!-- The same wide, short hit box Module Contents gives its twisty: it is the thing
                  aimed at most in a tree and the glyph itself is a 10px target. -->

--- a/SWLOR.Toolset/Shell/Views/AreaContentsView.axaml
+++ b/SWLOR.Toolset/Shell/Views/AreaContentsView.axaml
@@ -36,15 +36,7 @@
          list is where the key lands. -->
     <ListBox Grid.Row="1" Background="Transparent" BorderThickness="0"
              ItemsSource="{Binding Rows}" SelectedItem="{Binding SelectedRow}"
-             DoubleTapped="OnRowDoubleTapped" KeyDown="OnRowKeyDown"
-             ContextRequested="OnRowContextRequested">
-      <ListBox.ContextMenu>
-        <ContextMenu>
-          <MenuItem Header="Open properties..."
-                    Command="{Binding OpenPropertiesCommand}"
-                    CommandParameter="{Binding SelectedRow}" />
-        </ContextMenu>
-      </ListBox.ContextMenu>
+             DoubleTapped="OnRowDoubleTapped" KeyDown="OnRowKeyDown">
       <ListBox.Styles>
         <Style Selector="ListBoxItem">
           <Setter Property="Padding" Value="0,2" />
@@ -53,7 +45,12 @@
       <ListBox.ItemTemplate>
         <DataTemplate DataType="panels:AreaContentsNodeViewModel">
           <Grid ColumnDefinitions="Auto,*,Auto" Margin="{Binding Indent}" Background="Transparent"
-                PointerPressed="OnRowPointerPressed">
+                PointerPressed="OnRowPointerPressed" ContextRequested="OnRowContextRequested">
+            <Grid.ContextMenu>
+              <ContextMenu>
+                <MenuItem Header="Open properties..." Click="OnOpenPropertiesClick" />
+              </ContextMenu>
+            </Grid.ContextMenu>
 
             <!-- The same wide, short hit box Module Contents gives its twisty: it is the thing
                  aimed at most in a tree and the glyph itself is a 10px target. -->

--- a/SWLOR.Toolset/Shell/Views/AreaContentsView.axaml
+++ b/SWLOR.Toolset/Shell/Views/AreaContentsView.axaml
@@ -48,7 +48,7 @@
                 PointerPressed="OnRowPointerPressed" ContextRequested="OnRowContextRequested">
             <Grid.ContextMenu>
               <ContextMenu>
-                <MenuItem Header="Open properties..." Click="OnOpenPropertiesClick" />
+                <MenuItem Header="{Binding OpenPropertiesLabel}" Click="OnOpenPropertiesClick" />
               </ContextMenu>
             </Grid.ContextMenu>
 

--- a/SWLOR.Toolset/Shell/Views/AreaContentsView.axaml.cs
+++ b/SWLOR.Toolset/Shell/Views/AreaContentsView.axaml.cs
@@ -11,6 +11,25 @@ namespace SWLOR.Toolset.Shell.Views
             InitializeComponent();
         }
 
+        /// <summary>Right-click selects the row under the pointer before its menu is evaluated.</summary>
+        private void OnRowPointerPressed(object? sender, PointerPressedEventArgs e)
+        {
+            if (!e.GetCurrentPoint(this).Properties.IsRightButtonPressed ||
+                sender is not Control { DataContext: AreaContentsNodeViewModel node } ||
+                DataContext is not AreaContentsViewModel viewModel)
+                return;
+
+            viewModel.SelectedRow = node;
+        }
+
+        /// <summary>Branches have no properties menu; their right-click remains inert.</summary>
+        private void OnRowContextRequested(object? sender, ContextRequestedEventArgs e)
+        {
+            if (DataContext is not AreaContentsViewModel
+                { SelectedRow.Kind: AreaContentsNodeKind.Instance })
+                e.Handled = true;
+        }
+
         /// <summary>Opening a row sends the camera to the object, or opens the branch.</summary>
         private void OnRowDoubleTapped(object? sender, TappedEventArgs e)
         {

--- a/SWLOR.Toolset/Shell/Views/AreaContentsView.axaml.cs
+++ b/SWLOR.Toolset/Shell/Views/AreaContentsView.axaml.cs
@@ -32,7 +32,7 @@ namespace SWLOR.Toolset.Shell.Views
         private void OnRowContextRequested(object? sender, ContextRequestedEventArgs e)
         {
             if (sender is not Control
-                { DataContext: AreaContentsNodeViewModel { IsInstance: true } node } ||
+                { DataContext: AreaContentsNodeViewModel { CanOpenProperties: true } node } ||
                 DataContext is not AreaContentsViewModel viewModel)
             {
                 _contextRow = null;
@@ -42,6 +42,14 @@ namespace SWLOR.Toolset.Shell.Views
 
             _contextRow = node;
             viewModel.SelectedRow = node;
+
+            // Open explicitly instead of depending on the ContextMenu attached-property handler's
+            // ordering relative to the ListBox's routed event. The latter works headlessly but can
+            // be swallowed by the realised ListBoxItem on Windows before the popup opens.
+            if (sender is Control { ContextMenu: { } menu } owner && !menu.IsOpen)
+                menu.Open(owner);
+
+            e.Handled = true;
         }
 
         private void OnOpenPropertiesClick(object? sender, RoutedEventArgs e)

--- a/SWLOR.Toolset/Shell/Views/AreaContentsView.axaml.cs
+++ b/SWLOR.Toolset/Shell/Views/AreaContentsView.axaml.cs
@@ -1,11 +1,14 @@
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using SWLOR.Toolset.Shell.Panels;
 
 namespace SWLOR.Toolset.Shell.Views
 {
     public partial class AreaContentsView : UserControl
     {
+        private AreaContentsNodeViewModel? _contextRow;
+
         public AreaContentsView()
         {
             InitializeComponent();
@@ -22,12 +25,31 @@ namespace SWLOR.Toolset.Shell.Views
             viewModel.SelectedRow = node;
         }
 
-        /// <summary>Branches have no properties menu; their right-click remains inert.</summary>
+        /// <summary>
+        /// The menu belongs to the realised row rather than the ListBox, so empty-space clicks have
+        /// no menu to open and can never act on an earlier selection.
+        /// </summary>
         private void OnRowContextRequested(object? sender, ContextRequestedEventArgs e)
         {
-            if (DataContext is not AreaContentsViewModel
-                { SelectedRow.Kind: AreaContentsNodeKind.Instance })
+            if (sender is not Control
+                { DataContext: AreaContentsNodeViewModel { IsInstance: true } node } ||
+                DataContext is not AreaContentsViewModel viewModel)
+            {
+                _contextRow = null;
                 e.Handled = true;
+                return;
+            }
+
+            _contextRow = node;
+            viewModel.SelectedRow = node;
+        }
+
+        private void OnOpenPropertiesClick(object? sender, RoutedEventArgs e)
+        {
+            if (DataContext is AreaContentsViewModel viewModel && _contextRow != null)
+                viewModel.OpenPropertiesCommand.Execute(_contextRow);
+
+            _contextRow = null;
         }
 
         /// <summary>Opening a row sends the camera to the object, or opens the branch.</summary>

--- a/SWLOR.Toolset/Shell/Views/ModuleExplorerView.axaml
+++ b/SWLOR.Toolset/Shell/Views/ModuleExplorerView.axaml
@@ -54,7 +54,7 @@
     <Grid Grid.Row="2">
       <ListBox x:Name="ModuleTree" Background="Transparent" BorderThickness="0"
                ItemsSource="{Binding Rows}" SelectedItem="{Binding SelectedRow}"
-               DoubleTapped="OnItemsDoubleTapped">
+               DoubleTapped="OnItemsDoubleTapped" KeyDown="OnModuleTreeKeyDown">
         <ListBox.Styles>
           <Style Selector="ListBoxItem">
             <Setter Property="Padding" Value="0,2" />

--- a/SWLOR.Toolset/Shell/Views/ModuleExplorerView.axaml.cs
+++ b/SWLOR.Toolset/Shell/Views/ModuleExplorerView.axaml.cs
@@ -11,6 +11,7 @@ namespace SWLOR.Toolset.Shell.Views
         private ExplorerNodeViewModel? _dragSource;
         private ExplorerNodeViewModel? _dropTarget;
         private Control? _dragSurface;
+        private IPointer? _capturedPointer;
         private ListBoxItem? _dragSourceContainer;
         private ListBoxItem? _dropTargetContainer;
         private Avalonia.Point _dragStart;
@@ -53,7 +54,35 @@ namespace SWLOR.Toolset.Shell.Views
             _dragStart = e.GetPosition(ModuleTree);
             if (DataContext is ModuleExplorerViewModel viewModel)
                 viewModel.SelectedRow = row;
+            _capturedPointer = e.Pointer;
             e.Pointer.Capture(surface);
+        }
+
+        private void OnModuleTreeKeyDown(object? sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Escape && _dragSource != null)
+            {
+                CancelRowDrag();
+                e.Handled = true;
+                return;
+            }
+
+            if (DataContext is not ModuleExplorerViewModel viewModel)
+                return;
+
+            if (e.Key == Key.Z && e.KeyModifiers == KeyModifiers.Control &&
+                viewModel.UndoResourceMoveCommand.CanExecute(null))
+            {
+                viewModel.UndoResourceMoveCommand.Execute(null);
+                e.Handled = true;
+            }
+            else if (((e.Key == Key.Y && e.KeyModifiers == KeyModifiers.Control) ||
+                      (e.Key == Key.Z && e.KeyModifiers == (KeyModifiers.Control | KeyModifiers.Shift))) &&
+                     viewModel.RedoResourceMoveCommand.CanExecute(null))
+            {
+                viewModel.RedoResourceMoveCommand.Execute(null);
+                e.Handled = true;
+            }
         }
 
         private void OnRowPointerMoved(object? sender, PointerEventArgs e)
@@ -163,13 +192,15 @@ namespace SWLOR.Toolset.Shell.Views
 
         private void CancelRowDrag(IPointer? pointer = null)
         {
+            var pointerToRelease = pointer ?? _capturedPointer;
             _dragSourceContainer?.Classes.Remove("drag-source");
             ClearDropTarget();
             _dragSource = null;
             _dragSurface = null;
+            _capturedPointer = null;
             _dragSourceContainer = null;
             _isDragging = false;
-            pointer?.Capture(null);
+            pointerToRelease?.Capture(null);
         }
     }
 }

--- a/SWLOR.Toolset/Viewport/AreaViewportState.cs
+++ b/SWLOR.Toolset/Viewport/AreaViewportState.cs
@@ -1,0 +1,16 @@
+using System.Numerics;
+
+namespace SWLOR.Toolset.Viewport
+{
+    /// <summary>
+    /// The complete orbit-camera state that belongs to an open area document. The GL control is a
+    /// transient view and can be recreated as dock tabs change; this snapshot lets the document put
+    /// a replacement control back exactly where the builder left it.
+    /// </summary>
+    public readonly record struct AreaViewportState(
+        Vector3 Target,
+        float Distance,
+        float InitialDistance,
+        float Azimuth,
+        float Elevation);
+}

--- a/SWLOR.Toolset/Viewport/GlAreaControl.cs
+++ b/SWLOR.Toolset/Viewport/GlAreaControl.cs
@@ -949,6 +949,20 @@ void main()
         /// <summary>True when this instance should draw its resolved model rather than a marker.</summary>
         private static bool DrawsAsModel(InstanceMarker instance) => instance.Model != null;
 
+        /// <summary>
+        /// Whether the placed model can use NWN's ordinary back-face culling pass.
+        /// </summary>
+        /// <remarks>
+        /// Dynamic creature bodies are assembled from independently-authored body, armor, helmet,
+        /// cloak, and weapon parts. Their triangle winding is not consistent across those resources;
+        /// applying the tile/placeable culling rule to the combined model discards visible equipment
+        /// even though the same geometry renders correctly in the two-sided blueprint preview.
+        /// Creature counts are small compared with area placeables, so drawing them two-sided fixes
+        /// the authored equipment without giving up culling on the thousands of props in dense areas.
+        /// </remarks>
+        private static bool CullInstanceModelFaces(InstanceMarkerKind kind) =>
+            kind != InstanceMarkerKind.Creature;
+
         /// <summary>Layered resource index used to resolve tile/mesh textures and MTR materials. Null degrades every mesh to a flat gray fallback.</summary>
         public ResourceIndex? ResourceIndex { get; set; }
 
@@ -3072,51 +3086,67 @@ void main()
             var preview = PreviewAnimation();
             var previewNeedsFrames = false;
 
-            BeginModelFaceCulling();
-            foreach (var raw in scene.Instances)
+            var faceCullingEnabled = false;
+            try
             {
-                if (!DrawsAsModel(raw))
-                    continue;
-
-                var instance = Displayed(raw);
-
-                // Culled like the tile pass already is. esriauncharted holds 5,249 placeables and each
-                // visible-model instance issues several draw calls, so submitting every one of them every
-                // frame made a dense area unusable however little of it was on screen.
-                if (!IsInstanceVisible(instance))
-                    continue;
-
-                var instanceTransform = AreaPicking.ComputeInstanceTransform(instance);
-
-                var buffer = GetOrBuildModelBuffer(raw.Model!);
-                previewNeedsFrames |= preview.Running &&
-                                      buffer.Animations.Any(animation =>
-                                          string.Equals(
-                                              animation.Name,
-                                              preview.Name,
-                                              StringComparison.OrdinalIgnoreCase) &&
-                                          animation.IsPlayable);
-                _gl!.BindVertexArray(buffer.Vao);
-                SetUniformBool("unlit", false);
-                UseLayerColors(instance.LayerColorIndices, raw.Model);
-
-                foreach (var meshRange in buffer.MeshRanges)
+                foreach (var raw in scene.Instances)
                 {
-                    SetUniformMatrix4(
-                        "model",
-                        PreviewMeshTransform(meshRange, buffer, preview, idleElapsed) * instanceTransform);
-                    BindMeshTexture(meshRange.TextureName);
+                    if (!DrawsAsModel(raw))
+                        continue;
 
-                    unsafe
+                    var instance = Displayed(raw);
+
+                    // Culled like the tile pass already is. esriauncharted holds 5,249 placeables and each
+                    // visible-model instance issues several draw calls, so submitting every one of them every
+                    // frame made a dense area unusable however little of it was on screen.
+                    if (!IsInstanceVisible(instance))
+                        continue;
+
+                    var shouldCullFaces = CullInstanceModelFaces(raw.Kind);
+                    if (shouldCullFaces != faceCullingEnabled)
                     {
-                        _gl.DrawElements(PrimitiveType.Triangles, (uint)meshRange.IndexCount,
-                            DrawElementsType.UnsignedInt,
-                            (void*)PreviewMeshIndexOffset(meshRange, buffer, preview, idleElapsed));
+                        if (shouldCullFaces)
+                            BeginModelFaceCulling();
+                        else
+                            EndModelFaceCulling();
+                        faceCullingEnabled = shouldCullFaces;
+                    }
+
+                    var instanceTransform = AreaPicking.ComputeInstanceTransform(instance);
+
+                    var buffer = GetOrBuildModelBuffer(raw.Model!);
+                    previewNeedsFrames |= preview.Running &&
+                                          buffer.Animations.Any(animation =>
+                                              string.Equals(
+                                                  animation.Name,
+                                                  preview.Name,
+                                                  StringComparison.OrdinalIgnoreCase) &&
+                                              animation.IsPlayable);
+                    _gl!.BindVertexArray(buffer.Vao);
+                    SetUniformBool("unlit", false);
+                    UseLayerColors(instance.LayerColorIndices, raw.Model);
+
+                    foreach (var meshRange in buffer.MeshRanges)
+                    {
+                        SetUniformMatrix4(
+                            "model",
+                            PreviewMeshTransform(meshRange, buffer, preview, idleElapsed) * instanceTransform);
+                        BindMeshTexture(meshRange.TextureName);
+
+                        unsafe
+                        {
+                            _gl.DrawElements(PrimitiveType.Triangles, (uint)meshRange.IndexCount,
+                                DrawElementsType.UnsignedInt,
+                                (void*)PreviewMeshIndexOffset(meshRange, buffer, preview, idleElapsed));
+                        }
                     }
                 }
             }
-
-            EndModelFaceCulling();
+            finally
+            {
+                if (faceCullingEnabled)
+                    EndModelFaceCulling();
+            }
 
             DrawPreviewEmitters(scene, preview);
             if (previewNeedsFrames)
@@ -3544,6 +3574,7 @@ void main()
                 Position = position,
                 Orientation = _snappedDoorAnchor?.Orientation ?? ghost.Orientation,
                 VisualTransform = ghost.VisualTransform,
+                LayerColorIndices = ghost.LayerColorIndices,
                 Model = ghost.Model
             };
 
@@ -3564,6 +3595,7 @@ void main()
             {
                 var buffer = GetOrBuildModelBuffer(placed.Model!);
                 _gl.BindVertexArray(buffer.Vao);
+                UseLayerColors(placed.LayerColorIndices, placed.Model);
 
                 if (refused)
                 {
@@ -3573,7 +3605,9 @@ void main()
                     SetUniformVec3("flatColor", PlacementRefusedColor);
                 }
 
-                BeginModelFaceCulling();
+                var cullFaces = CullInstanceModelFaces(placed.Kind);
+                if (cullFaces)
+                    BeginModelFaceCulling();
                 try
                 {
                     foreach (var meshRange in buffer.MeshRanges)
@@ -3591,7 +3625,8 @@ void main()
                 }
                 finally
                 {
-                    EndModelFaceCulling();
+                    if (cullFaces)
+                        EndModelFaceCulling();
                 }
             }
             else if (_markerMeshBuffer is { } marker)

--- a/SWLOR.Toolset/Viewport/GlAreaControl.cs
+++ b/SWLOR.Toolset/Viewport/GlAreaControl.cs
@@ -323,6 +323,10 @@ void main()
 
             public string? TextureName { get; init; }
 
+            /// <summary>Equipment-specific PLT dyes; empty means use the instance/model palette.</summary>
+            public IReadOnlyDictionary<int, int> LayerColorIndices { get; init; } =
+                new Dictionary<int, int>();
+
             /// <summary>
             /// The source node's MDL <c>tilefade</c> flag - see <see cref="RenderMesh.TileFade"/>.
             /// Non-zero marks the tileset's own overhead geometry, which the tile pass drops unless
@@ -3124,13 +3128,13 @@ void main()
                                               animation.IsPlayable);
                     _gl!.BindVertexArray(buffer.Vao);
                     SetUniformBool("unlit", false);
-                    UseLayerColors(instance.LayerColorIndices, raw.Model);
-
                     foreach (var meshRange in buffer.MeshRanges)
                     {
                         SetUniformMatrix4(
                             "model",
                             PreviewMeshTransform(meshRange, buffer, preview, idleElapsed) * instanceTransform);
+                        UseLayerColors(
+                            meshRange.LayerColorIndices, instance.LayerColorIndices, raw.Model);
                         BindMeshTexture(meshRange.TextureName);
 
                         unsafe
@@ -3595,8 +3599,6 @@ void main()
             {
                 var buffer = GetOrBuildModelBuffer(placed.Model!);
                 _gl.BindVertexArray(buffer.Vao);
-                UseLayerColors(placed.LayerColorIndices, placed.Model);
-
                 if (refused)
                 {
                     SetUniformBool("hasTexture", false);
@@ -3614,7 +3616,11 @@ void main()
                     {
                         SetUniformMatrix4("model", meshRange.MeshTransform * transform);
                         if (!refused)
+                        {
+                            UseLayerColors(
+                                meshRange.LayerColorIndices, placed.LayerColorIndices, placed.Model);
                             BindMeshTexture(meshRange.TextureName);
+                        }
 
                         unsafe
                         {
@@ -4555,6 +4561,7 @@ void main()
                     AnimationFrames = mesh.AnimationFrames,
                     AnimationIndexOffsets = animationIndexOffsets,
                     TextureName = string.IsNullOrEmpty(mesh.TextureName) ? null : mesh.TextureName,
+                    LayerColorIndices = mesh.LayerColorIndices,
                     TileFade = mesh.TileFade
                 });
             }
@@ -4596,10 +4603,18 @@ void main()
         /// trigger. PLT surfaces are only coloured at load, so this has to be set before the first
         /// BindMeshTexture of the model and stays set for the rest of its draw.
         /// </summary>
-        private void UseLayerColors(IReadOnlyDictionary<int, int>? instanceColors, RenderModel? model)
+        private void UseLayerColors(
+            IReadOnlyDictionary<int, int>? meshColors,
+            IReadOnlyDictionary<int, int>? instanceColors,
+            RenderModel? model)
         {
-            // The instance wins: it can change dye without the model being rebuilt.
-            var colors = instanceColors is { Count: > 0 } ? instanceColors : model?.LayerColorIndices;
+            // A garment's own item dyes win over the creature instance's chest-armor palette. The
+            // instance remains next because it can change its body/armor dye without rebuilding.
+            var colors = meshColors is { Count: > 0 }
+                ? meshColors
+                : instanceColors is { Count: > 0 }
+                    ? instanceColors
+                    : model?.LayerColorIndices;
             if (colors == null || colors.Count == 0)
             {
                 _layerColors = null;

--- a/SWLOR.Toolset/Viewport/GlAreaControl.cs
+++ b/SWLOR.Toolset/Viewport/GlAreaControl.cs
@@ -465,6 +465,13 @@ void main()
         private float _initialDistance = 50f;
         private Vector3 _cameraEye;
 
+        /// <summary>
+        /// A Go To request can arrive while an area is still being built. Applying it immediately
+        /// would be lost when the first scene performs its initial framing, so retain the newest
+        /// request until that scene has been attached.
+        /// </summary>
+        private Vector3? _pendingFocus;
+
         /// <summary>Whether this control has ever framed a scene - see the <c>Scene</c> setter.</summary>
         private bool _cameraFramed;
 
@@ -1067,6 +1074,12 @@ void main()
                 {
                     _cameraFramed = true;
                     ResetCameraForScene(value);
+                }
+
+                if (value != null && _pendingFocus is { } pendingFocus)
+                {
+                    _pendingFocus = null;
+                    ApplyFocus(pendingFocus);
                 }
 
                 RequestNextFrameRendering();
@@ -2270,11 +2283,22 @@ void main()
         /// </remarks>
         public void FocusOn(Vector3 position)
         {
+            if (Scene == null)
+            {
+                _pendingFocus = position;
+                return;
+            }
+
+            _pendingFocus = null;
+            ApplyFocus(position);
+            RequestNextFrameRendering();
+        }
+
+        private void ApplyFocus(Vector3 position)
+        {
             _target = position;
             _distance = AreaCameraMath.ClampDistance(
                 MathF.Min(_distance, FocusDistance), _initialDistance);
-
-            RequestNextFrameRendering();
         }
 
         public void HandlePointerWheel(PointerWheelEventArgs e)

--- a/SWLOR.Toolset/Viewport/GlAreaControl.cs
+++ b/SWLOR.Toolset/Viewport/GlAreaControl.cs
@@ -479,6 +479,12 @@ void main()
         /// <summary>Whether this control has ever framed a scene - see the <c>Scene</c> setter.</summary>
         private bool _cameraFramed;
 
+        /// <summary>
+        /// A restored camera arrived before its first scene. That scene still supplies the baseline
+        /// used to compare later rebuilds, but must not replace the restored orbit itself.
+        /// </summary>
+        private bool _restoredCameraAwaitingScene;
+
         /// <summary>Captures the current orbit camera once a scene has supplied its framing scale.</summary>
         public AreaViewportState? CaptureViewportState()
         {
@@ -504,6 +510,18 @@ void main()
             _azimuth = state.Azimuth;
             _elevation = AreaCameraMath.ClampElevation(state.Elevation);
             _cameraFramed = true;
+            if (Scene == null)
+            {
+                _framedTarget = _target;
+                _framedDistance = _distance;
+                _restoredCameraAwaitingScene = true;
+            }
+            else
+            {
+                // The current scene has already supplied the correct comparison baseline. Restoring
+                // a panned/zoomed camera must not replace it with the user's current orbit.
+                _restoredCameraAwaitingScene = false;
+            }
             RequestNextFrameRendering();
         }
 
@@ -1088,7 +1106,12 @@ void main()
                 // that distance when the base type changed to a 1.9m mannequin (and the reverse
                 // showing an item as a speck). An appearance edit rebuilds geometry of about the
                 // same size, so it compares equal here and keeps the builder's view.
-                if (value != null && (!_cameraFramed || NeedsRefit(value)))
+                if (value != null && _restoredCameraAwaitingScene)
+                {
+                    _restoredCameraAwaitingScene = false;
+                    RecordSceneFramingBaseline(value);
+                }
+                else if (value != null && (!_cameraFramed || NeedsRefit(value)))
                 {
                     _cameraFramed = true;
                     ResetCameraForScene(value);
@@ -1155,15 +1178,10 @@ void main()
 
         private void ResetCameraForScene(AreaScene scene)
         {
-            var aspect = _viewportWidth > 0 && _viewportHeight > 0
-                ? (float)_viewportWidth / _viewportHeight
-                : 1.5f;
-
             // A single-model preview scene frames the MODEL where it stands, not the grid it
             // nominally sits on - otherwise the camera sits back far enough to hold a whole 10m
             // tile and an item renders as a speck.
-            var (target, distance) = AreaCameraMath.ComputeSceneFraming(
-                scene, AreaSceneBuilder.TileSize, VerticalFovRadians, aspect);
+            var (target, distance) = SceneFraming(scene);
 
             _target = target;
             _distance = distance;
@@ -1179,6 +1197,20 @@ void main()
             _elevation = isSingleModelPreview
                 ? PreviewElevationRadians
                 : AreaCameraMath.DefaultElevationRadians;
+        }
+
+        private void RecordSceneFramingBaseline(AreaScene scene)
+        {
+            (_framedTarget, _framedDistance) = SceneFraming(scene);
+        }
+
+        private (Vector3 Target, float Distance) SceneFraming(AreaScene scene)
+        {
+            var aspect = _viewportWidth > 0 && _viewportHeight > 0
+                ? (float)_viewportWidth / _viewportHeight
+                : 1.5f;
+            return AreaCameraMath.ComputeSceneFraming(
+                scene, AreaSceneBuilder.TileSize, VerticalFovRadians, aspect);
         }
 
         // ----- Pointer input: middle orbits, middle+left pans, wheel zooms -----

--- a/SWLOR.Toolset/Viewport/GlAreaControl.cs
+++ b/SWLOR.Toolset/Viewport/GlAreaControl.cs
@@ -4437,6 +4437,8 @@ void main()
             return data;
         }
 
+        private static readonly Vector3 AuroraWaypointMarkerColor = new(0.98f, 0.80f, 0.10f);
+
         private static Vector3 MarkerColor(InstanceMarkerKind kind) => kind switch
         {
             InstanceMarkerKind.Creature => new Vector3(0.85f, 0.15f, 0.15f),
@@ -4444,10 +4446,11 @@ void main()
             InstanceMarkerKind.Item => new Vector3(0.9f, 0.85f, 0.2f),
             InstanceMarkerKind.Placeable => new Vector3(0.2f, 0.45f, 0.9f),
             InstanceMarkerKind.Sound => new Vector3(0.2f, 0.8f, 0.8f),
-            InstanceMarkerKind.Store => new Vector3(0.2f, 0.8f, 0.3f),
+            // Aurora represents merchants with the same yellow marker it uses for waypoints.
+            InstanceMarkerKind.Store => AuroraWaypointMarkerColor,
             InstanceMarkerKind.Trigger => new Vector3(0.95f, 0.55f, 0.15f),
             // Aurora's waypoint yellow, for a waypoint whose appearance row names no model.
-            InstanceMarkerKind.Waypoint => new Vector3(0.98f, 0.80f, 0.10f),
+            InstanceMarkerKind.Waypoint => AuroraWaypointMarkerColor,
             _ => new Vector3(0.7f, 0.7f, 0.7f)
         };
 

--- a/SWLOR.Toolset/Viewport/GlAreaControl.cs
+++ b/SWLOR.Toolset/Viewport/GlAreaControl.cs
@@ -468,6 +468,37 @@ void main()
         /// <summary>Whether this control has ever framed a scene - see the <c>Scene</c> setter.</summary>
         private bool _cameraFramed;
 
+        /// <summary>Captures the current orbit camera once a scene has supplied its framing scale.</summary>
+        public AreaViewportState? CaptureViewportState()
+        {
+            if (!_cameraFramed)
+                return null;
+
+            return new AreaViewportState(
+                _target, _distance, _initialDistance, _azimuth, _elevation);
+        }
+
+        /// <summary>Restores a camera saved by the owning area document.</summary>
+        public void RestoreViewportState(AreaViewportState state)
+        {
+            if (!IsFinite(state.Target) ||
+                !float.IsFinite(state.Distance) || state.Distance <= 0f ||
+                !float.IsFinite(state.InitialDistance) || state.InitialDistance <= 0f ||
+                !float.IsFinite(state.Azimuth) || !float.IsFinite(state.Elevation))
+                return;
+
+            _target = state.Target;
+            _initialDistance = state.InitialDistance;
+            _distance = AreaCameraMath.ClampDistance(state.Distance, _initialDistance);
+            _azimuth = state.Azimuth;
+            _elevation = AreaCameraMath.ClampElevation(state.Elevation);
+            _cameraFramed = true;
+            RequestNextFrameRendering();
+        }
+
+        private static bool IsFinite(Vector3 value) =>
+            float.IsFinite(value.X) && float.IsFinite(value.Y) && float.IsFinite(value.Z);
+
         /// <summary>What the camera was last fitted to, so <see cref="NeedsRefit"/> can tell a
         /// same-size rebuild from a genuinely different model.</summary>
         private Vector3 _framedTarget;

--- a/SWLOR.Toolset/Workspace/BlueprintPreviewRenderer.cs
+++ b/SWLOR.Toolset/Workspace/BlueprintPreviewRenderer.cs
@@ -572,14 +572,14 @@ namespace SWLOR.Toolset.Workspace
             // translations shared with the wearer. Those missing channels must inherit the wearer's
             // bind pose; taking them from the robe's zeroed skin skeleton collapses the legs upward.
             var skinParts = new List<(BlueprintModelPart Part, MdlModel Model)>();
-            var rigidParts = new List<(string PartType, string ModelResRef)>();
+            var rigidParts = new List<BlueprintModelPart>();
             foreach (var part in parts)
             {
                 var model = LoadMdl(part.ModelResRef, withSupermodelAnims: false);
                 if (model != null && MdlMeshBuilder.ContainsNamedSkinWeights(model))
                     skinParts.Add((part, model));
                 else
-                    rigidParts.Add((part.PartType, part.ModelResRef));
+                    rigidParts.Add(part);
             }
 
             var renderModels = new List<RenderModel>();
@@ -619,22 +619,33 @@ namespace SWLOR.Toolset.Workspace
             if (rigidParts.Count > 0)
             {
                 MdlModel? composed;
+                IReadOnlyList<IReadOnlyDictionary<int, int>?> rigidLayerColors =
+                    Array.Empty<IReadOnlyDictionary<int, int>?>();
                 lock (_composerGate)
                 {
                     // _partTextures is filled by LoadComposerModel as the composer pulls each part in,
                     // so it has to be cleared and read inside the same lock that owns the compose run.
                     _partTextures.Clear();
-                    composed = _partComposer.Compose(skeletonResRef, rigidParts, adjustSeams: true);
+                    composed = _partComposer.Compose(
+                        skeletonResRef,
+                        rigidParts.Select(part => (part.PartType, part.ModelResRef)).ToList(),
+                        adjustSeams: true);
                     if (composed != null)
+                    {
+                        rigidLayerColors = CaptureComposedLayerColors(composed, rigidParts);
+                        ApplyComposedTextureOverrides(composed, rigidParts);
                         _partTextures.Restore(composed, TextureExists);
+                    }
                 }
 
                 if (composed != null)
                 {
                     var frames = sharedFrames ?? IdleFrames(composed);
-                    renderModels.Add(includeCreatureAnimations
+                    var rigidModel = includeCreatureAnimations
                         ? MdlMeshBuilder.BuildAnimatedPreview(composed, frames, sharedAnimations)
-                        : MdlMeshBuilder.Build(composed, frames));
+                        : MdlMeshBuilder.Build(composed, frames);
+                    ApplyLayerColors(rigidModel, rigidLayerColors);
+                    renderModels.Add(rigidModel);
                 }
             }
 
@@ -651,6 +662,7 @@ namespace SWLOR.Toolset.Workspace
 
             renderModels.AddRange(skinParts.Select(part =>
             {
+                ApplyTextureOverride(part.Model, part.Part.TextureResRef);
                 var frames = sharedFrames ?? IdleFrames(part.Model);
                 var model = includeCreatureAnimations
                     ? MdlMeshBuilder.BuildAnimatedPreview(part.Model, frames, sharedAnimations)
@@ -665,6 +677,88 @@ namespace SWLOR.Toolset.Workspace
             }));
 
             return CombineRenderModels(skeletonResRef, renderModels);
+        }
+
+        /// <summary>
+        /// Applies cloakmodel.2da's surface selection before authored-texture restoration. The part
+        /// composer stamps each attached mesh with its source model resref, which makes that value a
+        /// reliable key even when two cloak appearances share the same geometry.
+        /// </summary>
+        private static void ApplyComposedTextureOverrides(
+            MdlModel composed,
+            IReadOnlyList<BlueprintModelPart> parts)
+        {
+            var overrides = parts
+                .Where(part => !string.IsNullOrWhiteSpace(part.TextureResRef))
+                .GroupBy(part => part.ModelResRef, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(
+                    group => group.Key,
+                    group => group.Last().TextureResRef!,
+                    StringComparer.OrdinalIgnoreCase);
+            if (overrides.Count == 0)
+                return;
+
+            foreach (var mesh in composed.GetMeshNodes())
+            {
+                if (overrides.TryGetValue(mesh.Bitmap, out var textureResRef))
+                    mesh.Bitmap = textureResRef;
+            }
+        }
+
+        /// <summary>
+        /// Captures each composed mesh's equipment palette while the composer's model-resref stamp is
+        /// still present. Texture restoration deliberately replaces that stamp, so the association
+        /// must be retained before surfaces are corrected.
+        /// </summary>
+        private static IReadOnlyList<IReadOnlyDictionary<int, int>?> CaptureComposedLayerColors(
+            MdlModel composed,
+            IReadOnlyList<BlueprintModelPart> parts)
+        {
+            var colorsByModel = parts
+                .Where(part => part.LayerColorIndices is { Count: > 0 })
+                .GroupBy(part => part.ModelResRef, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(
+                    group => group.Key,
+                    group => group.Last().LayerColorIndices!,
+                    StringComparer.OrdinalIgnoreCase);
+            var result = new List<IReadOnlyDictionary<int, int>?>();
+            foreach (var mesh in composed.GetMeshNodes())
+            {
+                // Keep this filter aligned with MdlMeshBuilder.BuildInternal so list indices match
+                // the RenderMesh sequence produced immediately afterwards.
+                if (mesh.IsWalkmesh || !mesh.Render ||
+                    mesh.Name.Equals("sam", StringComparison.OrdinalIgnoreCase) ||
+                    mesh.Name.Equals("rootdummy", StringComparison.OrdinalIgnoreCase) ||
+                    mesh.Vertices.Length == 0 || mesh.Faces.Length == 0)
+                {
+                    continue;
+                }
+
+                result.Add(colorsByModel.TryGetValue(mesh.Bitmap, out var colors) ? colors : null);
+            }
+
+            return result;
+        }
+
+        private static void ApplyLayerColors(
+            RenderModel model,
+            IReadOnlyList<IReadOnlyDictionary<int, int>?> layerColors)
+        {
+            for (var index = 0; index < Math.Min(model.Meshes.Count, layerColors.Count); index++)
+            {
+                if (layerColors[index] is { Count: > 0 } colors)
+                    model.Meshes[index].LayerColorIndices = colors;
+            }
+        }
+
+        /// <summary>Applies a selected surface to a weighted garment before its meshes are built.</summary>
+        private static void ApplyTextureOverride(MdlModel model, string? textureResRef)
+        {
+            if (string.IsNullOrWhiteSpace(textureResRef))
+                return;
+
+            foreach (var mesh in model.GetMeshNodes())
+                mesh.Bitmap = textureResRef;
         }
 
         /// <summary>

--- a/SWLOR.Toolset/Workspace/BlueprintPreviewRenderer.cs
+++ b/SWLOR.Toolset/Workspace/BlueprintPreviewRenderer.cs
@@ -217,7 +217,10 @@ namespace SWLOR.Toolset.Workspace
             {
                 BlueprintModelKind.Simple when reference.ModelResRef != null =>
                     type == ResourceType.Utc
-                        ? BuildCreatureRenderModel(reference.ModelResRef)
+                        ? reference.Parts.Count > 0
+                            ? ComposeSegmented(reference, includeCreatureAnimations: true) ??
+                              BuildCreatureRenderModel(reference.ModelResRef)
+                            : BuildCreatureRenderModel(reference.ModelResRef)
                         : BuildRenderModel(reference.ModelResRef),
                 BlueprintModelKind.Segmented => ComposeSegmented(reference, type == ResourceType.Utc),
                 BlueprintModelKind.ItemComposite => ComposeItemParts(reference),
@@ -533,7 +536,8 @@ namespace SWLOR.Toolset.Workspace
             BlueprintModelReference reference,
             bool includeCreatureAnimations)
         {
-            if (_partComposer == null || reference.SkeletonResRef == null)
+            var skeletonResRef = reference.SkeletonResRef ?? reference.ModelResRef;
+            if (_partComposer == null || skeletonResRef == null)
                 return null;
 
             var parts = ApplyRobeCoverage(reference.Parts);
@@ -556,7 +560,7 @@ namespace SWLOR.Toolset.Workspace
             }
 
             var renderModels = new List<RenderModel>();
-            var skeleton = LoadMdl(reference.SkeletonResRef, withSupermodelAnims: false);
+            var skeleton = LoadMdl(skeletonResRef, withSupermodelAnims: false);
             var weightedRobe = skinParts
                 .Where(part => part.PartType.Equals("robe", StringComparison.OrdinalIgnoreCase))
                 .Select(part => part.Model)
@@ -597,7 +601,7 @@ namespace SWLOR.Toolset.Workspace
                     // _partTextures is filled by LoadComposerModel as the composer pulls each part in,
                     // so it has to be cleared and read inside the same lock that owns the compose run.
                     _partTextures.Clear();
-                    composed = _partComposer.Compose(reference.SkeletonResRef, rigidParts, adjustSeams: true);
+                    composed = _partComposer.Compose(skeletonResRef, rigidParts, adjustSeams: true);
                     if (composed != null)
                         _partTextures.Restore(composed, TextureExists);
                 }
@@ -611,6 +615,17 @@ namespace SWLOR.Toolset.Workspace
                 }
             }
 
+            // A simple creature model already carries its body geometry in the skeleton model. If
+            // its only attachment is a weighted cloak, there are no rigid parts to make Compose()
+            // clone that body, so include it explicitly before adding the garment overlay.
+            if (rigidParts.Count == 0 && reference.ModelResRef != null && skeleton != null)
+            {
+                var frames = sharedFrames ?? IdleFrames(skeleton);
+                renderModels.Add(includeCreatureAnimations
+                    ? MdlMeshBuilder.BuildAnimatedPreview(skeleton, frames, sharedAnimations)
+                    : MdlMeshBuilder.Build(skeleton, frames));
+            }
+
             renderModels.AddRange(skinParts.Select(part =>
             {
                 var frames = sharedFrames ?? IdleFrames(part.Model);
@@ -619,7 +634,7 @@ namespace SWLOR.Toolset.Workspace
                     : MdlMeshBuilder.Build(part.Model, frames);
             }));
 
-            return CombineRenderModels(reference.SkeletonResRef, renderModels);
+            return CombineRenderModels(skeletonResRef, renderModels);
         }
 
         /// <summary>

--- a/SWLOR.Toolset/Workspace/BlueprintPreviewRenderer.cs
+++ b/SWLOR.Toolset/Workspace/BlueprintPreviewRenderer.cs
@@ -52,6 +52,7 @@ namespace SWLOR.Toolset.Workspace
         private readonly DoorTypeService? _doors;
         private readonly WaypointAppearanceService? _waypoints;
         private readonly BaseItemIconService? _baseItems;
+        private readonly CloakModelService? _cloakModels;
         private readonly PortraitService? _portraits;
         private readonly TwoDaService? _twoDa;
         private readonly ArmorDyeSwatchService _dyeSwatches;
@@ -90,6 +91,7 @@ namespace SWLOR.Toolset.Workspace
             _doors = doors;
             _waypoints = waypoints;
             _baseItems = baseItems;
+            _cloakModels = twoDa == null ? null : new CloakModelService(twoDa);
             _portraits = portraits;
             _twoDa = twoDa;
             _dyeSwatches = new ArmorDyeSwatchService(resourceIndex);
@@ -211,24 +213,43 @@ namespace SWLOR.Toolset.Workspace
                 type, root, _appearances, _placeables, _doors,
                 itemResRef => LoadItemBlueprintRoot(itemResRef, useIndexedBlueprint),
                 PartModelExists, _waypoints, _baseItems == null ? null : _baseItems.GetOrNull,
-                armorPreviewFemale);
+                armorPreviewFemale, _cloakModels);
 
-            var model = reference.Kind switch
+            var model = BuildResolvedModel(
+                type, reference, includeCreatureAnimations: type == ResourceType.Utc);
+
+            return WithLayerColors(model, reference);
+        }
+
+        /// <summary>
+        /// Builds one resolved reference for both live editor geometry and software thumbnails.
+        /// Keeping the switch shared prevents simple-model creatures from losing helmets, cloaks,
+        /// and held weapons only in the palette thumbnail path.
+        /// </summary>
+        private RenderModel? BuildResolvedModel(
+            ResourceType type,
+            BlueprintModelReference reference,
+            bool includeCreatureAnimations)
+        {
+            return reference.Kind switch
             {
                 BlueprintModelKind.Simple when reference.ModelResRef != null =>
                     type == ResourceType.Utc
                         ? reference.Parts.Count > 0
-                            ? ComposeSegmented(reference, includeCreatureAnimations: true) ??
-                              BuildCreatureRenderModel(reference.ModelResRef)
-                            : BuildCreatureRenderModel(reference.ModelResRef)
+                            ? ComposeSegmented(reference, includeCreatureAnimations) ??
+                              BuildCreatureModel(reference.ModelResRef, includeCreatureAnimations)
+                            : BuildCreatureModel(reference.ModelResRef, includeCreatureAnimations)
                         : BuildRenderModel(reference.ModelResRef),
-                BlueprintModelKind.Segmented => ComposeSegmented(reference, type == ResourceType.Utc),
+                BlueprintModelKind.Segmented => ComposeSegmented(reference, includeCreatureAnimations),
                 BlueprintModelKind.ItemComposite => ComposeItemParts(reference),
                 _ => null
             };
-
-            return WithLayerColors(model, reference);
         }
+
+        private RenderModel? BuildCreatureModel(string modelResRef, bool includeCreatureAnimations) =>
+            includeCreatureAnimations
+                ? BuildCreatureRenderModel(modelResRef)
+                : BuildRenderModel(modelResRef);
 
         /// <summary>
         /// Hands the blueprint's dye choices to the model so the viewport can colour its PLT layers.
@@ -335,15 +356,10 @@ namespace SWLOR.Toolset.Workspace
             var reference = BlueprintModelResolver.Resolve(
                 type, root, _appearances, _placeables, _doors,
                 itemResRef => LoadItemBlueprintRoot(itemResRef, useIndexedBlueprint),
-                PartModelExists, _waypoints, _baseItems == null ? null : _baseItems.GetOrNull);
+                PartModelExists, _waypoints, _baseItems == null ? null : _baseItems.GetOrNull,
+                cloakModels: _cloakModels);
 
-            var model = reference.Kind switch
-            {
-                BlueprintModelKind.Simple when reference.ModelResRef != null => BuildRenderModel(reference.ModelResRef),
-                BlueprintModelKind.Segmented => ComposeSegmented(reference, includeCreatureAnimations: false),
-                BlueprintModelKind.ItemComposite => ComposeItemParts(reference),
-                _ => null
-            };
+            var model = BuildResolvedModel(type, reference, includeCreatureAnimations: false);
 
             IReadOnlyDictionary<int, int> layerColors = reference.LayerColorIndices;
             if (layerColorOverrides is { Count: > 0 })
@@ -357,8 +373,15 @@ namespace SWLOR.Toolset.Workspace
             Func<string, TextureImage?>? resolveTexture = _textures == null
                 ? null
                 : texture => _textures.Get(texture, layerColors);
+            Func<string, IReadOnlyDictionary<int, int>?, TextureImage?>? resolveLayeredTexture =
+                _textures == null
+                    ? null
+                    : (texture, meshColors) => _textures.Get(
+                        texture,
+                        meshColors is { Count: > 0 } ? meshColors : layerColors);
             var pixels = ThumbnailRenderer.Render(
-                model, ModelRenderSize, palette: null, resolveTexture: resolveTexture);
+                model, ModelRenderSize, palette: null, resolveTexture: resolveTexture,
+                resolveLayeredTexture: resolveLayeredTexture);
             return pixels == null ? null : new IconImage(ModelRenderSize, ModelRenderSize, pixels);
         }
 
@@ -548,13 +571,13 @@ namespace SWLOR.Toolset.Workspace
             // an overlay: it supplies coat-helper tracks and body rotations, but deliberately omits
             // translations shared with the wearer. Those missing channels must inherit the wearer's
             // bind pose; taking them from the robe's zeroed skin skeleton collapses the legs upward.
-            var skinParts = new List<(string PartType, MdlModel Model)>();
+            var skinParts = new List<(BlueprintModelPart Part, MdlModel Model)>();
             var rigidParts = new List<(string PartType, string ModelResRef)>();
             foreach (var part in parts)
             {
                 var model = LoadMdl(part.ModelResRef, withSupermodelAnims: false);
                 if (model != null && MdlMeshBuilder.ContainsNamedSkinWeights(model))
-                    skinParts.Add((part.PartType, model));
+                    skinParts.Add((part, model));
                 else
                     rigidParts.Add((part.PartType, part.ModelResRef));
             }
@@ -562,7 +585,7 @@ namespace SWLOR.Toolset.Workspace
             var renderModels = new List<RenderModel>();
             var skeleton = LoadMdl(skeletonResRef, withSupermodelAnims: false);
             var weightedRobe = skinParts
-                .Where(part => part.PartType.Equals("robe", StringComparison.OrdinalIgnoreCase))
+                .Where(part => part.Part.PartType.Equals("robe", StringComparison.OrdinalIgnoreCase))
                 .Select(part => part.Model)
                 .FirstOrDefault();
             IReadOnlyList<IReadOnlyDictionary<string, PosedNode>>? sharedFrames = null;
@@ -629,9 +652,16 @@ namespace SWLOR.Toolset.Workspace
             renderModels.AddRange(skinParts.Select(part =>
             {
                 var frames = sharedFrames ?? IdleFrames(part.Model);
-                return includeCreatureAnimations
+                var model = includeCreatureAnimations
                     ? MdlMeshBuilder.BuildAnimatedPreview(part.Model, frames, sharedAnimations)
                     : MdlMeshBuilder.Build(part.Model, frames);
+                if (part.Part.LayerColorIndices is { Count: > 0 } partColors)
+                {
+                    foreach (var mesh in model.Meshes)
+                        mesh.LayerColorIndices = partColors;
+                }
+
+                return model;
             }));
 
             return CombineRenderModels(skeletonResRef, renderModels);

--- a/SWLOR.Toolset/Workspace/BlueprintPreviewRenderer.cs
+++ b/SWLOR.Toolset/Workspace/BlueprintPreviewRenderer.cs
@@ -370,9 +370,6 @@ namespace SWLOR.Toolset.Workspace
                 layerColors = merged;
             }
 
-            Func<string, TextureImage?>? resolveTexture = _textures == null
-                ? null
-                : texture => _textures.Get(texture, layerColors);
             Func<string, IReadOnlyDictionary<int, int>?, TextureImage?>? resolveLayeredTexture =
                 _textures == null
                     ? null
@@ -380,7 +377,7 @@ namespace SWLOR.Toolset.Workspace
                         texture,
                         meshColors is { Count: > 0 } ? meshColors : layerColors);
             var pixels = ThumbnailRenderer.Render(
-                model, ModelRenderSize, palette: null, resolveTexture: resolveTexture,
+                model, ModelRenderSize, palette: null,
                 resolveLayeredTexture: resolveLayeredTexture);
             return pixels == null ? null : new IconImage(ModelRenderSize, ModelRenderSize, pixels);
         }
@@ -724,15 +721,11 @@ namespace SWLOR.Toolset.Workspace
             var result = new List<IReadOnlyDictionary<int, int>?>();
             foreach (var mesh in composed.GetMeshNodes())
             {
-                // Keep this filter aligned with MdlMeshBuilder.BuildInternal so list indices match
-                // the RenderMesh sequence produced immediately afterwards.
-                if (mesh.IsWalkmesh || !mesh.Render ||
-                    mesh.Name.Equals("sam", StringComparison.OrdinalIgnoreCase) ||
-                    mesh.Name.Equals("rootdummy", StringComparison.OrdinalIgnoreCase) ||
-                    mesh.Vertices.Length == 0 || mesh.Faces.Length == 0)
-                {
+                // The source-node order is stable even when names are duplicated. Use the builder's
+                // exact predicate so this list remains parallel to its RenderMesh output, including
+                // when a malformed source node has faces but none with valid vertex indices.
+                if (!MdlMeshBuilder.IsRenderableMesh(mesh))
                     continue;
-                }
 
                 result.Add(colorsByModel.TryGetValue(mesh.Bitmap, out var colors) ? colors : null);
             }
@@ -744,7 +737,13 @@ namespace SWLOR.Toolset.Workspace
             RenderModel model,
             IReadOnlyList<IReadOnlyDictionary<int, int>?> layerColors)
         {
-            for (var index = 0; index < Math.Min(model.Meshes.Count, layerColors.Count); index++)
+            if (model.Meshes.Count != layerColors.Count)
+            {
+                throw new InvalidDataException(
+                    $"Composed mesh palette count {layerColors.Count} does not match rendered mesh count {model.Meshes.Count}.");
+            }
+
+            for (var index = 0; index < model.Meshes.Count; index++)
             {
                 if (layerColors[index] is { Count: > 0 } colors)
                     model.Meshes[index].LayerColorIndices = colors;

--- a/SWLOR.Toolset/Workspace/ModuleFileWatcher.cs
+++ b/SWLOR.Toolset/Workspace/ModuleFileWatcher.cs
@@ -66,15 +66,19 @@ namespace SWLOR.Toolset.Workspace
                 return;
 
             var affectsTagIndex = AffectsTagIndex(path);
+            var affectsPlacementIndex = AffectsPlacementIndex(path);
             var affectsScriptUsages = AffectsScriptUsages(path);
             var affectsPaletteChoices = TryResolvePalette(path, out var paletteResRef);
             var resolved = TryResolveResource(path, out var type, out var resRef);
-            if (!affectsTagIndex && !affectsScriptUsages && !affectsPaletteChoices && !resolved)
+            if (!affectsTagIndex && !affectsPlacementIndex && !affectsScriptUsages &&
+                !affectsPaletteChoices && !resolved)
                 return;
 
             Avalonia.Threading.Dispatcher.UIThread.Post(() =>
             {
-                if (affectsTagIndex)
+                if (affectsPlacementIndex)
+                    _workspaceContext.InvalidateGitIndexes();
+                else if (affectsTagIndex)
                     _workspaceContext.InvalidateTagIndex();
                 if (affectsPaletteChoices)
                     _workspaceContext.InvalidatePaletteChoices(paletteResRef);
@@ -144,6 +148,13 @@ namespace SWLOR.Toolset.Workspace
                    fileName.EndsWith(".uti.json", StringComparison.OrdinalIgnoreCase) ||
                    fileName.EndsWith(".utw.json", StringComparison.OrdinalIgnoreCase);
         }
+
+        /// <summary>
+        /// True only when changing this file can add, remove, reorder, or move a placed instance.
+        /// ARE and blueprint files affect names/tags but are not inputs to the placement scan.
+        /// </summary>
+        public static bool AffectsPlacementIndex(string path) =>
+            Path.GetFileName(path).EndsWith(".git.json", StringComparison.OrdinalIgnoreCase);
 
         /// <summary>
         /// True when changing this file can alter Find Usages or the script picker's usage counts.

--- a/SWLOR.Toolset/Workspace/ThumbnailDiskCache.cs
+++ b/SWLOR.Toolset/Workspace/ThumbnailDiskCache.cs
@@ -68,8 +68,12 @@ namespace SWLOR.Toolset.Workspace
         /// v15: generic door appearances resolve through genericdoors.2da instead of treating their
         /// GenericType_New value as a doortypes.2da row.
         /// </para>
+        /// <para>
+        /// v16: creature thumbnails compose visible armor, helmets, cloaks, held weapons, equipment
+        /// dyes, cloak texture mappings, and cloak visibility flags.
+        /// </para>
         /// </remarks>
-        private const string FormatVersion = "v15";
+        private const string FormatVersion = "v16";
 
         private const string MissingArtworkExtension = ".none";
 

--- a/SWLOR.Toolset/Workspace/ThumbnailService.cs
+++ b/SWLOR.Toolset/Workspace/ThumbnailService.cs
@@ -1096,6 +1096,7 @@ namespace SWLOR.Toolset.Workspace
                 var creature = creatureBlueprint.Fields;
                 return BlueprintModelResolver.GetVisibleEquippedItemResRefs(creature)
                     .Select(itemResRef => workspace.GetResourcePath(ResourceType.Uti, itemResRef))
+                    .Where(File.Exists)
                     .Distinct(StringComparer.OrdinalIgnoreCase)
                     .ToList();
             }

--- a/SWLOR.Toolset/Workspace/ThumbnailService.cs
+++ b/SWLOR.Toolset/Workspace/ThumbnailService.cs
@@ -233,10 +233,8 @@ namespace SWLOR.Toolset.Workspace
                     }
 
                     var creature = creatureBlueprint.Fields;
-                    if (string.Equals(
-                            BlueprintModelResolver.GetEquippedChestArmorResRef(creature),
-                            itemResRef,
-                            StringComparison.OrdinalIgnoreCase))
+                    if (BlueprintModelResolver.GetVisibleEquippedItemResRefs(creature)
+                        .Contains(itemResRef, StringComparer.OrdinalIgnoreCase))
                     {
                         // A loose module UTI cannot affect the independent Standard-content preview.
                         InvalidateOne(ResourceType.Utc, creatureResRef, useIndexedBlueprint: false);
@@ -1090,10 +1088,10 @@ namespace SWLOR.Toolset.Workspace
                     return Array.Empty<string>();
 
                 var creature = creatureBlueprint.Fields;
-                var itemResRef = BlueprintModelResolver.GetEquippedChestArmorResRef(creature);
-                return string.IsNullOrWhiteSpace(itemResRef)
-                    ? Array.Empty<string>()
-                    : new[] { workspace.GetResourcePath(ResourceType.Uti, itemResRef) };
+                return BlueprintModelResolver.GetVisibleEquippedItemResRefs(creature)
+                    .Select(itemResRef => workspace.GetResourcePath(ResourceType.Uti, itemResRef))
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToList();
             }
             catch (Exception)
             {

--- a/SWLOR.Toolset/Workspace/ThumbnailService.cs
+++ b/SWLOR.Toolset/Workspace/ThumbnailService.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using Avalonia.Media.Imaging;
 using Avalonia.Platform;
 using Avalonia.Threading;
+using Serilog;
 using SWLOR.Toolset.Domain.GameData.Resources;
 using SWLOR.Toolset.Domain.Render;
 using SWLOR.Toolset.Domain.Render.Icons;
@@ -240,10 +241,15 @@ namespace SWLOR.Toolset.Workspace
                         InvalidateOne(ResourceType.Utc, creatureResRef, useIndexedBlueprint: false);
                     }
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
                     // A malformed creature is independently unrenderable and must not prevent the
                     // remaining dependency invalidations.
+                    Log.ForContext<ThumbnailService>().Warning(
+                        ex,
+                        "Failed to scan visible equipment for creature {CreatureResRef} while invalidating item {ItemResRef}.",
+                        creatureResRef,
+                        itemResRef);
                 }
             }
         }

--- a/SWLOR.Toolset/Workspace/WorkspaceContext.cs
+++ b/SWLOR.Toolset/Workspace/WorkspaceContext.cs
@@ -260,7 +260,10 @@ namespace SWLOR.Toolset.Workspace
 
         private void InvalidatePlacementIndexWhenRelevant(ResourceType type)
         {
-            if (type == ResourceType.Area || ModuleWorkspace.BlueprintTypes.Contains(type))
+            // Blueprint contents are not placement-index inputs. Their ordinary saves must not
+            // restart a module-wide GIT scan; rename workflows that rewrite GIT references call
+            // InvalidatePlacementIndex explicitly after the rename commits.
+            if (type == ResourceType.Area)
                 InvalidatePlacementIndex();
         }
 

--- a/SWLOR.Toolset/Workspace/WorkspaceContext.cs
+++ b/SWLOR.Toolset/Workspace/WorkspaceContext.cs
@@ -70,6 +70,26 @@ namespace SWLOR.Toolset.Workspace
             openStopwatch.Stop();
             _log.AppendLine($"Opened module root '{moduleRoot}' in {openStopwatch.ElapsedMilliseconds}ms.");
 
+            var placementIndex = Workspace.PlacementIndex;
+            placementIndex.AreaReadFailed += (areaResRef, ex) =>
+                _log.AppendLine($"Placement index skipped area '{areaResRef}': {ex.Message}");
+            var placementIndexStopwatch = Stopwatch.StartNew();
+            _ = placementIndex.WarmAsync().ContinueWith(task =>
+            {
+                placementIndexStopwatch.Stop();
+                if (task.IsCompletedSuccessfully)
+                {
+                    _log.AppendLine(
+                        $"Placement index ready in {placementIndexStopwatch.ElapsedMilliseconds}ms.");
+                }
+                else if (task.Exception != null)
+                {
+                    _log.AppendLine(
+                        $"Placement index failed after {placementIndexStopwatch.ElapsedMilliseconds}ms: " +
+                        task.Exception.GetBaseException().Message);
+                }
+            }, TaskScheduler.Default);
+
             var catalogStopwatch = Stopwatch.StartNew();
             var lastLoggedPercent = -1;
 
@@ -151,6 +171,7 @@ namespace SWLOR.Toolset.Workspace
         public void RefreshCatalogEntry(ResourceType type, string resRef)
         {
             InvalidateTagIndexWhenRelevant(type);
+            InvalidatePlacementIndexWhenRelevant(type);
             InvalidateScriptUsagesWhenRelevant(type);
             if (IsCatalogIndexedType(type))
                 Catalog?.RefreshEntry(type, resRef);
@@ -165,6 +186,7 @@ namespace SWLOR.Toolset.Workspace
         public void RemoveCatalogEntry(ResourceType type, string resRef)
         {
             InvalidateTagIndexWhenRelevant(type);
+            InvalidatePlacementIndexWhenRelevant(type);
             InvalidateScriptUsagesWhenRelevant(type);
             if (IsCatalogIndexedType(type))
                 Catalog?.RemoveEntry(type, resRef);
@@ -172,8 +194,9 @@ namespace SWLOR.Toolset.Workspace
         }
 
         /// <summary>
-        /// Drops the lazy transition-tag lookup after a paired GIT file changes. GIT is not a
-        /// first-class <see cref="ResourceType"/>, so the file watcher calls this directly.
+        /// Drops the lazy transition-tag lookup and module placement index after a paired GIT file
+        /// changes. GIT is not a first-class <see cref="ResourceType"/>, so the file watcher calls
+        /// this directly.
         /// </summary>
         public void InvalidateTagIndex()
         {
@@ -201,7 +224,16 @@ namespace SWLOR.Toolset.Workspace
         private void InvalidateTagIndexWhenRelevant(ResourceType type)
         {
             if (type is ResourceType.Area or ResourceType.Utd or ResourceType.Utw or ResourceType.Uti)
-                InvalidateTagIndex();
+            {
+                Workspace?.TagIndex.Invalidate();
+                TagIndexInvalidated?.Invoke();
+            }
+        }
+
+        private void InvalidatePlacementIndexWhenRelevant(ResourceType type)
+        {
+            if (type == ResourceType.Area || ModuleWorkspace.BlueprintTypes.Contains(type))
+                Workspace?.PlacementIndex.Invalidate();
         }
 
         private void InvalidateScriptUsagesWhenRelevant(ResourceType type)

--- a/SWLOR.Toolset/Workspace/WorkspaceContext.cs
+++ b/SWLOR.Toolset/Workspace/WorkspaceContext.cs
@@ -21,7 +21,9 @@ namespace SWLOR.Toolset.Workspace
         public BlueprintCatalog? Catalog { get; private set; }
 
         public event Action? WorkspaceOpened;
+        public event Action? CatalogBuildCompleted;
         public event Action<ResourceType, string>? CatalogEntryRefreshed;
+        public event Action? PlacementIndexInvalidated;
         public event Action? ScriptUsagesInvalidated;
         public event Action? TagIndexInvalidated;
         public event Action<string>? PaletteChoicesInvalidated;
@@ -66,7 +68,10 @@ namespace SWLOR.Toolset.Workspace
                 _log.AppendLine($"Recovered '{recovered}' from an interrupted ERF import.");
 
             var openStopwatch = Stopwatch.StartNew();
-            Workspace = _workspaceFactory(moduleRoot);
+            var replacementWorkspace = _workspaceFactory(moduleRoot);
+            Workspace?.PlacementIndex.Invalidate();
+            Workspace = replacementWorkspace;
+            Catalog = null;
             openStopwatch.Stop();
             _log.AppendLine($"Opened module root '{moduleRoot}' in {openStopwatch.ElapsedMilliseconds}ms.");
 
@@ -82,6 +87,12 @@ namespace SWLOR.Toolset.Workspace
                 {
                     _log.AppendLine(
                         "Placement index ready. " +
+                        $"DurationMs={placementIndexStopwatch.ElapsedMilliseconds}.");
+                }
+                else if (task.IsCanceled)
+                {
+                    _log.AppendLine(
+                        "Placement index warm-up canceled because its snapshot was invalidated. " +
                         $"DurationMs={placementIndexStopwatch.ElapsedMilliseconds}.");
                 }
                 else if (task.Exception != null)
@@ -138,6 +149,8 @@ namespace SWLOR.Toolset.Workspace
                 {
                     _log.AppendLine(
                         $"Catalog build complete: {catalog.Entries.Count} entries in {catalogStopwatch.ElapsedMilliseconds}ms.");
+                    if (ReferenceEquals(catalog, Catalog))
+                        CatalogBuildCompleted?.Invoke();
                 }
                 else if (task.Exception != null)
                 {
@@ -204,8 +217,20 @@ namespace SWLOR.Toolset.Workspace
         public void InvalidateTagIndex()
         {
             Workspace?.TagIndex.Invalidate();
-            Workspace?.PlacementIndex.Invalidate();
+            InvalidatePlacementIndex();
             TagIndexInvalidated?.Invoke();
+        }
+
+        /// <summary>
+        /// Drops the module-wide placement snapshot and tells open Source tabs to reload it.
+        /// </summary>
+        public void InvalidatePlacementIndex()
+        {
+            if (Workspace == null)
+                return;
+
+            Workspace.PlacementIndex.Invalidate();
+            PlacementIndexInvalidated?.Invoke();
         }
 
         /// <summary>
@@ -236,7 +261,7 @@ namespace SWLOR.Toolset.Workspace
         private void InvalidatePlacementIndexWhenRelevant(ResourceType type)
         {
             if (type == ResourceType.Area || ModuleWorkspace.BlueprintTypes.Contains(type))
-                Workspace?.PlacementIndex.Invalidate();
+                InvalidatePlacementIndex();
         }
 
         private void InvalidateScriptUsagesWhenRelevant(ResourceType type)

--- a/SWLOR.Toolset/Workspace/WorkspaceContext.cs
+++ b/SWLOR.Toolset/Workspace/WorkspaceContext.cs
@@ -72,7 +72,8 @@ namespace SWLOR.Toolset.Workspace
 
             var placementIndex = Workspace.PlacementIndex;
             placementIndex.AreaReadFailed += (areaResRef, ex) =>
-                _log.AppendLine($"Placement index skipped area '{areaResRef}': {ex.Message}");
+                _log.AppendLine(
+                    $"Placement index area read failed. AreaResRef='{areaResRef}'. Exception={ex}");
             var placementIndexStopwatch = Stopwatch.StartNew();
             _ = placementIndex.WarmAsync().ContinueWith(task =>
             {
@@ -80,13 +81,15 @@ namespace SWLOR.Toolset.Workspace
                 if (task.IsCompletedSuccessfully)
                 {
                     _log.AppendLine(
-                        $"Placement index ready in {placementIndexStopwatch.ElapsedMilliseconds}ms.");
+                        "Placement index ready. " +
+                        $"DurationMs={placementIndexStopwatch.ElapsedMilliseconds}.");
                 }
                 else if (task.Exception != null)
                 {
                     _log.AppendLine(
-                        $"Placement index failed after {placementIndexStopwatch.ElapsedMilliseconds}ms: " +
-                        task.Exception.GetBaseException().Message);
+                        "Placement index warm-up failed. " +
+                        $"DurationMs={placementIndexStopwatch.ElapsedMilliseconds}. " +
+                        $"Exception={task.Exception.GetBaseException()}");
                 }
             }, TaskScheduler.Default);
 

--- a/SWLOR.Toolset/Workspace/WorkspaceContext.cs
+++ b/SWLOR.Toolset/Workspace/WorkspaceContext.cs
@@ -178,6 +178,7 @@ namespace SWLOR.Toolset.Workspace
         public void InvalidateTagIndex()
         {
             Workspace?.TagIndex.Invalidate();
+            Workspace?.PlacementIndex.Invalidate();
             TagIndexInvalidated?.Invoke();
         }
 

--- a/SWLOR.Toolset/Workspace/WorkspaceContext.cs
+++ b/SWLOR.Toolset/Workspace/WorkspaceContext.cs
@@ -212,15 +212,25 @@ namespace SWLOR.Toolset.Workspace
         }
 
         /// <summary>
-        /// Drops the lazy transition-tag lookup and module placement index after a paired GIT file
-        /// changes. GIT is not a first-class <see cref="ResourceType"/>, so the file watcher calls
-        /// this directly.
+        /// Drops the lazy transition-tag lookup after a resource that contributes behavior tags
+        /// changes. Blueprint and ARE changes affect tags without changing any placed-instance row,
+        /// so placement invalidation is deliberately separate.
         /// </summary>
         public void InvalidateTagIndex()
         {
             Workspace?.TagIndex.Invalidate();
-            InvalidatePlacementIndex();
             TagIndexInvalidated?.Invoke();
+        }
+
+        /// <summary>
+        /// Drops every index whose source is a paired GIT file. GIT is not a first-class
+        /// <see cref="ResourceType"/>, so file-watcher, import, and merchant-update paths call this
+        /// explicitly instead of routing through catalog refresh.
+        /// </summary>
+        public void InvalidateGitIndexes()
+        {
+            InvalidateTagIndex();
+            InvalidatePlacementIndex();
         }
 
         /// <summary>

--- a/SWLOR.Toolset/Workspace/WorkspaceContext.cs
+++ b/SWLOR.Toolset/Workspace/WorkspaceContext.cs
@@ -187,7 +187,6 @@ namespace SWLOR.Toolset.Workspace
         public void RefreshCatalogEntry(ResourceType type, string resRef)
         {
             InvalidateTagIndexWhenRelevant(type);
-            InvalidatePlacementIndexWhenRelevant(type);
             InvalidateScriptUsagesWhenRelevant(type);
             if (IsCatalogIndexedType(type))
                 Catalog?.RefreshEntry(type, resRef);
@@ -202,7 +201,10 @@ namespace SWLOR.Toolset.Workspace
         public void RemoveCatalogEntry(ResourceType type, string resRef)
         {
             InvalidateTagIndexWhenRelevant(type);
-            InvalidatePlacementIndexWhenRelevant(type);
+            // Removing an area also removes every placement in its paired GIT. Ordinary ARE saves
+            // do not affect placements and deliberately avoid this module-wide rebuild.
+            if (type == ResourceType.Area)
+                InvalidatePlacementIndex();
             InvalidateScriptUsagesWhenRelevant(type);
             if (IsCatalogIndexedType(type))
                 Catalog?.RemoveEntry(type, resRef);
@@ -256,15 +258,6 @@ namespace SWLOR.Toolset.Workspace
                 Workspace?.TagIndex.Invalidate();
                 TagIndexInvalidated?.Invoke();
             }
-        }
-
-        private void InvalidatePlacementIndexWhenRelevant(ResourceType type)
-        {
-            // Blueprint contents are not placement-index inputs. Their ordinary saves must not
-            // restart a module-wide GIT scan; rename workflows that rewrite GIT references call
-            // InvalidatePlacementIndex explicitly after the rename commits.
-            if (type == ResourceType.Area)
-                InvalidatePlacementIndex();
         }
 
         private void InvalidateScriptUsagesWhenRelevant(ResourceType type)


### PR DESCRIPTION
## Summary

- add property-opening actions for Area Contents entries and objects selected directly in the area viewport
- make Area Contents context menus open reliably for both individual and grouped placement rows
- preserve camera position, selection, active tab, expanded sections, and scroll position while switching between area tabs
- move area document parsing and scene preparation off the UI thread so large areas do not block other Toolset work
- add shared Source tabs that list placed instances across areas and provide Go To navigation
- retain item obtainability information alongside the new placement source list
- make Module Contents drag-and-drop moves undoable with Ctrl+Z, redoable with Ctrl+Y/Ctrl+Shift+Z, and cancellable with Escape
- render placed and blueprint NPC armor, dyes, helmets, cloaks, and held weapons, including wearer-specific cloak geometry and per-item palettes

## Why

Area object details were difficult to reach, changing tabs recreated editor state, and loading large areas synchronously made the Toolset unresponsive. Object editors also lacked a consistent way to find and navigate to placed instances.

The underlying issues were missing context actions, view-owned camera state, synchronous area parsing, the absence of a shared placement index, and creature rendering that only understood referenced chest armor rather than the complete equipment embedded in placed GIT instances.

## Impact

Builders can inspect objects from either Area Contents or the viewport, move between open areas without losing their place, continue working while large areas load, and navigate from an object's editor to any placed instance. Module Contents organization now follows familiar file-move behavior and preserves exact prior folder membership when a move is undone. Placed NPCs now appear in the area viewport and thumbnails with their authored clothing colors and visible equipment; cloak geometry follows the wearer’s race/gender/phenotype and equipment edits invalidate dependent previews.

## Validation

- `dotnet build SWLOR.Toolset.Tests\SWLOR.Toolset.Tests.csproj --no-restore -p:RunPostBuildEvent=Never`
- focused feature suite: 66 passed
- affected-editor and binding suite: 109 passed
- Module Contents/category persistence suite: 25 passed
- NPC equipment model, composer, thumbnail, and viewport regression suite: 72 passed
- thumbnail cache and equipment-invalidation suite: 16 passed
- renamed-resource move-history regression suite: 6 passed
- rendered Area Contents right-click, grouped-placement, and binding suite: 28 passed
- `git diff --check`
- the unfiltered Toolset suite was attempted but exceeded the three-minute local command bound without reporting a failure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Source tabs showing blueprint placements with area details, coordinates, and “Go To” navigation.
  * Added “Open properties...” actions from area contents.
  * Added placement indexing with refresh, retry, and mixed-encoding support.
  * Added resource move undo/redo with keyboard shortcuts.
  * Preserved tabs, expanded sections, scroll positions, and 3D viewport state.

* **Bug Fixes**
  * Improved navigation when placement data is outdated or deleted.
  * Improved creature equipment, cloak, dye, and facing rendering.
  * Prevented stale asynchronous results and improved loading error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->