### PR TITLE
Report actual Hobbled stamina drain

### DIFF
--- a/SWLOR.Game.Server.Tests/Perks/GeneratedWeaponPerkBehaviorTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/GeneratedWeaponPerkBehaviorTests.cs
@@ -685,10 +685,32 @@ public class GeneratedWeaponPerkBehaviorTests
         combatSource.Should().Contain("ApplyHostileAbilityUsedAttackAdjustment(activator, ability)");
         combatSource.Should().Contain("public static void ApplyStatusAppliedTargetStaminaDrain(");
         combatSource.Should().Contain("TryUseStatTrigger(activator, StatType.StatusAppliedTargetStaminaDrain, cooldown)");
-        combatSource.Should().Contain("var staminaBefore = Stat.GetCurrentStamina(target)");
-        combatSource.Should().Contain("var staminaDrained = Math.Max(0, staminaBefore - Stat.GetCurrentStamina(target))");
-        combatSource.Should().Contain("ColorToken.Combat($\"-{staminaDrained} STM\")");
-        combatSource.Should().NotContain("ColorToken.Combat($\"-{staminaDrain} STM\")");
+        var staminaDrainMethodStart = combatSource.IndexOf(
+            "public static void ApplyStatusAppliedTargetStaminaDrain(",
+            StringComparison.Ordinal);
+        var staminaDrainMethodEnd = combatSource.IndexOf(
+            "private static void ApplyAreaAbilityTargetHitSequenceEffects(",
+            staminaDrainMethodStart,
+            StringComparison.Ordinal);
+        staminaDrainMethodEnd.Should().BeGreaterThan(staminaDrainMethodStart);
+        var staminaDrainMethod = combatSource[staminaDrainMethodStart..staminaDrainMethodEnd];
+        var staminaBeforeIndex = staminaDrainMethod.IndexOf(
+            "var staminaBefore = Stat.GetCurrentStamina(target)",
+            StringComparison.Ordinal);
+        var reduceStaminaIndex = staminaDrainMethod.IndexOf(
+            "Stat.ReduceStamina(target, staminaDrain)",
+            StringComparison.Ordinal);
+        var staminaDrainedIndex = staminaDrainMethod.IndexOf(
+            "var staminaDrained = Math.Max(0, staminaBefore - Stat.GetCurrentStamina(target))",
+            StringComparison.Ordinal);
+        var feedbackIndex = staminaDrainMethod.IndexOf(
+            "ColorToken.Combat($\"-{staminaDrained} STM\")",
+            StringComparison.Ordinal);
+        staminaBeforeIndex.Should().BeGreaterThanOrEqualTo(0);
+        reduceStaminaIndex.Should().BeGreaterThan(staminaBeforeIndex);
+        staminaDrainedIndex.Should().BeGreaterThan(reduceStaminaIndex);
+        feedbackIndex.Should().BeGreaterThan(staminaDrainedIndex);
+        staminaDrainMethod.Should().NotContain("ColorToken.Combat($\"-{staminaDrain} STM\")");
         statusEffectSource.Should().Contain("Combat.ApplyStatusAppliedTargetStaminaDrain(source, creature, statusEffect.Categories)");
         usePerkFeatSource.Should().Contain("public static bool InterruptAbilityActivation(uint activator)");
         usePerkFeatSource.Should().Contain("activation.Ability.ChannelInterruptAction?.Invoke(activator)");

--- a/SWLOR.Game.Server.Tests/Perks/GeneratedWeaponPerkBehaviorTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/GeneratedWeaponPerkBehaviorTests.cs
@@ -685,6 +685,10 @@ public class GeneratedWeaponPerkBehaviorTests
         combatSource.Should().Contain("ApplyHostileAbilityUsedAttackAdjustment(activator, ability)");
         combatSource.Should().Contain("public static void ApplyStatusAppliedTargetStaminaDrain(");
         combatSource.Should().Contain("TryUseStatTrigger(activator, StatType.StatusAppliedTargetStaminaDrain, cooldown)");
+        combatSource.Should().Contain("var staminaBefore = Stat.GetCurrentStamina(target)");
+        combatSource.Should().Contain("var staminaDrained = Math.Max(0, staminaBefore - Stat.GetCurrentStamina(target))");
+        combatSource.Should().Contain("ColorToken.Combat($\"-{staminaDrained} STM\")");
+        combatSource.Should().NotContain("ColorToken.Combat($\"-{staminaDrain} STM\")");
         statusEffectSource.Should().Contain("Combat.ApplyStatusAppliedTargetStaminaDrain(source, creature, statusEffect.Categories)");
         usePerkFeatSource.Should().Contain("public static bool InterruptAbilityActivation(uint activator)");
         usePerkFeatSource.Should().Contain("activation.Ability.ChannelInterruptAction?.Invoke(activator)");

--- a/SWLOR.Game.Server/Service/Combat.cs
+++ b/SWLOR.Game.Server/Service/Combat.cs
@@ -6567,9 +6567,11 @@ namespace SWLOR.Game.Server.Service
                 return;
             }
 
+            var staminaBefore = Stat.GetCurrentStamina(target);
             Stat.ReduceStamina(target, staminaDrain);
+            var staminaDrained = Math.Max(0, staminaBefore - Stat.GetCurrentStamina(target));
             FloatingTextStringOnCreature(
-                ColorToken.Combat($"-{staminaDrain} STM"),
+                ColorToken.Combat($"-{staminaDrained} STM"),
                 target,
                 false);
         }


### PR DESCRIPTION
## Summary

- report the stamina Hobbled actually removes instead of its configured maximum
- preserve accurate feedback when the target has less stamina than the drain, including zero
- add regression assertions for the before/after stamina calculation and feedback value

## Root cause

`ApplyStatusAppliedTargetStaminaDrain` reduced stamina with clamping but rendered the configured drain amount. Targets below that amount therefore saw inflated combat feedback.

Follow-up to the post-merge review finding on #2154.

## Verification

- `dotnet build SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj -p:RunPostBuildEvent=Never`
- `dotnet test SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj --no-build --filter "FullyQualifiedName~GeneratedWeaponPerkBehaviorTests"` (15 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Combat feedback now displays the actual stamina removed when a stamina-draining status effect is applied.
  - Prevents reported stamina loss from exceeding the target’s available stamina.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->