### PR TITLE
Fix Toolset Go To object navigation

### DIFF
--- a/SWLOR.Toolset.Tests/AreaContentsTests.cs
+++ b/SWLOR.Toolset.Tests/AreaContentsTests.cs
@@ -1,5 +1,9 @@
 using System.Numerics;
 using System.Text;
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
 using FluentAssertions;
 using NUnit.Framework;
 using SWLOR.NWN.Formats.Common;
@@ -9,6 +13,7 @@ using SWLOR.Toolset.Domain.Workspace;
 using SWLOR.Toolset.Editors;
 using SWLOR.Toolset.Services;
 using SWLOR.Toolset.Shell.Panels;
+using SWLOR.Toolset.Shell.Views;
 using SWLOR.Toolset.Workspace;
 
 namespace SWLOR.Toolset.Tests
@@ -302,6 +307,73 @@ namespace SWLOR.Toolset.Tests
         }
 
         [Test]
+        public void RevealingPlacement_BeforePanelsAttach_RetainsCameraAndContentsNavigation()
+        {
+            var editor = CreateEditor();
+            var expected = editor.SectionFor(ResourceType.Utp)!.Rows[0];
+            var placement = PlacementFor(expected);
+
+            editor.RevealPlacement(placement);
+
+            editor.TryTakePendingCameraFocus(out var cameraTarget).Should().BeTrue(
+                "a cold area has no view to consume the Go To camera request yet");
+            cameraTarget.Should().Be(new Vector3(expected.X, expected.Y, expected.Z));
+
+            var panel = CreatePanel(editor);
+            panel.SelectedRow.Should().NotBeNull();
+            panel.SelectedRow!.Kind.Should().Be(AreaContentsNodeKind.Instance);
+            panel.SelectedRow.Indices.Should().Equal(expected.Index);
+            panel.Rows.Should().Contain(panel.SelectedRow,
+                "the selected placement must be in the expanded visible tree");
+            panel.TryTakePendingRowReveal(out var scrollTarget).Should().BeTrue();
+            scrollTarget.Should().BeSameAs(panel.SelectedRow);
+        }
+
+        [AvaloniaTest]
+        public void RevealingPlacement_ScrollsToAnInstancePastTheLargeGroupCap()
+        {
+            var editor = CreateEditor();
+            var section = editor.SectionFor(ResourceType.Utp)!;
+            var copies = section.Rows
+                .Where(row => row.TemplateResRef == ReusedBlueprint)
+                .ToList();
+            copies.Should().HaveCountGreaterThan(200,
+                "the regression needs a target that the normal group cap does not realise");
+            var expected = copies[^1];
+            var panel = CreatePanel(editor, AreaContentsGrouping.Blueprint);
+            panel.Filter = "no-object-is-called-this-zzz";
+
+            var view = new AreaContentsView { DataContext = panel };
+            var window = new Window { Content = view, Width = 360, Height = 180 };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            try
+            {
+                editor.RevealPlacement(PlacementFor(expected));
+                Dispatcher.UIThread.RunJobs();
+                Dispatcher.UIThread.RunJobs();
+
+                panel.Filter.Should().BeEmpty("Go To must remove a filter that hides its target");
+                panel.SelectedRow.Should().NotBeNull();
+                panel.SelectedRow!.Indices.Should().Equal(expected.Index);
+                panel.Rows.Should().Contain(panel.SelectedRow,
+                    "the exact capped placement must be realised and its ancestors expanded");
+
+                var list = view.FindControl<ListBox>("RowsList")!;
+                list.SelectedItem.Should().BeSameAs(panel.SelectedRow);
+                var scroller = list.GetVisualDescendants().OfType<ScrollViewer>().Single();
+                scroller.Offset.Y.Should().BeGreaterThan(0,
+                    "the selected row is beyond the first screen and Go To must move the scrollbar to it");
+            }
+            finally
+            {
+                window.Close();
+                Dispatcher.UIThread.RunJobs();
+            }
+        }
+
+        [Test]
         public void RevealingPlacement_DoesNotSelectAnotherInstanceWhenTheSourceWasDeleted()
         {
             var editor = CreateEditor();
@@ -567,6 +639,16 @@ namespace SWLOR.Toolset.Tests
 
             throw new InvalidOperationException($"No placement under '{kind.Name}'.");
         }
+
+        private static ObjectPlacement PlacementFor(InstanceRow row) => new(
+            ResourceType.Utp,
+            row.TemplateResRef,
+            AreaResRef,
+            row.Index,
+            row.Tag,
+            row.X,
+            row.Y,
+            row.Z);
 
         private sealed class StubPrompts : IEditorPromptService
         {

--- a/SWLOR.Toolset.Tests/AreaViewportStateTests.cs
+++ b/SWLOR.Toolset.Tests/AreaViewportStateTests.cs
@@ -81,9 +81,12 @@ namespace SWLOR.Toolset.Tests
                 Diagnostics = new AreaSceneDiagnostics()
             };
 
-            control.CaptureViewportState()!.Value.Target.Should().Be(
+            var focused = control.CaptureViewportState()!.Value;
+            focused.Target.Should().Be(
                 expectedTarget,
                 "the first scene's default framing must not overwrite a Go To request made while it loaded");
+            focused.Distance.Should().BeLessThanOrEqualTo(15f,
+                "Go To must zoom from the full-area framing to an object-scale view");
         }
 
         [AvaloniaTest]

--- a/SWLOR.Toolset/Editors/AreaEditorViewModel.cs
+++ b/SWLOR.Toolset/Editors/AreaEditorViewModel.cs
@@ -200,6 +200,15 @@ namespace SWLOR.Toolset.Editors
 
         private (ResourceType Type, int Index)? _pendingSectionSelection;
 
+        /// <summary>
+        /// A Source-tab Go To can run before either the area view or the Area Contents panel has
+        /// attached to this document. Keep both requests on the document until their respective
+        /// views consume them, otherwise opening a cold area selects the row but loses the visible
+        /// camera/list navigation that made the action useful.
+        /// </summary>
+        private Vector3? _pendingCameraFocusRequest;
+        private (ResourceType Type, int Index)? _pendingAreaContentsReveal;
+
         private InstanceMarker? _selectedSceneInstance;
 
         /// <summary>
@@ -1595,8 +1604,59 @@ namespace SWLOR.Toolset.Editors
         /// </summary>
         public event Action<Vector3>? CameraFocusRequested;
 
+        /// <summary>Asks Area Contents to expand, select, and scroll to one exact placement.</summary>
+        public event Action<ResourceType, int>? AreaContentsRevealRequested;
+
         /// <summary>Asks the view to scroll the requested instance editor into view.</summary>
         public event Action<InstanceListSectionViewModel>? InstancePropertiesRequested;
+
+        /// <summary>
+        /// Consumes the newest camera request. The request remains here when Go To opens an area
+        /// whose visual tree has not been created yet, and is taken when that view attaches.
+        /// </summary>
+        public bool TryTakePendingCameraFocus(out Vector3 position)
+        {
+            if (_pendingCameraFocusRequest is not { } pending)
+            {
+                position = default;
+                return false;
+            }
+
+            _pendingCameraFocusRequest = null;
+            position = pending;
+            return true;
+        }
+
+        /// <summary>
+        /// Consumes the newest Area Contents reveal. This mirrors the camera hand-off so a newly
+        /// activated area cannot outrun the singleton panel's active-document update.
+        /// </summary>
+        public bool TryTakePendingAreaContentsReveal(out ResourceType type, out int index)
+        {
+            if (_pendingAreaContentsReveal is not { } pending)
+            {
+                type = default;
+                index = -1;
+                return false;
+            }
+
+            _pendingAreaContentsReveal = null;
+            type = pending.Type;
+            index = pending.Index;
+            return true;
+        }
+
+        private void RequestCameraFocus(Vector3 position)
+        {
+            _pendingCameraFocusRequest = position;
+            CameraFocusRequested?.Invoke(position);
+        }
+
+        private void RequestAreaContentsReveal(ResourceType type, int index)
+        {
+            _pendingAreaContentsReveal = (type, index);
+            AreaContentsRevealRequested?.Invoke(type, index);
+        }
 
         /// <summary>
         /// The name to show for one placement: its own if it has one, then its blueprint's, then its
@@ -1644,7 +1704,7 @@ namespace SWLOR.Toolset.Editors
             section.SelectedRow = row;
 
             if (frameCamera)
-                CameraFocusRequested?.Invoke(new Vector3(row.X, row.Y, row.Z));
+                RequestCameraFocus(new Vector3(row.X, row.Y, row.Z));
         }
 
         /// <summary>
@@ -1683,7 +1743,10 @@ namespace SWLOR.Toolset.Editors
             }
 
             if (index >= 0)
+            {
                 RevealInstance(placement.BlueprintType, index, frameCamera: true);
+                RequestAreaContentsReveal(placement.BlueprintType, index);
+            }
         }
 
         private static bool MatchesPlacementIdentity(InstanceRow row, ObjectPlacement placement) =>

--- a/SWLOR.Toolset/Editors/EditorService.cs
+++ b/SWLOR.Toolset/Editors/EditorService.cs
@@ -1096,6 +1096,7 @@ namespace SWLOR.Toolset.Editors
             Avalonia.Threading.Dispatcher.UIThread.Post(() =>
             {
                 _factory.ActivateDocument(editor);
+                _factory.ShowAreaContents();
                 editor.RevealPlacement(placement);
             });
         }

--- a/SWLOR.Toolset/Editors/Views/AreaEditorView.axaml.cs
+++ b/SWLOR.Toolset/Editors/Views/AreaEditorView.axaml.cs
@@ -13,7 +13,6 @@ namespace SWLOR.Toolset.Editors
     {
         private AreaEditorViewModel? _viewModel;
         private bool _viewportStateRestored;
-        private Vector3? _pendingCameraFocus;
 
         public AreaEditorView()
         {
@@ -66,7 +65,6 @@ namespace SWLOR.Toolset.Editors
             }
 
             _viewModel = null;
-            _pendingCameraFocus = null;
 
             base.OnDetachedFromVisualTree(e);
         }
@@ -100,7 +98,6 @@ namespace SWLOR.Toolset.Editors
                 _viewModel.PaintRejected -= OnPaintRejected;
             }
 
-            _pendingCameraFocus = null;
             _viewModel = next;
             if (_viewModel == null)
                 return;
@@ -111,7 +108,6 @@ namespace SWLOR.Toolset.Editors
             AreaView.InvalidateGameResources();
             AreaView.Scene = _viewModel.AreaScene;
             RestoreViewportStateWhenReady();
-            ApplyPendingCameraFocus();
             AreaView.SelectedInstance = _viewModel.SelectedSceneInstance;
             AreaView.IsPlacementActive = _viewModel.IsPlacementPending;
             AreaView.PlacementGhost = _viewModel.PlacementGhost;
@@ -127,6 +123,8 @@ namespace SWLOR.Toolset.Editors
             _viewModel.CameraFocusRequested += OnCameraFocusRequested;
             _viewModel.InstancePropertiesRequested += OnInstancePropertiesRequested;
             _viewModel.PaintRejected += OnPaintRejected;
+
+            ConsumePendingCameraFocus();
 
             // Opening an area shows its map. Not gated on the 3D View tab being selected: it always is
             // (it is the first tab), and reading IsSelected here raced the TabControl's own setup - the
@@ -187,7 +185,7 @@ namespace SWLOR.Toolset.Editors
             {
                 AreaView.Scene = _viewModel.AreaScene;
                 RestoreViewportStateWhenReady();
-                ApplyPendingCameraFocus();
+                ConsumePendingCameraFocus();
             }
             else if (e.PropertyName == nameof(AreaEditorViewModel.GameResourceRevision))
                 AreaView.InvalidateGameResources();
@@ -219,31 +217,32 @@ namespace SWLOR.Toolset.Editors
         /// The tab switch is not optional. Double-clicking a row while Properties is in front would
         /// otherwise move a camera nobody can see, which reads as the row having done nothing.
         /// </remarks>
-        private void OnCameraFocusRequested(Vector3 position)
+        private void OnCameraFocusRequested(Vector3 _)
+        {
+            ConsumePendingCameraFocus();
+        }
+
+        /// <summary>
+        /// Takes a retained request from the document only after its normal scene-change path has
+        /// restored the area's saved camera. Until then the document keeps the position.
+        /// </summary>
+        private void ConsumePendingCameraFocus()
+        {
+            // Leave the request on the document until a scene exists. That makes it survive a tab
+            // swap while a large area is still loading; the next view consumes it only after it has
+            // restored this area's retained camera.
+            if (AreaView.Scene == null ||
+                _viewModel?.TryTakePendingCameraFocus(out var position) != true)
+                return;
+
+            ApplyCameraFocus(position);
+        }
+
+        private void ApplyCameraFocus(Vector3 position)
         {
             if (_viewModel != null)
                 _viewModel.SelectedRootTabIndex = 0;
 
-            if (AreaView.Scene == null)
-            {
-                _pendingCameraFocus = position;
-                return;
-            }
-
-            _pendingCameraFocus = null;
-            AreaView.FocusOn(position);
-        }
-
-        /// <summary>
-        /// Applies a Go To request only after the area's retained camera has been restored. Focusing
-        /// from the scene setter would let the later restore overwrite the requested object.
-        /// </summary>
-        private void ApplyPendingCameraFocus()
-        {
-            if (AreaView.Scene == null || _pendingCameraFocus is not { } position)
-                return;
-
-            _pendingCameraFocus = null;
             AreaView.FocusOn(position);
         }
 

--- a/SWLOR.Toolset/Shell/Panels/AreaContentsViewModel.cs
+++ b/SWLOR.Toolset/Shell/Panels/AreaContentsViewModel.cs
@@ -45,6 +45,16 @@ namespace SWLOR.Toolset.Shell.Panels
         private readonly List<AreaContentsNodeViewModel> _roots = new();
 
         private AreaEditorViewModel? _editor;
+        private (ResourceType Type, int Index)? _forcedVisibleInstance;
+        private AreaContentsNodeViewModel? _pendingRowReveal;
+        private bool _syncingSelection;
+
+        /// <summary>
+        /// Raised after a Go To has made its exact instance row visible. The view consumes the
+        /// retained row after layout and scrolls it into view; retaining it matters when the Area
+        /// Contents tool tab is activated in the same dispatcher turn as the request.
+        /// </summary>
+        public event Action? RowRevealRequested;
 
         /// <summary>The visible rows: every node whose ancestors are all expanded.</summary>
         public ObservableCollection<AreaContentsNodeViewModel> Rows { get; } = new();
@@ -106,17 +116,50 @@ namespace SWLOR.Toolset.Shell.Panels
                 return;
 
             if (_editor != null)
+            {
                 _editor.ContentsChanged -= Rebuild;
+                _editor.AreaContentsRevealRequested -= OnAreaContentsRevealRequested;
+            }
 
             _editor = editor;
 
             if (_editor != null)
+            {
                 _editor.ContentsChanged += Rebuild;
+                _editor.AreaContentsRevealRequested += OnAreaContentsRevealRequested;
+            }
 
             AreaResRef = _editor?.AreaResRef ?? string.Empty;
+            _forcedVisibleInstance = null;
+            _pendingRowReveal = null;
             OnPropertyChanged(nameof(HasArea));
             SelectedRow = null;
             Rebuild();
+
+            ConsumePendingEditorReveal();
+        }
+
+        private void OnAreaContentsRevealRequested(ResourceType _, int __) =>
+            ConsumePendingEditorReveal();
+
+        private void ConsumePendingEditorReveal()
+        {
+            if (_editor?.TryTakePendingAreaContentsReveal(out var type, out var index) == true)
+                RevealInstanceRow(type, index);
+        }
+
+        /// <summary>Lets the attached view take exactly one retained scroll request.</summary>
+        public bool TryTakePendingRowReveal(out AreaContentsNodeViewModel row)
+        {
+            if (_pendingRowReveal == null)
+            {
+                row = null!;
+                return false;
+            }
+
+            row = _pendingRowReveal;
+            _pendingRowReveal = null;
+            return true;
         }
 
         partial void OnFilterChanged(string value) => Rebuild();
@@ -219,11 +262,12 @@ namespace SWLOR.Toolset.Shell.Panels
 
             if (Grouping == AreaContentsGrouping.Flat)
             {
-                foreach (var row in rows.Take(MaxRealizedGroupMembers))
+                var realized = RealizedRows(section.BlueprintType, rows);
+                foreach (var row in realized)
                     node.Children.Add(BuildInstanceNode(section, row, depth: 1, leadWithName: true));
 
-                if (rows.Count > MaxRealizedGroupMembers)
-                    node.Children.Add(BuildOverflowNode(type, rows.Count - MaxRealizedGroupMembers, depth: 1));
+                if (rows.Count > realized.Count)
+                    node.Children.Add(BuildOverflowNode(type, rows.Count - realized.Count, depth: 1));
 
                 return node;
             }
@@ -260,20 +304,40 @@ namespace SWLOR.Toolset.Shell.Panels
                 Indices = members.Select(row => row.Index).ToList()
             };
 
-            foreach (var row in members.Take(MaxRealizedGroupMembers))
+            var realized = RealizedRows(section.BlueprintType, members);
+            foreach (var row in realized)
             {
                 // Inside a group the members share a name by definition, so the position leads and
                 // the resref trails - a column of the same word repeated tells you nothing.
                 node.Children.Add(BuildInstanceNode(section, row, depth: 2, leadWithName: false));
             }
 
-            if (members.Count > MaxRealizedGroupMembers)
+            if (members.Count > realized.Count)
             {
                 node.Children.Add(BuildOverflowNode(
-                    section.BlueprintType, members.Count - MaxRealizedGroupMembers, depth: 2));
+                    section.BlueprintType, members.Count - realized.Count, depth: 2));
             }
 
             return node;
+        }
+
+        /// <summary>
+        /// Keeps the normal 200-row performance cap while ensuring an explicitly requested source
+        /// instance is realised even when it is the 648th copy in a large group.
+        /// </summary>
+        private IReadOnlyList<InstanceRow> RealizedRows(
+            ResourceType type, IReadOnlyList<InstanceRow> rows)
+        {
+            var realized = rows.Take(MaxRealizedGroupMembers).ToList();
+            if (_forcedVisibleInstance is not { } forced || forced.Type != type ||
+                realized.Any(row => row.Index == forced.Index))
+                return realized;
+
+            var requested = rows.FirstOrDefault(row => row.Index == forced.Index);
+            if (requested != null)
+                realized.Add(requested);
+
+            return realized;
         }
 
         private AreaContentsNodeViewModel BuildInstanceNode(
@@ -364,6 +428,66 @@ namespace SWLOR.Toolset.Shell.Panels
                 Publish(child);
         }
 
+        /// <summary>
+        /// Clears any filter hiding the target, realises it past the large-group cap, opens every
+        /// ancestor, selects it, and retains a scroll request for the view.
+        /// </summary>
+        private void RevealInstanceRow(ResourceType type, int index)
+        {
+            _forcedVisibleInstance = (type, index);
+            _syncingSelection = true;
+            try
+            {
+                if (HasFilter)
+                    Filter = string.Empty;
+                else
+                    Rebuild();
+
+                var path = new List<AreaContentsNodeViewModel>();
+                var found = _roots
+                    .Where(root => root.BlueprintType == type)
+                    .Any(root => TryFindPath(
+                        root,
+                        node => node.Kind == AreaContentsNodeKind.Instance &&
+                                node.Indices.Count == 1 && node.Indices[0] == index,
+                        path));
+                if (!found || path.Count == 0)
+                    return;
+
+                foreach (var ancestor in path.Take(path.Count - 1))
+                    ancestor.IsExpanded = true;
+
+                PublishVisibleRows();
+                SelectedRow = path[^1];
+                _pendingRowReveal = SelectedRow;
+            }
+            finally
+            {
+                _syncingSelection = false;
+            }
+
+            RowRevealRequested?.Invoke();
+        }
+
+        private static bool TryFindPath(
+            AreaContentsNodeViewModel node,
+            Func<AreaContentsNodeViewModel, bool> predicate,
+            List<AreaContentsNodeViewModel> path)
+        {
+            path.Add(node);
+            if (predicate(node))
+                return true;
+
+            foreach (var child in node.Children)
+            {
+                if (TryFindPath(child, predicate, path))
+                    return true;
+            }
+
+            path.RemoveAt(path.Count - 1);
+            return false;
+        }
+
         // ----- what the rows do -----
 
         [RelayCommand]
@@ -382,7 +506,8 @@ namespace SWLOR.Toolset.Shell.Panels
         /// </summary>
         partial void OnSelectedRowChanged(AreaContentsNodeViewModel? value)
         {
-            if (_editor == null || value is not { Kind: AreaContentsNodeKind.Instance } instance)
+            if (_syncingSelection || _editor == null ||
+                value is not { Kind: AreaContentsNodeKind.Instance } instance)
                 return;
 
             _editor.RevealInstance(instance.BlueprintType, instance.Indices[0], frameCamera: false);

--- a/SWLOR.Toolset/Shell/ToolsetDockFactory.cs
+++ b/SWLOR.Toolset/Shell/ToolsetDockFactory.cs
@@ -248,6 +248,9 @@ namespace SWLOR.Toolset.Shell
                 SetFocusedDockable(owner, dockable);
         }
 
+        /// <summary>Brings Area Contents to the front for an explicit Source-tab Go To.</summary>
+        public void ShowAreaContents() => Focus(_areaContents);
+
         /// <summary>Requests that Dock close a document after the editor has approved any prompt.</summary>
         public void CloseDocument(Document document)
         {

--- a/SWLOR.Toolset/Shell/Views/AreaContentsView.axaml
+++ b/SWLOR.Toolset/Shell/Views/AreaContentsView.axaml
@@ -34,7 +34,7 @@
 
     <!-- KeyDown rather than a KeyBinding: Delete acts on the row the list has selected, and the
          list is where the key lands. -->
-    <ListBox Grid.Row="1" Background="Transparent" BorderThickness="0"
+    <ListBox x:Name="RowsList" Grid.Row="1" Background="Transparent" BorderThickness="0"
              ItemsSource="{Binding Rows}" SelectedItem="{Binding SelectedRow}"
              DoubleTapped="OnRowDoubleTapped" KeyDown="OnRowKeyDown">
       <ListBox.Styles>

--- a/SWLOR.Toolset/Shell/Views/AreaContentsView.axaml.cs
+++ b/SWLOR.Toolset/Shell/Views/AreaContentsView.axaml.cs
@@ -1,6 +1,9 @@
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
 using SWLOR.Toolset.Shell.Panels;
 
 namespace SWLOR.Toolset.Shell.Views
@@ -8,10 +11,61 @@ namespace SWLOR.Toolset.Shell.Views
     public partial class AreaContentsView : UserControl
     {
         private AreaContentsNodeViewModel? _contextRow;
+        private AreaContentsViewModel? _viewModel;
 
         public AreaContentsView()
         {
             InitializeComponent();
+            DataContextChanged += (_, _) => AttachViewModel();
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            AttachViewModel();
+            QueuePendingRowReveal();
+        }
+
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            if (_viewModel != null)
+                _viewModel.RowRevealRequested -= QueuePendingRowReveal;
+
+            _viewModel = null;
+            base.OnDetachedFromVisualTree(e);
+        }
+
+        private void AttachViewModel()
+        {
+            var next = DataContext as AreaContentsViewModel;
+            if (ReferenceEquals(next, _viewModel))
+                return;
+
+            if (_viewModel != null)
+                _viewModel.RowRevealRequested -= QueuePendingRowReveal;
+
+            _viewModel = next;
+            if (_viewModel != null)
+            {
+                _viewModel.RowRevealRequested += QueuePendingRowReveal;
+                QueuePendingRowReveal();
+            }
+        }
+
+        /// <summary>
+        /// Scroll after Dock has activated this tool and ListBox has generated its containers. The
+        /// row stays pending on the view model until this callback actually runs in a visual tree.
+        /// </summary>
+        private void QueuePendingRowReveal()
+        {
+            Dispatcher.UIThread.Post(() =>
+            {
+                if (VisualRoot == null ||
+                    _viewModel?.TryTakePendingRowReveal(out var row) != true)
+                    return;
+
+                RowsList.ScrollIntoView(row);
+            }, DispatcherPriority.Render);
         }
 
         /// <summary>Right-click selects the row under the pointer before its menu is evaluated.</summary>


### PR DESCRIPTION
## Summary

- make Source-tab **Go To** activate the target area and bring **Area Contents** to the front
- select the exact placed instance in both the area editor and Area Contents tree
- expand the target's tree ancestors, clear a hiding filter, and automatically scroll the row into view
- retain camera and tree navigation requests while a large area or its views are still loading
- zoom the viewport from full-area framing to the selected object
- realize explicitly requested instances beyond the normal 200-row large-group cap without removing that performance safeguard

## Root cause

Go To activated the area document and selected its underlying instance row, but the camera request was transient and could fire before the viewport existed. Area Contents was not explicitly activated and had no corresponding reveal/scroll request, so its grouped tree could remain collapsed or omit a target beyond the realization cap.

## Impact

Go To now completes the full navigation action for both cold and already-open areas: the correct area opens, the object is selected, the viewport zooms to it, Area Contents selects the same instance, and the scrollbar follows it. Switching tabs while a large area loads no longer loses the pending focus.

## Validation

- `dotnet build SWLOR.Toolset.Tests\SWLOR.Toolset.Tests.csproj --no-restore -p:RunPostBuildEvent=Never`
- focused Go To, Area Contents, viewport, source, merchant, and context-menu suite: 65 passed
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Revealing area placements now automatically opens the Area Contents panel, expands the relevant hierarchy, selects the placement, and scrolls it into view.
  * Camera focus and placement navigation requests are preserved while scenes, tabs, or panels are loading.
  * Large placement groups can now reveal items beyond the initial display limit.

* **Bug Fixes**
  * Improved camera focus reliability during scene loading and tab changes.
  * Prevented filters and delayed panel attachment from blocking placement navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->