### PR TITLE
Fix late door transition review issues

### DIFF
--- a/SWLOR.Toolset.Domain/Editors/Doors/DoorAppearanceCatalog.cs
+++ b/SWLOR.Toolset.Domain/Editors/Doors/DoorAppearanceCatalog.cs
@@ -16,7 +16,8 @@ namespace SWLOR.Toolset.Domain.Editors.Doors
                     DoorAppearanceKind.Generic,
                     row.Id,
                     $"Generic \u25b8 {row.DisplayName}",
-                    row.Model))
+                    row.Model,
+                    IsDoorTransition: !row.VisibleModel))
                 .Concat(
                     doors.GetAll()
                         .Where(row => row.Id > 0 && !string.IsNullOrWhiteSpace(row.Model))
@@ -24,7 +25,8 @@ namespace SWLOR.Toolset.Domain.Editors.Doors
                             DoorAppearanceKind.Specific,
                             row.Id,
                             $"Specific \u25b8 {row.DisplayName}",
-                            row.Model)))
+                            row.Model,
+                            IsDoorTransition: !row.VisibleModel)))
                 .ToList();
 
             return choices;

--- a/SWLOR.Toolset.Domain/Editors/Doors/DoorAppearanceChoice.cs
+++ b/SWLOR.Toolset.Domain/Editors/Doors/DoorAppearanceChoice.cs
@@ -5,7 +5,8 @@ namespace SWLOR.Toolset.Domain.Editors.Doors
         DoorAppearanceKind Kind,
         int Id,
         string Display,
-        string? Model)
+        string? Model,
+        bool IsDoorTransition = false)
     {
         public override string ToString() => Display;
     }

--- a/SWLOR.Toolset.Domain/Render/AreaCameraMath.cs
+++ b/SWLOR.Toolset.Domain/Render/AreaCameraMath.cs
@@ -163,12 +163,26 @@ namespace SWLOR.Toolset.Domain.Render
         {
             ArgumentNullException.ThrowIfNull(scene);
 
-            if (scene.Tiles.Count == 0 && scene.Instances.Count == 1 &&
-                scene.Instances[0].Model?.ComputeBounds() is { } bounds)
+            if (scene.Tiles.Count == 0 && scene.Instances.Count == 1)
             {
-                var offset = scene.Instances[0].Position;
-                return ComputeModelFraming(
-                    bounds.Minimum + offset, bounds.Maximum + offset, verticalFovRadians, aspectRatio);
+                var instance = scene.Instances[0];
+                var bounds = instance.Model?.ComputeBounds();
+                if (bounds == null && instance.IsDoorTransition)
+                {
+                    bounds = (
+                        DoorTransitionMarker.LocalMinimum,
+                        DoorTransitionMarker.LocalMaximum);
+                }
+
+                if (bounds is { } previewBounds)
+                {
+                    var offset = instance.Position;
+                    return ComputeModelFraming(
+                        previewBounds.Minimum + offset,
+                        previewBounds.Maximum + offset,
+                        verticalFovRadians,
+                        aspectRatio);
+                }
             }
 
             return ComputeInitialFraming(

--- a/SWLOR.Toolset.Domain/Render/ThumbnailRenderer.cs
+++ b/SWLOR.Toolset.Domain/Render/ThumbnailRenderer.cs
@@ -149,8 +149,28 @@ namespace SWLOR.Toolset.Domain.Render
             // Back to front: the far side of a model must not paint over its near side.
             projected.Sort(static (left, right) => left.Depth.CompareTo(right.Depth));
 
+            var painted = false;
             foreach (var triangle in projected)
-                FillTriangle(pixels, size, triangle, palette);
+                painted |= FillTriangle(pixels, size, triangle, palette);
+
+            if (!painted && isDoorTransition && !usingDoorTransitionFallback)
+            {
+                triangles = CollectTriangles(
+                    DoorTransitionMarker.CreateFallbackModel(),
+                    resolveTexture: null,
+                    resolveLayeredTexture: null);
+                projected = Project(triangles, view, size, out any);
+                if (!any)
+                    return null;
+
+                FillBackground(pixels, palette.Background);
+                projected.Sort(static (left, right) => left.Depth.CompareTo(right.Depth));
+                foreach (var triangle in projected)
+                    painted |= FillTriangle(pixels, size, triangle, palette);
+
+                if (!painted)
+                    return null;
+            }
 
             return pixels;
         }
@@ -361,7 +381,11 @@ namespace SWLOR.Toolset.Domain.Render
             }
         }
 
-        private static void FillTriangle(byte[] pixels, int size, ProjectedTriangle triangle, ThumbnailPalette palette)
+        private static bool FillTriangle(
+            byte[] pixels,
+            int size,
+            ProjectedTriangle triangle,
+            ThumbnailPalette palette)
         {
             var minX = Math.Max(0, (int)MathF.Floor(MathF.Min(triangle.A.X, MathF.Min(triangle.B.X, triangle.C.X))));
             var maxX = Math.Min(size - 1, (int)MathF.Ceiling(MathF.Max(triangle.A.X, MathF.Max(triangle.B.X, triangle.C.X))));
@@ -370,7 +394,7 @@ namespace SWLOR.Toolset.Domain.Render
 
             var area = EdgeFunction(triangle.A, triangle.B, triangle.C);
             if (MathF.Abs(area) < 1e-6f)
-                return;
+                return false;
 
             var shade = palette.Ambient + (1f - palette.Ambient) * triangle.Shade;
 
@@ -382,6 +406,7 @@ namespace SWLOR.Toolset.Domain.Render
             var flatB = (byte)Math.Clamp(palette.BaseB * tintB, 0, 255);
             var flatG = (byte)Math.Clamp(palette.BaseG * tintG, 0, 255);
             var flatR = (byte)Math.Clamp(palette.BaseR * tintR, 0, 255);
+            var painted = false;
 
             for (var y = minY; y <= maxY; y++)
             {
@@ -411,8 +436,11 @@ namespace SWLOR.Toolset.Domain.Render
                     pixels[offset + 1] = g;
                     pixels[offset + 2] = r;
                     pixels[offset + 3] = 255;
+                    painted = true;
                 }
             }
+
+            return painted;
         }
 
         /// <summary>

--- a/SWLOR.Toolset.Tests/AppearanceGalleryTests.cs
+++ b/SWLOR.Toolset.Tests/AppearanceGalleryTests.cs
@@ -202,6 +202,23 @@ namespace SWLOR.Toolset.Tests
             var thumbnails = new ThumbnailService(
                 new WorkspaceContext(_ => throw new NotSupportedException(), new OutputLogService()),
                 source);
+
+            thumbnails.RequestTileAsync("tn_gdoor_08", _ => { });
+            DrainDispatcher();
+            var ordinary = thumbnails.CachedTile("tn_gdoor_08");
+
+            thumbnails.RequestTileAsync(
+                "tn_gdoor_08",
+                _ => { },
+                renderDoorTransitionFallback: true);
+            DrainDispatcher();
+            var transition = thumbnails.CachedTile(
+                "tn_gdoor_08",
+                renderDoorTransitionFallback: true);
+
+            ordinary.Should().NotBeNull();
+            transition.Should().NotBeNull().And.NotBeSameAs(ordinary);
+
             using var section = new AppearanceGallerySectionViewModel(
                 [
                     new AppearanceOption(
@@ -216,11 +233,16 @@ namespace SWLOR.Toolset.Tests
                 _ => true,
                 noun: "appearance");
 
-            section.EnsurePreview(section.Tiles.Single());
+            var tile = section.Tiles.Single();
+            tile.Preview.Should().BeSameAs(transition,
+                "the rebuilt gallery must read the transition-aware cache entry");
+            tile.PreviewRequested.Should().BeTrue();
+
+            section.EnsurePreview(tile);
             DrainDispatcher();
 
-            source.ModelTransitionRequests.Should().Equal(true);
-            section.Tiles.Single().Preview.Should().NotBeNull();
+            source.ModelTransitionRequests.Should().Equal(new[] { false, true },
+                "the cached transition preview should avoid a third render request");
         }
 
         [AvaloniaTest]

--- a/SWLOR.Toolset.Tests/AppearanceGalleryTests.cs
+++ b/SWLOR.Toolset.Tests/AppearanceGalleryTests.cs
@@ -1,4 +1,5 @@
 using Avalonia.Headless.NUnit;
+using System.Collections.Concurrent;
 using Avalonia.Controls;
 using Avalonia.Logging;
 using Avalonia.Threading;
@@ -192,6 +193,34 @@ namespace SWLOR.Toolset.Tests
             source.AppearanceCalls.Should().Be(3,
                 "only the currently published page is retried");
             section.Tiles.Should().OnlyContain(tile => tile.Preview != null);
+        }
+
+        [AvaloniaTest]
+        public void DoorAppearancePreviewRequestsTransitionFallbackRendering()
+        {
+            var source = new AppearancePreviewSource { IsAvailable = true };
+            var thumbnails = new ThumbnailService(
+                new WorkspaceContext(_ => throw new NotSupportedException(), new OutputLogService()),
+                source);
+            using var section = new AppearanceGallerySectionViewModel(
+                [
+                    new AppearanceOption(
+                        "transition",
+                        "Transition",
+                        "tn_gdoor_08",
+                        ModelResRef: "tn_gdoor_08",
+                        IsDoorTransition: true)
+                ],
+                thumbnails,
+                () => "transition",
+                _ => true,
+                noun: "appearance");
+
+            section.EnsurePreview(section.Tiles.Single());
+            DrainDispatcher();
+
+            source.ModelTransitionRequests.Should().Equal(true);
+            section.Tiles.Single().Preview.Should().NotBeNull();
         }
 
         [AvaloniaTest]
@@ -588,11 +617,16 @@ namespace SWLOR.Toolset.Tests
             public bool IsAvailable { get; set; }
             public DateTime ContentVersionUtc => new(2026, 1, 1);
             public int AppearanceCalls;
+            public ConcurrentQueue<bool> ModelTransitionRequests { get; } = new();
 
             public IconImage? Render(ResourceType type, string resRef, bool useIndexedBlueprint = false) =>
                 Image();
 
-            public IconImage? RenderModel(string modelResRef) => Image();
+            public IconImage? RenderModel(string modelResRef, bool renderDoorTransitionFallback = false)
+            {
+                ModelTransitionRequests.Enqueue(renderDoorTransitionFallback);
+                return Image();
+            }
 
             public IconImage? RenderTileGroup(
                 IReadOnlyList<string> slotModelResRefs, int columns, int rows) => Image();

--- a/SWLOR.Toolset.Tests/DoorTransitionPreviewTests.cs
+++ b/SWLOR.Toolset.Tests/DoorTransitionPreviewTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using NUnit.Framework;
+using SWLOR.Toolset.Domain.Editors.Doors;
 using SWLOR.Toolset.Domain.GameData.Lookups;
 using SWLOR.Toolset.Domain.GameData.Resources;
 using SWLOR.Toolset.Domain.GameData.Tlk;
@@ -50,10 +51,15 @@ namespace SWLOR.Toolset.Tests
                 var door = TransitionDoor();
 
                 var result = renderer.BuildModelResult(ResourceType.Utd, door);
+                var appearance = DoorAppearanceCatalog.Read(doors).Should().ContainSingle().Subject;
 
                 result.Model.Should().BeNull("the synthetic transition MDL does not exist");
                 result.IsDoorTransition.Should().BeTrue(
                     "the 2DA classification must survive independently of nullable geometry");
+                appearance.IsDoorTransition.Should().BeTrue(
+                    "the appearance gallery must retain the same classification");
+                renderer.RenderModel(appearance.Model!, appearance.IsDoorTransition).Should().NotBeNull(
+                    "a missing transition model should render the fixed doorway thumbnail");
             }
             finally
             {
@@ -69,12 +75,32 @@ namespace SWLOR.Toolset.Tests
                 "test",
                 isInstance: false,
                 RunEdit,
+                appearances:
+                [
+                    new DoorAppearanceChoice(
+                        DoorAppearanceKind.Generic,
+                        0,
+                        "Transition",
+                        "missing_transition_model",
+                        IsDoorTransition: true)
+                ],
                 resolveModel: _ => new BlueprintModelRenderResult(null, IsDoorTransition: true));
 
             editor.PreviewScene.Should().NotBeNull();
             var marker = editor.PreviewScene!.Instances.Should().ContainSingle().Subject;
             marker.Model.Should().BeNull();
             marker.IsDoorTransition.Should().BeTrue();
+            editor.Appearance.Tiles.Should().ContainSingle()
+                .Which.Option.IsDoorTransition.Should().BeTrue();
+
+            var (target, distance) = AreaCameraMath.ComputeSceneFraming(
+                editor.PreviewScene,
+                AreaSceneBuilder.TileSize,
+                MathF.PI / 4f,
+                aspectRatio: 1f);
+            target.Should().Be(new System.Numerics.Vector3(5f, 5f, 0f));
+            distance.Should().BeLessThan(6f,
+                "the missing-model doorway fallback should fill its dedicated preview");
         }
 
         [Test]

--- a/SWLOR.Toolset.Tests/PalettePreviewInvalidationTests.cs
+++ b/SWLOR.Toolset.Tests/PalettePreviewInvalidationTests.cs
@@ -100,7 +100,7 @@ namespace SWLOR.Toolset.Tests
                 return new IconImage(2, 2, new byte[2 * 2 * 4]);
             }
 
-            public IconImage? RenderModel(string modelResRef) => null;
+            public IconImage? RenderModel(string modelResRef, bool renderDoorTransitionFallback = false) => null;
 
             public IconImage? RenderTileGroup(IReadOnlyList<string> slotModelResRefs, int columns, int rows) => null;
 

--- a/SWLOR.Toolset.Tests/ThumbnailRendererTests.cs
+++ b/SWLOR.Toolset.Tests/ThumbnailRendererTests.cs
@@ -156,6 +156,24 @@ namespace SWLOR.Toolset.Tests
         }
 
         [Test]
+        public void A_Transition_Model_With_Collinear_Triangles_Renders_The_Doorway_Fallback()
+        {
+            var collinear = Box(1f, 0f, 0f);
+            var transition = new RenderModel
+            {
+                Name = collinear.Name,
+                Meshes = collinear.Meshes,
+                IsDoorTransitionGeometry = true
+            };
+
+            var pixels = ThumbnailRenderer.Render(transition, Size);
+
+            pixels.Should().NotBeNull();
+            OpaquePixels(pixels!).Should().BeGreaterThan(0,
+                "a nonzero projected span is not enough when every authored triangle has zero area");
+        }
+
+        [Test]
         public void A_Null_Model_Renders_Nothing()
         {
             ThumbnailRenderer.Render(null, Size).Should().BeNull();

--- a/SWLOR.Toolset.Tests/ThumbnailServiceTests.cs
+++ b/SWLOR.Toolset.Tests/ThumbnailServiceTests.cs
@@ -42,6 +42,31 @@ namespace SWLOR.Toolset.Tests
         }
 
         [AvaloniaTest]
+        public void DoorTransitionModelsUseTheirOwnFallbackAwareCacheEntry()
+        {
+            var source = new CountingSource();
+            var service = new ThumbnailService(
+                new WorkspaceContext(_ => throw new NotSupportedException(), new OutputLogService()),
+                source);
+
+            service.RequestTileAsync(
+                "shared_model",
+                _ => { },
+                renderDoorTransitionFallback: true);
+            Drain();
+
+            service.CachedTile("shared_model", renderDoorTransitionFallback: true).Should().NotBeNull();
+            service.CachedTile("shared_model").Should().BeNull(
+                "an ordinary model render must not reuse a transition fallback thumbnail");
+
+            service.RequestTileAsync("shared_model", _ => { });
+            Drain();
+
+            source.ModelCalls.Should().Be(2);
+            source.ModelTransitionRequests.Should().Equal(true, false);
+        }
+
+        [AvaloniaTest]
         public void EveryCallerWaitingOnOneRenderIsCalledBack()
         {
             // Four tileset groups routinely share a preview model. An earlier version tracked only
@@ -462,6 +487,7 @@ namespace SWLOR.Toolset.Tests
             public int ModelCalls;
             public int AppearanceCalls;
             public ConcurrentQueue<int> AppearanceOrder { get; } = new();
+            public ConcurrentQueue<bool> ModelTransitionRequests { get; } = new();
 
             public IconImage? AppearanceResult { get; set; } = Image();
 
@@ -473,10 +499,11 @@ namespace SWLOR.Toolset.Tests
             public IconImage? RenderTileGroup(IReadOnlyList<string> slotModelResRefs, int columns, int rows) =>
                 RenderModel(slotModelResRefs.FirstOrDefault(slot => !string.IsNullOrWhiteSpace(slot)) ?? string.Empty);
 
-            public IconImage? RenderModel(string modelResRef)
+            public IconImage? RenderModel(string modelResRef, bool renderDoorTransitionFallback = false)
             {
                 _gate.Wait(TimeSpan.FromSeconds(5));
                 Interlocked.Increment(ref ModelCalls);
+                ModelTransitionRequests.Enqueue(renderDoorTransitionFallback);
 
                 if (ThrowOnModel)
                     throw new InvalidOperationException("unparseable model");

--- a/SWLOR.Toolset/Editors/Appearance/AppearanceGallerySectionViewModel.cs
+++ b/SWLOR.Toolset/Editors/Appearance/AppearanceGallerySectionViewModel.cs
@@ -233,7 +233,10 @@ namespace SWLOR.Toolset.Editors.Appearance
             if (!string.IsNullOrWhiteSpace(tile.Option.ModelResRef))
             {
                 tile.PreviewRequested = true;
-                _thumbnails.RequestTileAsync(tile.Option.ModelResRef, bitmap => tile.Preview = bitmap);
+                _thumbnails.RequestTileAsync(
+                    tile.Option.ModelResRef,
+                    bitmap => tile.Preview = bitmap,
+                    renderDoorTransitionFallback: tile.Option.IsDoorTransition);
             }
         }
 

--- a/SWLOR.Toolset/Editors/Appearance/AppearanceGallerySectionViewModel.cs
+++ b/SWLOR.Toolset/Editors/Appearance/AppearanceGallerySectionViewModel.cs
@@ -360,7 +360,9 @@ namespace SWLOR.Toolset.Editors.Appearance
             }
             else if (!string.IsNullOrWhiteSpace(tile.Option.ModelResRef))
             {
-                tile.Preview = _thumbnails.CachedTile(tile.Option.ModelResRef);
+                tile.Preview = _thumbnails.CachedTile(
+                    tile.Option.ModelResRef,
+                    renderDoorTransitionFallback: tile.Option.IsDoorTransition);
             }
 
             if (tile.Preview != null)

--- a/SWLOR.Toolset/Editors/Appearance/AppearanceOption.cs
+++ b/SWLOR.Toolset/Editors/Appearance/AppearanceOption.cs
@@ -22,13 +22,18 @@ namespace SWLOR.Toolset.Editors.Appearance
     /// True for MODELTYPE P rows, whose representative preview composes a generic full creature
     /// for that row's race rather than rendering one fixed model resource.
     /// </param>
+    /// <param name="IsDoorTransition">
+    /// True when a door choice needs hidden editor geometry or the fixed doorway fallback instead
+    /// of an ordinary visible-model thumbnail.
+    /// </param>
     public sealed record AppearanceOption(
         string Key,
         string Caption,
         string? Detail,
         string? ModelResRef = null,
         int? CreatureAppearanceId = null,
-        bool IsSegmentedCreatureAppearance = false)
+        bool IsSegmentedCreatureAppearance = false,
+        bool IsDoorTransition = false)
     {
         /// <summary>Everything the search box matches against, lowercased once at construction.</summary>
         public string SearchText { get; } =

--- a/SWLOR.Toolset/Editors/Doors/DoorEditorViewModel.cs
+++ b/SWLOR.Toolset/Editors/Doors/DoorEditorViewModel.cs
@@ -138,7 +138,8 @@ namespace SWLOR.Toolset.Editors.Doors
                         AppearanceKey(choice),
                         choice.Display,
                         choice.Model,
-                        ModelResRef: choice.Model))
+                        ModelResRef: choice.Model,
+                        IsDoorTransition: choice.IsDoorTransition))
                     .ToList(),
                 thumbnails,
                 () => _store.GetAppearance(_appearances) is { } current

--- a/SWLOR.Toolset/Workspace/BlueprintPreviewRenderer.cs
+++ b/SWLOR.Toolset/Workspace/BlueprintPreviewRenderer.cs
@@ -415,15 +415,19 @@ namespace SWLOR.Toolset.Workspace
         /// a tile is a row in a .set file, not a module resource, so there is nothing to load fields from
         /// - only geometry to draw.
         /// </summary>
-        public IconImage? RenderModel(string modelResRef)
+        public IconImage? RenderModel(string modelResRef, bool renderDoorTransitionFallback = false)
         {
             if (!IsAvailable || string.IsNullOrWhiteSpace(modelResRef))
                 return null;
 
             var pixels = ThumbnailRenderer.Render(
-                BuildRenderModel(modelResRef), ModelRenderSize,
+                renderDoorTransitionFallback
+                    ? BuildDoorTransitionModel(modelResRef)
+                    : BuildRenderModel(modelResRef),
+                ModelRenderSize,
                 palette: null,
-                resolveTexture: _textures == null ? null : texture => _textures.Get(texture));
+                resolveTexture: _textures == null ? null : texture => _textures.Get(texture),
+                renderDoorTransitionFallback: renderDoorTransitionFallback);
 
             return pixels == null ? null : new IconImage(ModelRenderSize, ModelRenderSize, pixels);
         }

--- a/SWLOR.Toolset/Workspace/IPreviewImageSource.cs
+++ b/SWLOR.Toolset/Workspace/IPreviewImageSource.cs
@@ -36,7 +36,7 @@ namespace SWLOR.Toolset.Workspace
         IconImage? Render(ResourceType type, string resRef, bool useIndexedBlueprint = false);
 
         /// <summary>A model by resref, with no blueprint involved — how a tile gets its picture.</summary>
-        IconImage? RenderModel(string modelResRef);
+        IconImage? RenderModel(string modelResRef, bool renderDoorTransitionFallback = false);
 
         /// <summary>
         /// A multi-tile palette group laid out on the grid, so its thumbnail shows the footprint it

--- a/SWLOR.Toolset/Workspace/ThumbnailService.cs
+++ b/SWLOR.Toolset/Workspace/ThumbnailService.cs
@@ -371,7 +371,8 @@ namespace SWLOR.Toolset.Workspace
             Action<Bitmap> onReady,
             IReadOnlyList<string>? footprintModelResRefs = null,
             int columns = 1,
-            int rows = 1)
+            int rows = 1,
+            bool renderDoorTransitionFallback = false)
         {
             ArgumentNullException.ThrowIfNull(onReady);
 
@@ -379,7 +380,12 @@ namespace SWLOR.Toolset.Workspace
                 return;
 
             var composite = IsCompositeFootprint(footprintModelResRefs, columns, rows);
-            var key = TileKey(modelResRef, footprintModelResRefs, columns, rows);
+            var key = TileKey(
+                modelResRef,
+                footprintModelResRefs,
+                columns,
+                rows,
+                renderDoorTransitionFallback);
             if (_memory.TryGet(key, out var known))
             {
                 if (known != null)
@@ -398,8 +404,8 @@ namespace SWLOR.Toolset.Workspace
                 {
                     var image = composite
                         ? _renderer.RenderTileGroup(footprintModelResRefs!, columns, rows)
-                          ?? _renderer.RenderModel(modelResRef)
-                        : _renderer.RenderModel(modelResRef);
+                          ?? _renderer.RenderModel(modelResRef, renderDoorTransitionFallback)
+                        : _renderer.RenderModel(modelResRef, renderDoorTransitionFallback);
                     if (image != null)
                         bitmap = ToBitmap(image);
                 }
@@ -804,8 +810,9 @@ namespace SWLOR.Toolset.Workspace
         /// The cached tile thumbnail if it is already decoded, else null.
         /// </summary>
         /// <remarks>
-        /// Must be called with the same footprint, columns and rows <see cref="RequestTileAsync"/>
-        /// was (or will be) called with, or this looks up the wrong slot: a multi-slot group renders
+        /// Must be called with the same footprint, columns, rows, and transition-fallback flag
+        /// <see cref="RequestTileAsync"/> was (or will be) called with, or this looks up the wrong
+        /// slot: a multi-slot group renders
         /// and caches under a composite key of its whole footprint, not under
         /// <paramref name="modelResRef"/> alone, because two groups can share a first tile and still
         /// look nothing alike. Passing only <paramref name="modelResRef"/> for a real group would
@@ -816,8 +823,16 @@ namespace SWLOR.Toolset.Workspace
             string modelResRef,
             IReadOnlyList<string>? footprintModelResRefs = null,
             int columns = 1,
-            int rows = 1) =>
-            _memory.TryGet(TileKey(modelResRef, footprintModelResRefs, columns, rows), out var bitmap)
+            int rows = 1,
+            bool renderDoorTransitionFallback = false) =>
+            _memory.TryGet(
+                TileKey(
+                    modelResRef,
+                    footprintModelResRefs,
+                    columns,
+                    rows,
+                    renderDoorTransitionFallback),
+                out var bitmap)
                 ? bitmap
                 : null;
 
@@ -832,10 +847,17 @@ namespace SWLOR.Toolset.Workspace
         /// distinct; anything else is keyed by its own model resref.
         /// </summary>
         private static string TileKey(
-            string modelResRef, IReadOnlyList<string>? footprintModelResRefs, int columns, int rows) =>
-            IsCompositeFootprint(footprintModelResRefs, columns, rows)
+            string modelResRef,
+            IReadOnlyList<string>? footprintModelResRefs,
+            int columns,
+            int rows,
+            bool renderDoorTransitionFallback)
+        {
+            var key = IsCompositeFootprint(footprintModelResRefs, columns, rows)
                 ? "tilegroup:" + columns + "x" + rows + ":" + string.Join(",", footprintModelResRefs!)
                 : "tile:" + modelResRef;
+            return renderDoorTransitionFallback ? "door-transition:" + key : key;
+        }
 
         /// <summary>
         /// The shared symbol for a blueprint type, drawn on first use. Shared rather than per-blueprint


### PR DESCRIPTION
## Summary

- fall back to the fixed doorway thumbnail when authored transition triangles project with span but paint no pixels
- frame missing or meshless transition-door previews from the shared 2m-by-3m fallback bounds
- preserve transition metadata through the door appearance catalog, gallery request, thumbnail cache, and model renderer

## Root cause

The original transition fix handled missing and zero-span geometry, but three independent paths still lost useful editor semantics: collinear projected triangles could return a blank thumbnail, model-less preview scenes fell back to one-tile camera framing, and the appearance gallery reduced a transition choice to a plain model resref.

## Impact

Door transitions now remain visible and recognizable in software thumbnails, dedicated door previews, and the appearance gallery, including missing, meshless, and degenerate authored models. Ordinary model thumbnails retain separate cache entries and behavior.

## Validation

- `dotnet build SWLOR.Toolset.Tests\SWLOR.Toolset.Tests.csproj -p:RunPostBuildEvent=Never -m:1 -p:BuildInParallel=false -p:UseSharedCompilation=false -nodeReuse:false`
- `dotnet test SWLOR.Toolset.Tests\SWLOR.Toolset.Tests.csproj --no-build --filter "FullyQualifiedName~ThumbnailRendererTests|FullyQualifiedName~DoorTransitionPreviewTests|FullyQualifiedName~ThumbnailServiceTests|FullyQualifiedName~AppearanceGalleryTests|FullyQualifiedName~AreaCameraMathTests|FullyQualifiedName~DoorBehaviorTests"` (119 passed)

Follow-up to #2151.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved door appearance previews for transition doors, including options without usable model geometry.
  * Added reliable doorway fallback rendering when previews are empty or contain degenerate geometry.
  * Improved scene framing so transition previews remain centered and visible.
* **Performance**
  * Separated cached transition previews from standard previews to prevent incorrect image reuse.
* **Tests**
  * Added regression coverage for fallback rendering, scene framing, preview requests, and cache behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->