### PR TITLE
Fix four stale Toolset tests against the drifted module corpus

### DIFF
--- a/Module/git/v_repubbase_hang.git.json
+++ b/Module/git/v_repubbase_hang.git.json
@@ -50939,7 +50939,7 @@
         },
         "YPosition": {
           "type": "float",
-          "value": 54.6
+          "value": 54.59999847412109
         },
         "ZPosition": {
           "type": "float",

--- a/SWLOR.Toolset.Tests/BlueprintModelResolverTests.cs
+++ b/SWLOR.Toolset.Tests/BlueprintModelResolverTests.cs
@@ -228,7 +228,23 @@ namespace SWLOR.Toolset.Tests
             var root = BlueprintRoot(ResourceType.Utc, "darthgravius");
             root.SetInt("BodyPart_LShoul", GffFieldType.Byte, 1);
             root.SetInt("BodyPart_RShoul", GffFieldType.Byte, 1);
-            JsonGffStruct? LoadItem(string resRef) => BlueprintRoot(ResourceType.Uti, resRef);
+            JsonGffStruct? LoadItem(string resRef)
+            {
+                var item = BlueprintRoot(ResourceType.Uti, resRef);
+                if (resRef == "jeweled_cloak")
+                {
+                    // The corpus item moved to the basic cloak (row 20: MODEL 20, TEXTURE 20,
+                    // shoulders kept) when its old appearance's models were KILLed. Pin the
+                    // divergent row 10 (MODEL 7, TEXTURE 14, hides both shoulders) so the split
+                    // geometry/texture mapping and the shoulder-hiding flags stay covered. Both
+                    // fields must move together: ItemAppearanceValues.Read prefers the larger of
+                    // the byte and its xModelPart1 word companion.
+                    item.SetInt("ModelPart1", GffFieldType.Byte, 10);
+                    item.SetInt("xModelPart1", GffFieldType.Word, 10);
+                }
+
+                return item;
+            }
 
             var result = BlueprintModelResolver.Resolve(
                 ResourceType.Utc, root, Appearances(), null, null,

--- a/SWLOR.Toolset.Tests/CreatureEquipmentRenderTests.cs
+++ b/SWLOR.Toolset.Tests/CreatureEquipmentRenderTests.cs
@@ -134,8 +134,8 @@ namespace SWLOR.Toolset.Tests
             cloakMeshes.Should().OnlyContain(mesh => mesh.LayerColorIndices.ContainsKey(
                 SWLOR.NWN.Formats.Plt.PltLayers.Cloth1));
             cloakMeshes.Should().OnlyContain(mesh =>
-                mesh.TextureName.Equals("pfe0_cloak_014", StringComparison.OrdinalIgnoreCase),
-                "cloak appearance 10 reuses geometry 7 but selects texture 14");
+                mesh.TextureName.Equals("pfe0_cloak_020", StringComparison.OrdinalIgnoreCase),
+                "cloak appearance 20 maps to geometry 20 and texture 20 through cloakmodel.2da");
             cloakMeshes.Select(mesh =>
                     mesh.LayerColorIndices[SWLOR.NWN.Formats.Plt.PltLayers.Cloth1])
                 .Should().OnlyContain(cloth => cloth == 45,

--- a/SWLOR.Toolset.Tests/WaypointBehaviorTests.cs
+++ b/SWLOR.Toolset.Tests/WaypointBehaviorTests.cs
@@ -40,8 +40,8 @@ namespace SWLOR.Toolset.Tests
             [WaypointBehaviorCatalog.CreatureSpawnPointId] = 1952,
             [WaypointBehaviorCatalog.FishingPointId] = 431,
             [WaypointBehaviorCatalog.MapNoteId] = 376,
-            [WaypointBehaviorCatalog.StuckRescuePointId] = 300,
-            [WaypointBehaviorCatalog.TransitionDestinationId] = 227,
+            [WaypointBehaviorCatalog.StuckRescuePointId] = 306,
+            [WaypointBehaviorCatalog.TransitionDestinationId] = 229,
             [WaypointBehaviorCatalog.PropertyEntranceId] = 43,
             [WaypointBehaviorCatalog.StarshipDockId] = 11,
             [WaypointBehaviorCatalog.PlanetLandingId] = 10,
@@ -49,7 +49,7 @@ namespace SWLOR.Toolset.Tests
             [WaypointBehaviorCatalog.TaxiStopId] = 4,
             [WaypointBehaviorCatalog.DeathRespawnId] = 1,
             [WaypointBehaviorCatalog.RebuildId] = 2,
-            [WaypointBehaviorCatalog.CustomId] = 548
+            [WaypointBehaviorCatalog.CustomId] = 550
         };
 
         private static string GameServerSourceRoot =>
@@ -94,7 +94,7 @@ namespace SWLOR.Toolset.Tests
                 .ToDictionary(group => group.Key, group => group.Count());
 
             counts.Should().BeEquivalentTo(ExpectedPlacementCounts);
-            counts.Values.Sum().Should().Be(3915);
+            counts.Values.Sum().Should().Be(3925);
         }
 
         [Test]


### PR DESCRIPTION
## Summary

Four `SWLOR.Toolset.Tests` failures pre-existing on `feature/combat-upgrade` were baked-in snapshots that the module corpus drifted away from. Each was diagnosed to its introducing commit; in three cases the test expectation was stale and in one the corpus itself carried an invalid float lexeme.

- **Cloak resolver test** (`Resolve_EquippedCloak_UsesTheWearersBodyPrefixAndItsOwnDyes`): #2146 intentionally moved `jeweled_cloak` off KILLed cloak appearance 10 onto the surviving basic cloak 20, whose `cloakmodel.2da` row is degenerate (MODEL 20, TEXTURE 20, shoulders kept). The 2da and resolver were never wrong. The test now pins the loaded item back to divergent row 10 in its item loader — setting `ModelPart1` and its authoritative `xModelPart1` word companion together — so the split geometry/texture mapping and shoulder-hiding regression stay covered unchanged.
- **Cloak render test** (`EquippedCloakUsesWearerGeometryTextureAndOwnDyes`): renders real mesh assets, so it follows the corpus to `pfe0_cloak_020`; its key regression (the cloak keeps its own Cloth1 45 dye instead of the robe's 97) is untouched.
- **Float formatter conformance** (`EveryFloatLiteralInCorpus_ReformatsIdentically`): the stuck-rescue waypoint hand-added to `v_repubbase_hang` in #2148 carried `YPosition: 54.6` — a lexeme `nwn_gff` can never emit, since 54.6 is not float32-representable. The formatter is correct; the corpus lexeme is rewritten to the canonical `54.59999847412109` (identical float32 value, byte-level CRLF-preserving edit). **Requires a module repack on deploy.**
- **Waypoint placement counts** (`PlacementBehaviorCountsMatchTheModuleCorpus`): all +10 placements trace to intentional content in #2146/#2148 — 6 stuck-rescue waypoints, 2 transition destinations (`WP_V_RepBaseInt_to_RepBaseExt`, `WP_V_JuniorMess_to_RepBaseExt`), and 2 Korriban valley waypoints. Baked counts updated to 306/229/550, total 3925.

## Testing

- Full `SWLOR.Toolset.Tests` suite: **2755 passed, 1 skipped (the always-skipped corpus summary printer), 0 failed** (27 min run).
- `AnAppearanceRowIsPickedFromPicturesOnThePage` failed once under parallel execution during verification and passed on every re-run including the full suite — unrelated pre-existing flake, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected cloak appearance resolution so the expected visual variant is rendered.
  * Improved placement data precision for more accurate positioning.

* **Updates**
  * Expanded waypoint coverage, including additional rescue, transition, and custom placement points.
  * Updated validation coverage to reflect the latest appearance and waypoint data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->