### PR TITLE
Fix Combat Upgrade tracker retest failures

### DIFF
--- a/SWLOR.Game.Server.Tests/Perks/DevicesGrenadierTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/DevicesGrenadierTests.cs
@@ -244,6 +244,8 @@ public class DevicesGrenadierTests
         ionGrenade.Should().Contain("Ability.ApplyCombatImpact(");
         ionGrenade.Should().Contain("damageType: CombatDamageType.Electrical");
         ionGrenade.Should().Contain("damagePercentAdjustment: impactedTarget => IsDroid(impactedTarget) ? droidBonusPercent : 0");
+        ionGrenade.Should().Contain("racialType == RacialType.Droid");
+        ionGrenade.Should().Contain("racialType == RacialType.Construct");
         ionGrenade.Should().Contain("racialType == RacialType.Robot");
         ionGrenade.Should().NotContain("GameMath.PercentOf(baseDamage, droidBonusPercent)");
 

--- a/SWLOR.Game.Server.Tests/Perks/DevicesGrenadierTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/DevicesGrenadierTests.cs
@@ -243,6 +243,9 @@ public class DevicesGrenadierTests
         ionGrenade.Should().Contain("while (GetIsObjectValid(creature))");
         ionGrenade.Should().Contain("Ability.ApplyCombatImpact(");
         ionGrenade.Should().Contain("damageType: CombatDamageType.Electrical");
+        ionGrenade.Should().Contain("damagePercentAdjustment: impactedTarget => IsDroid(impactedTarget) ? droidBonusPercent : 0");
+        ionGrenade.Should().Contain("racialType == RacialType.Robot");
+        ionGrenade.Should().NotContain("GameMath.PercentOf(baseDamage, droidBonusPercent)");
 
         concussionGrenade.Should().Contain("Ability.ApplyTelegraphedCombatImpact(");
         concussionGrenade.Should().Contain("DeviceAbilityEffects.ApplyBlastRadiusBonus(activator, 3f)");

--- a/SWLOR.Game.Server.Tests/Perks/GeneratedWeaponPerkBehaviorTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/GeneratedWeaponPerkBehaviorTests.cs
@@ -656,6 +656,8 @@ public class GeneratedWeaponPerkBehaviorTests
         combatSource.Should().Contain("ApplyHostileAbilityHitNextAutoAttackNoDelay(activator, ability)");
         combatSource.Should().Contain("GrantNextAutoAttackNoDelay(activator, duration)");
         combatSource.Should().Contain("StatType.NextAutoAttackNoDelayAllSkills");
+        combatSource.Should().Contain("var appliesToSkill = skillType != SkillType.Invalid && storedSkillType == skillType");
+        combatSource.Should().Contain("if (appliesToSkill)");
         combatSource.Should().Contain("First Strike +{damageBonus} DMG ({remaining} {stackLabel} remaining)");
         combatSource.Should().Contain("ApplyHostileAbilityUsedAttackAdjustment(activator, ability)");
         combatSource.Should().Contain("public static void ApplyStatusAppliedTargetStaminaDrain(");

--- a/SWLOR.Game.Server.Tests/Perks/GeneratedWeaponPerkBehaviorTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/GeneratedWeaponPerkBehaviorTests.cs
@@ -51,6 +51,7 @@ public class GeneratedWeaponPerkBehaviorTests
         AssertSourceStat("VibroknifePerkDefinition.cs", StatType.DirectDamageToStatusCategoryOrStealthBonusCategory, "(int)StatusEffectCategory.Incapacitating");
         AssertSourceStat("VibroknifePerkDefinition.cs", StatType.HostileAbilityUsedAttackPercentAdjustment, "5");
         AssertSourceStat("VibroknifePerkDefinition.cs", StatType.StatusAppliedTargetStaminaDrainRequiredCategory, "(int)StatusEffectCategory.StaminaDrainTrigger");
+        AssertSourceStat("VibroknifePerkDefinition.cs", StatType.HostileAbilityHitNextAutoAttackNoDelayAllSkills, "1");
 
         AssertSourceStat("HeavyVibrobladePerkDefinition.cs", StatType.HeavyVibrobladeOffenseEssenceHunter, "1");
         AssertSourceStat("HeavyVibrobladePerkDefinition.cs", StatType.HeavyVibrobladeOffenseSoulAscension, "1");
@@ -526,6 +527,10 @@ public class GeneratedWeaponPerkBehaviorTests
             .Should().Be(StatTypeCategory.NonBeneficial);
         Stat.GetStatTypeCategory(StatType.HostileAbilityHitNextAutoAttackNoDelaySkillType)
             .Should().Be(StatTypeCategory.NonBeneficial);
+        Stat.GetStatTypeCategory(StatType.HostileAbilityHitNextAutoAttackNoDelayAllSkills)
+            .Should().Be(StatTypeCategory.BeneficialWhenPositive);
+        Stat.GetStatTypeCategory(StatType.NextAutoAttackNoDelayAllSkills)
+            .Should().Be(StatTypeCategory.NonBeneficial);
         Stat.GetStatTypeCategory(StatType.SourceStatusAutoAttackCycleDamage)
             .Should().Be(StatTypeCategory.BeneficialWhenPositive);
         Stat.GetStatTypeCategory(StatType.StatusAppliedTargetStaminaDrain)
@@ -648,9 +653,16 @@ public class GeneratedWeaponPerkBehaviorTests
         combatSource.Should().Contain("IdleSkillAbilityCriticalDamagePercentAdjustment");
         combatSource.Should().Contain("TargetHasSourceAppliedStatusCategory(defender, attacker, category)");
         combatSource.Should().Contain("ApplySourceStatusStackEffects(attacker, defender)");
-        combatSource.Should().Contain("ApplyHostileAbilityHitNextAutoAttackNoDelay(activator, ability, skillType)");
+        combatSource.Should().Contain("ApplyHostileAbilityHitNextAutoAttackNoDelay(activator, ability)");
+        combatSource.Should().Contain("GrantNextAutoAttackNoDelay(activator, duration)");
+        combatSource.Should().Contain("StatType.NextAutoAttackNoDelayAllSkills");
+        combatSource.Should().Contain("First Strike +{damageBonus} DMG ({remaining} {stackLabel} remaining)");
         combatSource.Should().Contain("ApplyHostileAbilityUsedAttackAdjustment(activator, ability)");
-        combatSource.Should().Contain("ApplyStatusAppliedTargetStaminaDrain(");
+        combatSource.Should().Contain("public static void ApplyStatusAppliedTargetStaminaDrain(");
+        combatSource.Should().Contain("TryUseStatTrigger(activator, StatType.StatusAppliedTargetStaminaDrain, cooldown)");
+        statusEffectSource.Should().Contain("Combat.ApplyStatusAppliedTargetStaminaDrain(source, creature, statusEffect.Categories)");
+        usePerkFeatSource.Should().Contain("public static bool InterruptAbilityActivation(uint activator)");
+        usePerkFeatSource.Should().Contain("activation.Ability.ChannelInterruptAction?.Invoke(activator)");
         combatSource.Should().Contain("StatusEffectCategory.Infection => typeof(InfectionStatusEffect)");
         abilitySource.Should().Contain("beforeSuccessfulImpactRiders?.Invoke(target)");
         abilitySource.Should().Contain("Combat.ApplySuccessfulAbilityImpactRiders(");
@@ -714,11 +726,21 @@ public class GeneratedWeaponPerkBehaviorTests
             .Should().HaveCount(2, "the high-STM Exposed rule must have one canonical case-insensitive branch");
         AssertAbilitySourceContains(root, "Staff", "WorldbreakerAbilityDefinition.cs", "RequiredTargetStatusCategoryForConditionalStatus = StatusEffectCategory.Control");
         AssertAbilitySourceContains(root, "Vibroknife", "PathogenStrikeAbilityDefinition.cs", "SourceStatusEffectsToExtend = new[] { typeof(VenomStatusEffect), typeof(InfectionStatusEffect) }");
+        AssertAbilitySourceContains(root, "Vibroknife", "BackstabAbilityDefinition.cs", "ExtraDamageIfBehindFeedbackLabel = \"Backstab\"");
         AssertAbilitySourceContains(root, "Vibroknife", "ViralCascadeAbilityDefinition.cs", "ExtraDamageSourceStatusEffect = typeof(VenomStatusEffect)");
         AssertAbilitySourceContains(root, "Vibroknife", "ViralCascadeAbilityDefinition.cs", "ExtraDamageSourceStackStatusEffect = typeof(InfectionStatusEffect)");
         AssertAbilitySourceContains(root, "Vibroknife", "ViralCascadeAbilityDefinition.cs", "ConsumeSourceStatusEffectsOnHit = true");
         AssertAbilitySourceContains(root, "Vibroknife", "ViralCascadeAbilityDefinition.cs", "SuppressSourceStatusStackRiders = true");
         AssertAbilitySourceContains(root, "TwinBlade", "RedBloomAbilityDefinition.cs", "SpreadHemorrhageFromTarget = true");
+
+        var weaponBaseSource = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "SWLOR.Game.Server",
+            "Feature",
+            "AbilityDefinition",
+            "WeaponActiveAbilityDefinitionBase.cs"));
+        weaponBaseSource.Should().Contain("UsePerkFeat.InterruptAbilityActivation(target)");
+        weaponBaseSource.Should().Contain("Extended {extendedCount} {statusLabel} by {SourceStatusExtensionSeconds}s");
     }
 
     [Test]

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/IonGrenadeAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Devices/IonGrenadeAbilityDefinition.cs
@@ -110,22 +110,19 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
             {
                 if (creature != activator && GetIsReactionTypeHostile(creature, activator))
                 {
-                    var damage = IsDroid(creature)
-                        ? baseDamage + GameMath.PercentOf(baseDamage, droidBonusPercent)
-                        : baseDamage;
-
                     Ability.ApplyCombatImpact(
                         activator,
                         creature,
                         GetLocation(creature),
                         SkillType.Devices,
-                        damage,
+                        baseDamage,
                         12,
                         statusEffect,
                         false,
                         Array.Empty<Type>(),
                         damageType: CombatDamageType.Electrical,
-                        targetVisualEffect: VisualEffect.Vfx_Com_Hit_Electrical);
+                        targetVisualEffect: VisualEffect.Vfx_Com_Hit_Electrical,
+                        damagePercentAdjustment: impactedTarget => IsDroid(impactedTarget) ? droidBonusPercent : 0);
                 }
 
                 creature = GetNextObjectInShape(Shape.Sphere, DeviceAbilityEffects.ApplyBlastRadiusBonus(activator, 3f), location, true);
@@ -145,7 +142,9 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Devices
         private static bool IsDroid(uint target)
         {
             var racialType = GetRacialType(target);
-            return racialType == RacialType.Droid || racialType == RacialType.Construct;
+            return racialType == RacialType.Droid ||
+                   racialType == RacialType.Construct ||
+                   racialType == RacialType.Robot;
         }
 
     }

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Vibroknife/BackstabAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Vibroknife/BackstabAbilityDefinition.cs
@@ -44,6 +44,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Vibroknife
                 new GeneratedWeaponAbilityProfile
                 {
                     ExtraDamageIfBehind = 10,
+                    ExtraDamageIfBehindFeedbackLabel = "Backstab",
                     ConditionalTargetStatusEffect = typeof(KnockdownStatusEffect),
                     ConditionalTargetStatusDurationSeconds = 6,
                     RequireBehindForConditionalStatus = true
@@ -76,6 +77,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Vibroknife
                 new GeneratedWeaponAbilityProfile
                 {
                     ExtraDamageIfBehind = 20,
+                    ExtraDamageIfBehindFeedbackLabel = "Backstab",
                     ConditionalTargetStatusEffect = typeof(KnockdownStatusEffect),
                     ConditionalTargetStatusDurationSeconds = 6,
                     RequireBehindForConditionalStatus = true

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/WeaponActiveAbilityDefinitionBase.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/WeaponActiveAbilityDefinitionBase.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using SWLOR.Game.Server.Feature;
 using SWLOR.Game.Server.Service;
 using SWLOR.Game.Server.Service.AbilityService;
 using SWLOR.Game.Server.Service.CombatService;
@@ -51,6 +52,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition
             public Type ExtraDamageTargetStatusEffect { get; init; }
             public int ExtraDamageIfTargetStatusEffect { get; init; }
             public int ExtraDamageIfBehind { get; init; }
+            public string ExtraDamageIfBehindFeedbackLabel { get; init; }
             public Type ExtraDamageSourceStatusEffect { get; init; }
             public int ExtraDamageIfSourceStatusEffect { get; init; }
             public Type ExtraDamageSourceStackStatusEffect { get; init; }
@@ -246,7 +248,16 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition
                 }
 
                 if (ExtraDamageIfBehind != 0 && Combat.IsTargetNotFacingAttacker(activator, target))
+                {
                     bonus += ExtraDamageIfBehind;
+                    if (GetIsPC(activator) && !string.IsNullOrWhiteSpace(ExtraDamageIfBehindFeedbackLabel))
+                    {
+                        FloatingTextStringOnCreature(
+                            ColorToken.Combat($"{ExtraDamageIfBehindFeedbackLabel} +{ExtraDamageIfBehind} DMG"),
+                            activator,
+                            false);
+                    }
+                }
 
                 if (ExtraDamageIfSourceStatusEffect != 0 &&
                     ExtraDamageSourceStatusEffect != null &&
@@ -344,7 +355,10 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition
             public void AfterSuccessfulHit(uint activator, uint target, CombatDamageType damageType)
             {
                 if (ClearTargetActionsOnHit)
+                {
                     AssignCommand(target, () => ClearAllActions());
+                    UsePerkFeat.InterruptAbilityActivation(target);
+                }
 
                 if (RestoreStaminaOnHit > 0)
                     Stat.RestoreStamina(activator, RestoreStaminaOnHit);
@@ -388,16 +402,29 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition
                 if (SourceStatusExtensionSeconds <= 0 || SourceStatusEffectsToExtend == null)
                     return;
 
+                var extendedCount = 0;
                 foreach (var statusEffectType in SourceStatusEffectsToExtend)
                 {
                     if (statusEffectType == null)
                         continue;
 
-                    StatusEffect.ExtendStatusEffectDuration(
+                    if (StatusEffect.ExtendStatusEffectDuration(
                         target,
                         statusEffectType,
                         activator,
-                        SourceStatusExtensionSeconds);
+                        SourceStatusExtensionSeconds))
+                    {
+                        extendedCount++;
+                    }
+                }
+
+                if (extendedCount > 0 && GetIsPC(activator))
+                {
+                    var statusLabel = extendedCount == 1 ? "status" : "statuses";
+                    FloatingTextStringOnCreature(
+                        ColorToken.Combat($"Extended {extendedCount} {statusLabel} by {SourceStatusExtensionSeconds}s"),
+                        activator,
+                        false);
                 }
             }
 

--- a/SWLOR.Game.Server/Feature/PerkDefinition/VibroknifePerkDefinition.cs
+++ b/SWLOR.Game.Server/Feature/PerkDefinition/VibroknifePerkDefinition.cs
@@ -191,7 +191,7 @@ namespace SWLOR.Game.Server.Feature.PerkDefinition
                 .AddPerkLevel()
                 .GrantsFeat(FeatType.VenomTempoTrait)
                 .Description("After successfully landing a hostile combat ability, your next auto-attack comes out instantly.")
-                .IncreasesStat(StatType.HostileAbilityHitNextAutoAttackNoDelaySkillType, (int)SkillType.Vibroknife)
+                .IncreasesStat(StatType.HostileAbilityHitNextAutoAttackNoDelayAllSkills, 1)
                 .IncreasesStat(StatType.HostileAbilityHitNextAutoAttackNoDelayDurationSeconds, 30)
                 .Price(4)
                 .RequirementSkill(SkillType.Vibroknife, 25);

--- a/SWLOR.Game.Server/Feature/UsePerkFeat.cs
+++ b/SWLOR.Game.Server/Feature/UsePerkFeat.cs
@@ -6,6 +6,7 @@ using SWLOR.Game.Server.Core.NWNX.Enum;
 using SWLOR.Game.Server.Service;
 using SWLOR.Game.Server.Service.AbilityService;
 using SWLOR.Game.Server.Service.ActivityService;
+using SWLOR.Game.Server.Service.LogService;
 using SWLOR.Game.Server.Service.PerkService;
 using SWLOR.Game.Server.Service.SkillService;
 using SWLOR.Game.Server.Service.StatService;
@@ -132,6 +133,14 @@ namespace SWLOR.Game.Server.Feature
             {
                 return false;
             }
+
+            Log.WriteStructured(
+                LogGroup.Server,
+                "Ability activation interrupted: Activator={Activator} ActivationId={ActivationId} Ability={Ability} IsChanneled={IsChanneled}",
+                activator,
+                activation.ActivationId,
+                activation.Ability.Name,
+                activation.Ability.IsChanneled);
 
             RemoveEffectByTag(activator, "ACTIVATION_VFX");
             CancelActivationTargetingTelegraphs(activation.TelegraphIds);

--- a/SWLOR.Game.Server/Feature/UsePerkFeat.cs
+++ b/SWLOR.Game.Server/Feature/UsePerkFeat.cs
@@ -28,12 +28,21 @@ namespace SWLOR.Game.Server.Feature
             Completed = 3
         }
 
+        private sealed class ActiveAbilityActivation
+        {
+            public string ActivationId { get; init; }
+            public AbilityDetail Ability { get; init; }
+            public List<string> TelegraphIds { get; init; }
+            public uint ResumeAttackTarget { get; init; }
+        }
+
         // Variable names for queued abilities.
         private const string ActiveAbilityIdName = "ACTIVE_ABILITY_ID";
         private const string ActiveAbilityFeatIdName = "ACTIVE_ABILITY_FEAT_ID";
         private const string ActiveAbilityEffectivePerkLevelName = "ACTIVE_ABILITY_EFFECTIVE_PERK_LEVEL";
         private const string ActiveAbilityWeaponIneffectiveFeedbackSuppressedName = "ACTIVE_ABILITY_WEAPON_INEFFECTIVE_FEEDBACK_SUPPRESSED";
         private const string ActiveAbilityWeaponIneffectiveFeedbackWasHiddenName = "ACTIVE_ABILITY_WEAPON_INEFFECTIVE_FEEDBACK_WAS_HIDDEN";
+        private static readonly Dictionary<uint, ActiveAbilityActivation> _activeAbilityActivations = new();
 
         private static uint GetResumeAttackTarget(uint activator, uint target, AbilityDetail ability)
         {
@@ -104,6 +113,52 @@ namespace SWLOR.Game.Server.Feature
             {
                 ActionAttack(target);
             });
+        }
+
+        /// <summary>
+        /// Interrupts the creature's current cast or channel, if one is active.
+        /// </summary>
+        public static bool InterruptAbilityActivation(uint activator)
+        {
+            return InterruptAbilityActivation(activator, null);
+        }
+
+        private static bool InterruptAbilityActivation(uint activator, string expectedActivationId)
+        {
+            if (!_activeAbilityActivations.TryGetValue(activator, out var activation) ||
+                !string.IsNullOrWhiteSpace(expectedActivationId) &&
+                activation.ActivationId != expectedActivationId ||
+                GetLocalInt(activator, activation.ActivationId) != (int)ActivationStatus.Started)
+            {
+                return false;
+            }
+
+            RemoveEffectByTag(activator, "ACTIVATION_VFX");
+            CancelActivationTargetingTelegraphs(activation.TelegraphIds);
+            if (GetIsPC(activator))
+                PlayerPlugin.StopGuiTimingBar(activator, string.Empty);
+
+            Messaging.SendMessageNearbyToPlayers(
+                activator,
+                receiver => $"{PlayerName.GetDisplayName(receiver, activator)}'s ability has been interrupted.");
+            SetLocalInt(activator, activation.ActivationId, (int)ActivationStatus.Interrupted);
+            Activity.ClearBusy(activator);
+
+            if (activation.Ability.IsChanneled)
+                activation.Ability.ChannelInterruptAction?.Invoke(activator);
+
+            _activeAbilityActivations.Remove(activator);
+            ResumeAttack(activator, activation.ResumeAttackTarget);
+            return true;
+        }
+
+        private static void ClearActiveAbilityActivation(uint activator, string activationId)
+        {
+            if (_activeAbilityActivations.TryGetValue(activator, out var activation) &&
+                activation.ActivationId == activationId)
+            {
+                _activeAbilityActivations.Remove(activator);
+            }
         }
 
         private static void ResumeAttackAfterDelay(uint activator, uint target, float delay, bool clearActions = true)
@@ -412,9 +467,9 @@ namespace SWLOR.Game.Server.Feature
             {
                 if (!GetIsPC(activator)) return;
 
-                // Completed abilities should no longer run.
+                // Completed and externally interrupted abilities should no longer run.
                 var status = GetLocalInt(activator, activationId);
-                if (status == (int)ActivationStatus.Completed || status == (int)ActivationStatus.Invalid) return;
+                if (status != (int)ActivationStatus.Started) return;
 
                 var currentPosition = GetPosition(activator);
 
@@ -422,23 +477,7 @@ namespace SWLOR.Game.Server.Feature
                     currentPosition.Y != originalPosition.Y ||
                     currentPosition.Z != originalPosition.Z)
                 {
-                    RemoveEffectByTag(activator, "ACTIVATION_VFX");
-                    CancelActivationTargetingTelegraphs(activationTelegraphIds);
-                    PlayerPlugin.StopGuiTimingBar(activator, string.Empty);
-                    Messaging.SendMessageNearbyToPlayers(
-                        activator,
-                        receiver => $"{PlayerName.GetDisplayName(receiver, activator)}'s ability has been interrupted.");
-                    SetLocalInt(activator, activationId, (int)ActivationStatus.Interrupted);
-
-                    // Release the activator immediately - the busy state must not linger for the
-                    // remainder of the activation delay.
-                    Activity.ClearBusy(activator);
-
-                    // Channeled abilities granted their effects at channel start; end them early.
-                    if (ability.IsChanneled)
-                        ability.ChannelInterruptAction?.Invoke(activator);
-
-                    ResumeAttack(activator, resumeAttackTarget);
+                    InterruptAbilityActivation(activator, activationId);
                     return;
                 }
 
@@ -450,6 +489,7 @@ namespace SWLOR.Game.Server.Feature
             {
                 void CancelActivation(bool resumeAttack)
                 {
+                    ClearActiveAbilityActivation(activator, activationId);
                     DeleteLocalInt(activator, activationId);
                     CancelActivationTargetingTelegraphs(activationTelegraphIds);
 
@@ -462,6 +502,7 @@ namespace SWLOR.Game.Server.Feature
                 // may have started a new activation since - don't clear that one's busy state.
                 if (GetLocalInt(activator, activationId) == (int)ActivationStatus.Interrupted)
                 {
+                    ClearActiveAbilityActivation(activator, activationId);
                     DeleteLocalInt(activator, activationId);
                     return;
                 }
@@ -522,6 +563,13 @@ namespace SWLOR.Game.Server.Feature
             var resumeAttackTarget = GetResumeAttackTarget(activator, target, ability);
             var activationTelegraphIds = ProcessAnimationAndVisualEffects(activationDelay);
             SetLocalInt(activator, activationId, (int)ActivationStatus.Started);
+            _activeAbilityActivations[activator] = new ActiveAbilityActivation
+            {
+                ActivationId = activationId,
+                Ability = ability,
+                TelegraphIds = activationTelegraphIds,
+                ResumeAttackTarget = resumeAttackTarget
+            };
             CheckForActivationInterruption(activationId, position, activationTelegraphIds, resumeAttackTarget);
 
             var executeImpact = ability.ActivationAction == null
@@ -530,6 +578,7 @@ namespace SWLOR.Game.Server.Feature
 
             if (executeImpact != true)
             {
+                ClearActiveAbilityActivation(activator, activationId);
                 DeleteLocalInt(activator, activationId);
                 CancelActivationTargetingTelegraphs(activationTelegraphIds);
                 ResumeAttack(activator, resumeAttackTarget);

--- a/SWLOR.Game.Server/Service/Combat.cs
+++ b/SWLOR.Game.Server/Service/Combat.cs
@@ -7741,17 +7741,33 @@ namespace SWLOR.Game.Server.Service
 
         public static bool ConsumeNextAutoAttackNoDelay(uint creature, SkillType skillType)
         {
-            if (!HasNextAutoAttackNoDelay(creature, skillType))
-                return false;
-
-            TemporaryStatModifier.Consume(
+            var appliesToAllSkills = TemporaryStatModifier.GetStatAdjustment(
                 creature,
                 StatType.NextAutoAttackNoDelayAllSkills,
-                StatType.NextAutoAttackNoDelayAllSkills);
-            TemporaryStatModifier.Consume(
+                StatType.NextAutoAttackNoDelayAllSkills) > 0;
+            var storedSkillType = GetSkillTypeFromStat(TemporaryStatModifier.GetStatAdjustment(
                 creature,
                 StatType.NextAutoAttackNoDelaySkillType,
-                StatType.NextAutoAttackNoDelaySkillType);
+                StatType.NextAutoAttackNoDelaySkillType));
+            var appliesToSkill = skillType != SkillType.Invalid && storedSkillType == skillType;
+            if (!appliesToAllSkills && !appliesToSkill)
+                return false;
+
+            if (appliesToAllSkills)
+            {
+                TemporaryStatModifier.Consume(
+                    creature,
+                    StatType.NextAutoAttackNoDelayAllSkills,
+                    StatType.NextAutoAttackNoDelayAllSkills);
+            }
+
+            if (appliesToSkill)
+            {
+                TemporaryStatModifier.Consume(
+                    creature,
+                    StatType.NextAutoAttackNoDelaySkillType,
+                    StatType.NextAutoAttackNoDelaySkillType);
+            }
 
             return true;
         }

--- a/SWLOR.Game.Server/Service/Combat.cs
+++ b/SWLOR.Game.Server/Service/Combat.cs
@@ -5081,7 +5081,7 @@ namespace SWLOR.Game.Server.Service
                 ApplySourceStatusStackEffects(activator, target);
             }
 
-            ApplyHostileAbilityHitNextAutoAttackNoDelay(activator, ability, skillType);
+            ApplyHostileAbilityHitNextAutoAttackNoDelay(activator, ability);
             ApplySameTargetHostileAbilityHitEffects(activator, target, ability);
             ApplyAbilityStatusRiders(
                 activator,
@@ -5218,16 +5218,18 @@ namespace SWLOR.Game.Server.Service
 
         private static void ApplyHostileAbilityHitNextAutoAttackNoDelay(
             uint activator,
-            AbilityDetail ability,
-            SkillType skillType)
+            AbilityDetail ability)
         {
             if (ability?.IsHostileAbility != true)
                 return;
 
+            var appliesToAllSkills = Stat.GetStatAdjustment(
+                activator,
+                StatType.HostileAbilityHitNextAutoAttackNoDelayAllSkills) > 0;
             var autoAttackSkillType = GetSkillTypeFromStat(Stat.GetStatAdjustment(
                 activator,
                 StatType.HostileAbilityHitNextAutoAttackNoDelaySkillType));
-            if (autoAttackSkillType == SkillType.Invalid)
+            if (!appliesToAllSkills && autoAttackSkillType == SkillType.Invalid)
                 return;
 
             var duration = Stat.GetStatAdjustment(
@@ -5236,7 +5238,10 @@ namespace SWLOR.Game.Server.Service
             if (duration <= 0)
                 return;
 
-            GrantNextAutoAttackNoDelay(activator, autoAttackSkillType, duration);
+            if (appliesToAllSkills)
+                GrantNextAutoAttackNoDelay(activator, duration);
+            else
+                GrantNextAutoAttackNoDelay(activator, autoAttackSkillType, duration);
         }
 
         private static void ApplyAbilityStatusRiders(
@@ -5832,6 +5837,17 @@ namespace SWLOR.Game.Server.Service
                 LastHit = now,
                 RechargeAvailableAt = rechargeAvailableAt
             };
+
+            var damageBonus = Stat.GetStatAdjustment(attacker, StatType.FirstHostileAbilityHitDamageBonus);
+            if (damageBonus > 0 && GetIsPC(attacker))
+            {
+                var remaining = maximumCount - newCount;
+                var stackLabel = remaining == 1 ? "stack" : "stacks";
+                FloatingTextStringOnCreature(
+                    ColorToken.Combat($"First Strike +{damageBonus} DMG ({remaining} {stackLabel} remaining)"),
+                    attacker,
+                    false);
+            }
         }
 
         private static void RechargeFirstHostileAbilityHitStacks(uint attacker, int maximumCount)
@@ -6415,11 +6431,6 @@ namespace SWLOR.Game.Server.Service
 
             ApplyStatusAppliedSelfEffects(activator);
             ApplyStatusAppliedTargetEffects(activator, target);
-            ApplyStatusAppliedTargetStaminaDrain(
-                activator,
-                target,
-                primaryStatusEffect,
-                additionalStatusEffects);
         }
 
         private static void ApplyStatusAppliedSelfEffects(uint activator)
@@ -6532,13 +6543,14 @@ namespace SWLOR.Game.Server.Service
                 StatType.AbilityTargetStatusPhysicalDefensePercentAdjustment);
         }
 
-        private static void ApplyStatusAppliedTargetStaminaDrain(
+        public static void ApplyStatusAppliedTargetStaminaDrain(
             uint activator,
             uint target,
-            Type primaryStatusEffect,
-            IEnumerable<Type> additionalStatusEffects)
+            StatusEffectCategory appliedCategories)
         {
-            if (!GetIsObjectValid(target))
+            if (!GetIsObjectValid(activator) ||
+                !GetIsObjectValid(target) ||
+                activator == target)
                 return;
 
             var requiredCategory = GetStatusEffectCategoryFromStat(Stat.GetStatAdjustment(
@@ -6549,13 +6561,17 @@ namespace SWLOR.Game.Server.Service
             if (requiredCategory == 0 ||
                 staminaDrain <= 0 ||
                 cooldown <= 0 ||
-                !AbilityAppliedAnyStatusCategory(primaryStatusEffect, additionalStatusEffects, requiredCategory) ||
-                !TryUseStatTrigger(target, StatType.StatusAppliedTargetStaminaDrain, cooldown))
+                (appliedCategories & requiredCategory) == 0 ||
+                !TryUseStatTrigger(activator, StatType.StatusAppliedTargetStaminaDrain, cooldown))
             {
                 return;
             }
 
             Stat.ReduceStamina(target, staminaDrain);
+            FloatingTextStringOnCreature(
+                ColorToken.Combat($"-{staminaDrain} STM"),
+                target,
+                false);
         }
 
         private static void ApplyAreaAbilityTargetHitSequenceEffects(
@@ -7706,9 +7722,15 @@ namespace SWLOR.Game.Server.Service
 
         public static bool HasNextAutoAttackNoDelay(uint creature, SkillType skillType)
         {
+            var appliesToAllSkills = TemporaryStatModifier.GetStatAdjustment(
+                creature,
+                StatType.NextAutoAttackNoDelayAllSkills,
+                StatType.NextAutoAttackNoDelayAllSkills) > 0;
+            if (appliesToAllSkills)
+                return true;
+
             if (skillType == SkillType.Invalid)
                 return false;
-
             var storedSkillType = GetSkillTypeFromStat(TemporaryStatModifier.GetStatAdjustment(
                 creature,
                 StatType.NextAutoAttackNoDelaySkillType,
@@ -7722,6 +7744,10 @@ namespace SWLOR.Game.Server.Service
             if (!HasNextAutoAttackNoDelay(creature, skillType))
                 return false;
 
+            TemporaryStatModifier.Consume(
+                creature,
+                StatType.NextAutoAttackNoDelayAllSkills,
+                StatType.NextAutoAttackNoDelayAllSkills);
             TemporaryStatModifier.Consume(
                 creature,
                 StatType.NextAutoAttackNoDelaySkillType,
@@ -7765,6 +7791,19 @@ namespace SWLOR.Game.Server.Service
                 (int)skillType,
                 durationSeconds,
                 StatType.NextAutoAttackNoDelaySkillType);
+        }
+
+        public static void GrantNextAutoAttackNoDelay(uint creature, int durationSeconds)
+        {
+            if (!GetIsObjectValid(creature) || durationSeconds <= 0)
+                return;
+
+            TemporaryStatModifier.Replace(
+                creature,
+                StatType.NextAutoAttackNoDelayAllSkills,
+                1,
+                durationSeconds,
+                StatType.NextAutoAttackNoDelayAllSkills);
         }
 
         public static void GrantNextAutoAttackCriticalRateBonus(

--- a/SWLOR.Game.Server/Service/StatService/StatType.cs
+++ b/SWLOR.Game.Server/Service/StatService/StatType.cs
@@ -5711,6 +5711,20 @@ namespace SWLOR.Game.Server.Service.StatService
         [StatType(StatTypeCategory.NonBeneficial)]
         RangedRepeatedTargetDamageDurationSeconds = 992,
 
+        /// <summary>
+        /// When enabled, landing any hostile ability grants minimum delay to the next auto-attack,
+        /// regardless of the weapon skill used for that attack.
+        /// </summary>
+        [StatType(StatTypeCategory.BeneficialWhenPositive)]
+        HostileAbilityHitNextAutoAttackNoDelayAllSkills = 993,
+
+        /// <summary>
+        /// Internal temporary flag that causes the next auto-attack from any weapon skill to use
+        /// the default minimum delay, then is consumed.
+        /// </summary>
+        [StatType(StatTypeCategory.NonBeneficial)]
+        NextAutoAttackNoDelayAllSkills = 994,
+
     }
 
     public class StatTypeAttribute : Attribute

--- a/SWLOR.Game.Server/Service/StatusEffect.cs
+++ b/SWLOR.Game.Server/Service/StatusEffect.cs
@@ -562,6 +562,7 @@ namespace SWLOR.Game.Server.Service
             }
 
             ApplyTrackedNWNEffect(creature, statusEffect, durationTicks, isPermanent);
+            Combat.ApplyStatusAppliedTargetStaminaDrain(source, creature, statusEffect.Categories);
 
             if (statusEffect.SendsApplicationMessage)
             {

--- a/tools/GenerateWeaponArchetypeImplementation.py
+++ b/tools/GenerateWeaponArchetypeImplementation.py
@@ -930,7 +930,7 @@ def description_stat_entries(row, base):
         add_stat(stats, "SourceStatusStackMaximum", parse_count(r"max (\d+) stacks", description) or 5)
         add_stat(stats, "SourceStatusStackDurationSeconds", parse_count(r"Stacks last (\d+) seconds", description) or 18)
     if base == "Venom Tempo":
-        add_stat(stats, "HostileAbilityHitNextAutoAttackNoDelaySkillType", skill_expr)
+        add_stat(stats, "HostileAbilityHitNextAutoAttackNoDelayAllSkills", 1)
         add_stat(stats, "HostileAbilityHitNextAutoAttackNoDelayDurationSeconds", parse_duration(description) or 30)
     if base == "Propagation":
         add_stat(stats, "SourceStatusAutoAttackCycleRequiredCategory", status_category_expression("Venom"))
@@ -1883,6 +1883,7 @@ def profile_property_lines(row, level, primary_status):
 
     if base == "Backstab":
         add_profile_property("ExtraDamageIfBehind", str(first_int(r"additional \+\s*(\d+) DMG", description)))
+        add_profile_property("ExtraDamageIfBehindFeedbackLabel", "\"Backstab\"")
         add_profile_property("ConditionalTargetStatusEffect", "typeof(KnockdownStatusEffect)")
         add_profile_property("ConditionalTargetStatusDurationSeconds", str(parse_count(r"Knockdown for (\d+) seconds", description) or parse_duration(description) or 6))
         add_profile_property("RequireBehindForConditionalStatus", "true")


### PR DESCRIPTION
## Summary

- fix Ion Grenade mechanical-race bonus scaling and Robot coverage
- make generated cast interruption cancel SWLOR casts/channels
- move status-applied stamina drain into the shared status pipeline
- make Venom Tempo's next auto-attack benefit cross-skill
- add Pathogen Strike, First Strike, and Backstab verification feedback
- update the generator and focused regression coverage

The 16 failed rows in the Combat Upgrade testing tracker have notes appended and are set to **Retest**. Their descriptions were checked against the local Combat Upgrade Bible and already matched.

## Verification

- `dotnet build SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj -p:RunPostBuildEvent=Never`
- focused tests: 21 passed
- full `SWLOR.Game.Server.Tests` suite: 1,755 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Combat Improvements**
  - Venom Tempo and related effects now reduce the next auto-attack delay across all weapon skills.
  - Hostile ability hits can grant and consume all-skill attack speed benefits.
  - Ion Grenades correctly apply bonus damage to droids and robots.
  - Applying certain status effects now provides clearer stamina-drain feedback.

- **Ability Feedback**
  - Backstab bonus damage now displays dedicated combat feedback.
  - Interrupting an active ability properly ends its effects, visual indicators, and attack sequence.
  - Successful status-duration extensions now show a summary of extended effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->