### PR TITLE
Fix Toolset door transition rendering

### DIFF
--- a/SWLOR.Toolset.Domain/GameData/Lookups/DoorTypeService.cs
+++ b/SWLOR.Toolset.Domain/GameData/Lookups/DoorTypeService.cs
@@ -13,7 +13,15 @@ namespace SWLOR.Toolset.Domain.GameData.Lookups
         int Id,
         string Label,
         string DisplayName,
-        string? Model);
+        string? Model)
+    {
+        /// <summary>
+        /// Whether the door's model is visible in game. A false value identifies Aurora's
+        /// toolset-only transition planes: the engine hides their model, but an editor must still
+        /// draw their authored selection geometry so a builder can see and select them.
+        /// </summary>
+        public bool VisibleModel { get; init; } = true;
+    }
 
     /// <summary>
     /// Editor lookup over doortypes.2da and genericdoors.2da. Results are built once on first use
@@ -115,7 +123,10 @@ namespace SWLOR.Toolset.Domain.GameData.Lookups
                     row,
                     label!,
                     displayName,
-                    model));
+                    model)
+                {
+                    VisibleModel = TryGetInt(table, row, "VisibleModel") != 0
+                });
             }
 
             return results;
@@ -149,7 +160,10 @@ namespace SWLOR.Toolset.Domain.GameData.Lookups
                     row,
                     label!,
                     DisplayNameResolver.Resolve(tlk, nameStrRef, label!.Replace('_', ' ')),
-                    model));
+                    model)
+                {
+                    VisibleModel = TryGetInt(table, row, "VisibleModel") != 0
+                });
             }
 
             return results;

--- a/SWLOR.Toolset.Domain/GameData/Lookups/DoorTypeService.cs
+++ b/SWLOR.Toolset.Domain/GameData/Lookups/DoorTypeService.cs
@@ -107,6 +107,12 @@ namespace SWLOR.Toolset.Domain.GameData.Lookups
                     continue;
                 }
 
+                var visibleModel = TryGetInt(table, row, "VisibleModel");
+                if (visibleModel is null)
+                {
+                    continue;
+                }
+
                 int? strref = null;
                 try
                 {
@@ -125,7 +131,7 @@ namespace SWLOR.Toolset.Domain.GameData.Lookups
                     displayName,
                     model)
                 {
-                    VisibleModel = TryGetInt(table, row, "VisibleModel") != 0
+                    VisibleModel = visibleModel != 0
                 });
             }
 
@@ -155,6 +161,12 @@ namespace SWLOR.Toolset.Domain.GameData.Lookups
                     continue;
                 }
 
+                var visibleModel = TryGetInt(table, row, "VisibleModel");
+                if (visibleModel is null)
+                {
+                    continue;
+                }
+
                 var nameStrRef = TryGetInt(table, row, "Name") ?? TryGetInt(table, row, "StrRef");
                 results.Add(new GenericDoorRow(
                     row,
@@ -162,7 +174,7 @@ namespace SWLOR.Toolset.Domain.GameData.Lookups
                     DisplayNameResolver.Resolve(tlk, nameStrRef, label!.Replace('_', ' ')),
                     model)
                 {
-                    VisibleModel = TryGetInt(table, row, "VisibleModel") != 0
+                    VisibleModel = visibleModel != 0
                 });
             }
 

--- a/SWLOR.Toolset.Domain/GameData/Lookups/GenericDoorRow.cs
+++ b/SWLOR.Toolset.Domain/GameData/Lookups/GenericDoorRow.cs
@@ -5,5 +5,12 @@ namespace SWLOR.Toolset.Domain.GameData.Lookups
         int Id,
         string Label,
         string DisplayName,
-        string? Model);
+        string? Model)
+    {
+        /// <summary>
+        /// Whether the engine renders this door model. The generic transition door is deliberately
+        /// invisible in game and needs an editor-only translucent representation instead.
+        /// </summary>
+        public bool VisibleModel { get; init; } = true;
+    }
 }

--- a/SWLOR.Toolset.Domain/GameData/Lookups/TwoDaLookupService.cs
+++ b/SWLOR.Toolset.Domain/GameData/Lookups/TwoDaLookupService.cs
@@ -138,13 +138,18 @@ namespace SWLOR.Toolset.Domain.GameData.Lookups
         public static readonly TwoDaLookupTable PlaceableModel =
             new("placeables", "Label", "StrRef", ["ModelName"]);
 
-        /// <summary>doortypes.2da - specific door appearances need a model and display strref.</summary>
+        /// <summary>
+        /// doortypes.2da - specific door appearances need a model, display strref, and visibility
+        /// metadata so the editor can distinguish ordinary doors from transition planes.
+        /// </summary>
         public static readonly TwoDaLookupTable DoorType =
-            new("doortypes", "Label", "StringRefGame", ["Model", "StringRefGame"]);
+            new("doortypes", "Label", "StringRefGame", ["Model", "StringRefGame", "VisibleModel"]);
 
-        /// <summary>genericdoors.2da - generic door appearances need a model.</summary>
+        /// <summary>
+        /// genericdoors.2da - generic door appearances need a model and visibility metadata.
+        /// </summary>
         public static readonly TwoDaLookupTable GenericDoor =
-            new("genericdoors", "Label", "Name", ["ModelName"]);
+            new("genericdoors", "Label", "Name", ["ModelName", "VisibleModel"]);
 
         /// <summary>
         /// iprp_spells.2da - a Cast Spell subtype must identify a real spell, its levels, supported

--- a/SWLOR.Toolset.Domain/Render/AreaPicking.cs
+++ b/SWLOR.Toolset.Domain/Render/AreaPicking.cs
@@ -37,7 +37,9 @@ namespace SWLOR.Toolset.Domain.Render
 
         /// <summary>True when <paramref name="instance"/> should be hit-tested (and drawn) as its resolved model rather than its kind-colored marker pyramid - must mirror GlAreaControl.DrawsAsModel exactly so picking always matches what is on screen.</summary>
         public static bool DrawsAsModel(InstanceMarker instance, bool showPlaceableModels) =>
-            instance.Model != null && (showPlaceableModels || instance.Kind != InstanceMarkerKind.Placeable);
+            !instance.IsDoorTransition &&
+            instance.Model is { Meshes.Count: > 0 } &&
+            (showPlaceableModels || instance.Kind != InstanceMarkerKind.Placeable);
 
         /// <summary>
         /// The local-to-world transform for one instance marker: apply its optional visual
@@ -72,9 +74,11 @@ namespace SWLOR.Toolset.Domain.Render
 
             foreach (var instance in scene.Instances)
             {
-                var hitDistance = DrawsAsModel(instance, showPlaceableModels)
-                    ? PickModelInstance(ray, instance)
-                    : PickMarkerInstance(ray, instance);
+                var hitDistance = instance.IsDoorTransition
+                    ? PickDoorTransition(ray, instance)
+                    : DrawsAsModel(instance, showPlaceableModels)
+                        ? PickModelInstance(ray, instance)
+                        : PickMarkerInstance(ray, instance);
 
                 if (hitDistance is { } distance && distance < closestDistance)
                 {
@@ -95,7 +99,20 @@ namespace SWLOR.Toolset.Domain.Render
         /// re-scanning every instance in the scene.
         /// </summary>
         public static float? PickInstance(PickRay ray, InstanceMarker instance, bool drawsAsModel) =>
-            drawsAsModel ? PickModelInstance(ray, instance) : PickMarkerInstance(ray, instance);
+            instance.IsDoorTransition
+                ? PickDoorTransition(ray, instance)
+                : drawsAsModel
+                    ? PickModelInstance(ray, instance)
+                    : PickMarkerInstance(ray, instance);
+
+        private static float? PickDoorTransition(PickRay ray, InstanceMarker instance)
+        {
+            if (instance.Model is { Meshes.Count: > 0 })
+                return PickModelInstance(ray, instance);
+
+            var bounds = ComputeDoorTransitionWorldBounds(instance);
+            return RayAabbIntersect(ray, bounds.Min, bounds.Max);
+        }
 
         /// <summary>World-space AABB of one instance's transformed marker pyramid.</summary>
         public static (Vector3 Min, Vector3 Max) ComputeMarkerWorldBounds(InstanceMarker instance)
@@ -130,6 +147,21 @@ namespace SWLOR.Toolset.Domain.Render
         }
 
         /// <summary>
+        /// World bounds of the translucent transition representation: its authored hidden-model
+        /// geometry when available, otherwise the standard two-by-three-metre doorway plane.
+        /// </summary>
+        public static (Vector3 Min, Vector3 Max) ComputeDoorTransitionWorldBounds(InstanceMarker instance)
+        {
+            if (ComputeModelWorldBounds(instance) is { } modelBounds)
+                return modelBounds;
+
+            return TransformAabb(
+                DoorTransitionMarker.LocalMinimum,
+                DoorTransitionMarker.LocalMaximum,
+                ComputeInstanceTransform(instance));
+        }
+
+        /// <summary>
         /// World-space AABB for an instance as it is currently displayed: its merged model bounds
         /// when <paramref name="drawsAsModel"/> (falling back to the marker bounds if it somehow has
         /// no mesh), otherwise the marker pyramid's bounds. Used by GlAreaControl to draw a
@@ -137,6 +169,9 @@ namespace SWLOR.Toolset.Domain.Render
         /// </summary>
         public static (Vector3 Min, Vector3 Max) ComputeInstanceWorldBounds(InstanceMarker instance, bool drawsAsModel)
         {
+            if (instance.IsDoorTransition)
+                return ComputeDoorTransitionWorldBounds(instance);
+
             if (drawsAsModel && ComputeModelWorldBounds(instance) is { } modelBounds)
                 return modelBounds;
 

--- a/SWLOR.Toolset.Domain/Render/AreaScene.cs
+++ b/SWLOR.Toolset.Domain/Render/AreaScene.cs
@@ -132,6 +132,12 @@ namespace SWLOR.Toolset.Domain.Render
         public RenderModel? Model { get; init; }
 
         /// <summary>
+        /// This door's 2DA row declares <c>VisibleModel=0</c>, making it an invisible runtime area
+        /// transition that the toolset must represent with translucent editor geometry.
+        /// </summary>
+        public bool IsDoorTransition { get; init; }
+
+        /// <summary>
         /// A sound instance's MinDistance in metres - the range it plays at full volume, which
         /// Aurora draws as the dotted sphere around the marker. Null for every other kind and for
         /// sounds that carry no such field.
@@ -189,6 +195,7 @@ namespace SWLOR.Toolset.Domain.Render
                 VisualTransform = VisualTransform,
                 Geometry = geometry,
                 Model = Model,
+                IsDoorTransition = IsDoorTransition,
                 SoundMinDistance = SoundMinDistance,
                 SoundMaxDistance = SoundMaxDistance,
                 IsPositionalSound = IsPositionalSound

--- a/SWLOR.Toolset.Domain/Render/AreaSceneBuilder.cs
+++ b/SWLOR.Toolset.Domain/Render/AreaSceneBuilder.cs
@@ -231,7 +231,8 @@ namespace SWLOR.Toolset.Domain.Render
                 resolveModel: resolveCreatureModel,
                 modelCorrection: CreatureModelFacing.ForwardCorrection);
             AddMarkers(markers, git.Doors, InstanceMarkerKind.Door, ResourceType.Utd,
-                resolveModel: instance => ResolveDoorModel(instance, doorTypes, modelCache));
+                resolveModel: instance => ResolveDoorModel(instance, doorTypes, modelCache),
+                isDoorTransition: instance => IsDoorTransition(instance, doorTypes));
             AddMarkers(markers, git.Items, InstanceMarkerKind.Item, ResourceType.Uti);
             AddMarkers(markers, git.Placeables, InstanceMarkerKind.Placeable, ResourceType.Utp,
                 resolveModel: instance => ResolvePlaceableModel(instance, placeableAppearances, modelCache));
@@ -259,7 +260,8 @@ namespace SWLOR.Toolset.Domain.Render
             bool includeGeometry = false,
             Func<JsonGffStruct, RenderModel?>? resolveModel = null,
             Matrix4x4? modelCorrection = null,
-            IReadOnlyList<TilePlacement>? tiles = null)
+            IReadOnlyList<TilePlacement>? tiles = null,
+            Func<JsonGffStruct, bool>? isDoorTransition = null)
         {
             foreach (var instance in instances)
             {
@@ -300,6 +302,7 @@ namespace SWLOR.Toolset.Domain.Render
                         : InstanceFieldMap.GetVisualTransform(instance),
                     Geometry = geometry,
                     Model = resolveModel?.Invoke(instance),
+                    IsDoorTransition = isDoorTransition?.Invoke(instance) ?? false,
                     SoundMinDistance = kind == InstanceMarkerKind.Sound ? instance.GetSingleOrNull("MinDistance") : null,
                     SoundMaxDistance = kind == InstanceMarkerKind.Sound ? instance.GetSingleOrNull("MaxDistance") : null,
                     IsPositionalSound = kind == InstanceMarkerKind.Sound && (instance.GetIntOrNull("Positional") ?? 0) != 0
@@ -406,16 +409,42 @@ namespace SWLOR.Toolset.Domain.Render
                 return null;
 
             var appearance = instance.GetIntOrNull("Appearance") ?? 0;
-            var modelResRef = appearance > 0
-                ? doorTypes.GetAll().FirstOrDefault(row => row.Id == appearance)?.Model
-                : doorTypes.GetGenericAll().FirstOrDefault(row =>
+            var specific = appearance > 0
+                ? doorTypes.GetAll().FirstOrDefault(row => row.Id == appearance)
+                : null;
+            var generic = appearance == 0
+                ? doorTypes.GetGenericAll().FirstOrDefault(row =>
                     row.Id == (instance.GetIntOrNull("GenericType_New")
                                ?? instance.GetIntOrNull("GenericType")
-                               ?? 0))?.Model;
+                               ?? 0))
+                : null;
+            var modelResRef = specific?.Model ?? generic?.Model;
+            var visibleModel = specific?.VisibleModel ?? generic?.VisibleModel ?? true;
 
             return string.IsNullOrWhiteSpace(modelResRef)
                 ? null
-                : modelCache.GetOrBuild(modelResRef);
+                : visibleModel
+                    ? modelCache.GetOrBuild(modelResRef)
+                    : modelCache.GetOrBuildDoorTransition(modelResRef);
+        }
+
+        /// <summary>
+        /// <c>VisibleModel=0</c> is how both genericdoors.2da and doortypes.2da identify the
+        /// invisible area-transition planes that Aurora still shows while editing.
+        /// </summary>
+        private static bool IsDoorTransition(JsonGffStruct instance, DoorTypeService? doorTypes)
+        {
+            if (doorTypes == null)
+                return false;
+
+            var appearance = instance.GetIntOrNull("Appearance") ?? 0;
+            if (appearance > 0)
+                return doorTypes.GetAll().FirstOrDefault(row => row.Id == appearance) is { VisibleModel: false };
+
+            var genericType = instance.GetIntOrNull("GenericType_New")
+                              ?? instance.GetIntOrNull("GenericType")
+                              ?? 0;
+            return doorTypes.GetGenericAll().FirstOrDefault(row => row.Id == genericType) is { VisibleModel: false };
         }
 
         private static IReadOnlyList<Vector3>? ReadGeometry(JsonGffStruct instance)

--- a/SWLOR.Toolset.Domain/Render/BlueprintModelResolver.cs
+++ b/SWLOR.Toolset.Domain/Render/BlueprintModelResolver.cs
@@ -58,6 +58,13 @@ namespace SWLOR.Toolset.Domain.Render
         /// <summary>The single model resref for <see cref="BlueprintModelKind.Simple"/>; null otherwise.</summary>
         public string? ModelResRef { get; init; }
 
+        /// <summary>
+        /// The resolved door row declares <c>VisibleModel=0</c>. These are area-transition planes:
+        /// invisible at runtime, but drawn translucently by the toolset from the model's hidden
+        /// selection geometry.
+        /// </summary>
+        public bool IsDoorTransition { get; init; }
+
         /// <summary>The skeleton/supermodel resref for <see cref="BlueprintModelKind.Segmented"/>; null otherwise.</summary>
         public string? SkeletonResRef { get; init; }
 
@@ -858,6 +865,7 @@ namespace SWLOR.Toolset.Domain.Render
                 : null;
             var displayName = specific?.DisplayName ?? generic?.DisplayName;
             var model = specific?.Model ?? generic?.Model;
+            var visibleModel = specific?.VisibleModel ?? generic?.VisibleModel ?? true;
             var table = specific != null ? "doortypes.2da" : "genericdoors.2da";
 
             if (displayName == null)
@@ -872,7 +880,8 @@ namespace SWLOR.Toolset.Domain.Render
             {
                 Kind = BlueprintModelKind.Simple,
                 Status = $"{displayName} ({model}.mdl)",
-                ModelResRef = model
+                ModelResRef = model,
+                IsDoorTransition = !visibleModel
             };
         }
 

--- a/SWLOR.Toolset.Domain/Render/DoorTransitionMarker.cs
+++ b/SWLOR.Toolset.Domain/Render/DoorTransitionMarker.cs
@@ -18,5 +18,53 @@ namespace SWLOR.Toolset.Domain.Render
 
         public static readonly Vector3 LocalMaximum =
             new(HalfWidth, HalfDepth, HalfHeight);
+
+        /// <summary>
+        /// Creates the fixed doorway box used when a transition MDL has no usable authored
+        /// geometry. The software thumbnail renderer consumes the same dimensions as viewport
+        /// drawing and picking, so every editor surface shows the same fallback silhouette.
+        /// </summary>
+        public static RenderModel CreateFallbackModel()
+        {
+            var min = LocalMinimum;
+            var max = LocalMaximum;
+            return new RenderModel
+            {
+                Name = "door_transition_fallback",
+                IsDoorTransitionGeometry = true,
+                Meshes =
+                [
+                    new RenderMesh
+                    {
+                        NodeName = "door_transition_fallback",
+                        TextureName = string.Empty,
+                        DiffuseColor = new Vector3(0.52f, 0.52f, 0.82f),
+                        Positions =
+                        [
+                            min.X, min.Y, min.Z,
+                            max.X, min.Y, min.Z,
+                            max.X, max.Y, min.Z,
+                            min.X, max.Y, min.Z,
+                            min.X, min.Y, max.Z,
+                            max.X, min.Y, max.Z,
+                            max.X, max.Y, max.Z,
+                            min.X, max.Y, max.Z
+                        ],
+                        Normals = Array.Empty<float>(),
+                        TexCoords = Array.Empty<float>(),
+                        Indices =
+                        [
+                            3, 2, 1, 3, 1, 0,
+                            4, 5, 6, 4, 6, 7,
+                            0, 1, 5, 0, 5, 4,
+                            2, 3, 7, 2, 7, 6,
+                            3, 0, 4, 3, 4, 7,
+                            1, 2, 6, 1, 6, 5
+                        ],
+                        Transform = Matrix4x4.Identity
+                    }
+                ]
+            };
+        }
     }
 }

--- a/SWLOR.Toolset.Domain/Render/DoorTransitionMarker.cs
+++ b/SWLOR.Toolset.Domain/Render/DoorTransitionMarker.cs
@@ -1,0 +1,22 @@
+using System.Numerics;
+
+namespace SWLOR.Toolset.Domain.Render
+{
+    /// <summary>
+    /// Fallback editor shape for an invisible area-transition door whose MDL cannot be resolved.
+    /// Door models span local +X along the wall, with their stored position at the centre of the
+    /// doorway; the standard Aurora transition plane is two metres wide and three metres high.
+    /// </summary>
+    public static class DoorTransitionMarker
+    {
+        public const float HalfWidth = 1f;
+        public const float HalfDepth = 0.05f;
+        public const float HalfHeight = 1.5f;
+
+        public static readonly Vector3 LocalMinimum =
+            new(-HalfWidth, -HalfDepth, -HalfHeight);
+
+        public static readonly Vector3 LocalMaximum =
+            new(HalfWidth, HalfDepth, HalfHeight);
+    }
+}

--- a/SWLOR.Toolset.Domain/Render/MdlMeshBuilder.cs
+++ b/SWLOR.Toolset.Domain/Render/MdlMeshBuilder.cs
@@ -150,6 +150,12 @@ namespace SWLOR.Toolset.Domain.Render
         public string? DefaultAnimationName { get; init; }
 
         /// <summary>
+        /// This model was built from an invisible transition door's editor-only geometry. Area
+        /// viewports draw it flat and translucent instead of treating it as ordinary game artwork.
+        /// </summary>
+        public bool IsDoorTransitionGeometry { get; init; }
+
+        /// <summary>
         /// The palette index each PLT layer is dyed with (skin, hair, metal, cloth, leather, tattoo),
         /// or empty for a model with no dyed textures.
         /// </summary>
@@ -231,6 +237,7 @@ namespace SWLOR.Toolset.Domain.Render
                 model,
                 poseFrames,
                 includePlaceableMetadata: false,
+                includeDoorTransitionGeometry: false,
                 skinSurfaceClearance: skinSurfaceClearance,
                 skinSurfaceClearanceExcludedBones: excludedBones,
                 sampledAnimations: null);
@@ -259,6 +266,7 @@ namespace SWLOR.Toolset.Domain.Render
                 model,
                 restingPoseFrames,
                 includePlaceableMetadata: false,
+                includeDoorTransitionGeometry: false,
                 skinSurfaceClearance,
                 skinSurfaceClearanceExcludedBones?.ToHashSet(StringComparer.OrdinalIgnoreCase),
                 animations);
@@ -275,6 +283,28 @@ namespace SWLOR.Toolset.Domain.Render
                 model,
                 poseFrames: null,
                 includePlaceableMetadata: true,
+                includeDoorTransitionGeometry: false,
+                skinSurfaceClearance: 0f,
+                skinSurfaceClearanceExcludedBones: null,
+                sampledAnimations: null);
+        }
+
+        /// <summary>
+        /// Builds the authored editor geometry for a door row whose <c>VisibleModel</c> is zero.
+        /// Those transition planes commonly put their selectable surface on <c>render 0</c> meshes:
+        /// correct for the game, but not for an area editor where the otherwise invisible object has
+        /// to remain visible and selectable.
+        /// </summary>
+        public static RenderModel BuildDoorTransition(
+            MdlModel model,
+            IReadOnlyList<IReadOnlyDictionary<string, PosedNode>>? poseFrames = null)
+        {
+            ArgumentNullException.ThrowIfNull(model);
+            return BuildInternal(
+                model,
+                poseFrames,
+                includePlaceableMetadata: false,
+                includeDoorTransitionGeometry: true,
                 skinSurfaceClearance: 0f,
                 skinSurfaceClearanceExcludedBones: null,
                 sampledAnimations: null);
@@ -336,6 +366,7 @@ namespace SWLOR.Toolset.Domain.Render
             MdlModel model,
             IReadOnlyList<IReadOnlyDictionary<string, PosedNode>>? poseFrames,
             bool includePlaceableMetadata,
+            bool includeDoorTransitionGeometry,
             float skinSurfaceClearance,
             IReadOnlySet<string>? skinSurfaceClearanceExcludedBones,
             IReadOnlyList<MdlAnimationPose.SampledAnimation>? sampledAnimations)
@@ -360,7 +391,7 @@ namespace SWLOR.Toolset.Domain.Render
                 // arrives at the default of true, and it carries no bitmap - which drew it as a flat
                 // grey slab across the ground of every tile that had one. The area view gets its
                 // walkmesh from the tile's .wok (see TileWalkmeshCache), never from here.
-                if (!IsRenderableMesh(mesh))
+                if (!(includeDoorTransitionGeometry ? IsDoorTransitionMesh(mesh) : IsRenderableMesh(mesh)))
                     continue;
 
                 var built = BuildMesh(
@@ -412,7 +443,8 @@ namespace SWLOR.Toolset.Domain.Render
                 Meshes = renderMeshes,
                 Animations = renderAnimations,
                 Emitters = renderEmitters,
-                DefaultAnimationName = defaultAnimationName
+                DefaultAnimationName = defaultAnimationName,
+                IsDoorTransitionGeometry = includeDoorTransitionGeometry
             };
         }
 
@@ -425,6 +457,27 @@ namespace SWLOR.Toolset.Domain.Render
         {
             ArgumentNullException.ThrowIfNull(mesh);
             if (mesh.IsWalkmesh || !mesh.Render || PlaceholderNames.Contains(mesh.Name) ||
+                mesh.Vertices.Length == 0 || mesh.Faces.Length == 0)
+            {
+                return false;
+            }
+
+            var vertexCount = mesh.Vertices.Length;
+            return mesh.Faces.Any(face =>
+                face.VertexIndex0 < vertexCount &&
+                face.VertexIndex1 < vertexCount &&
+                face.VertexIndex2 < vertexCount);
+        }
+
+        /// <summary>
+        /// A transition door may expose its toolset selection surface with <c>render 0</c>. Keep
+        /// those meshes while retaining the ordinary exclusions for collision and placeholder
+        /// nodes; both rendered and non-rendered authored surfaces contribute to the editor shape.
+        /// </summary>
+        private static bool IsDoorTransitionMesh(MdlTrimeshNode mesh)
+        {
+            ArgumentNullException.ThrowIfNull(mesh);
+            if (mesh.IsWalkmesh || PlaceholderNames.Contains(mesh.Name) ||
                 mesh.Vertices.Length == 0 || mesh.Faces.Length == 0)
             {
                 return false;

--- a/SWLOR.Toolset.Domain/Render/ThumbnailRenderer.cs
+++ b/SWLOR.Toolset.Domain/Render/ThumbnailRenderer.cs
@@ -95,19 +95,35 @@ namespace SWLOR.Toolset.Domain.Render
         /// takes precedence over <paramref name="resolveTexture"/> and lets equipped garments keep
         /// dyes that differ from the creature's chest armor.
         /// </param>
+        /// <param name="renderDoorTransitionFallback">
+        /// Draws the fixed editor doorway when transition metadata exists but the authored model is
+        /// null or has no triangles.
+        /// </param>
         public static byte[]? Render(
             RenderModel? model,
             int size,
             ThumbnailPalette? palette = null,
             Func<string, TextureImage?>? resolveTexture = null,
-            Func<string, IReadOnlyDictionary<int, int>?, TextureImage?>? resolveLayeredTexture = null)
+            Func<string, IReadOnlyDictionary<int, int>?, TextureImage?>? resolveLayeredTexture = null,
+            bool renderDoorTransitionFallback = false)
         {
-            if (model == null || size <= 0)
+            if (size <= 0)
                 return null;
 
             palette ??= ThumbnailPalette.Default;
 
-            var triangles = CollectTriangles(model, resolveTexture, resolveLayeredTexture);
+            var triangles = model == null
+                ? new List<SourceTriangle>()
+                : CollectTriangles(model, resolveTexture, resolveLayeredTexture);
+            if (triangles.Count == 0 &&
+                (renderDoorTransitionFallback || model?.IsDoorTransitionGeometry == true))
+            {
+                triangles = CollectTriangles(
+                    DoorTransitionMarker.CreateFallbackModel(),
+                    resolveTexture: null,
+                    resolveLayeredTexture: null);
+            }
+
             if (triangles.Count == 0)
                 return null;
 

--- a/SWLOR.Toolset.Domain/Render/ThumbnailRenderer.cs
+++ b/SWLOR.Toolset.Domain/Render/ThumbnailRenderer.cs
@@ -97,7 +97,7 @@ namespace SWLOR.Toolset.Domain.Render
         /// </param>
         /// <param name="renderDoorTransitionFallback">
         /// Draws the fixed editor doorway when transition metadata exists but the authored model is
-        /// null or has no triangles.
+        /// null, has no triangles, or has no triangles that survive projection.
         /// </param>
         public static byte[]? Render(
             RenderModel? model,
@@ -112,16 +112,18 @@ namespace SWLOR.Toolset.Domain.Render
 
             palette ??= ThumbnailPalette.Default;
 
+            var isDoorTransition = renderDoorTransitionFallback || model?.IsDoorTransitionGeometry == true;
+            var usingDoorTransitionFallback = false;
             var triangles = model == null
                 ? new List<SourceTriangle>()
                 : CollectTriangles(model, resolveTexture, resolveLayeredTexture);
-            if (triangles.Count == 0 &&
-                (renderDoorTransitionFallback || model?.IsDoorTransitionGeometry == true))
+            if (triangles.Count == 0 && isDoorTransition)
             {
                 triangles = CollectTriangles(
                     DoorTransitionMarker.CreateFallbackModel(),
                     resolveTexture: null,
                     resolveLayeredTexture: null);
+                usingDoorTransitionFallback = true;
             }
 
             if (triangles.Count == 0)
@@ -132,6 +134,15 @@ namespace SWLOR.Toolset.Domain.Render
 
             var view = BuildViewBasis();
             var projected = Project(triangles, view, size, out var any);
+            if (!any && isDoorTransition && !usingDoorTransitionFallback)
+            {
+                triangles = CollectTriangles(
+                    DoorTransitionMarker.CreateFallbackModel(),
+                    resolveTexture: null,
+                    resolveLayeredTexture: null);
+                projected = Project(triangles, view, size, out any);
+            }
+
             if (!any)
                 return null;
 

--- a/SWLOR.Toolset.Domain/Render/TileModelCache.cs
+++ b/SWLOR.Toolset.Domain/Render/TileModelCache.cs
@@ -21,6 +21,8 @@ namespace SWLOR.Toolset.Domain.Render
             new(StringComparer.OrdinalIgnoreCase);
         private readonly ConcurrentDictionary<string, RenderModel?> _placeablePreviewCache =
             new(StringComparer.OrdinalIgnoreCase);
+        private readonly ConcurrentDictionary<string, RenderModel?> _doorTransitionCache =
+            new(StringComparer.OrdinalIgnoreCase);
 
         public TileModelCache(ResourceIndex resourceIndex)
         {
@@ -32,6 +34,7 @@ namespace SWLOR.Toolset.Domain.Render
         {
             _cache.Clear();
             _placeablePreviewCache.Clear();
+            _doorTransitionCache.Clear();
         }
 
         /// <summary>
@@ -61,6 +64,19 @@ namespace SWLOR.Toolset.Domain.Render
             return _placeablePreviewCache.GetOrAdd(modelResRef, BuildPlaceablePreview);
         }
 
+        /// <summary>
+        /// Resolves an invisible transition-door model including its <c>render 0</c> editor
+        /// selection surfaces. Kept separate from the ordinary cache so the same MDL remains
+        /// invisible when used as normal game artwork.
+        /// </summary>
+        public RenderModel? GetOrBuildDoorTransition(string? modelResRef)
+        {
+            if (string.IsNullOrWhiteSpace(modelResRef))
+                return null;
+
+            return _doorTransitionCache.GetOrAdd(modelResRef, BuildDoorTransition);
+        }
+
         private RenderModel? Build(string modelResRef)
         {
             var model = Load(modelResRef);
@@ -71,6 +87,12 @@ namespace SWLOR.Toolset.Domain.Render
         {
             var model = Load(modelResRef);
             return model == null ? null : MdlMeshBuilder.BuildPlaceablePreview(model);
+        }
+
+        private RenderModel? BuildDoorTransition(string modelResRef)
+        {
+            var model = Load(modelResRef);
+            return model == null ? null : MdlMeshBuilder.BuildDoorTransition(model);
         }
 
         private MdlModel? Load(string modelResRef)

--- a/SWLOR.Toolset.Domain/Render/TileModelCache.cs
+++ b/SWLOR.Toolset.Domain/Render/TileModelCache.cs
@@ -92,7 +92,20 @@ namespace SWLOR.Toolset.Domain.Render
         private RenderModel? BuildDoorTransition(string modelResRef)
         {
             var model = Load(modelResRef);
-            return model == null ? null : MdlMeshBuilder.BuildDoorTransition(model);
+            if (model == null)
+                return null;
+
+            try
+            {
+                return MdlMeshBuilder.BuildDoorTransition(model);
+            }
+            catch (Exception)
+            {
+                // Hidden editor meshes are less constrained than runtime artwork. A malformed
+                // parent chain or other mesh-build failure must fall back to the fixed transition
+                // doorway instead of aborting assembly of the entire area.
+                return null;
+            }
         }
 
         private MdlModel? Load(string modelResRef)

--- a/SWLOR.Toolset.Tests/AreaPickingTests.cs
+++ b/SWLOR.Toolset.Tests/AreaPickingTests.cs
@@ -15,7 +15,7 @@ namespace SWLOR.Toolset.Tests
     {
         private static InstanceMarker MakeMarkerInstance(
             InstanceMarkerKind kind, Vector3 position, string tag, RenderModel? model = null,
-            Matrix4x4? visualTransform = null) => new()
+            Matrix4x4? visualTransform = null, bool isDoorTransition = false) => new()
         {
             Kind = kind,
             TemplateResRef = tag,
@@ -23,7 +23,8 @@ namespace SWLOR.Toolset.Tests
             Position = position,
             Orientation = new Vector2(1f, 0f),
             VisualTransform = visualTransform ?? Matrix4x4.Identity,
-            Model = model
+            Model = model,
+            IsDoorTransition = isDoorTransition
         };
 
         private static RenderMesh MakeMesh(float[] positions, int[] indices) => new()
@@ -299,6 +300,27 @@ namespace SWLOR.Toolset.Tests
             var (min, max) = AreaPicking.ComputeInstanceWorldBounds(instance, drawsAsModel: false);
 
             (max.X - min.X).Should().BeApproximately(0.8f, 0.0001f);
+        }
+
+        [Test]
+        public void DoorTransitionWithoutResolvedGeometry_UsesTheVisibleDoorwayPlaneForBoundsAndPicking()
+        {
+            var instance = MakeMarkerInstance(
+                InstanceMarkerKind.Door,
+                new Vector3(10f, 20f, 4f),
+                "transition",
+                isDoorTransition: true);
+
+            var (min, max) = AreaPicking.ComputeInstanceWorldBounds(instance, drawsAsModel: false);
+            var hit = AreaPicking.PickClosestInstance(
+                DownwardRayAt(10f, 20f), MakeScene(instance), showPlaceableModels: true);
+
+            (max.X - min.X).Should().BeApproximately(2f, 0.0001f);
+            (max.Z - min.Z).Should().BeApproximately(3f, 0.0001f);
+            hit.Should().BeSameAs(instance,
+                "the fallback transition plane must be selectable instead of an invisible marker");
+            AreaPicking.DrawsAsModel(instance, showPlaceableModels: true).Should().BeFalse(
+                "transition geometry has its own translucent render pass");
         }
 
         // ----- PickInstance (WP5.2: single-instance hit-test for the move/rotate gizmo's press check) -----

--- a/SWLOR.Toolset.Tests/AreaSceneBuilderTests.cs
+++ b/SWLOR.Toolset.Tests/AreaSceneBuilderTests.cs
@@ -303,6 +303,78 @@ namespace SWLOR.Toolset.Tests
         }
 
         [Test]
+        public void Build_InvisibleDoorType_PreservesAnEditorTransitionWhenItsModelIsUnavailable()
+        {
+            var scratch = Path.Combine(
+                TestContext.CurrentContext.WorkDirectory,
+                $"door-transition-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(scratch);
+            try
+            {
+                File.WriteAllText(
+                    Path.Combine(scratch, "genericdoors.2da"),
+                    "2DA V2.0\r\n\r\nLabel StrRef ModelName BlockSight VisibleModel SoundAppType Name\r\n" +
+                    "0 Transition 123 missing_transition_model 0 0 **** 123\r\n");
+                File.WriteAllText(
+                    Path.Combine(scratch, "doortypes.2da"),
+                    "2DA V2.0\r\n\r\nLabel Model TileSet TemplateResRef StringRefGame BlockSight VisibleModel SoundAppType\r\n");
+                var doors = new DoorTypeService(
+                    new Domain.GameData.TwoDa.TwoDaService(scratch),
+                    new Domain.GameData.Tlk.TlkService(
+                        Domain.GameData.Tlk.TlkJsonFile.Parse("{\"language\":0,\"entries\":[]}")));
+
+                var (are, git) = LoadArea("dan_smugcaverns");
+                var transition = git.Doors.Single(door =>
+                    door.GetStringOrNull("Tag") == "dan_smugcave");
+                transition.Get("Appearance").SetInteger(0);
+                transition.Get("GenericType_New").SetInteger(0);
+
+                var previewReference = BlueprintModelResolver.Resolve(
+                    ResourceType.Utd, transition, null, null, doors);
+                previewReference.IsDoorTransition.Should().BeTrue(
+                    "door-editor previews and placement ghosts consume the same 2DA metadata");
+                previewReference.ModelResRef.Should().Be("missing_transition_model");
+
+                var index = BuildHakOnlyIndex();
+                var scene = AreaSceneBuilder.Build(
+                    are,
+                    git,
+                    new TilesetCatalog(index),
+                    new TileModelCache(index),
+                    doorTypes: doors);
+
+                var marker = scene.Instances.Single(instance => instance.Tag == "dan_smugcave");
+                marker.IsDoorTransition.Should().BeTrue();
+                marker.Model.Should().BeNull(
+                    "the viewport's fixed transition plane must cover a missing editor MDL");
+            }
+            finally
+            {
+                Directory.Delete(scratch, recursive: true);
+            }
+        }
+
+        [Test]
+        public void BaseGameTransitionDoor_PreservesTransitionSemanticsWithoutDrawableGeometry()
+        {
+            var installPath = NwnInstallLocator.Locate();
+            if (installPath == null)
+            {
+                Assert.Ignore("No local NWN:EE installation found; transition-door MDL is base-game data.");
+                return;
+            }
+
+            var baseLayer = KeyBifCatalog.Load(Path.Combine(installPath, "data"));
+            var index = new ResourceIndex(baseLayer, Array.Empty<ResourceIndex.HakLayer>());
+            var model = new TileModelCache(index).GetOrBuildDoorTransition("tn_gdoor_08");
+
+            model.Should().NotBeNull("the generic transition door is present in the base resource layer");
+            model!.IsDoorTransitionGeometry.Should().BeTrue();
+            model.Meshes.Should().BeEmpty(
+                "tn_gdoor_08 intentionally has no drawable surfaces, so the viewport must use its fixed transition plane");
+        }
+
+        [Test]
         public void Build_TileIdBeyondTilesetRange_FallsBackWithoutThrowing()
         {
             var (are, git) = LoadArea("bank");

--- a/SWLOR.Toolset.Tests/DoorTransitionPreviewTests.cs
+++ b/SWLOR.Toolset.Tests/DoorTransitionPreviewTests.cs
@@ -1,0 +1,171 @@
+using FluentAssertions;
+using NUnit.Framework;
+using SWLOR.Toolset.Domain.GameData.Lookups;
+using SWLOR.Toolset.Domain.GameData.Resources;
+using SWLOR.Toolset.Domain.GameData.Tlk;
+using SWLOR.Toolset.Domain.GameData.TwoDa;
+using SWLOR.Toolset.Domain.Render;
+using SWLOR.Toolset.Domain.Workspace;
+using SWLOR.Toolset.Editors;
+using SWLOR.Toolset.Editors.Doors;
+using SWLOR.Toolset.Services;
+using SWLOR.Toolset.Shell.Panels;
+using SWLOR.Toolset.Workspace;
+
+namespace SWLOR.Toolset.Tests
+{
+    /// <summary>
+    /// Transition classification is editor metadata, not a side effect of successfully loading an
+    /// MDL. These tests keep the fallback alive through the renderer, placement ghost, and door
+    /// preview paths when the authored geometry is unavailable.
+    /// </summary>
+    [TestFixture]
+    public sealed class DoorTransitionPreviewTests
+    {
+        [Test]
+        public void MissingTransitionModel_PreservesResolvedTransitionMetadata()
+        {
+            var scratch = Path.Combine(
+                TestContext.CurrentContext.WorkDirectory,
+                $"door-transition-preview-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(scratch);
+            try
+            {
+                File.WriteAllText(
+                    Path.Combine(scratch, "genericdoors.2da"),
+                    "2DA V2.0\r\n\r\nLabel StrRef ModelName BlockSight VisibleModel SoundAppType Name\r\n" +
+                    "0 Transition 123 missing_transition_model 0 0 **** 123\r\n");
+                File.WriteAllText(
+                    Path.Combine(scratch, "doortypes.2da"),
+                    "2DA V2.0\r\n\r\nLabel Model TileSet TemplateResRef StringRefGame BlockSight VisibleModel SoundAppType\r\n");
+
+                var index = new ResourceIndex(null, Array.Empty<ResourceIndex.HakLayer>());
+                index.EnsureInitialized();
+                var log = new OutputLogService();
+                var context = new WorkspaceContext(path => new ModuleWorkspace(path, index), log);
+                var doors = new DoorTypeService(
+                    new TwoDaService(scratch),
+                    new TlkService(TlkJsonFile.Parse("{\"language\":0,\"entries\":[]}")));
+                var renderer = new BlueprintPreviewRenderer(context, index, doors: doors);
+                var door = TransitionDoor();
+
+                var result = renderer.BuildModelResult(ResourceType.Utd, door);
+
+                result.Model.Should().BeNull("the synthetic transition MDL does not exist");
+                result.IsDoorTransition.Should().BeTrue(
+                    "the 2DA classification must survive independently of nullable geometry");
+            }
+            finally
+            {
+                Directory.Delete(scratch, recursive: true);
+            }
+        }
+
+        [Test]
+        public void DoorEditor_MissingTransitionModel_StillCreatesFallbackPreviewMarker()
+        {
+            using var editor = new DoorEditorViewModel(
+                TransitionDoor(),
+                "test",
+                isInstance: false,
+                RunEdit,
+                resolveModel: _ => new BlueprintModelRenderResult(null, IsDoorTransition: true));
+
+            editor.PreviewScene.Should().NotBeNull();
+            var marker = editor.PreviewScene!.Instances.Should().ContainSingle().Subject;
+            marker.Model.Should().BeNull();
+            marker.IsDoorTransition.Should().BeTrue();
+        }
+
+        [Test]
+        public void PlacementGhost_MissingTransitionModel_StillUsesTransitionFallback()
+        {
+            var moduleRoot = CopyArea("dan_smugcaverns");
+            try
+            {
+                var log = new OutputLogService();
+                var context = new WorkspaceContext(_ => throw new NotSupportedException(), log);
+                var editor = new AreaEditorViewModel(
+                    "dan_smugcaverns",
+                    new ModuleWorkspace(moduleRoot),
+                    new LookupOptionProvider(context),
+                    gameCodeIndex: null,
+                    log,
+                    prompts: new StubPrompts(),
+                    resolveBlueprintModel: (_, _, _) =>
+                        new BlueprintModelRenderResult(null, IsDoorTransition: true));
+
+                editor.ArmPlacement(
+                    ResourceType.Utd,
+                    "missing_transition",
+                    PaletteSource.Custom).Should().BeTrue();
+
+                editor.PlacementGhost.Should().NotBeNull();
+                editor.PlacementGhost!.Model.Should().BeNull();
+                editor.PlacementGhost.IsDoorTransition.Should().BeTrue();
+            }
+            finally
+            {
+                Directory.Delete(moduleRoot, recursive: true);
+            }
+        }
+
+        private static Domain.Gff.JsonGffStruct TransitionDoor()
+        {
+            var door = new ModuleWorkspace(CorpusLocator.ModuleDirectory)
+                .LoadBlueprint(ResourceType.Utd, "_mdrn_dt_bars")
+                .Fields;
+            door.Get("Appearance").SetUnsignedInteger(0);
+            door.Get("GenericType_New").SetUnsignedInteger(0);
+            return door;
+        }
+
+        private static string CopyArea(string resRef)
+        {
+            var moduleRoot = Path.Combine(
+                Path.GetTempPath(),
+                $"swlor-transition-placement-{Guid.NewGuid():N}");
+            foreach (var folder in CorpusLocator.GffFolders)
+                Directory.CreateDirectory(Path.Combine(moduleRoot, folder));
+
+            foreach (var folder in new[] { "are", "git", "gic" })
+            {
+                var source = Path.Combine(
+                    CorpusLocator.ModuleDirectory,
+                    folder,
+                    $"{resRef}.{folder}.json");
+                File.Copy(source, Path.Combine(moduleRoot, folder, Path.GetFileName(source)));
+            }
+
+            return moduleRoot;
+        }
+
+        private static bool RunEdit(string _, Action mutation)
+        {
+            mutation();
+            return true;
+        }
+
+        private sealed class StubPrompts : IEditorPromptService
+        {
+            public Task<UnsavedChangesChoice> ConfirmCloseAsync(string name) =>
+                Task.FromResult(UnsavedChangesChoice.Cancel);
+
+            public Task<ExternalChangeChoice> ConfirmExternalChangeAsync(string path) =>
+                Task.FromResult(ExternalChangeChoice.Cancel);
+
+            public Task<string?> PromptForTextAsync(
+                string headline,
+                string message,
+                string initialValue,
+                string confirmLabel) =>
+                Task.FromResult<string?>(null);
+
+            public Task<bool> ConfirmDestructiveAsync(
+                string headline,
+                string message,
+                string confirmLabel) =>
+                Task.FromResult(false);
+        }
+    }
+}

--- a/SWLOR.Toolset.Tests/MdlMeshBuilderPlaceholderTests.cs
+++ b/SWLOR.Toolset.Tests/MdlMeshBuilderPlaceholderTests.cs
@@ -140,6 +140,29 @@ namespace SWLOR.Toolset.Tests
             MdlMeshBuilder.Build(ModelOf(malformed)).Meshes.Should().BeEmpty();
         }
 
+        [Test]
+        public void AnUnsignedMinusOneFaceIndex_NeverReachesARenderBuffer()
+        {
+            var malformed = Trimesh("malformed");
+            malformed.Faces =
+            [
+                new MdlFace
+                {
+                    // MDL face indices are ushort. A raw -1 sentinel is represented as 0xFFFF,
+                    // so the existing upper-bound validation is also its non-negative guard.
+                    VertexIndex0 = unchecked((ushort)-1),
+                    VertexIndex1 = 1,
+                    VertexIndex2 = 2
+                }
+            ];
+
+            MdlMeshBuilder.IsRenderableMesh(malformed).Should().BeFalse();
+            MdlMeshBuilder.Build(ModelOf(malformed)).Meshes.Should().BeEmpty();
+
+            malformed.Render = false;
+            MdlMeshBuilder.BuildDoorTransition(ModelOf(malformed)).Meshes.Should().BeEmpty();
+        }
+
         /// <summary>
         /// The Aurora "no texture" literal must resolve the same way whether it came from an ASCII
         /// MDL (already lowercased/blanked by <see cref="AsciiMdlReader"/>) or a binary MDL (which

--- a/SWLOR.Toolset.Tests/MdlMeshBuilderPlaceholderTests.cs
+++ b/SWLOR.Toolset.Tests/MdlMeshBuilderPlaceholderTests.cs
@@ -97,6 +97,37 @@ namespace SWLOR.Toolset.Tests
         }
 
         [Test]
+        public void DoorTransitionBuild_KeepsHiddenSelectionGeometryOnlyForTheEditor()
+        {
+            var hiddenPlane = Trimesh("transition_plane", bitmap: null);
+            hiddenPlane.Render = false;
+
+            var ordinary = MdlMeshBuilder.Build(ModelOf(hiddenPlane));
+            var transition = MdlMeshBuilder.BuildDoorTransition(ModelOf(hiddenPlane));
+
+            ordinary.Meshes.Should().BeEmpty("render 0 geometry stays invisible in game artwork");
+            transition.Meshes.Should().ContainSingle()
+                .Which.NodeName.Should().Be("transition_plane");
+            transition.IsDoorTransitionGeometry.Should().BeTrue();
+        }
+
+        [Test]
+        public void DoorTransitionBuild_StillExcludesCollisionAndPlaceholderMeshes()
+        {
+            var hiddenPlane = Trimesh("transition_plane", bitmap: null);
+            hiddenPlane.Render = false;
+            var collision = Trimesh("collision", bitmap: null);
+            collision.IsWalkmesh = true;
+            var placeholder = Trimesh("sam", bitmap: null);
+
+            var transition = MdlMeshBuilder.BuildDoorTransition(
+                ModelOf(hiddenPlane, collision, placeholder));
+
+            transition.Meshes.Should().ContainSingle()
+                .Which.NodeName.Should().Be("transition_plane");
+        }
+
+        [Test]
         public void AMeshWhoseFacesAllReferenceMissingVertices_IsNotBuilt()
         {
             var malformed = Trimesh("malformed");

--- a/SWLOR.Toolset.Tests/ThumbnailRendererTests.cs
+++ b/SWLOR.Toolset.Tests/ThumbnailRendererTests.cs
@@ -139,6 +139,23 @@ namespace SWLOR.Toolset.Tests
         }
 
         [Test]
+        public void A_Transition_Model_With_Unprojectable_Triangles_Renders_The_Doorway_Fallback()
+        {
+            var degenerate = Box(0f, 0f, 0f);
+            var transition = new RenderModel
+            {
+                Name = degenerate.Name,
+                Meshes = degenerate.Meshes,
+                IsDoorTransitionGeometry = true
+            };
+
+            var pixels = ThumbnailRenderer.Render(transition, Size);
+
+            pixels.Should().NotBeNull();
+            OpaquePixels(pixels!).Should().BeGreaterThan(0);
+        }
+
+        [Test]
         public void A_Null_Model_Renders_Nothing()
         {
             ThumbnailRenderer.Render(null, Size).Should().BeNull();

--- a/SWLOR.Toolset.Tests/ThumbnailRendererTests.cs
+++ b/SWLOR.Toolset.Tests/ThumbnailRendererTests.cs
@@ -111,6 +111,34 @@ namespace SWLOR.Toolset.Tests
         }
 
         [Test]
+        public void A_Transition_Model_With_No_Triangles_Renders_The_Doorway_Fallback()
+        {
+            var transition = new RenderModel
+            {
+                Name = "transition",
+                Meshes = Array.Empty<RenderMesh>(),
+                IsDoorTransitionGeometry = true
+            };
+
+            var pixels = ThumbnailRenderer.Render(transition, Size);
+
+            pixels.Should().NotBeNull();
+            OpaquePixels(pixels!).Should().BeGreaterThan(0);
+        }
+
+        [Test]
+        public void Transition_Metadata_Without_A_Model_Renders_The_Doorway_Fallback()
+        {
+            var pixels = ThumbnailRenderer.Render(
+                model: null,
+                size: Size,
+                renderDoorTransitionFallback: true);
+
+            pixels.Should().NotBeNull();
+            OpaquePixels(pixels!).Should().BeGreaterThan(0);
+        }
+
+        [Test]
         public void A_Null_Model_Renders_Nothing()
         {
             ThumbnailRenderer.Render(null, Size).Should().BeNull();

--- a/SWLOR.Toolset.Tests/TwoDaChoicePolicyTests.cs
+++ b/SWLOR.Toolset.Tests/TwoDaChoicePolicyTests.cs
@@ -123,16 +123,19 @@ namespace SWLOR.Toolset.Tests
                     "2DA V2.0\r\n\r\nLabel StrRef ModelName BlockSight VisibleModel SoundAppType Name\r\n" +
                     "0 GenericDoor 123 generic_model 1 1 1 123\r\n" +
                     "1 User002 **** **** **** **** **** ****\r\n" +
-                    "2 MissingModel 123 **** 1 1 1 123\r\n");
+                    "2 MissingModel 123 **** 1 1 1 123\r\n" +
+                    "3 Transition 124 transition_model 0 0 **** 124\r\n");
                 var service = new DoorTypeService(
                     new TwoDaService(scratch),
                     new TlkService(TlkJsonFile.Parse("{\"language\":0,\"entries\":[]}")));
 
                 service.GetAll().Should().ContainSingle()
                     .Which.Should().Be(new DoorTypeRow(0, "RealDoor", "RealDoor", "real_model"));
-                service.GetGenericAll().Should().ContainSingle()
-                    .Which.Should().Match<GenericDoorRow>(row =>
-                        row.Id == 0 && row.Label == "GenericDoor" && row.Model == "generic_model");
+                service.GetGenericAll().Should().HaveCount(2);
+                service.GetGeneric(0).Should().Match<GenericDoorRow>(row =>
+                    row.Label == "GenericDoor" && row.Model == "generic_model" && row.VisibleModel);
+                service.GetGeneric(3).Should().Match<GenericDoorRow>(row =>
+                    row.Label == "Transition" && row.Model == "transition_model" && !row.VisibleModel);
             }
             finally
             {

--- a/SWLOR.Toolset.Tests/TwoDaChoicePolicyTests.cs
+++ b/SWLOR.Toolset.Tests/TwoDaChoicePolicyTests.cs
@@ -117,14 +117,16 @@ namespace SWLOR.Toolset.Tests
                     "1 Reserved47 **** **** **** **** **** **** ****\r\n" +
                     "2 User002 **** **** **** **** **** **** ****\r\n" +
                     "3 MissingModel **** TST01 missing_model 123 1 1 1\r\n" +
-                    "4 MissingStringRef another_model TST01 missing_strref **** 1 1 1\r\n");
+                    "4 MissingStringRef another_model TST01 missing_strref **** 1 1 1\r\n" +
+                    "5 MissingVisibility another_model TST01 missing_visibility 124 1 **** 1\r\n");
                 File.WriteAllText(
                     Path.Combine(scratch, "genericdoors.2da"),
                     "2DA V2.0\r\n\r\nLabel StrRef ModelName BlockSight VisibleModel SoundAppType Name\r\n" +
                     "0 GenericDoor 123 generic_model 1 1 1 123\r\n" +
                     "1 User002 **** **** **** **** **** ****\r\n" +
                     "2 MissingModel 123 **** 1 1 1 123\r\n" +
-                    "3 Transition 124 transition_model 0 0 **** 124\r\n");
+                    "3 Transition 124 transition_model 0 0 **** 124\r\n" +
+                    "4 MissingVisibility 125 missing_visibility 1 **** 1 125\r\n");
                 var service = new DoorTypeService(
                     new TwoDaService(scratch),
                     new TlkService(TlkJsonFile.Parse("{\"language\":0,\"entries\":[]}")));
@@ -136,6 +138,36 @@ namespace SWLOR.Toolset.Tests
                     row.Label == "GenericDoor" && row.Model == "generic_model" && row.VisibleModel);
                 service.GetGeneric(3).Should().Match<GenericDoorRow>(row =>
                     row.Label == "Transition" && row.Model == "transition_model" && !row.VisibleModel);
+            }
+            finally
+            {
+                Directory.Delete(scratch, recursive: true);
+            }
+        }
+
+        [Test]
+        public void DoorChoicesFailClosedWhenVisibilityColumnIsMissing()
+        {
+            var scratch = Path.Combine(
+                TestContext.CurrentContext.WorkDirectory,
+                $"door-visibility-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(scratch);
+            try
+            {
+                File.WriteAllText(
+                    Path.Combine(scratch, "doortypes.2da"),
+                    "2DA V2.0\r\n\r\nLabel Model StringRefGame\r\n" +
+                    "0 RealDoor real_model 123\r\n");
+                File.WriteAllText(
+                    Path.Combine(scratch, "genericdoors.2da"),
+                    "2DA V2.0\r\n\r\nLabel ModelName Name\r\n" +
+                    "0 GenericDoor generic_model 123\r\n");
+                var service = new DoorTypeService(
+                    new TwoDaService(scratch),
+                    new TlkService(TlkJsonFile.Parse("{\"language\":0,\"entries\":[]}")));
+
+                service.GetAll().Should().BeEmpty();
+                service.GetGenericAll().Should().BeEmpty();
             }
             finally
             {

--- a/SWLOR.Toolset/Editors/AreaEditorViewModel.cs
+++ b/SWLOR.Toolset/Editors/AreaEditorViewModel.cs
@@ -1243,7 +1243,9 @@ namespace SWLOR.Toolset.Editors
                     InstanceMarkerKind.Waypoint => WaypointMarkerModel.ForwardCorrection,
                     _ => Matrix4x4.Identity
                 },
-                Model = model
+                Model = model,
+                IsDoorTransition = kind.Value == InstanceMarkerKind.Door &&
+                                   model?.IsDoorTransitionGeometry == true
             };
         }
 

--- a/SWLOR.Toolset/Editors/AreaEditorViewModel.cs
+++ b/SWLOR.Toolset/Editors/AreaEditorViewModel.cs
@@ -67,8 +67,8 @@ namespace SWLOR.Toolset.Editors
         private readonly DoorTypeService? _doorTypes;
         private readonly WaypointAppearanceService? _waypointAppearances;
 
-        /// <summary>Builds an armed blueprint's geometry for the placement ghost. Null degrades the ghost to a marker.</summary>
-        private readonly Func<ResourceType, string, bool, RenderModel?>? _resolveBlueprintModel;
+        /// <summary>Builds an armed blueprint's geometry and fallback metadata for the placement ghost.</summary>
+        private readonly Func<ResourceType, string, bool, BlueprintModelRenderResult>? _resolveBlueprintModel;
         private readonly Func<JsonGffStruct, RenderModel?>? _resolvePlacedCreatureModel;
         private readonly TileWalkmeshCache? _tileWalkmeshCache;
         private readonly IEditorPromptService _prompts;
@@ -1209,17 +1209,19 @@ namespace SWLOR.Toolset.Editors
             if (kind == null)
                 return null;
 
-            RenderModel? model = null;
+            var preview = default(BlueprintModelRenderResult);
             try
             {
                 // A store has no appearance of its own. Aurora always previews it as the yellow
                 // waypoint flag, which must be the same model the completed scene build uses.
-                model = kind == InstanceMarkerKind.Store
-                    ? _tileModelCache?.GetOrBuild(WaypointMarkerModel.MerchantModelResRef)
+                preview = kind == InstanceMarkerKind.Store
+                    ? new BlueprintModelRenderResult(
+                        _tileModelCache?.GetOrBuild(WaypointMarkerModel.MerchantModelResRef),
+                        IsDoorTransition: false)
                     // Everything else is built through the same path as the palette thumbnail the
                     // builder just clicked, including segmented creatures whose body parts have to
                     // be composed.
-                    : _resolveBlueprintModel?.Invoke(type, resRef, useIndexedBlueprint);
+                    : _resolveBlueprintModel?.Invoke(type, resRef, useIndexedBlueprint) ?? default;
             }
             catch (Exception ex)
             {
@@ -1243,9 +1245,8 @@ namespace SWLOR.Toolset.Editors
                     InstanceMarkerKind.Waypoint => WaypointMarkerModel.ForwardCorrection,
                     _ => Matrix4x4.Identity
                 },
-                Model = model,
-                IsDoorTransition = kind.Value == InstanceMarkerKind.Door &&
-                                   model?.IsDoorTransitionGeometry == true
+                Model = preview.Model,
+                IsDoorTransition = kind.Value == InstanceMarkerKind.Door && preview.IsDoorTransition
             };
         }
 
@@ -1494,7 +1495,7 @@ namespace SWLOR.Toolset.Editors
             Action<ResourceType, string>? openBlueprint = null,
             Func<uint, string?>? resolveStrRef = null,
             WaypointAppearanceService? waypointAppearances = null,
-            Func<ResourceType, string, bool, RenderModel?>? resolveBlueprintModel = null,
+            Func<ResourceType, string, bool, BlueprintModelRenderResult>? resolveBlueprintModel = null,
             IScriptSlotHost? scriptSlotHost = null,
             Func<JsonGffStruct, RenderModel?>? resolvePlacedCreatureModel = null,
             Doors.DoorEditorServices? doorEditorServices = null,

--- a/SWLOR.Toolset/Editors/Doors/DoorDocumentViewModel.cs
+++ b/SWLOR.Toolset/Editors/Doors/DoorDocumentViewModel.cs
@@ -67,7 +67,7 @@ namespace SWLOR.Toolset.Editors.Doors
             Func<string, IReadOnlyList<BehaviorChoice>>? resolveChoices = null,
             IReadOnlyList<DoorAppearanceChoice>? appearances = null,
             ResourceIndex? resourceIndex = null,
-            Func<JsonGffStruct, RenderModel?>? resolveModel = null,
+            Func<JsonGffStruct, BlueprintModelRenderResult>? resolveModel = null,
             ThumbnailService? thumbnails = null,
             ChoicePreviewService? choicePreviews = null,
             BlueprintSaveCoordinator? saveCoordinator = null,

--- a/SWLOR.Toolset/Editors/Doors/DoorEditorServices.cs
+++ b/SWLOR.Toolset/Editors/Doors/DoorEditorServices.cs
@@ -16,7 +16,7 @@ namespace SWLOR.Toolset.Editors.Doors
         Func<string, IReadOnlyList<BehaviorChoice>>? ResolveChoices,
         IReadOnlyList<DoorAppearanceChoice> Appearances,
         ResourceIndex? ResourceIndex,
-        Func<JsonGffStruct, RenderModel?>? ResolveModel,
+        Func<JsonGffStruct, BlueprintModelRenderResult>? ResolveModel,
         ThumbnailService? Thumbnails = null,
         ChoicePreviewService? ChoicePreviews = null,
         Services.IEditorPromptService? Prompts = null);

--- a/SWLOR.Toolset/Editors/Doors/DoorEditorViewModel.cs
+++ b/SWLOR.Toolset/Editors/Doors/DoorEditorViewModel.cs
@@ -25,7 +25,7 @@ namespace SWLOR.Toolset.Editors.Doors
         private readonly Func<BehaviorTagScope, string, string?>? _resolveTag;
         private readonly Func<string, IReadOnlyList<BehaviorChoice>>? _resolveChoices;
         private readonly IReadOnlyList<DoorAppearanceChoice> _appearances;
-        private readonly Func<JsonGffStruct, RenderModel?>? _resolveModel;
+        private readonly Func<JsonGffStruct, BlueprintModelRenderResult>? _resolveModel;
         private readonly ChoicePreviewService? _choicePreviews;
         private readonly bool _isInstance;
         private ModelPreviewControl? _previewView;
@@ -106,7 +106,7 @@ namespace SWLOR.Toolset.Editors.Doors
             Func<string, IReadOnlyList<BehaviorChoice>>? resolveChoices = null,
             IReadOnlyList<DoorAppearanceChoice>? appearances = null,
             ResourceIndex? resourceIndex = null,
-            Func<JsonGffStruct, RenderModel?>? resolveModel = null,
+            Func<JsonGffStruct, BlueprintModelRenderResult>? resolveModel = null,
             bool isDirty = false,
             ThumbnailService? thumbnails = null,
             ChoicePreviewService? choicePreviews = null,
@@ -455,8 +455,8 @@ namespace SWLOR.Toolset.Editors.Doors
             if (_disposed)
                 return;
 
-            var model = _resolveModel?.Invoke(_store.Door);
-            PreviewScene = model == null
+            var preview = _resolveModel?.Invoke(_store.Door) ?? default;
+            PreviewScene = preview.Model == null && !preview.IsDoorTransition
                 ? null
                 : new AreaScene
                 {
@@ -476,8 +476,8 @@ namespace SWLOR.Toolset.Editors.Doors
                                 AreaSceneBuilder.TileSize / 2f,
                                 0f),
                             Orientation = new Vector2(1f, 0f),
-                            Model = model,
-                            IsDoorTransition = model.IsDoorTransitionGeometry
+                            Model = preview.Model,
+                            IsDoorTransition = preview.IsDoorTransition
                         }
                     },
                     Diagnostics = new AreaSceneDiagnostics()

--- a/SWLOR.Toolset/Editors/Doors/DoorEditorViewModel.cs
+++ b/SWLOR.Toolset/Editors/Doors/DoorEditorViewModel.cs
@@ -476,7 +476,8 @@ namespace SWLOR.Toolset.Editors.Doors
                                 AreaSceneBuilder.TileSize / 2f,
                                 0f),
                             Orientation = new Vector2(1f, 0f),
-                            Model = model
+                            Model = model,
+                            IsDoorTransition = model.IsDoorTransitionGeometry
                         }
                     },
                     Diagnostics = new AreaSceneDiagnostics()

--- a/SWLOR.Toolset/Editors/EditorService.cs
+++ b/SWLOR.Toolset/Editors/EditorService.cs
@@ -1566,7 +1566,7 @@ namespace SWLOR.Toolset.Editors
                 DoorAppearances(),
                 _resourceIndex,
                 _previewRenderer != null
-                    ? door => _previewRenderer.BuildModel(ResourceType.Utd, door)
+                    ? door => _previewRenderer.BuildModelResult(ResourceType.Utd, door)
                     : null,
                 _thumbnails,
                 ChoicePreviews(),
@@ -3312,7 +3312,7 @@ namespace SWLOR.Toolset.Editors
                     _tlkService != null ? _tlkService.GetString : null, _waypointAppearances,
                     _previewRenderer != null
                         ? (type, blueprintResRef, useIndexed) =>
-                            _previewRenderer.BuildModel(type, blueprintResRef, useIndexed)
+                            _previewRenderer.BuildModelResult(type, blueprintResRef, useIndexed)
                         : null,
                     CreateScriptSlotHost($"Area '{resRef}'"),
                     _previewRenderer != null
@@ -3325,7 +3325,7 @@ namespace SWLOR.Toolset.Editors
                         DoorAppearances(),
                         _resourceIndex,
                         _previewRenderer != null
-                            ? door => _previewRenderer.BuildModel(ResourceType.Utd, door)
+                            ? door => _previewRenderer.BuildModelResult(ResourceType.Utd, door)
                             : null,
                         _thumbnails,
                         ChoicePreviews()),

--- a/SWLOR.Toolset/Viewport/GlAreaControl.cs
+++ b/SWLOR.Toolset/Viewport/GlAreaControl.cs
@@ -62,6 +62,12 @@ namespace SWLOR.Toolset.Viewport
         private const float MarkerHeight = 1.2f;
         private const float MarkerGroundOffset = 0.05f;
 
+        // Aurora keeps runtime-invisible area-transition doors editable as a translucent
+        // lavender plane in the doorway. The model's authored hidden geometry supplies the shape;
+        // DoorTransitionMarker supplies the fixed 2m x 3m fallback when that MDL is unavailable.
+        private static readonly Vector3 DoorTransitionColor = new(0.52f, 0.52f, 0.82f);
+        private const float DoorTransitionAlpha = 0.42f;
+
         /// <summary>Net press-to-release pointer movement (logical px) below which a left button press+release is treated as a pick click rather than a (degenerate/aborted) orbit drag.</summary>
         private const float ClickDragThresholdPixels = 4f;
 
@@ -423,6 +429,7 @@ void main()
 
         private StaticMeshBuffer? _fallbackCubeBuffer;
         private StaticMeshBuffer? _markerMeshBuffer;
+        private StaticMeshBuffer? _doorTransitionBuffer;
         private StaticMeshBuffer? _particleQuadBuffer;
 
         // Sound marker geometry: a billboarded musical note (indices split into a red head range
@@ -983,7 +990,8 @@ void main()
         }
 
         /// <summary>True when this instance should draw its resolved model rather than a marker.</summary>
-        private static bool DrawsAsModel(InstanceMarker instance) => instance.Model != null;
+        private static bool DrawsAsModel(InstanceMarker instance) =>
+            !instance.IsDoorTransition && instance.Model is { Meshes.Count: > 0 };
 
         /// <summary>
         /// Whether the placed model can use NWN's ordinary back-face culling pass.
@@ -1581,6 +1589,7 @@ void main()
             VisualTransform = source.VisualTransform,
             Geometry = source.Geometry,
             Model = source.Model,
+            IsDoorTransition = source.IsDoorTransition,
             SoundMinDistance = source.SoundMinDistance,
             SoundMaxDistance = source.SoundMaxDistance,
             IsPositionalSound = source.IsPositionalSound
@@ -2503,6 +2512,9 @@ void main()
                         DeleteBuffer(cube.Vao, cube.Vbo, cube.Ebo);
                     if (_markerMeshBuffer is { } marker)
                         DeleteBuffer(marker.Vao, marker.Vbo, marker.Ebo);
+                    if (_doorTransitionBuffer is { } transition)
+                        DeleteBuffer(transition.Vao, transition.Vbo, transition.Ebo);
+                    _doorTransitionBuffer = null;
                     if (_particleQuadBuffer is { } particle)
                         DeleteBuffer(particle.Vao, particle.Vbo, particle.Ebo);
                     _particleQuadBuffer = null;
@@ -3201,6 +3213,8 @@ void main()
                     EndModelFaceCulling();
             }
 
+            DrawDoorTransitions(scene);
+
             DrawPreviewEmitters(scene, preview);
             if (previewNeedsFrames)
                 RequestNextFrameRendering();
@@ -3217,7 +3231,7 @@ void main()
 
             foreach (var raw in scene.Instances)
             {
-                if (DrawsAsModel(raw))
+                if (DrawsAsModel(raw) || raw.IsDoorTransition)
                     continue;
 
                 var instance = Displayed(raw);
@@ -3235,6 +3249,80 @@ void main()
                     _gl.DrawElements(PrimitiveType.Triangles, (uint)marker.IndexCount,
                         DrawElementsType.UnsignedInt, (void*)0);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Draws runtime-invisible area-transition doors from their authored hidden MDL surfaces,
+        /// falling back to Aurora's standard two-by-three-metre doorway plane. Depth testing stays
+        /// on so walls can occlude the plane naturally; depth writes are disabled so its transparent
+        /// surface does not punch holes in geometry drawn later in the frame.
+        /// </summary>
+        private void DrawDoorTransitions(AreaScene scene)
+        {
+            if (_gl == null || !scene.Instances.Any(instance => instance.IsDoorTransition))
+                return;
+
+            _gl.Enable(EnableCap.Blend);
+            _gl.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
+            _gl.DepthMask(false);
+
+            SetUniformBool("hasTexture", false);
+            SetUniformBool("useTextureAlpha", false);
+            SetUniformBool("unlit", true);
+            SetUniformFloat("alphaCutoff", 0f);
+            SetUniformFloat("flatAlpha", DoorTransitionAlpha);
+            SetUniformVec3("flatColor", DoorTransitionColor);
+
+            foreach (var raw in scene.Instances)
+            {
+                if (!raw.IsDoorTransition)
+                    continue;
+
+                var instance = Displayed(raw);
+                if (!IsInstanceVisible(instance))
+                    continue;
+
+                DrawDoorTransitionGeometry(instance);
+            }
+
+            _gl.DepthMask(true);
+            _gl.Disable(EnableCap.Blend);
+            SetUniformFloat("flatAlpha", 1f);
+        }
+
+        /// <summary>
+        /// Submits one transition door using flat-colour state already configured by the caller.
+        /// </summary>
+        private void DrawDoorTransitionGeometry(InstanceMarker instance)
+        {
+            var instanceTransform = AreaPicking.ComputeInstanceTransform(instance);
+            if (instance.Model is { Meshes.Count: > 0 } model)
+            {
+                var buffer = GetOrBuildModelBuffer(model);
+                _gl!.BindVertexArray(buffer.Vao);
+                foreach (var meshRange in buffer.MeshRanges)
+                {
+                    SetUniformMatrix4("model", meshRange.MeshTransform * instanceTransform);
+                    unsafe
+                    {
+                        _gl.DrawElements(PrimitiveType.Triangles, (uint)meshRange.IndexCount,
+                            DrawElementsType.UnsignedInt, (void*)meshRange.IndexOffset);
+                    }
+                }
+
+                return;
+            }
+
+            if (_doorTransitionBuffer is not { } fallback)
+                return;
+
+            _gl!.BindVertexArray(fallback.Vao);
+            SetUniformMatrix4("model", instanceTransform);
+            unsafe
+            {
+                _gl.DrawElements(PrimitiveType.Triangles, (uint)fallback.IndexCount,
+                    DrawElementsType.UnsignedInt, (void*)0);
             }
         }
 
@@ -3628,7 +3716,8 @@ void main()
                 Orientation = _snappedDoorAnchor?.Orientation ?? ghost.Orientation,
                 VisualTransform = ghost.VisualTransform,
                 LayerColorIndices = ghost.LayerColorIndices,
-                Model = ghost.Model
+                Model = ghost.Model,
+                IsDoorTransition = ghost.IsDoorTransition
             };
 
             var transform = AreaPicking.ComputeInstanceTransform(placed);
@@ -3644,7 +3733,16 @@ void main()
             // being placed, visibly not placeable here.
             var refused = SnapsToDoorAnchors && _snappedDoorAnchor == null;
 
-            if (DrawsAsModel(placed))
+            if (placed.IsDoorTransition)
+            {
+                SetUniformBool("hasTexture", false);
+                SetUniformBool("useTextureAlpha", false);
+                SetUniformBool("unlit", true);
+                SetUniformFloat("alphaCutoff", 0f);
+                SetUniformVec3("flatColor", refused ? PlacementRefusedColor : DoorTransitionColor);
+                DrawDoorTransitionGeometry(placed);
+            }
+            else if (DrawsAsModel(placed))
             {
                 var buffer = GetOrBuildModelBuffer(placed.Model!);
                 _gl.BindVertexArray(buffer.Vao);
@@ -4904,6 +5002,9 @@ void main()
             var (markerVertices, markerIndices) = BuildMarkerPyramidMesh();
             _markerMeshBuffer = UploadStaticMesh(markerVertices, markerIndices);
 
+            var (transitionVertices, transitionIndices) = BuildDoorTransitionMesh();
+            _doorTransitionBuffer = UploadStaticMesh(transitionVertices, transitionIndices);
+
             var (particleVertices, particleIndices) = BuildParticleQuadMesh();
             _particleQuadBuffer = UploadStaticMesh(particleVertices, particleIndices);
 
@@ -5144,6 +5245,33 @@ void main()
             builder.AddTriangle(b2, b3, apex);
             builder.AddTriangle(b3, b0, apex);
 
+            return builder.Build();
+        }
+
+        /// <summary>
+        /// Thin two-sided box matching <see cref="DoorTransitionMarker"/>'s fallback bounds. A
+        /// small depth keeps the transition visible from an edge-on editing angle and gives picking
+        /// the same stable volume the renderer shows.
+        /// </summary>
+        private static (float[] Vertices, uint[] Indices) BuildDoorTransitionMesh()
+        {
+            var min = DoorTransitionMarker.LocalMinimum;
+            var max = DoorTransitionMarker.LocalMaximum;
+            var c = new[]
+            {
+                new Vector3(min.X, min.Y, min.Z), new Vector3(max.X, min.Y, min.Z),
+                new Vector3(max.X, max.Y, min.Z), new Vector3(min.X, max.Y, min.Z),
+                new Vector3(min.X, min.Y, max.Z), new Vector3(max.X, min.Y, max.Z),
+                new Vector3(max.X, max.Y, max.Z), new Vector3(min.X, max.Y, max.Z)
+            };
+
+            var builder = new BoxMeshBuilder();
+            builder.AddQuad(c[3], c[2], c[1], c[0], new Vector3(0, 0, -1));
+            builder.AddQuad(c[4], c[5], c[6], c[7], new Vector3(0, 0, 1));
+            builder.AddQuad(c[0], c[1], c[5], c[4], new Vector3(0, -1, 0));
+            builder.AddQuad(c[2], c[3], c[7], c[6], new Vector3(0, 1, 0));
+            builder.AddQuad(c[3], c[0], c[4], c[7], new Vector3(-1, 0, 0));
+            builder.AddQuad(c[1], c[2], c[6], c[5], new Vector3(1, 0, 0));
             return builder.Build();
         }
 

--- a/SWLOR.Toolset/Workspace/BlueprintModelRenderResult.cs
+++ b/SWLOR.Toolset/Workspace/BlueprintModelRenderResult.cs
@@ -1,0 +1,13 @@
+using SWLOR.Toolset.Domain.Render;
+
+namespace SWLOR.Toolset.Workspace
+{
+    /// <summary>
+    /// A blueprint's optional drawable geometry plus editor-only classification that must survive
+    /// when the geometry cannot be loaded. Transition doors use the classification to draw their
+    /// fixed doorway marker even when <see cref="Model"/> is null.
+    /// </summary>
+    public readonly record struct BlueprintModelRenderResult(
+        RenderModel? Model,
+        bool IsDoorTransition);
+}

--- a/SWLOR.Toolset/Workspace/BlueprintPreviewRenderer.cs
+++ b/SWLOR.Toolset/Workspace/BlueprintPreviewRenderer.cs
@@ -179,19 +179,30 @@ namespace SWLOR.Toolset.Workspace
         public RenderModel? BuildModel(
             ResourceType type,
             string resRef,
+            bool useIndexedBlueprint = false) =>
+            BuildModelResult(type, resRef, useIndexedBlueprint).Model;
+
+        /// <summary>
+        /// Builds a blueprint's optional geometry while retaining classifications that control its
+        /// editor fallback. Unlike <see cref="BuildModel(ResourceType, string, bool)"/>, this result
+        /// can still identify a transition door when its MDL is missing or cannot be built.
+        /// </summary>
+        public BlueprintModelRenderResult BuildModelResult(
+            ResourceType type,
+            string resRef,
             bool useIndexedBlueprint = false)
         {
             if (!IsAvailable || string.IsNullOrWhiteSpace(resRef))
-                return null;
+                return default;
 
             var workspace = _workspaceContext.Workspace;
             if (workspace == null)
-                return null;
+                return default;
 
             var blueprint = useIndexedBlueprint
                 ? workspace.LoadIndexedBlueprint(type, resRef)
                 : workspace.LoadBlueprint(type, resRef);
-            return BuildModel(type, blueprint.Fields, useIndexedBlueprint);
+            return BuildModelResult(type, blueprint.Fields, useIndexedBlueprint);
         }
 
         /// <summary>
@@ -203,11 +214,22 @@ namespace SWLOR.Toolset.Workspace
             ResourceType type,
             Domain.Gff.JsonGffStruct root,
             bool useIndexedBlueprint = false,
+            bool armorPreviewFemale = false) =>
+            BuildModelResult(type, root, useIndexedBlueprint, armorPreviewFemale).Model;
+
+        /// <summary>
+        /// Builds geometry from a live or embedded blueprint and returns its editor-only metadata
+        /// independently from that nullable geometry.
+        /// </summary>
+        public BlueprintModelRenderResult BuildModelResult(
+            ResourceType type,
+            Domain.Gff.JsonGffStruct root,
+            bool useIndexedBlueprint = false,
             bool armorPreviewFemale = false)
         {
             ArgumentNullException.ThrowIfNull(root);
             if (!IsAvailable)
-                return null;
+                return default;
 
             var reference = BlueprintModelResolver.Resolve(
                 type, root, _appearances, _placeables, _doors,
@@ -218,7 +240,9 @@ namespace SWLOR.Toolset.Workspace
             var model = BuildResolvedModel(
                 type, reference, includeCreatureAnimations: type == ResourceType.Utc);
 
-            return WithLayerColors(model, reference);
+            return new BlueprintModelRenderResult(
+                WithLayerColors(model, reference),
+                reference.IsDoorTransition);
         }
 
         /// <summary>
@@ -381,7 +405,8 @@ namespace SWLOR.Toolset.Workspace
                         meshColors is { Count: > 0 } ? meshColors : layerColors);
             var pixels = ThumbnailRenderer.Render(
                 model, ModelRenderSize, palette: null,
-                resolveLayeredTexture: resolveLayeredTexture);
+                resolveLayeredTexture: resolveLayeredTexture,
+                renderDoorTransitionFallback: reference.IsDoorTransition);
             return pixels == null ? null : new IconImage(ModelRenderSize, ModelRenderSize, pixels);
         }
 

--- a/SWLOR.Toolset/Workspace/BlueprintPreviewRenderer.cs
+++ b/SWLOR.Toolset/Workspace/BlueprintPreviewRenderer.cs
@@ -239,6 +239,8 @@ namespace SWLOR.Toolset.Workspace
                             ? ComposeSegmented(reference, includeCreatureAnimations) ??
                               BuildCreatureModel(reference.ModelResRef, includeCreatureAnimations)
                             : BuildCreatureModel(reference.ModelResRef, includeCreatureAnimations)
+                        : type == ResourceType.Utd && reference.IsDoorTransition
+                            ? BuildDoorTransitionModel(reference.ModelResRef)
                         : BuildRenderModel(reference.ModelResRef),
                 BlueprintModelKind.Segmented => ComposeSegmented(reference, includeCreatureAnimations),
                 BlueprintModelKind.ItemComposite => ComposeItemParts(reference),
@@ -268,6 +270,7 @@ namespace SWLOR.Toolset.Workspace
                 Animations = model.Animations,
                 Emitters = model.Emitters,
                 DefaultAnimationName = model.DefaultAnimationName,
+                IsDoorTransitionGeometry = model.IsDoorTransitionGeometry,
                 LayerColorIndices = reference.LayerColorIndices,
             };
         }
@@ -528,6 +531,24 @@ namespace SWLOR.Toolset.Workspace
             catch (Exception)
             {
                 // A model that cannot be turned into meshes falls back to the type symbol.
+                return null;
+            }
+        }
+
+        private RenderModel? BuildDoorTransitionModel(string modelResRef)
+        {
+            var model = LoadMdl(modelResRef, withSupermodelAnims: false);
+            if (model == null)
+                return null;
+
+            try
+            {
+                return MdlMeshBuilder.BuildDoorTransition(model, IdleFrames(model));
+            }
+            catch (Exception)
+            {
+                // The area viewport still has a fixed-size transition-plane fallback when the
+                // model's authored editor geometry cannot be built.
                 return null;
             }
         }


### PR DESCRIPTION
## Summary

- render door transitions in the SWLOR Toolset even when a door type is marked `VisibleModel=0`
- preserve and use hidden transition geometry when it exists, with a translucent editor marker fallback when the model contains no drawable meshes
- keep area picking, blueprint previews, and door-editor previews consistent with viewport rendering
- add focused regression coverage for invisible and meshless transition doors

## Root cause

The affected transition uses `GenericType_New=48`. Its `genericdoors.2da` row is intentionally invisible and resolves to a model with no drawable meshes. The Toolset treated that as an ordinary missing model and omitted it from the scene, so the transition could not be seen or selected.

## Impact

Builders can now see and select these door transitions in the area editor without changing their in-game visibility semantics.

## Validation

- `dotnet build SWLOR.Toolset.Tests\SWLOR.Toolset.Tests.csproj -p:RunPostBuildEvent=Never -m:1 -p:BuildInParallel=false -p:UseSharedCompilation=false -nodeReuse:false`
- `dotnet test SWLOR.Toolset.Tests\SWLOR.Toolset.Tests.csproj --no-build --filter "FullyQualifiedName~AreaPickingTests|FullyQualifiedName~MdlMeshBuilderPlaceholderTests|FullyQualifiedName~TwoDaChoicePolicyTests|Name=Build_InvisibleDoorType_PreservesAnEditorTransitionWhenItsModelIsUnavailable|Name=BaseGameTransitionDoor_PreservesTransitionSemanticsWithoutDrawableGeometry|FullyQualifiedName~BehaviorEditorViewRenderTests"` (72 passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for displaying door transition geometry in area editing, door previews, and blueprint previews.
  * Transition doors now use translucent authored geometry or a fallback doorway shape when model geometry is unavailable.
  * Door visibility settings are respected when resolving and previewing door models.
* **Bug Fixes**
  * Improved selection, placement, and thumbnail rendering for doors without usable model geometry.
  * Prevented transition doors from being treated as standard model markers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->