### PR TITLE
Fix Force combat behavior and feedback

### DIFF
--- a/SWLOR.Game.Server.Tests/Feature/PerksWindowTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/PerksWindowTests.cs
@@ -83,6 +83,40 @@ public class PerksWindowTests
     }
 
     [Test]
+    public void ForceAffinity_IsProminentAndExplainsEachSelectedForcePerk()
+    {
+        var root = FindRepositoryRoot();
+        var definitionSource = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "SWLOR.Game.Server",
+            "Feature",
+            "GuiDefinition",
+            "PerksDefinition.cs"));
+        var viewModelSource = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "SWLOR.Game.Server",
+            "Feature",
+            "GuiDefinition",
+            "ViewModel",
+            "PerksViewModel.cs"));
+
+        definitionSource.Should().Contain("model => model.IsForceAffinityVisible");
+        definitionSource.Should().Contain("model => model.ForceAffinityHeading");
+        definitionSource.Should().Contain("model => model.ForceAffinityExplanation");
+        definitionSource.Should().Contain("model => model.ForceAffinityColor");
+
+        viewModelSource.Should().Contain("dbPlayer.CharacterType == CharacterType.ForceSensitive");
+        viewModelSource.Should().Contain("FORCE AFFINITY: {affinityLabel}");
+        viewModelSource.Should().Contain("Owning any rank of a Light power contributes +1; a Dark power contributes -1.");
+        viewModelSource.Should().Contain("detail.ForceAffinityType.Value == ForceAffinityType.Light ? \"LIGHT\" : \"DARK\"");
+        viewModelSource.Should().Contain("{alignment}-ALIGNED FORCE POWER");
+        viewModelSource.Should().Contain("UNIVERSAL FORCE POWER");
+        viewModelSource.Should().Contain("Perk.GetForceAffinityMagnitudeMultiplier(Player, detail.Type)");
+        viewModelSource.Should().Contain("Perk.GetForceAffinityHitChanceAdjustment(Player, detail.Type)");
+        viewModelSource.Should().Contain("additional ranks do not add more affinity");
+    }
+
+    [Test]
     public void NativeStealthMode_IsAddedAndRemovedAsAModeToggle()
     {
         var root = FindRepositoryRoot();

--- a/SWLOR.Game.Server.Tests/Feature/PlayerGuideContentTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/PlayerGuideContentTests.cs
@@ -18,6 +18,7 @@ public class PlayerGuideContentTests
         "Skills",
         "Skill Decay",
         "Perks",
+        "Force Affinity",
         "Perk Refunds",
         "XP Debt",
         "Abilities",
@@ -117,6 +118,21 @@ public class PlayerGuideContentTests
 
         guideText.Should().Contain($"{Property.ElectionRegistrationDays}-day candidate-registration period");
         guideText.Should().Contain($"{Property.ElectionVotingDays} days of voting");
+    }
+
+    [Test]
+    public void ForceAffinityTopic_ExplainsContributionMagnitudeHitChanceAndDuration()
+    {
+        var topic = GetTopics().Single(topic => GetString(topic, "Name") == "Force Affinity");
+        var text = string.Join("\n", GetAllText(topic));
+
+        text.Should().Contain("-10 Dark to +10 Light");
+        text.Should().Contain("Additional ranks of the same perk do not contribute additional affinity");
+        text.Should().Contain("increases that power's damage, healing, shields, regeneration, or drain magnitude by 5 percent");
+        text.Should().Contain("At +10 Light, Light powers gain +5% hit chance and Dark powers suffer -5%");
+        text.Should().Contain("Universal Force powers");
+        text.Should().Contain("Force Affinity does not change effect duration");
+        text.Should().Contain("At +6 Light, a Light power uses 130% magnitude and gains +3% hit chance");
     }
 
     private static List<object> GetTopics()

--- a/SWLOR.Game.Server.Tests/Perks/ForceLightConsularTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/ForceLightConsularTests.cs
@@ -82,6 +82,20 @@ public class ForceLightConsularTests
     }
 
     [Test]
+    public void Renewal_RestoresTheBiblePercentEveryThreeSecondsForThirtySeconds()
+    {
+        var root = FindSourceRepositoryRoot();
+        var source = File.ReadAllText((root / "SWLOR.Game.Server" / "Feature" / "AbilityDefinition" / "Force" / "RenewalAbilityDefinition.cs").FullName);
+
+        source.Should().Contain("ApplyRenewal(activator, target, \"Renewal I\", 20f);");
+        source.Should().Contain("ApplyRenewal(activator, target, \"Renewal II\", 40f);");
+        source.Should().Contain("ApplyRenewal(activator, target, \"Renewal III\", 60f);");
+        source.Should().Contain("totalPercent * Ability.GetActiveForceAffinityMagnitudeMultiplier(activator)");
+        source.Should().Contain("new RegenerativeHealingStatusEffect(name, affinityAdjustedTotalPercent, 10)");
+        source.Should().Contain("30f);");
+    }
+
+    [Test]
     public void ForceSanctuary_UsesSingleAllyPulseAndPersistentAreaVisual()
     {
         var root = FindSourceRepositoryRoot();

--- a/SWLOR.Game.Server.Tests/Perks/GeneratedWeaponPerkBehaviorTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/GeneratedWeaponPerkBehaviorTests.cs
@@ -168,6 +168,29 @@ public class GeneratedWeaponPerkBehaviorTests
     }
 
     [Test]
+    public void PathogenStrike_ExtendsCasterOwnedVenomAndInfectionWithoutConsumingThem()
+    {
+        var root = FindRepositoryRoot();
+        var pathogenSource = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "SWLOR.Game.Server",
+            "Feature",
+            "AbilityDefinition",
+            "Vibroknife",
+            "PathogenStrikeAbilityDefinition.cs"));
+        var generatedAbilitySource = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "SWLOR.Game.Server",
+            "Feature",
+            "AbilityDefinition",
+            "WeaponActiveAbilityDefinitionBase.cs")).Replace("\r\n", "\n");
+
+        pathogenSource.Should().Contain("SourceStatusEffectsToExtend = new[] { typeof(VenomStatusEffect), typeof(InfectionStatusEffect) }");
+        pathogenSource.Should().NotContain("ConsumeSourceStatusEffectsOnHit = true");
+        generatedAbilitySource.Should().Contain("StatusEffect.ExtendStatusEffectDuration(\n                        target,\n                        statusEffectType,\n                        activator,");
+    }
+
+    [Test]
     public void SpottersRhythm_UsesSameTargetPressureInsteadOfIdleAbilityStats()
     {
         var root = FindRepositoryRoot();

--- a/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
@@ -179,12 +179,29 @@ public class CombatDamageTests
         abilitySource.Should().NotContain("GetCombatImpactEffectDamagePower");
         abilitySource.Should().NotContain("private static int GetCombatImpactWeaponDamage");
         combatSource.Should().NotContain("IsWeaponForSkill");
-        impactWeaponDamage.Should().Contain("var weapon = GetCombatImpactWeapon(activator);");
-        impactWeaponSelection.Should().Contain("IsCombatImpactWeapon(rightHand)");
-        impactWeaponSelection.Should().Contain("IsCombatImpactWeapon(leftHand)");
-        impactWeaponSelection.Should().NotContain("skillType");
+        impactWeaponDamage.Should().Contain("var weapon = GetCombatImpactWeapon(activator, skillType);");
+        impactWeaponSelection.Should().Contain("CanItemTriggerWeaponAbility(rightHand, skillType)");
+        impactWeaponSelection.Should().Contain("CanItemTriggerWeaponAbility(leftHand, skillType)");
         damageTypeSource.Should().NotContain("GetNWScriptDamagePower");
         damageTypeSource.Should().NotContain("DamagePower");
+    }
+
+    [Test]
+    public void WeaponAbilities_OnlyUseTheirDeclaredWeaponSkill()
+    {
+        Combat.CanWeaponSkillTriggerAbility(SkillType.Vibroknife, SkillType.Vibroknife).Should().BeTrue();
+        Combat.CanWeaponSkillTriggerAbility(SkillType.Spear, SkillType.Vibroknife).Should().BeFalse();
+        Combat.CanWeaponSkillTriggerAbility(SkillType.Vibroblade, SkillType.Lightsaber).Should().BeFalse();
+        Combat.CanWeaponSkillTriggerAbility(SkillType.Invalid, SkillType.Vibroknife).Should().BeFalse();
+        Combat.CanWeaponSkillTriggerAbility(SkillType.Spear, SkillType.Invalid).Should().BeTrue();
+
+        var root = FindRepositoryRoot();
+        var abilitySource = File.ReadAllText(Path.Combine(root.FullName, "SWLOR.Game.Server", "Service", "Ability.cs"));
+        var usePerkFeatSource = File.ReadAllText(Path.Combine(root.FullName, "SWLOR.Game.Server", "Feature", "UsePerkFeat.cs"));
+
+        abilitySource.Should().Contain("Combat.HasEquippedWeaponForAbilitySkill(activator, ability.SkillType)");
+        abilitySource.Should().Contain("You must equip a {skillName} weapon to use this ability.");
+        usePerkFeatSource.Should().Contain("Combat.CanItemTriggerWeaponAbility(item, abilityDetail.SkillType)");
     }
 
     [Test]
@@ -311,6 +328,7 @@ public class CombatDamageTests
         usePerkFeatSource.Should().Contain("ProcessQueuedWeaponAbility()");
         usePerkFeatSource.Should().Contain("Ability.BeginAbilityImpact(activator, abilityDetail);");
         usePerkFeatSource.Should().Contain("public static bool HasQueuedWeaponAbility(uint activator)");
+        usePerkFeatSource.Should().Contain("public static bool HasQueuedWeaponAbility(uint activator, SkillType weaponSkillType)");
         usePerkFeatSource.Should().Contain("public static bool TryGetQueuedWeaponAbility(uint activator, out AbilityDetail ability)");
         usePerkFeatSource.Should().Contain("var abilityId = GetLocalString(activator, ActiveAbilityIdName);");
         usePerkFeatSource.Should().Contain("if (string.IsNullOrWhiteSpace(abilityId))");
@@ -342,10 +360,10 @@ public class CombatDamageTests
         preparedAutoAttackCleanupBody.Should().Contain("StatType.CurrentAutoAttackDamageBonus");
         preparedAutoAttackCleanupBody.Should().Contain("ConsumeNextSkillAutoAttackDamageBonus(attacker, skillType);");
         preparedAutoAttackCleanupBody.Should().Contain("StatType.NextAutoAttackDamageBonus");
-        damageRollSource.Should().Contain("UsePerkFeat.HasQueuedWeaponAbility(attacker.m_idSelf)");
+        damageRollSource.Should().Contain("UsePerkFeat.HasQueuedWeaponAbility(attacker.m_idSelf, skillType)");
         damageRollSource.Should().Contain("Combat.ConsumeSuppressedAutoAttackDamageBonuses(attacker.m_idSelf, skillType);");
         var queuedAbilitySuppressionIndex = damageRollSource.IndexOf(
-            "UsePerkFeat.HasQueuedWeaponAbility(attacker.m_idSelf)",
+            "UsePerkFeat.HasQueuedWeaponAbility(attacker.m_idSelf, skillType)",
             StringComparison.Ordinal);
         var queuedAbilityCleanupIndex = damageRollSource.IndexOf(
             "Combat.ConsumeSuppressedAutoAttackDamageBonuses(attacker.m_idSelf, skillType);",
@@ -372,12 +390,12 @@ public class CombatDamageTests
         abilitySource.Should().MatchRegex(@"if \(shouldResolveHit\)\s*SendCombatImpactResultMessage");
         attackRollSource.Should().Contain("private static string BuildAttackFeedbackMessage");
         attackRollSource.Should().Contain("IsSuccessfulAttackResult(attackResultType)");
-        attackRollSource.Should().Contain("UsePerkFeat.TryGetQueuedWeaponAbility(attacker.m_idSelf, out var queuedAbility)");
+        attackRollSource.Should().Contain("UsePerkFeat.TryGetQueuedWeaponAbility(attacker.m_idSelf, weaponSkillType, out var queuedAbility)");
         attackRollSource.Should().Contain("Combat.BuildAbilityCombatLogMessage(");
         attackRollSource.Should().Contain("queuedAbility.Name");
         attackRollSource.Should().Contain("Combat.BuildCombatLogMessageNative(");
         var queuedWeaponHitBranchIndex = attackRollSource.IndexOf(
-            "if (UsePerkFeat.HasQueuedWeaponAbility(attacker.m_idSelf))",
+            "if (UsePerkFeat.HasQueuedWeaponAbility(attacker.m_idSelf, weaponSkillType))",
             StringComparison.Ordinal);
         var nativeCriticalPreparationIndex = attackRollSource.IndexOf(
             "var criticalStat = attackerStats.GetDEXStat();",

--- a/SWLOR.Game.Server.Tests/Service/StatusEffectDeliveryTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/StatusEffectDeliveryTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using NUnit.Framework;
+using SWLOR.Game.Server.Service;
 using SWLOR.Game.Server.Service.CombatService;
 using SWLOR.Game.Server.Service.StatusEffectService;
 using SWLOR.NWN.API.NWScript.Enum;
@@ -8,6 +9,40 @@ namespace SWLOR.Game.Server.Tests.Service;
 
 public class StatusEffectDeliveryTests
 {
+    [Test]
+    public void FiniteStatusEffects_CanBeExtendedWithoutBeingRemoved()
+    {
+        var effect = new LegacyDamageCallbackStatusEffect();
+        effect.ApplyEffect(1, 2, 5);
+
+        effect.ExtendDurationTicks(2);
+
+        effect.DurationTicks.Should().Be(7);
+        effect.IsFlaggedForRemoval.Should().BeFalse();
+    }
+
+    [Test]
+    public void DurationResistanceFeedback_ReportsTheEffectiveDuration()
+    {
+        StatusEffect.BuildDurationResistanceMessage(ResistanceType.Mobility, "Immobilized", 10, 9, 3f)
+            .Should().Be("Mobility Resistance reduced Immobilized duration from 30s to 27s.");
+        StatusEffect.BuildDurationResistanceMessage(ResistanceType.Mind, "Confusion", 5, 6, 1f)
+            .Should().Be("Mind Resistance increased Confusion duration from 5s to 6s.");
+        StatusEffect.BuildDurationResistanceMessage(ResistanceType.Trauma, "Venom", 5, 5, 6f)
+            .Should().BeEmpty();
+    }
+
+    [Test]
+    public void ForceAffinity_DoesNotAlterStatusDuration()
+    {
+        var root = FindRepositoryRoot();
+        var statusEffectSource = File.ReadAllText(Path.Combine(root.FullName, "SWLOR.Game.Server", "Service", "StatusEffect.cs"));
+        var abilitySource = File.ReadAllText(Path.Combine(root.FullName, "SWLOR.Game.Server", "Service", "Ability.cs"));
+
+        statusEffectSource.Should().NotContain("ApplyActiveForceAffinityDurationAdjustment");
+        abilitySource.Should().NotContain("ApplyActiveForceAffinityDurationAdjustment");
+    }
+
     [Test]
     public void LegacyDamageCallbacks_OnlyReceiveDirectDamage()
     {
@@ -41,5 +76,18 @@ public class StatusEffectDeliveryTests
         {
             LegacyDamageTakenCalls++;
         }
+    }
+
+    private static DirectoryInfo FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(TestContext.CurrentContext.TestDirectory);
+
+        while (directory != null && !File.Exists(Path.Combine(directory.FullName, "SWLOR.Game.Server.sln")))
+        {
+            directory = directory.Parent;
+        }
+
+        directory.Should().NotBeNull("repository root should be discoverable from the test directory");
+        return directory!;
     }
 }

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Force/RenewalAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Force/RenewalAbilityDefinition.cs
@@ -93,27 +93,28 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
 
         private static void Renewal1ImpactAction(uint activator, uint target, int level, Location targetLocation)
         {
-            ApplyRenewal(activator, target, "Renewal I", 12f);
+            ApplyRenewal(activator, target, "Renewal I", 20f);
         }
 
         private static void Renewal2ImpactAction(uint activator, uint target, int level, Location targetLocation)
         {
-            ApplyRenewal(activator, target, "Renewal II", 18f);
+            ApplyRenewal(activator, target, "Renewal II", 40f);
         }
 
         private static void Renewal3ImpactAction(uint activator, uint target, int level, Location targetLocation)
         {
-            ApplyRenewal(activator, target, "Renewal III", 24f);
+            ApplyRenewal(activator, target, "Renewal III", 60f);
         }
 
         private static void ApplyRenewal(uint activator, uint target, string name, float totalPercent)
         {
             var friendly = AbilityTargeting.ResolveFriendlyTarget(activator, target);
             var targetWasBelowHalfHP = ForceControlHealingEffects.IsBelowHalfHP(friendly);
+            var affinityAdjustedTotalPercent = totalPercent * Ability.GetActiveForceAffinityMagnitudeMultiplier(activator);
             StatusEffect.ApplyStatusEffect(
                 activator,
                 friendly,
-                new RegenerativeHealingStatusEffect(name, totalPercent, 6),
+                new RegenerativeHealingStatusEffect(name, affinityAdjustedTotalPercent, 10),
                 30f);
             ForceControlHealingEffects.ApplyRestorativeControlPower(activator, friendly, targetWasBelowHalfHP);
             ApplyEffectToObject(DurationType.Instant, EffectVisualEffect(VisualEffect.Vfx_Imp_Healing_M), friendly);

--- a/SWLOR.Game.Server/Feature/GuiDefinition/CharacterSheetDefinition.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/CharacterSheetDefinition.cs
@@ -503,6 +503,8 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
             Expression<Func<CharacterSheetViewModel, bool>> upgradeVisibleExpression,
             Expression<Func<CharacterSheetViewModel, Action>> clickExpression)
         {
+            const string attributeCapTooltip = " AP upgrades stop at 26. A racial bonus may raise one attribute to 27; that extra point remains part of combat formulas, while direct-effect scaling reaches its designed cap at 26.";
+
             col.AddRow(row =>
             {
                 row.SetHeight(StatRowHeight);
@@ -512,7 +514,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                     .SetWidth(112f)
                     .SetVerticalAlign(NuiVerticalAlign.Top)
                     .SetHorizontalAlign(NuiHorizontalAlign.Left)
-                    .SetTooltip(tooltip);
+                    .SetTooltip(tooltip + attributeCapTooltip);
 
                 row.AddLabel()
                     .BindText(valueExpression)

--- a/SWLOR.Game.Server/Feature/GuiDefinition/PerksDefinition.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/PerksDefinition.cs
@@ -108,6 +108,37 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                             .SetHeight(26f);
                     });
 
+                    col.AddRow(affinityRow =>
+                    {
+                        affinityRow.SetHeight(88f);
+                        affinityRow.BindIsVisible(model => model.IsForceAffinityVisible);
+                        affinityRow.AddGroup(group =>
+                        {
+                            group.SetScrollbars(NuiScrollbars.None);
+                            group.AddColumn(affinityColumn =>
+                            {
+                                affinityColumn.AddRow(row =>
+                                {
+                                    row.AddLabel()
+                                        .BindText(model => model.ForceAffinityHeading)
+                                        .BindColor(model => model.ForceAffinityColor)
+                                        .SetHorizontalAlign(NuiHorizontalAlign.Left)
+                                        .SetVerticalAlign(NuiVerticalAlign.Middle)
+                                        .SetHeight(24f);
+                                });
+
+                                affinityColumn.AddRow(row =>
+                                {
+                                    row.AddText()
+                                        .BindText(model => model.ForceAffinityExplanation)
+                                        .SetShowBorder(false)
+                                        .SetScrollbars(NuiScrollbars.None)
+                                        .SetHeight(58f);
+                                });
+                            });
+                        });
+                    });
+
                     col.AddRow(row =>
                     {
                         row.AddLabel()

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/CharacterSheetViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/CharacterSheetViewModel.cs
@@ -927,7 +927,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             AddStat("Paralysis", GetEffectStateLabel(EffectTypeScript.Paralyze), "Prevents auto attacks and other actions.");
             AddStat("Movement Speed", FormatMultiplier(Stat.GetMovementSpeedMultiplier(_target)), "Increases or decreases your movement speed.");
             AddStat("Force Evasion", FormatPercent(GetForceEvasion()), "Percent chance to completely evade a detrimental force ability.");
-            AddStat("Force Affinity", Perk.GetForceAffinity(_target).ToString(), "Affects Force ability effectiveness based on type. Range: -10 to 10. Negative represents Dark-side and positive represents Light-side.");
+            AddStat("Force Affinity", Perk.GetForceAffinity(_target).ToString(), "Range: -10 (Dark) to +10 (Light). Matching-side powers gain 5% magnitude per point, up to +50%, and +5% hit chance at full affinity; opposing powers lose the same. Affinity does not change duration, which remains subject to resistance and duration modifiers.");
             AddStat("Detection", Stat.GetDetection(_target).ToString(), "PER + WIL plus equipment, perk, and status-effect bonuses; Detect mode adds +5.");
             AddStat("Stealth", Stat.GetStealth(_target).ToString(), "Twice AGI plus equipment, perk, and status-effect bonuses.");
             AddStat("Experience", FormatPercent(Stat.GetStatAdjustment(_target, StatType.ExperiencePercentAdjustment)), "Bonus or penalty applied to experience gained from skill use.");

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/PerksViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/PerksViewModel.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using SWLOR.Game.Server.Core.NWNX.Enum;
 using SWLOR.Game.Server.Entity;
+using SWLOR.Game.Server.Enumeration;
 using SWLOR.Game.Server.Feature.GuiDefinition.RefreshEvent;
 using SWLOR.Game.Server.Service;
 using SWLOR.Game.Server.Service.AbilityService;
@@ -75,6 +76,30 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
         public string TotalSP
         {
             get => Get<string>();
+            set => Set(value);
+        }
+
+        public bool IsForceAffinityVisible
+        {
+            get => Get<bool>();
+            set => Set(value);
+        }
+
+        public string ForceAffinityHeading
+        {
+            get => Get<string>();
+            set => Set(value);
+        }
+
+        public string ForceAffinityExplanation
+        {
+            get => Get<string>();
+            set => Set(value);
+        }
+
+        public GuiColor ForceAffinityColor
+        {
+            get => Get<GuiColor>();
             set => Set(value);
         }
 
@@ -409,6 +434,8 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             var dbPlayer = DB.Get<Player>(playerId);
             var now = DateTime.UtcNow;
 
+            LoadForceAffinityDetails(dbPlayer);
+
             if (IsInMyPerksMode)
             {
                 AvailableSP = $"Available SP: {dbPlayer.UnallocatedSP}";
@@ -431,6 +458,32 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             ResetNextAvailable = $"Reset Available: {dateRefundAvailableText} [# Available: {Currency.GetCurrency(Player, CurrencyType.PerkRefundToken)}]";
             IsRefundEnabled = false;
             HasBeast = !string.IsNullOrWhiteSpace(dbPlayer.ActiveBeastId);
+        }
+
+        private void LoadForceAffinityDetails(Player dbPlayer)
+        {
+            IsForceAffinityVisible = IsInMyPerksMode &&
+                                     dbPlayer.CharacterType == CharacterType.ForceSensitive;
+            if (!IsForceAffinityVisible)
+            {
+                ForceAffinityHeading = string.Empty;
+                ForceAffinityExplanation = string.Empty;
+                ForceAffinityColor = GuiColor.White;
+                return;
+            }
+
+            var affinity = Perk.GetForceAffinity(Player);
+            var affinityLabel = FormatForceAffinity(affinity);
+            ForceAffinityHeading = $"FORCE AFFINITY: {affinityLabel}";
+            ForceAffinityExplanation =
+                "Owning any rank of a Light power contributes +1; a Dark power contributes -1. " +
+                "Each point changes aligned or opposed magnitude by 5%. At full affinity, hit chance shifts by 5%. " +
+                "Universal powers and effect durations are unaffected. Select a Force perk for its current result.";
+            ForceAffinityColor = affinity > 0
+                ? new GuiColor(120, 190, 255)
+                : affinity < 0
+                    ? new GuiColor(225, 100, 100)
+                    : new GuiColor(221, 181, 93);
         }
 
         private void LoadPerks()
@@ -624,6 +677,12 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
 
             selectedDetails += $"[{categoryDetail.Name}]\n";
 
+            var forceAffinityText = BuildForceAffinityPerkDetailText(detail);
+            if (!string.IsNullOrWhiteSpace(forceAffinityText))
+            {
+                selectedDetails += forceAffinityText + "\n";
+            }
+
             var recastGroupText = BuildRecastGroupText(detail);
             if (!string.IsNullOrWhiteSpace(recastGroupText))
             {
@@ -651,6 +710,52 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             }
 
             return selectedDetails;
+        }
+
+        private string BuildForceAffinityPerkDetailText(PerkDetail detail)
+        {
+            if (!IsForcePerkCategory(detail.Category))
+                return string.Empty;
+
+            if (detail.ForceAffinityType == null)
+            {
+                return "\nUNIVERSAL FORCE POWER\n" +
+                       "Does not change Force Affinity and receives no affinity magnitude or hit-chance adjustment.";
+            }
+
+            var affinity = Perk.GetForceAffinity(Player);
+            var alignment = detail.ForceAffinityType.Value == ForceAffinityType.Light ? "LIGHT" : "DARK";
+            var contribution = detail.ForceAffinityType.Value == ForceAffinityType.Light ? "+1 Light" : "-1 Dark";
+            var magnitudeAdjustment = (int)Math.Round(
+                (Perk.GetForceAffinityMagnitudeMultiplier(Player, detail.Type) - 1f) * 100f,
+                MidpointRounding.AwayFromZero);
+            var hitChanceAdjustment = Perk.GetForceAffinityHitChanceAdjustment(Player, detail.Type);
+
+            return $"\n{alignment}-ALIGNED FORCE POWER\n" +
+                   $"At {FormatForceAffinity(affinity)}: {FormatSignedPercent(magnitudeAdjustment)} magnitude, " +
+                   $"{FormatSignedPercent(hitChanceAdjustment)} hit chance.\n" +
+                   $"Owning any rank contributes {contribution}; additional ranks do not add more affinity.";
+        }
+
+        private static bool IsForcePerkCategory(PerkCategoryType category)
+        {
+            return category == PerkCategoryType.ForceAlter ||
+                   category == PerkCategoryType.ForceControl ||
+                   category == PerkCategoryType.ForceSense;
+        }
+
+        private static string FormatForceAffinity(int affinity)
+        {
+            return affinity > 0
+                ? $"+{affinity} Light"
+                : affinity < 0
+                    ? $"{affinity} Dark"
+                    : "0 Neutral";
+        }
+
+        private static string FormatSignedPercent(int adjustment)
+        {
+            return adjustment > 0 ? $"+{adjustment}%" : $"{adjustment}%";
         }
 
         private static string BuildRecastGroupText(PerkDetail detail)

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/PlayerGuideViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/PlayerGuideViewModel.cs
@@ -423,7 +423,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
                 new(
                     "Perks",
                     "Progression",
-                    "Perk ranks, SP prices, requirements, colors, beast perks, and granted effects.",
+                    "Perk ranks, SP prices, requirements, colors, Force Affinity, beast perks, and granted effects.",
                     "SP prices and requirements",
                     new[]
                     {
@@ -433,6 +433,8 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
                             "The list color is based on whether the next upgrade's requirements pass. The Buy button is enabled only when the next upgrade exists, requirements pass, and you have enough unallocated SP."),
                         new ArticleBlock("What Perks Can Do",
                             "Perk levels can grant active abilities, passive bonuses, and other effects."),
+                        new ArticleBlock("Force Affinity",
+                            "Force-sensitive characters see their current Force Affinity near the top of the Perks window. Selecting a Force perk also shows whether it is Light, Dark, or Universal and how the current affinity changes that power. See the Force Affinity guide topic for the full rules."),
                         new ArticleBlock("Requirements",
                             "A perk may require a skill rank, quest completion, character type, unlock, another perk, not having a conflicting perk, or beast level or role progress before the next rank can be purchased."),
                         new ArticleBlock("Beast Perks",
@@ -444,7 +446,37 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
                         new QuestionAnswer("When can I buy?", "When the next rank exists, requirements pass, and you have enough SP."),
                         new QuestionAnswer("What are beast perks?", "A Perks window mode that uses the active beast's SP and level.")
                     },
-                    new[] { "Perk Refunds", "Skills", "Abilities", "Skill Decay" }),
+                    new[] { "Force Affinity", "Perk Refunds", "Skills", "Abilities", "Skill Decay" }),
+
+                new(
+                    "Force Affinity",
+                    "Combat",
+                    "How Light, Dark, and Universal Force powers change—and are changed by—your affinity.",
+                    "Light, Dark, and Universal powers",
+                    new[]
+                    {
+                        new ArticleBlock("Reading Your Affinity",
+                            "Force Affinity ranges from -10 Dark to +10 Light. A value of 0 is neutral. Your current value is displayed prominently in the Perks window and in the Character Sheet's detailed statistics."),
+                        new ArticleBlock("How Affinity Changes",
+                            "Owning any rank of a Light-aligned perk contributes +1 Light affinity. Owning any rank of a Dark-aligned perk contributes -1 Dark affinity. Additional ranks of the same perk do not contribute additional affinity. Refunding the perk removes its contribution. Universal Force perks do not change affinity."),
+                        new ArticleBlock("Magnitude",
+                            "Each point toward a power's side increases that power's damage, healing, shields, regeneration, or drain magnitude by 5 percent. Each point toward the opposing side reduces it by 5 percent. The multiplier is limited to 50 percent at full opposition and 150 percent at full alignment."),
+                        new ArticleBlock("Hit Chance",
+                            "Affinity also changes the hit chance of detrimental Light and Dark Force powers. At +10 Light, Light powers gain +5% hit chance and Dark powers suffer -5%. At -10 Dark, Dark powers gain +5% and Light powers suffer -5%. The final chance shown in the combat log already includes this adjustment."),
+                        new ArticleBlock("Universal Powers and Durations",
+                            "Universal Force powers use their normal Willpower scaling but neither gain nor lose magnitude or hit chance from affinity. Force Affinity does not change effect duration. Status resistance and explicit duration modifiers can still change a duration."),
+                        new ArticleBlock("Example: +6 Light",
+                            "At +6 Light, a Light power uses 130% magnitude and gains +3% hit chance. A Dark power uses 70% magnitude and suffers -3% hit chance. A Universal power remains at 100% magnitude with no affinity hit adjustment.")
+                    },
+                    new[]
+                    {
+                        new QuestionAnswer("Do extra ranks of one power add more affinity?", "No. Owning any rank contributes one point for that perk; higher ranks of the same perk do not add more."),
+                        new QuestionAnswer("Why is my Dark power weaker?", "Positive Light affinity weakens Dark power magnitude and hit chance. Negative Dark affinity does the same to Light powers."),
+                        new QuestionAnswer("Do Universal powers move affinity?", "No. They neither change affinity nor receive its magnitude or hit-chance modifiers."),
+                        new QuestionAnswer("Does affinity change duration?", "No. Affinity changes magnitude and hit chance, while resistance and duration modifiers handle duration."),
+                        new QuestionAnswer("Where can I see the exact effect?", "The Perks window shows your current affinity and the current magnitude and hit-chance effect on a selected Force perk.")
+                    },
+                    new[] { "Perks", "Abilities", "Attributes", "Combat Basics" }),
 
                 new(
                     "Perk Refunds",

--- a/SWLOR.Game.Server/Feature/UsePerkFeat.cs
+++ b/SWLOR.Game.Server/Feature/UsePerkFeat.cs
@@ -639,6 +639,27 @@ namespace SWLOR.Game.Server.Feature
             return TryGetQueuedWeaponAbility(activator, out _);
         }
 
+        public static bool HasQueuedWeaponAbility(uint activator, SkillType weaponSkillType)
+        {
+            return TryGetQueuedWeaponAbility(activator, out var ability) &&
+                   Combat.CanWeaponSkillTriggerAbility(weaponSkillType, ability.SkillType);
+        }
+
+        public static bool TryGetQueuedWeaponAbility(
+            uint activator,
+            SkillType weaponSkillType,
+            out AbilityDetail ability)
+        {
+            if (!TryGetQueuedWeaponAbility(activator, out ability) ||
+                !Combat.CanWeaponSkillTriggerAbility(weaponSkillType, ability.SkillType))
+            {
+                ability = null;
+                return false;
+            }
+
+            return true;
+        }
+
         public static bool TryGetQueuedWeaponAbility(uint activator, out AbilityDetail ability)
         {
             if (!GetIsObjectValid(activator))
@@ -854,6 +875,9 @@ namespace SWLOR.Game.Server.Feature
             }
 
             var abilityDetail = Ability.GetAbilityDetail(activeWeaponAbility);
+            if (!Combat.CanItemTriggerWeaponAbility(item, abilityDetail.SkillType))
+                return;
+
             HandleStealthBreaking(activator, abilityDetail);
             var impactEnded = false;
             try

--- a/SWLOR.Game.Server/Native/GetDamageRoll.cs
+++ b/SWLOR.Game.Server/Native/GetDamageRoll.cs
@@ -97,15 +97,15 @@ namespace SWLOR.Game.Server.Native
 
                 // Extract weapon damage properties and get ability stats
                 var damageProfile = ExtractAttackDamageProfile(attacker, weapon);
-
-                // Imbuement Stance converts the wearer's hostile weapon auto-attacks to Force damage for an FP cost.
-                damageProfile = ApplyForceConversionStance(attacker, defender, damageProfile);
-
-                var attackerStatType = GetWeaponDamageAbilityType(attacker.m_idSelf, weapon);
-                var weaponDeltaCap = GetWeaponDeltaCap(weapon);
                 var weaponSkillType = weapon == null
                     ? SkillType.Invalid
                     : SWLOR.Game.Server.Service.Skill.GetSkillTypeByBaseItem((BaseItem)weapon.m_nBaseItem);
+
+                // Imbuement Stance converts the wearer's hostile weapon auto-attacks to Force damage for an FP cost.
+                damageProfile = ApplyForceConversionStance(attacker, defender, damageProfile, weaponSkillType);
+
+                var attackerStatType = GetWeaponDamageAbilityType(attacker.m_idSelf, weapon);
+                var weaponDeltaCap = GetWeaponDeltaCap(weapon);
 
                 var attackerStat = Stat.GetStatValueNative(attacker, attackerStatType);
 
@@ -214,7 +214,7 @@ namespace SWLOR.Game.Server.Native
             totalDamage = 0;
 
             if (targetObject.m_nObjectType == (int)ObjectType.Creature &&
-                UsePerkFeat.HasQueuedWeaponAbility(attacker.m_idSelf))
+                UsePerkFeat.HasQueuedWeaponAbility(attacker.m_idSelf, skillType))
             {
                 Combat.ConsumeSuppressedAutoAttackDamageBonuses(attacker.m_idSelf, skillType);
                 return physicalDamage;
@@ -280,7 +280,10 @@ namespace SWLOR.Game.Server.Native
         // their normal type and cost FP per swing. This only affects real auto-attacks against creatures; queued
         // weapon abilities apply their own damage and are excluded so they are neither converted nor charged.
         private static WeaponDamageProfile ApplyForceConversionStance(
-            CNWSCreature attacker, CNWSObject defender, WeaponDamageProfile damageProfile)
+            CNWSCreature attacker,
+            CNWSObject defender,
+            WeaponDamageProfile damageProfile,
+            SkillType weaponSkillType)
         {
             if (defender.m_nObjectType != (int)ObjectType.Creature)
                 return damageProfile;
@@ -294,7 +297,7 @@ namespace SWLOR.Game.Server.Native
                 return damageProfile;
 
             // Weapon abilities apply their own combat impact and suppress the auto-attack; do not convert/charge them.
-            if (UsePerkFeat.HasQueuedWeaponAbility(attacker.m_idSelf))
+            if (UsePerkFeat.HasQueuedWeaponAbility(attacker.m_idSelf, weaponSkillType))
                 return damageProfile;
 
             var fpCost = Stat.GetStatAdjustment(attacker.m_idSelf, StatType.StanceHostileAutoAttackFPCost);

--- a/SWLOR.Game.Server/Native/ResolveAttackRoll.cs
+++ b/SWLOR.Game.Server/Native/ResolveAttackRoll.cs
@@ -244,7 +244,7 @@ namespace SWLOR.Game.Server.Native
                 // Hit
                 if (isHit)
                 {
-                    if (UsePerkFeat.HasQueuedWeaponAbility(attacker.m_idSelf))
+                    if (UsePerkFeat.HasQueuedWeaponAbility(attacker.m_idSelf, weaponSkillType))
                     {
                         Log.Write(LogGroup.Attack, $"Queued weapon ability hit - attack result 1");
                         pAttackData.m_nAttackResult = AttackResultRegularHit;
@@ -346,13 +346,15 @@ namespace SWLOR.Game.Server.Native
                     attacker,
                     defender,
                     pAttackData.m_nAttackResult,
-                    hitRate);
+                    hitRate,
+                    weaponSkillType);
                 var defenderMessage = BuildAttackFeedbackMessage(
                     defender.m_idSelf,
                     attacker,
                     defender,
                     pAttackData.m_nAttackResult,
-                    hitRate);
+                    hitRate,
+                    weaponSkillType);
                 attacker.SendFeedbackString(new CExoString(attackerMessage));
                 defender.SendFeedbackString(new CExoString(defenderMessage));
 
@@ -371,10 +373,11 @@ namespace SWLOR.Game.Server.Native
             CNWSCreature attacker,
             CNWSCreature defender,
             int attackResultType,
-            int hitRate)
+            int hitRate,
+            SkillType weaponSkillType)
         {
             if (IsSuccessfulAttackResult(attackResultType) &&
-                UsePerkFeat.TryGetQueuedWeaponAbility(attacker.m_idSelf, out var queuedAbility))
+                UsePerkFeat.TryGetQueuedWeaponAbility(attacker.m_idSelf, weaponSkillType, out var queuedAbility))
             {
                 return Combat.BuildAbilityCombatLogMessage(
                     observer,

--- a/SWLOR.Game.Server/Service/Ability.cs
+++ b/SWLOR.Game.Server/Service/Ability.cs
@@ -278,15 +278,6 @@ namespace SWLOR.Game.Server.Service
             return amount;
         }
 
-        public static int ApplyActiveForceAffinityDurationAdjustment(uint activator, int durationTicks, bool isPermanent)
-        {
-            if (isPermanent || durationTicks <= 0)
-                return durationTicks;
-
-            var adjustedDuration = ApplyActiveForceAffinityMagnitude(activator, durationTicks);
-            return Math.Max(1, adjustedDuration);
-        }
-
         public static void ApplyHostileAbilityEnmity(uint activator, uint target, int damage = 0)
         {
             var amount = HostileAbilityBaseEnmity + Math.Max(0, damage);
@@ -414,6 +405,14 @@ namespace SWLOR.Game.Server.Service
             if (Activity.IsBusy(activator))
             {
                 return Deny("You are busy.");
+            }
+
+            if (ability.ActivationType == AbilityActivationType.Weapon &&
+                Combat.IsWeaponSkillType(ability.SkillType) &&
+                !Combat.HasEquippedWeaponForAbilitySkill(activator, ability.SkillType))
+            {
+                var skillName = Skill.GetSkillDetails(ability.SkillType).Name;
+                return Deny($"You must equip a {skillName} weapon to use this ability.");
             }
 
             if (Combat.GetAbilitySkillType(activator, ability) == SkillType.Force &&

--- a/SWLOR.Game.Server/Service/Combat.cs
+++ b/SWLOR.Game.Server/Service/Combat.cs
@@ -9291,29 +9291,46 @@ namespace SWLOR.Game.Server.Service
             if (!IsWeaponSkillType(skillType))
                 return 0;
 
-            var weapon = GetCombatImpactWeapon(activator);
+            var weapon = GetCombatImpactWeapon(activator, skillType);
             return GetIsObjectValid(weapon)
                 ? Item.GetDMG(weapon)
                 : 0;
         }
 
-        private static uint GetCombatImpactWeapon(uint activator)
+        private static uint GetCombatImpactWeapon(uint activator, SkillType skillType)
         {
             var rightHand = GetItemInSlot(InventorySlot.RightHand, activator);
-            if (IsCombatImpactWeapon(rightHand))
+            if (CanItemTriggerWeaponAbility(rightHand, skillType))
                 return rightHand;
 
             var leftHand = GetItemInSlot(InventorySlot.LeftHand, activator);
-            if (IsCombatImpactWeapon(leftHand))
+            if (CanItemTriggerWeaponAbility(leftHand, skillType))
                 return leftHand;
 
             return OBJECT_INVALID;
         }
 
-        private static bool IsCombatImpactWeapon(uint item)
+        public static bool HasEquippedWeaponForAbilitySkill(uint creature, SkillType abilitySkillType)
         {
-            return GetIsObjectValid(item) &&
-                   Skill.GetSkillTypeByBaseItem((BaseItem)GetBaseItemType(item)) != SkillType.Invalid;
+            if (!GetIsObjectValid(creature) || !IsWeaponSkillType(abilitySkillType))
+                return false;
+
+            return CanItemTriggerWeaponAbility(GetItemInSlot(InventorySlot.RightHand, creature), abilitySkillType) ||
+                   CanItemTriggerWeaponAbility(GetItemInSlot(InventorySlot.LeftHand, creature), abilitySkillType);
+        }
+
+        public static bool CanItemTriggerWeaponAbility(uint item, SkillType abilitySkillType)
+        {
+            if (!GetIsObjectValid(item))
+                return false;
+
+            var weaponSkillType = Skill.GetSkillTypeByBaseItem((BaseItem)GetBaseItemType(item));
+            return CanWeaponSkillTriggerAbility(weaponSkillType, abilitySkillType);
+        }
+
+        public static bool CanWeaponSkillTriggerAbility(SkillType weaponSkillType, SkillType abilitySkillType)
+        {
+            return !IsWeaponSkillType(abilitySkillType) || weaponSkillType == abilitySkillType;
         }
 
         public static bool IsWeaponSkillType(SkillType skillType)

--- a/SWLOR.Game.Server/Service/StatusEffect.cs
+++ b/SWLOR.Game.Server/Service/StatusEffect.cs
@@ -468,10 +468,10 @@ namespace SWLOR.Game.Server.Service
             CombatDamageType sourceDamageType = CombatDamageType.Invalid)
         {
             durationTicks = ApplyOutgoingStatusDurationAdjustments(statusEffect, source, durationTicks, isPermanent);
-            durationTicks = Ability.ApplyActiveForceAffinityDurationAdjustment(source, durationTicks, isPermanent);
             ApplyOutgoingStatusStatAdjustments(statusEffect, source);
 
             var resistanceType = ResolveResistanceType(statusEffect, resistanceOverride, sourceDamageType);
+            var durationResistanceMessage = string.Empty;
             if (!isPermanent &&
                 durationTicks > 0 &&
                 GetIsObjectValid(source) &&
@@ -486,7 +486,14 @@ namespace SWLOR.Game.Server.Service
                         return false;
                     }
 
+                    var durationTicksBeforeResistance = durationTicks;
                     durationTicks = Resistance.CalculateResistedTicks(creature, resistanceType, durationTicks);
+                    durationResistanceMessage = BuildDurationResistanceMessage(
+                        resistanceType,
+                        statusEffect.Name,
+                        durationTicksBeforeResistance,
+                        durationTicks,
+                        statusEffect.Frequency);
                 }
             }
 
@@ -563,6 +570,12 @@ namespace SWLOR.Game.Server.Service
 
             ApplyTrackedNWNEffect(creature, statusEffect, durationTicks, isPermanent);
 
+            if (!string.IsNullOrWhiteSpace(durationResistanceMessage) &&
+                (GetIsPC(source) || GetIsDM(source)))
+            {
+                SendMessageToPC(source, durationResistanceMessage);
+            }
+
             if (statusEffect.SendsApplicationMessage)
             {
                 Messaging.SendMessageNearbyToPlayers(creature, receiver =>
@@ -584,6 +597,40 @@ namespace SWLOR.Game.Server.Service
             }
 
             return true;
+        }
+
+        public static string BuildDurationResistanceMessage(
+            ResistanceType resistanceType,
+            string effectName,
+            int originalDurationTicks,
+            int adjustedDurationTicks,
+            float frequency)
+        {
+            if (resistanceType == ResistanceType.Invalid ||
+                originalDurationTicks <= 0 ||
+                adjustedDurationTicks <= 0 ||
+                originalDurationTicks == adjustedDurationTicks)
+            {
+                return string.Empty;
+            }
+
+            var direction = adjustedDurationTicks < originalDurationTicks
+                ? "reduced"
+                : "increased";
+            var secondsPerTick = Math.Max(1f, frequency);
+            var originalSeconds = FormatDurationSeconds(originalDurationTicks * secondsPerTick);
+            var adjustedSeconds = FormatDurationSeconds(adjustedDurationTicks * secondsPerTick);
+            var displayedEffectName = string.IsNullOrWhiteSpace(effectName) ? "the effect" : effectName;
+
+            return $"{resistanceType} Resistance {direction} {displayedEffectName} duration from {originalSeconds} to {adjustedSeconds}.";
+        }
+
+        private static string FormatDurationSeconds(float seconds)
+        {
+            var roundedSeconds = Math.Round(seconds);
+            return Math.Abs(seconds - roundedSeconds) < 0.01f
+                ? $"{(int)roundedSeconds}s"
+                : $"{seconds:0.#}s";
         }
 
         private static int ApplyOutgoingStatusDurationAdjustments(


### PR DESCRIPTION
## Summary

- correct Renewal's tier healing totals and tick delivery, while snapshotting Force Affinity when the effect is applied
- keep Force Affinity limited to magnitude and hit chance instead of altering effect duration
- report resistance-driven duration changes to the applying player
- require queued weapon abilities to match the equipped weapon and the attack that triggers them
- make Force Affinity and the attribute cap rules clearer in the character sheet, Perks window, and in-game Player Guide
- add focused regression coverage for combat damage, status delivery, Force perks, queued weapon abilities, and the updated UI documentation

## Root cause

Several related combat paths were applying shared state too broadly. Force Affinity's magnitude multiplier was also being reused for duration, and queued weapon-ability checks treated any queued weapon power as applicable to any weapon attack. That allowed cross-skill attacks to consume or resolve the wrong queued ability. Renewal's configured totals and tick count had also drifted from its intended values.

The UI exposed only a signed affinity value, leaving players without the contribution rules or the actual magnitude and accuracy effects for a selected Force power.

## Player impact

Force healing and status durations now follow their intended formulas, resistance changes are visible in combat feedback, and weapon abilities cannot trigger from an incompatible weapon. Force-sensitive players can see their current affinity prominently and inspect its exact effect on Light, Dark, and Universal perks.

## Validation

- `dotnet build SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj --no-restore -p:RunPostBuildEvent=Never`
- 92 focused tests passed across the six modified regression-test classes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Force Affinity details to the Perks window, including alignment effects, power scaling, hit chance, and universal powers.
  * Added a dedicated Force Affinity topic to the Player Guide.
  * Added attribute-cap explanations to character sheet tooltips.
  * Improved status-effect resistance feedback with effective-duration messages.

* **Bug Fixes**
  * Renewal abilities now provide stronger healing over a longer duration and scale with Force Affinity.
  * Weapon abilities now require a compatible equipped weapon and skill, preventing invalid activations.
  * Pathogen Strike correctly extends applicable effects without consuming them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->