### PR TITLE
Report First Strike stack state

### DIFF
--- a/SWLOR.Game.Server.Tests/Perks/GeneratedWeaponPerkBehaviorTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/GeneratedWeaponPerkBehaviorTests.cs
@@ -715,9 +715,8 @@ public class GeneratedWeaponPerkBehaviorTests
             StringComparison.Ordinal);
         trackCombatActivityEnd.Should().BeGreaterThan(trackCombatActivityStart);
         var trackCombatActivitySource = combatSource[trackCombatActivityStart..trackCombatActivityEnd];
-        trackCombatActivitySource.Should().Contain("ReportFirstStrikeCombatEntry(creature, now);");
-        trackCombatActivitySource.Should().Contain("!HasRecentCombatEntryActivity(creature, now)");
-        trackCombatActivitySource.IndexOf("ReportFirstStrikeCombatEntry(creature, now);", StringComparison.Ordinal)
+        trackCombatActivitySource.Should().Contain("ReportCombatEntryIfNeeded(creature, now);");
+        trackCombatActivitySource.IndexOf("ReportCombatEntryIfNeeded(creature, now);", StringComparison.Ordinal)
             .Should().BeLessThan(
                 trackCombatActivitySource.IndexOf("_lastCombatActivity[creature] = now;", StringComparison.Ordinal),
                 "combat entry must be evaluated before the activity timestamp is refreshed");
@@ -731,20 +730,32 @@ public class GeneratedWeaponPerkBehaviorTests
             StringComparison.Ordinal);
         hostileAbilityActivityEnd.Should().BeGreaterThan(hostileAbilityActivityStart);
         var hostileAbilityActivitySource = combatSource[hostileAbilityActivityStart..hostileAbilityActivityEnd];
+        hostileAbilityActivitySource.Should().Contain("ReportCombatEntryIfNeeded(creature, now);");
         hostileAbilityActivitySource.Should().Contain("_lastHostileAbilityAttemptActivity[creature] = now;");
         hostileAbilityActivitySource.Should().NotContain("_lastCombatActivity[creature] = now;",
             "hostile attempts must not suppress landed-opening riders such as Venatic Recovery");
 
         var incomingDamageActivityStart = hostileAbilityActivityEnd;
         var incomingDamageActivityEnd = combatSource.IndexOf(
-            "private static bool HasRecentCombatEntryActivity(",
+            "private static void ReportCombatEntryIfNeeded(",
             incomingDamageActivityStart,
             StringComparison.Ordinal);
         incomingDamageActivityEnd.Should().BeGreaterThan(incomingDamageActivityStart);
         var incomingDamageActivitySource = combatSource[incomingDamageActivityStart..incomingDamageActivityEnd];
+        incomingDamageActivitySource.Should().Contain("ReportCombatEntryIfNeeded(creature, now);");
         incomingDamageActivitySource.Should().Contain("_lastIncomingDamageActivity[creature] = now;");
         incomingDamageActivitySource.Should().NotContain("_lastCombatActivity[creature] = now;",
             "taking damage must not suppress Venatic Recovery on the defender's retaliation");
+
+        var reportCombatEntryStart = incomingDamageActivityEnd;
+        var reportCombatEntryEnd = combatSource.IndexOf(
+            "private static bool HasRecentCombatEntryActivity(",
+            reportCombatEntryStart,
+            StringComparison.Ordinal);
+        reportCombatEntryEnd.Should().BeGreaterThan(reportCombatEntryStart);
+        var reportCombatEntrySource = combatSource[reportCombatEntryStart..reportCombatEntryEnd];
+        reportCombatEntrySource.Should().Contain("!HasRecentCombatEntryActivity(creature, now)");
+        reportCombatEntrySource.Should().Contain("ReportFirstStrikeCombatEntry(creature, now);");
         combatSource.Should().Contain("TrackHostileDamageReceivedActivity(defender);");
 
         var hostileCombatImpactStart = abilitySource.IndexOf(

--- a/SWLOR.Game.Server.Tests/Perks/GeneratedWeaponPerkBehaviorTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/GeneratedWeaponPerkBehaviorTests.cs
@@ -726,7 +726,7 @@ public class GeneratedWeaponPerkBehaviorTests
             "public static void TrackHostileAbilityActivity(",
             StringComparison.Ordinal);
         var hostileAbilityActivityEnd = combatSource.IndexOf(
-            "private static bool HasRecentCombatEntryActivity(",
+            "private static void TrackHostileDamageReceivedActivity(",
             hostileAbilityActivityStart,
             StringComparison.Ordinal);
         hostileAbilityActivityEnd.Should().BeGreaterThan(hostileAbilityActivityStart);
@@ -734,6 +734,18 @@ public class GeneratedWeaponPerkBehaviorTests
         hostileAbilityActivitySource.Should().Contain("_lastHostileAbilityAttemptActivity[creature] = now;");
         hostileAbilityActivitySource.Should().NotContain("_lastCombatActivity[creature] = now;",
             "hostile attempts must not suppress landed-opening riders such as Venatic Recovery");
+
+        var incomingDamageActivityStart = hostileAbilityActivityEnd;
+        var incomingDamageActivityEnd = combatSource.IndexOf(
+            "private static bool HasRecentCombatEntryActivity(",
+            incomingDamageActivityStart,
+            StringComparison.Ordinal);
+        incomingDamageActivityEnd.Should().BeGreaterThan(incomingDamageActivityStart);
+        var incomingDamageActivitySource = combatSource[incomingDamageActivityStart..incomingDamageActivityEnd];
+        incomingDamageActivitySource.Should().Contain("_lastIncomingDamageActivity[creature] = now;");
+        incomingDamageActivitySource.Should().NotContain("_lastCombatActivity[creature] = now;",
+            "taking damage must not suppress Venatic Recovery on the defender's retaliation");
+        combatSource.Should().Contain("TrackHostileDamageReceivedActivity(defender);");
 
         var hostileCombatImpactStart = abilitySource.IndexOf(
             "private static int ApplyHostileCombatImpact(",

--- a/SWLOR.Game.Server.Tests/Perks/GeneratedWeaponPerkBehaviorTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/GeneratedWeaponPerkBehaviorTests.cs
@@ -725,7 +725,7 @@ public class GeneratedWeaponPerkBehaviorTests
             "public static void TrackHostileAbilityActivity(",
             StringComparison.Ordinal);
         var hostileAbilityActivityEnd = combatSource.IndexOf(
-            "private static void TrackHostileDamageReceivedActivity(",
+            "private static void TrackHostileDefensiveCombatEntryActivity(",
             hostileAbilityActivityStart,
             StringComparison.Ordinal);
         hostileAbilityActivityEnd.Should().BeGreaterThan(hostileAbilityActivityStart);
@@ -735,19 +735,19 @@ public class GeneratedWeaponPerkBehaviorTests
         hostileAbilityActivitySource.Should().NotContain("_lastCombatActivity[creature] = now;",
             "hostile attempts must not suppress landed-opening riders such as Venatic Recovery");
 
-        var incomingDamageActivityStart = hostileAbilityActivityEnd;
-        var incomingDamageActivityEnd = combatSource.IndexOf(
+        var defensiveCombatEntryActivityStart = hostileAbilityActivityEnd;
+        var defensiveCombatEntryActivityEnd = combatSource.IndexOf(
             "private static void ReportCombatEntryIfNeeded(",
-            incomingDamageActivityStart,
+            defensiveCombatEntryActivityStart,
             StringComparison.Ordinal);
-        incomingDamageActivityEnd.Should().BeGreaterThan(incomingDamageActivityStart);
-        var incomingDamageActivitySource = combatSource[incomingDamageActivityStart..incomingDamageActivityEnd];
-        incomingDamageActivitySource.Should().Contain("ReportCombatEntryIfNeeded(creature, now);");
-        incomingDamageActivitySource.Should().Contain("_lastIncomingDamageActivity[creature] = now;");
-        incomingDamageActivitySource.Should().NotContain("_lastCombatActivity[creature] = now;",
+        defensiveCombatEntryActivityEnd.Should().BeGreaterThan(defensiveCombatEntryActivityStart);
+        var defensiveCombatEntryActivitySource = combatSource[defensiveCombatEntryActivityStart..defensiveCombatEntryActivityEnd];
+        defensiveCombatEntryActivitySource.Should().Contain("ReportCombatEntryIfNeeded(creature, now);");
+        defensiveCombatEntryActivitySource.Should().Contain("_lastHostileIncomingActivity[creature] = now;");
+        defensiveCombatEntryActivitySource.Should().NotContain("_lastCombatActivity[creature] = now;",
             "taking damage must not suppress Venatic Recovery on the defender's retaliation");
 
-        var reportCombatEntryStart = incomingDamageActivityEnd;
+        var reportCombatEntryStart = defensiveCombatEntryActivityEnd;
         var reportCombatEntryEnd = combatSource.IndexOf(
             "private static bool HasRecentCombatEntryActivity(",
             reportCombatEntryStart,
@@ -756,7 +756,10 @@ public class GeneratedWeaponPerkBehaviorTests
         var reportCombatEntrySource = combatSource[reportCombatEntryStart..reportCombatEntryEnd];
         reportCombatEntrySource.Should().Contain("!HasRecentCombatEntryActivity(creature, now)");
         reportCombatEntrySource.Should().Contain("ReportFirstStrikeCombatEntry(creature, now);");
-        combatSource.Should().Contain("TrackHostileDamageReceivedActivity(defender);");
+        combatSource.Should().Contain("TrackHostileDefensiveCombatEntryActivity(defender);");
+        combatSource.Should().Contain("TrackHostileDefensiveCombatEntryActivity(creature);");
+        combatSource.Should().Contain("GetIsReactionTypeHostile(attacker, creature)");
+        nativeAttackSource.Should().Contain("Combat.TrackAvoidedAttack(defender.m_idSelf, attacker.m_idSelf);");
 
         var hostileCombatImpactStart = abilitySource.IndexOf(
             "private static int ApplyHostileCombatImpact(",

--- a/SWLOR.Game.Server.Tests/Perks/GeneratedWeaponPerkBehaviorTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/GeneratedWeaponPerkBehaviorTests.cs
@@ -706,6 +706,33 @@ public class GeneratedWeaponPerkBehaviorTests
         firstStrikeSource.Should().Contain("First Strike recharged: Attacker={Attacker}");
         firstStrikeSource.Should().Contain("First Strike reset after combat: Attacker={Attacker}");
 
+        var firstCombatAttackStart = combatSource.IndexOf(
+            "private static void ApplyFirstCombatAttackStaminaRestore(",
+            StringComparison.Ordinal);
+        var firstCombatAttackEnd = combatSource.IndexOf(
+            "private static void ApplyAutoAttackHamstringEffect(",
+            firstCombatAttackStart,
+            StringComparison.Ordinal);
+        firstCombatAttackEnd.Should().BeGreaterThan(firstCombatAttackStart);
+        var firstCombatAttackSource = combatSource[firstCombatAttackStart..firstCombatAttackEnd];
+        firstCombatAttackSource.Should().Contain("_firstCombatAttackConsumed.Add(attacker)");
+        firstCombatAttackSource.Should().NotContain("_lastCombatActivity",
+            "a prolonged combat entry can remain active through hostile attempts and incoming attacks");
+
+        var damageDealtEffectsStart = combatSource.IndexOf(
+            "public static void ApplyDamageDealtEffects(",
+            StringComparison.Ordinal);
+        var damageDealtEffectsEnd = combatSource.IndexOf(
+            "private static void ApplyHeavyVibrobladeDefenseDamageRecovery(",
+            damageDealtEffectsStart,
+            StringComparison.Ordinal);
+        damageDealtEffectsEnd.Should().BeGreaterThan(damageDealtEffectsStart);
+        var damageDealtEffectsSource = combatSource[damageDealtEffectsStart..damageDealtEffectsEnd];
+        damageDealtEffectsSource.IndexOf("TrackCombatActivity(attacker);", StringComparison.Ordinal)
+            .Should().BeLessThan(
+                damageDealtEffectsSource.IndexOf("ApplyFirstCombatAttackStaminaRestore(attacker);", StringComparison.Ordinal),
+                "combat entry must reset the consumed state before the opening landed attack evaluates Venatic Recovery");
+
         var trackCombatActivityStart = combatSource.IndexOf(
             "private static void TrackCombatActivity(",
             StringComparison.Ordinal);
@@ -725,7 +752,7 @@ public class GeneratedWeaponPerkBehaviorTests
             "public static void TrackHostileAbilityActivity(",
             StringComparison.Ordinal);
         var hostileAbilityActivityEnd = combatSource.IndexOf(
-            "private static void TrackHostileDefensiveCombatEntryActivity(",
+            "public static void TrackHostileDefensiveCombatEntryActivity(",
             hostileAbilityActivityStart,
             StringComparison.Ordinal);
         hostileAbilityActivityEnd.Should().BeGreaterThan(hostileAbilityActivityStart);
@@ -744,8 +771,9 @@ public class GeneratedWeaponPerkBehaviorTests
         var defensiveCombatEntryActivitySource = combatSource[defensiveCombatEntryActivityStart..defensiveCombatEntryActivityEnd];
         defensiveCombatEntryActivitySource.Should().Contain("ReportCombatEntryIfNeeded(creature, now);");
         defensiveCombatEntryActivitySource.Should().Contain("_lastHostileIncomingActivity[creature] = now;");
+        defensiveCombatEntryActivitySource.Should().Contain("GetIsReactionTypeHostile(attacker, creature)");
         defensiveCombatEntryActivitySource.Should().NotContain("_lastCombatActivity[creature] = now;",
-            "taking damage must not suppress Venatic Recovery on the defender's retaliation");
+            "incoming hostile actions must not suppress Venatic Recovery on the defender's retaliation");
 
         var reportCombatEntryStart = defensiveCombatEntryActivityEnd;
         var reportCombatEntryEnd = combatSource.IndexOf(
@@ -754,12 +782,24 @@ public class GeneratedWeaponPerkBehaviorTests
             StringComparison.Ordinal);
         reportCombatEntryEnd.Should().BeGreaterThan(reportCombatEntryStart);
         var reportCombatEntrySource = combatSource[reportCombatEntryStart..reportCombatEntryEnd];
-        reportCombatEntrySource.Should().Contain("!HasRecentCombatEntryActivity(creature, now)");
+        reportCombatEntrySource.Should().Contain("HasRecentCombatEntryActivity(creature, now)");
+        reportCombatEntrySource.Should().Contain("_firstCombatAttackConsumed.Remove(creature);");
         reportCombatEntrySource.Should().Contain("ReportFirstStrikeCombatEntry(creature, now);");
-        combatSource.Should().Contain("TrackHostileDefensiveCombatEntryActivity(defender);");
-        combatSource.Should().Contain("TrackHostileDefensiveCombatEntryActivity(creature);");
-        combatSource.Should().Contain("GetIsReactionTypeHostile(attacker, creature)");
+        combatSource.Should().Contain("TrackHostileDefensiveCombatEntryActivity(defender, attacker);");
+        combatSource.Should().Contain("TrackHostileDefensiveCombatEntryActivity(creature, attacker);");
         nativeAttackSource.Should().Contain("Combat.TrackAvoidedAttack(defender.m_idSelf, attacker.m_idSelf);");
+        nativeAttackSource.Should().Contain("var wasSuccessfulBeforeDefensiveEffects = IsSuccessfulAttackResult(");
+        nativeAttackSource.Should().Contain("wasSuccessfulBeforeDefensiveEffects &&");
+        var defensiveEffectsIndex = nativeAttackSource.IndexOf(
+            "attacker.ResolveDefensiveEffects(defender, isHit ? 1 : 0);",
+            StringComparison.Ordinal);
+        defensiveEffectsIndex.Should().BeGreaterThan(-1);
+        nativeAttackSource.IndexOf(
+                "Combat.TrackAvoidedAttack(defender.m_idSelf, attacker.m_idSelf);",
+                defensiveEffectsIndex,
+                StringComparison.Ordinal)
+            .Should().BeGreaterThan(defensiveEffectsIndex,
+                "concealment can convert a provisional hit into an avoided attack");
 
         var hostileCombatImpactStart = abilitySource.IndexOf(
             "private static int ApplyHostileCombatImpact(",
@@ -771,10 +811,15 @@ public class GeneratedWeaponPerkBehaviorTests
         hostileCombatImpactEnd.Should().BeGreaterThan(hostileCombatImpactStart);
         var hostileCombatImpactSource = abilitySource[hostileCombatImpactStart..hostileCombatImpactEnd];
         hostileCombatImpactSource.Should().Contain("Combat.TrackHostileAbilityActivity(activator);");
+        hostileCombatImpactSource.Should().Contain("Combat.TrackHostileDefensiveCombatEntryActivity(target, activator);");
         hostileCombatImpactSource.IndexOf("Combat.TrackHostileAbilityActivity(activator);", StringComparison.Ordinal)
             .Should().BeLessThan(
                 hostileCombatImpactSource.IndexOf("Combat.TryResolveAbilityHit(", StringComparison.Ordinal),
                 "a missed opening cast still enters combat and must report First Strike readiness");
+        hostileCombatImpactSource.IndexOf("Combat.TrackHostileDefensiveCombatEntryActivity(target, activator);", StringComparison.Ordinal)
+            .Should().BeLessThan(
+                hostileCombatImpactSource.IndexOf("Combat.TryResolveAbilityHit(", StringComparison.Ordinal),
+                "the defender must enter combat even when the opening hostile cast misses");
         hostileCombatImpactSource.Should().Contain("firstHostileAbilityHitDamageBonusApplied: true");
         abilitySource.Should().Contain("bool firstHostileAbilityHitDamageBonusApplied = false");
         combatSource.Should().Contain("if (firstHostileAbilityHitDamageBonusApplied)");

--- a/SWLOR.Game.Server.Tests/Perks/GeneratedWeaponPerkBehaviorTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/GeneratedWeaponPerkBehaviorTests.cs
@@ -701,6 +701,10 @@ public class GeneratedWeaponPerkBehaviorTests
         firstStrikeSource.Should().Contain("SendMessageToPC(attacker, feedback);");
         firstStrikeSource.Should().Contain("Count = 0");
         firstStrikeSource.Should().Contain("LastHit = DateTime.MinValue");
+        firstStrikeSource.Should().Contain("First Strike ready: Attacker={Attacker}");
+        firstStrikeSource.Should().Contain("First Strike stack consumed: Attacker={Attacker}");
+        firstStrikeSource.Should().Contain("First Strike recharged: Attacker={Attacker}");
+        firstStrikeSource.Should().Contain("First Strike reset after combat: Attacker={Attacker}");
 
         var trackCombatActivityStart = combatSource.IndexOf(
             "private static void TrackCombatActivity(",

--- a/SWLOR.Game.Server.Tests/Perks/GeneratedWeaponPerkBehaviorTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/GeneratedWeaponPerkBehaviorTests.cs
@@ -681,7 +681,41 @@ public class GeneratedWeaponPerkBehaviorTests
         combatSource.Should().Contain("StatType.NextAutoAttackNoDelayAllSkills");
         combatSource.Should().Contain("var appliesToSkill = skillType != SkillType.Invalid && storedSkillType == skillType");
         combatSource.Should().Contain("if (appliesToSkill)");
+        combatSource.Should().Contain("First Strike ready: {maximumCount} {stackLabel} (+{damageBonus} DMG each).");
+        combatSource.Should().Contain("First Strike deals +{damageBonus} DMG ({remaining} {stackLabel} remaining{rechargeText}).");
         combatSource.Should().Contain("First Strike +{damageBonus} DMG ({remaining} {stackLabel} remaining)");
+        combatSource.Should().Contain("First Strike is recharging ({remainingSeconds} seconds remaining).");
+
+        var firstStrikeStart = combatSource.IndexOf(
+            "private static int GetFirstHostileAbilityHitDamageBonus(",
+            StringComparison.Ordinal);
+        var firstStrikeEnd = combatSource.IndexOf(
+            "private static int GetAbilityDamageToSourceAppliedStatusTargetAdjustment(",
+            firstStrikeStart,
+            StringComparison.Ordinal);
+        firstStrikeEnd.Should().BeGreaterThan(firstStrikeStart);
+        var firstStrikeSource = combatSource[firstStrikeStart..firstStrikeEnd];
+        firstStrikeSource.Should().Contain("ability?.IsHostileAbility != true");
+        firstStrikeSource.Should().NotContain("SkillType.",
+            "the Bible grants First Strike to any hostile combat ability, including cross-skill abilities");
+        firstStrikeSource.Should().Contain("SendMessageToPC(attacker, feedback);");
+        firstStrikeSource.Should().Contain("Count = 0");
+        firstStrikeSource.Should().Contain("LastHit = DateTime.MinValue");
+
+        var trackCombatActivityStart = combatSource.IndexOf(
+            "private static void TrackCombatActivity(",
+            StringComparison.Ordinal);
+        var trackCombatActivityEnd = combatSource.IndexOf(
+            "public static void TrackAttackActivity(",
+            trackCombatActivityStart,
+            StringComparison.Ordinal);
+        trackCombatActivityEnd.Should().BeGreaterThan(trackCombatActivityStart);
+        var trackCombatActivitySource = combatSource[trackCombatActivityStart..trackCombatActivityEnd];
+        trackCombatActivitySource.Should().Contain("ReportFirstStrikeCombatEntry(creature, now);");
+        trackCombatActivitySource.IndexOf("ReportFirstStrikeCombatEntry(creature, now);", StringComparison.Ordinal)
+            .Should().BeLessThan(
+                trackCombatActivitySource.IndexOf("_lastCombatActivity[creature] = now;", StringComparison.Ordinal),
+                "combat entry must be evaluated before the activity timestamp is refreshed");
         combatSource.Should().Contain("ApplyHostileAbilityUsedAttackAdjustment(activator, ability)");
         combatSource.Should().Contain("public static void ApplyStatusAppliedTargetStaminaDrain(");
         combatSource.Should().Contain("TryUseStatTrigger(activator, StatType.StatusAppliedTargetStaminaDrain, cooldown)");

--- a/SWLOR.Game.Server.Tests/Perks/GeneratedWeaponPerkBehaviorTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/GeneratedWeaponPerkBehaviorTests.cs
@@ -716,10 +716,24 @@ public class GeneratedWeaponPerkBehaviorTests
         trackCombatActivityEnd.Should().BeGreaterThan(trackCombatActivityStart);
         var trackCombatActivitySource = combatSource[trackCombatActivityStart..trackCombatActivityEnd];
         trackCombatActivitySource.Should().Contain("ReportFirstStrikeCombatEntry(creature, now);");
+        trackCombatActivitySource.Should().Contain("!HasRecentCombatEntryActivity(creature, now)");
         trackCombatActivitySource.IndexOf("ReportFirstStrikeCombatEntry(creature, now);", StringComparison.Ordinal)
             .Should().BeLessThan(
                 trackCombatActivitySource.IndexOf("_lastCombatActivity[creature] = now;", StringComparison.Ordinal),
                 "combat entry must be evaluated before the activity timestamp is refreshed");
+
+        var hostileAbilityActivityStart = combatSource.IndexOf(
+            "public static void TrackHostileAbilityActivity(",
+            StringComparison.Ordinal);
+        var hostileAbilityActivityEnd = combatSource.IndexOf(
+            "private static bool HasRecentCombatEntryActivity(",
+            hostileAbilityActivityStart,
+            StringComparison.Ordinal);
+        hostileAbilityActivityEnd.Should().BeGreaterThan(hostileAbilityActivityStart);
+        var hostileAbilityActivitySource = combatSource[hostileAbilityActivityStart..hostileAbilityActivityEnd];
+        hostileAbilityActivitySource.Should().Contain("_lastHostileAbilityAttemptActivity[creature] = now;");
+        hostileAbilityActivitySource.Should().NotContain("_lastCombatActivity[creature] = now;",
+            "hostile attempts must not suppress landed-opening riders such as Venatic Recovery");
 
         var hostileCombatImpactStart = abilitySource.IndexOf(
             "private static int ApplyHostileCombatImpact(",
@@ -735,6 +749,9 @@ public class GeneratedWeaponPerkBehaviorTests
             .Should().BeLessThan(
                 hostileCombatImpactSource.IndexOf("Combat.TryResolveAbilityHit(", StringComparison.Ordinal),
                 "a missed opening cast still enters combat and must report First Strike readiness");
+        hostileCombatImpactSource.Should().Contain("firstHostileAbilityHitDamageBonusApplied: true");
+        abilitySource.Should().Contain("bool firstHostileAbilityHitDamageBonusApplied = false");
+        combatSource.Should().Contain("if (firstHostileAbilityHitDamageBonusApplied)");
         combatSource.Should().Contain("ApplyHostileAbilityUsedAttackAdjustment(activator, ability)");
         combatSource.Should().Contain("public static void ApplyStatusAppliedTargetStaminaDrain(");
         combatSource.Should().Contain("TryUseStatTrigger(activator, StatType.StatusAppliedTargetStaminaDrain, cooldown)");

--- a/SWLOR.Game.Server.Tests/Perks/GeneratedWeaponPerkBehaviorTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/GeneratedWeaponPerkBehaviorTests.cs
@@ -720,6 +720,21 @@ public class GeneratedWeaponPerkBehaviorTests
             .Should().BeLessThan(
                 trackCombatActivitySource.IndexOf("_lastCombatActivity[creature] = now;", StringComparison.Ordinal),
                 "combat entry must be evaluated before the activity timestamp is refreshed");
+
+        var hostileCombatImpactStart = abilitySource.IndexOf(
+            "private static int ApplyHostileCombatImpact(",
+            StringComparison.Ordinal);
+        var hostileCombatImpactEnd = abilitySource.IndexOf(
+            "private static bool ShouldResolveCombatImpactHit(",
+            hostileCombatImpactStart,
+            StringComparison.Ordinal);
+        hostileCombatImpactEnd.Should().BeGreaterThan(hostileCombatImpactStart);
+        var hostileCombatImpactSource = abilitySource[hostileCombatImpactStart..hostileCombatImpactEnd];
+        hostileCombatImpactSource.Should().Contain("Combat.TrackHostileAbilityActivity(activator);");
+        hostileCombatImpactSource.IndexOf("Combat.TrackHostileAbilityActivity(activator);", StringComparison.Ordinal)
+            .Should().BeLessThan(
+                hostileCombatImpactSource.IndexOf("Combat.TryResolveAbilityHit(", StringComparison.Ordinal),
+                "a missed opening cast still enters combat and must report First Strike readiness");
         combatSource.Should().Contain("ApplyHostileAbilityUsedAttackAdjustment(activator, ability)");
         combatSource.Should().Contain("public static void ApplyStatusAppliedTargetStaminaDrain(");
         combatSource.Should().Contain("TryUseStatTrigger(activator, StatType.StatusAppliedTargetStaminaDrain, cooldown)");

--- a/SWLOR.Game.Server/Native/ResolveAttackRoll.cs
+++ b/SWLOR.Game.Server/Native/ResolveAttackRoll.cs
@@ -314,7 +314,7 @@ namespace SWLOR.Game.Server.Native
                 // Miss
                 else
                 {
-                    Combat.TrackAvoidedAttack(defender.m_idSelf);
+                    Combat.TrackAvoidedAttack(defender.m_idSelf, attacker.m_idSelf);
                     Combat.TrackAttackActivity(attacker.m_idSelf);
 
                     if (deflected)

--- a/SWLOR.Game.Server/Native/ResolveAttackRoll.cs
+++ b/SWLOR.Game.Server/Native/ResolveAttackRoll.cs
@@ -338,7 +338,13 @@ namespace SWLOR.Game.Server.Native
                 Log.Write(LogGroup.Attack, $"Resolving NWN defensive effects");
                 // Resolve any defensive effects (like concealment).  Do this after all the above so that the attack data is
                 // accurate.
+                var wasSuccessfulBeforeDefensiveEffects = IsSuccessfulAttackResult(pAttackData.m_nAttackResult);
                 attacker.ResolveDefensiveEffects(defender, isHit ? 1 : 0);
+                if (wasSuccessfulBeforeDefensiveEffects &&
+                    !IsSuccessfulAttackResult(pAttackData.m_nAttackResult))
+                {
+                    Combat.TrackAvoidedAttack(defender.m_idSelf, attacker.m_idSelf);
+                }
 
                 Log.Write(LogGroup.Attack, $"Building combat log message");
                 var attackerMessage = BuildAttackFeedbackMessage(

--- a/SWLOR.Game.Server/Service/Ability.cs
+++ b/SWLOR.Game.Server/Service/Ability.cs
@@ -2110,6 +2110,7 @@ namespace SWLOR.Game.Server.Service
         {
             using var damageDerivedHealing = Combat.BeginDamageDerivedHealing(activator);
             var trackedImpact = GetTrackedAbilityImpact(activator);
+            Combat.TrackHostileAbilityActivity(activator);
             var perkType = trackedImpact?.Ability?.EffectiveLevelPerkType ?? PerkType.Invalid;
             var usesNPCStatScaling = ShouldUseNPCStatScaling(activator, useNPCStatScaling);
             var damageAbility = combatImpactDamageAbility != AbilityType.Invalid

--- a/SWLOR.Game.Server/Service/Ability.cs
+++ b/SWLOR.Game.Server/Service/Ability.cs
@@ -2113,6 +2113,7 @@ namespace SWLOR.Game.Server.Service
             using var damageDerivedHealing = Combat.BeginDamageDerivedHealing(activator);
             var trackedImpact = GetTrackedAbilityImpact(activator);
             Combat.TrackHostileAbilityActivity(activator);
+            Combat.TrackHostileDefensiveCombatEntryActivity(target, activator);
             var perkType = trackedImpact?.Ability?.EffectiveLevelPerkType ?? PerkType.Invalid;
             var usesNPCStatScaling = ShouldUseNPCStatScaling(activator, useNPCStatScaling);
             var damageAbility = combatImpactDamageAbility != AbilityType.Invalid

--- a/SWLOR.Game.Server/Service/Ability.cs
+++ b/SWLOR.Game.Server/Service/Ability.cs
@@ -1994,7 +1994,8 @@ namespace SWLOR.Game.Server.Service
             Action<uint> afterSuccessfulHit = null,
             Action<uint> beforeSuccessfulImpactRiders = null,
             bool awardsCombatPoints = true,
-            DamageType? effectDamageType = null)
+            DamageType? effectDamageType = null,
+            bool firstHostileAbilityHitDamageBonusApplied = false)
         {
             using var damageDerivedHealing = Combat.BeginDamageDerivedHealing(activator);
             var trackedImpact = GetTrackedAbilityImpact(activator);
@@ -2070,7 +2071,8 @@ namespace SWLOR.Game.Server.Service
                 damage,
                 statusApplied,
                 statusEffect,
-                additionalStatusEffects);
+                additionalStatusEffects,
+                firstHostileAbilityHitDamageBonusApplied);
 
             if ((damage > 0 || statusApplied) && targetVisualEffect != VisualEffect.None)
             {
@@ -2178,7 +2180,8 @@ namespace SWLOR.Game.Server.Service
                 afterSuccessfulHit,
                 beforeSuccessfulImpactRiders,
                 awardsCombatPoints,
-                effectDamageType);
+                effectDamageType,
+                firstHostileAbilityHitDamageBonusApplied: true);
         }
 
         private static bool ShouldResolveCombatImpactHit(TrackedAbilityImpact trackedImpact)

--- a/SWLOR.Game.Server/Service/Combat.cs
+++ b/SWLOR.Game.Server/Service/Combat.cs
@@ -65,6 +65,7 @@ namespace SWLOR.Game.Server.Service
         private static readonly Dictionary<uint, DateTime> _lastCombatActivity = new();
         private static readonly Dictionary<uint, DateTime> _lastHostileAbilityAttemptActivity = new();
         private static readonly Dictionary<uint, DateTime> _lastHostileIncomingActivity = new();
+        private static readonly HashSet<uint> _firstCombatAttackConsumed = new();
         private static readonly Dictionary<uint, DateTime> _lastAttackActivity = new();
         private static readonly Dictionary<uint, DateTime> _lastCombatAbilityUse = new();
         private static readonly Dictionary<(uint, uint), SuppressionAbilityUseState> _pendingSuppressionAbilityUses = new();
@@ -1072,11 +1073,8 @@ namespace SWLOR.Game.Server.Service
             if (staminaRestore <= 0 || cooldownSeconds <= 0)
                 return;
 
-            if (_lastCombatActivity.TryGetValue(attacker, out var lastActivity) &&
-                (DateTime.UtcNow - lastActivity).TotalSeconds <= 30)
-            {
+            if (!_firstCombatAttackConsumed.Add(attacker))
                 return;
-            }
 
             if (!TryUseStatTrigger(attacker, StatType.FirstCombatAttackStaminaRestore, cooldownSeconds))
                 return;
@@ -1295,19 +1293,16 @@ namespace SWLOR.Game.Server.Service
 
             var appliesDirectDamageEffects = deliveryType == CombatDamageDeliveryType.Direct;
 
-            // Must run before TrackCombatActivity below updates the "last combat activity"
-            // timestamp, since this checks whether the attacker was already active in combat.
-            // Runs for direct hits only (auto-attacks and ability impacts), not DoT ticks, so
-            // that a hostile ability opener still counts as the "first attack" for Vibroknife's
-            // Venatic Recovery rather than only a raw auto-attack.
-            if (appliesDirectDamageEffects)
-                ApplyFirstCombatAttackStaminaRestore(attacker);
-
             TrackCombatActivity(attacker);
             TrackRecentDamageTarget(attacker, defender);
 
             if (!appliesDirectDamageEffects)
                 return;
+
+            // The combat-entry tracker resets this rider's consumed state before the first landed
+            // direct attack. Missed casts and incoming hostile actions keep that state alive without
+            // consuming it, so Venatic Recovery cannot trigger twice during one prolonged engagement.
+            ApplyFirstCombatAttackStaminaRestore(attacker);
 
             ApplySameTargetPressureDamageEffects(attacker, defender, skillType);
             ApplySideAttackDamageEffects(attacker, defender, skillType, damage);
@@ -2205,7 +2200,7 @@ namespace SWLOR.Game.Server.Service
 
             if (GetIsObjectValid(attacker) && GetIsReactionTypeHostile(attacker, defender))
             {
-                TrackHostileDefensiveCombatEntryActivity(defender);
+                TrackHostileDefensiveCombatEntryActivity(defender, attacker);
                 EmbattledStatusEffect.Refresh(defender, attacker);
             }
         }
@@ -2850,9 +2845,11 @@ namespace SWLOR.Game.Server.Service
             _lastHostileAbilityAttemptActivity[creature] = now;
         }
 
-        private static void TrackHostileDefensiveCombatEntryActivity(uint creature)
+        public static void TrackHostileDefensiveCombatEntryActivity(uint creature, uint attacker)
         {
-            if (!GetIsObjectValid(creature))
+            if (!GetIsObjectValid(creature) ||
+                !GetIsObjectValid(attacker) ||
+                !GetIsReactionTypeHostile(attacker, creature))
                 return;
 
             var now = DateTime.UtcNow;
@@ -2864,8 +2861,11 @@ namespace SWLOR.Game.Server.Service
 
         private static void ReportCombatEntryIfNeeded(uint creature, DateTime now)
         {
-            if (!HasRecentCombatEntryActivity(creature, now))
-                ReportFirstStrikeCombatEntry(creature, now);
+            if (HasRecentCombatEntryActivity(creature, now))
+                return;
+
+            _firstCombatAttackConsumed.Remove(creature);
+            ReportFirstStrikeCombatEntry(creature, now);
         }
 
         private static bool HasRecentCombatEntryActivity(uint creature, DateTime now)
@@ -3079,8 +3079,7 @@ namespace SWLOR.Game.Server.Service
             if (!GetIsObjectValid(creature))
                 return;
 
-            if (GetIsObjectValid(attacker) && GetIsReactionTypeHostile(attacker, creature))
-                TrackHostileDefensiveCombatEntryActivity(creature);
+            TrackHostileDefensiveCombatEntryActivity(creature, attacker);
 
             var skillType = GetSkillTypeFromStat(Stat.GetStatAdjustment(creature, StatType.AvoidedAttackNextSkillAbilitySkillType));
             var adjustment = Stat.GetStatAdjustment(creature, StatType.AvoidedAttackNextSkillAbilityStaminaCostAdjustment);
@@ -4659,6 +4658,7 @@ namespace SWLOR.Game.Server.Service
             _lastCombatActivity.Remove(creature);
             _lastHostileAbilityAttemptActivity.Remove(creature);
             _lastHostileIncomingActivity.Remove(creature);
+            _firstCombatAttackConsumed.Remove(creature);
             _lastAttackActivity.Remove(creature);
             _lastCombatAbilityUse.Remove(creature);
             foreach (var key in _pendingSuppressionAbilityUses.Keys.Where(x => x.Item1 == creature || x.Item2 == creature).ToList())

--- a/SWLOR.Game.Server/Service/Combat.cs
+++ b/SWLOR.Game.Server/Service/Combat.cs
@@ -64,7 +64,7 @@ namespace SWLOR.Game.Server.Service
         private static readonly Dictionary<uint, DateTime> _recentDeflections = new();
         private static readonly Dictionary<uint, DateTime> _lastCombatActivity = new();
         private static readonly Dictionary<uint, DateTime> _lastHostileAbilityAttemptActivity = new();
-        private static readonly Dictionary<uint, DateTime> _lastIncomingDamageActivity = new();
+        private static readonly Dictionary<uint, DateTime> _lastHostileIncomingActivity = new();
         private static readonly Dictionary<uint, DateTime> _lastAttackActivity = new();
         private static readonly Dictionary<uint, DateTime> _lastCombatAbilityUse = new();
         private static readonly Dictionary<(uint, uint), SuppressionAbilityUseState> _pendingSuppressionAbilityUses = new();
@@ -2205,7 +2205,7 @@ namespace SWLOR.Game.Server.Service
 
             if (GetIsObjectValid(attacker) && GetIsReactionTypeHostile(attacker, defender))
             {
-                TrackHostileDamageReceivedActivity(defender);
+                TrackHostileDefensiveCombatEntryActivity(defender);
                 EmbattledStatusEffect.Refresh(defender, attacker);
             }
         }
@@ -2850,16 +2850,16 @@ namespace SWLOR.Game.Server.Service
             _lastHostileAbilityAttemptActivity[creature] = now;
         }
 
-        private static void TrackHostileDamageReceivedActivity(uint creature)
+        private static void TrackHostileDefensiveCombatEntryActivity(uint creature)
         {
             if (!GetIsObjectValid(creature))
                 return;
 
             var now = DateTime.UtcNow;
             ReportCombatEntryIfNeeded(creature, now);
-            // Incoming damage starts combat for First Strike visibility without consuming the
+            // Incoming hostile actions start combat for First Strike visibility without consuming the
             // landed-opening timestamp that Venatic Recovery reads when the defender retaliates.
-            _lastIncomingDamageActivity[creature] = now;
+            _lastHostileIncomingActivity[creature] = now;
         }
 
         private static void ReportCombatEntryIfNeeded(uint creature, DateTime now)
@@ -2874,8 +2874,8 @@ namespace SWLOR.Game.Server.Service
                     (now - lastCombatActivity).TotalSeconds <= 30) ||
                 (_lastHostileAbilityAttemptActivity.TryGetValue(creature, out var lastHostileAbilityAttempt) &&
                     (now - lastHostileAbilityAttempt).TotalSeconds <= 30) ||
-                (_lastIncomingDamageActivity.TryGetValue(creature, out var lastIncomingDamage) &&
-                    (now - lastIncomingDamage).TotalSeconds <= 30);
+                (_lastHostileIncomingActivity.TryGetValue(creature, out var lastHostileIncomingActivity) &&
+                    (now - lastHostileIncomingActivity).TotalSeconds <= 30);
         }
 
         public static void TrackStealthOpeningWindow(uint creature)
@@ -3074,10 +3074,13 @@ namespace SWLOR.Game.Server.Service
             ApplyGuardedHitNextSkillAbilityStatusEffects(creature);
         }
 
-        public static void TrackAvoidedAttack(uint creature)
+        public static void TrackAvoidedAttack(uint creature, uint attacker)
         {
             if (!GetIsObjectValid(creature))
                 return;
+
+            if (GetIsObjectValid(attacker) && GetIsReactionTypeHostile(attacker, creature))
+                TrackHostileDefensiveCombatEntryActivity(creature);
 
             var skillType = GetSkillTypeFromStat(Stat.GetStatAdjustment(creature, StatType.AvoidedAttackNextSkillAbilitySkillType));
             var adjustment = Stat.GetStatAdjustment(creature, StatType.AvoidedAttackNextSkillAbilityStaminaCostAdjustment);
@@ -4655,7 +4658,7 @@ namespace SWLOR.Game.Server.Service
             _recentDeflections.Remove(creature);
             _lastCombatActivity.Remove(creature);
             _lastHostileAbilityAttemptActivity.Remove(creature);
-            _lastIncomingDamageActivity.Remove(creature);
+            _lastHostileIncomingActivity.Remove(creature);
             _lastAttackActivity.Remove(creature);
             _lastCombatAbilityUse.Remove(creature);
             foreach (var key in _pendingSuppressionAbilityUses.Keys.Where(x => x.Item1 == creature || x.Item2 == creature).ToList())

--- a/SWLOR.Game.Server/Service/Combat.cs
+++ b/SWLOR.Game.Server/Service/Combat.cs
@@ -64,6 +64,7 @@ namespace SWLOR.Game.Server.Service
         private static readonly Dictionary<uint, DateTime> _recentDeflections = new();
         private static readonly Dictionary<uint, DateTime> _lastCombatActivity = new();
         private static readonly Dictionary<uint, DateTime> _lastHostileAbilityAttemptActivity = new();
+        private static readonly Dictionary<uint, DateTime> _lastIncomingDamageActivity = new();
         private static readonly Dictionary<uint, DateTime> _lastAttackActivity = new();
         private static readonly Dictionary<uint, DateTime> _lastCombatAbilityUse = new();
         private static readonly Dictionary<(uint, uint), SuppressionAbilityUseState> _pendingSuppressionAbilityUses = new();
@@ -2203,7 +2204,10 @@ namespace SWLOR.Game.Server.Service
             ApplyRecentDamageTargetHitEffects(defender, attacker);
 
             if (GetIsObjectValid(attacker) && GetIsReactionTypeHostile(attacker, defender))
+            {
+                TrackHostileDamageReceivedActivity(defender);
                 EmbattledStatusEffect.Refresh(defender, attacker);
+            }
         }
 
         private static void ApplyDamageTakenNextSkillAbilityDamage(uint defender)
@@ -2852,12 +2856,28 @@ namespace SWLOR.Game.Server.Service
             _lastHostileAbilityAttemptActivity[creature] = now;
         }
 
+        private static void TrackHostileDamageReceivedActivity(uint creature)
+        {
+            if (!GetIsObjectValid(creature))
+                return;
+
+            var now = DateTime.UtcNow;
+            if (!HasRecentCombatEntryActivity(creature, now))
+                ReportFirstStrikeCombatEntry(creature, now);
+
+            // Incoming damage starts combat for First Strike visibility without consuming the
+            // landed-opening timestamp that Venatic Recovery reads when the defender retaliates.
+            _lastIncomingDamageActivity[creature] = now;
+        }
+
         private static bool HasRecentCombatEntryActivity(uint creature, DateTime now)
         {
             return (_lastCombatActivity.TryGetValue(creature, out var lastCombatActivity) &&
                     (now - lastCombatActivity).TotalSeconds <= 30) ||
                 (_lastHostileAbilityAttemptActivity.TryGetValue(creature, out var lastHostileAbilityAttempt) &&
-                    (now - lastHostileAbilityAttempt).TotalSeconds <= 30);
+                    (now - lastHostileAbilityAttempt).TotalSeconds <= 30) ||
+                (_lastIncomingDamageActivity.TryGetValue(creature, out var lastIncomingDamage) &&
+                    (now - lastIncomingDamage).TotalSeconds <= 30);
         }
 
         public static void TrackStealthOpeningWindow(uint creature)
@@ -4637,6 +4657,7 @@ namespace SWLOR.Game.Server.Service
             _recentDeflections.Remove(creature);
             _lastCombatActivity.Remove(creature);
             _lastHostileAbilityAttemptActivity.Remove(creature);
+            _lastIncomingDamageActivity.Remove(creature);
             _lastAttackActivity.Remove(creature);
             _lastCombatAbilityUse.Remove(creature);
             foreach (var key in _pendingSuppressionAbilityUses.Keys.Where(x => x.Item1 == creature || x.Item2 == creature).ToList())

--- a/SWLOR.Game.Server/Service/Combat.cs
+++ b/SWLOR.Game.Server/Service/Combat.cs
@@ -2819,7 +2819,14 @@ namespace SWLOR.Game.Server.Service
             if (!GetIsObjectValid(creature))
                 return;
 
-            _lastCombatActivity[creature] = DateTime.UtcNow;
+            var now = DateTime.UtcNow;
+            var isEnteringCombat = !_lastCombatActivity.TryGetValue(creature, out var lastActivity) ||
+                (now - lastActivity).TotalSeconds > 30;
+
+            if (isEnteringCombat)
+                ReportFirstStrikeCombatEntry(creature, now);
+
+            _lastCombatActivity[creature] = now;
         }
 
         public static void TrackAttackActivity(uint creature)
@@ -5792,9 +5799,8 @@ namespace SWLOR.Game.Server.Service
             if (bonus <= 0 || maximumCount <= 0 || ability?.IsHostileAbility != true)
                 return 0;
 
-            RechargeFirstHostileAbilityHitStacks(attacker, maximumCount);
-            _firstHostileAbilityHitCounts.TryGetValue(attacker, out var state);
-            return (state?.Count ?? 0) < maximumCount
+            var state = EnsureFirstHostileAbilityHitState(attacker, maximumCount, bonus, out _);
+            return state.Count < maximumCount
                 ? bonus
                 : 0;
         }
@@ -5805,12 +5811,11 @@ namespace SWLOR.Game.Server.Service
             if (maximumCount <= 0 || ability?.IsHostileAbility != true)
                 return;
 
-            RechargeFirstHostileAbilityHitStacks(attacker, maximumCount);
+            var damageBonus = Stat.GetStatAdjustment(attacker, StatType.FirstHostileAbilityHitDamageBonus);
+            var state = EnsureFirstHostileAbilityHitState(attacker, maximumCount, damageBonus, out _);
 
             var now = DateTime.UtcNow;
-            _firstHostileAbilityHitCounts.TryGetValue(attacker, out var state);
             if (ability.IsAreaAbility &&
-                state != null &&
                 (now - state.LastHit).TotalSeconds <= 1)
             {
                 return;
@@ -5838,16 +5843,83 @@ namespace SWLOR.Game.Server.Service
                 RechargeAvailableAt = rechargeAvailableAt
             };
 
-            var damageBonus = Stat.GetStatAdjustment(attacker, StatType.FirstHostileAbilityHitDamageBonus);
             if (damageBonus > 0 && GetIsPC(attacker))
             {
                 var remaining = maximumCount - newCount;
                 var stackLabel = remaining == 1 ? "stack" : "stacks";
+                var cooldownSeconds = Stat.GetStatAdjustment(attacker, StatType.FirstHostileAbilityHitCooldownSeconds);
+                var rechargeText = remaining == 0
+                    ? cooldownSeconds > 0
+                        ? $"; recharges in {cooldownSeconds} seconds"
+                        : "; recharges after combat"
+                    : string.Empty;
+                var feedback = ColorToken.Combat(
+                    $"First Strike deals +{damageBonus} DMG ({remaining} {stackLabel} remaining{rechargeText}).");
+
+                SendMessageToPC(attacker, feedback);
                 FloatingTextStringOnCreature(
                     ColorToken.Combat($"First Strike +{damageBonus} DMG ({remaining} {stackLabel} remaining)"),
                     attacker,
                     false);
             }
+        }
+
+        private static TargetHitSequenceState EnsureFirstHostileAbilityHitState(
+            uint attacker,
+            int maximumCount,
+            int damageBonus,
+            out bool becameReady)
+        {
+            RechargeFirstHostileAbilityHitStacks(attacker, maximumCount);
+            if (_firstHostileAbilityHitCounts.TryGetValue(attacker, out var state))
+            {
+                becameReady = false;
+                return state;
+            }
+
+            state = new TargetHitSequenceState
+            {
+                Count = 0,
+                LastHit = DateTime.MinValue
+            };
+            _firstHostileAbilityHitCounts[attacker] = state;
+            becameReady = true;
+
+            if (damageBonus > 0 && GetIsPC(attacker))
+            {
+                var stackLabel = maximumCount == 1 ? "stack" : "stacks";
+                var feedback = ColorToken.Combat(
+                    $"First Strike ready: {maximumCount} {stackLabel} (+{damageBonus} DMG each).");
+                SendMessageToPC(attacker, feedback);
+                FloatingTextStringOnCreature(
+                    ColorToken.Combat($"First Strike ready ({maximumCount} {stackLabel})"),
+                    attacker,
+                    false);
+            }
+
+            return state;
+        }
+
+        private static void ReportFirstStrikeCombatEntry(uint attacker, DateTime now)
+        {
+            var maximumCount = Stat.GetStatAdjustment(attacker, StatType.FirstHostileAbilityHitMaximumCount);
+            var damageBonus = Stat.GetStatAdjustment(attacker, StatType.FirstHostileAbilityHitDamageBonus);
+            if (maximumCount <= 0 || damageBonus <= 0)
+                return;
+
+            var state = EnsureFirstHostileAbilityHitState(attacker, maximumCount, damageBonus, out var becameReady);
+            if (becameReady ||
+                state.Count < maximumCount ||
+                state.RechargeAvailableAt == null ||
+                !GetIsPC(attacker))
+            {
+                return;
+            }
+
+            var remainingSeconds = Math.Max(1, (int)Math.Ceiling((state.RechargeAvailableAt.Value - now).TotalSeconds));
+            SendMessageToPC(
+                attacker,
+                ColorToken.Combat($"First Strike is recharging ({remainingSeconds} seconds remaining)."));
         }
 
         private static void RechargeFirstHostileAbilityHitStacks(uint attacker, int maximumCount)

--- a/SWLOR.Game.Server/Service/Combat.cs
+++ b/SWLOR.Game.Server/Service/Combat.cs
@@ -5843,6 +5843,15 @@ namespace SWLOR.Game.Server.Service
                 RechargeAvailableAt = rechargeAvailableAt
             };
 
+            Log.WriteStructured(
+                LogGroup.Attack,
+                "First Strike stack consumed: Attacker={Attacker} Count={Count} MaximumCount={MaximumCount} DamageBonus={DamageBonus} RechargeAvailableAt={RechargeAvailableAt}",
+                attacker,
+                newCount,
+                maximumCount,
+                damageBonus,
+                rechargeAvailableAt);
+
             if (damageBonus > 0 && GetIsPC(attacker))
             {
                 var remaining = maximumCount - newCount;
@@ -5884,6 +5893,14 @@ namespace SWLOR.Game.Server.Service
             };
             _firstHostileAbilityHitCounts[attacker] = state;
             becameReady = true;
+
+            Log.WriteStructured(
+                LogGroup.Attack,
+                "First Strike ready: Attacker={Attacker} Count={Count} MaximumCount={MaximumCount} DamageBonus={DamageBonus}",
+                attacker,
+                state.Count,
+                maximumCount,
+                damageBonus);
 
             if (damageBonus > 0 && GetIsPC(attacker))
             {
@@ -5933,6 +5950,13 @@ namespace SWLOR.Game.Server.Service
                 if (DateTime.UtcNow >= state.RechargeAvailableAt.Value)
                 {
                     _firstHostileAbilityHitCounts.Remove(attacker);
+                    Log.WriteStructured(
+                        LogGroup.Attack,
+                        "First Strike recharged: Attacker={Attacker} PreviousCount={PreviousCount} MaximumCount={MaximumCount} RechargeAvailableAt={RechargeAvailableAt}",
+                        attacker,
+                        state.Count,
+                        maximumCount,
+                        state.RechargeAvailableAt.Value);
                 }
 
                 return;
@@ -5946,6 +5970,12 @@ namespace SWLOR.Game.Server.Service
             }
 
             _firstHostileAbilityHitCounts.Remove(attacker);
+            Log.WriteStructured(
+                LogGroup.Attack,
+                "First Strike reset after combat: Attacker={Attacker} PreviousCount={PreviousCount} MaximumCount={MaximumCount}",
+                attacker,
+                state.Count,
+                maximumCount);
         }
 
         private static int GetAbilityDamageToSourceAppliedStatusTargetAdjustment(

--- a/SWLOR.Game.Server/Service/Combat.cs
+++ b/SWLOR.Game.Server/Service/Combat.cs
@@ -63,6 +63,7 @@ namespace SWLOR.Game.Server.Service
         private static readonly Dictionary<uint, DateTime> _recentGuardedHits = new();
         private static readonly Dictionary<uint, DateTime> _recentDeflections = new();
         private static readonly Dictionary<uint, DateTime> _lastCombatActivity = new();
+        private static readonly Dictionary<uint, DateTime> _lastHostileAbilityAttemptActivity = new();
         private static readonly Dictionary<uint, DateTime> _lastAttackActivity = new();
         private static readonly Dictionary<uint, DateTime> _lastCombatAbilityUse = new();
         private static readonly Dictionary<(uint, uint), SuppressionAbilityUseState> _pendingSuppressionAbilityUses = new();
@@ -2820,8 +2821,7 @@ namespace SWLOR.Game.Server.Service
                 return;
 
             var now = DateTime.UtcNow;
-            var isEnteringCombat = !_lastCombatActivity.TryGetValue(creature, out var lastActivity) ||
-                (now - lastActivity).TotalSeconds > 30;
+            var isEnteringCombat = !HasRecentCombatEntryActivity(creature, now);
 
             if (isEnteringCombat)
                 ReportFirstStrikeCombatEntry(creature, now);
@@ -2840,7 +2840,24 @@ namespace SWLOR.Game.Server.Service
 
         public static void TrackHostileAbilityActivity(uint creature)
         {
-            TrackCombatActivity(creature);
+            if (!GetIsObjectValid(creature))
+                return;
+
+            var now = DateTime.UtcNow;
+            if (!HasRecentCombatEntryActivity(creature, now))
+                ReportFirstStrikeCombatEntry(creature, now);
+
+            // Keep cast attempts separate from landed combat activity. Opening-hit riders such as
+            // Venatic Recovery must still observe the previous landed-combat timestamp.
+            _lastHostileAbilityAttemptActivity[creature] = now;
+        }
+
+        private static bool HasRecentCombatEntryActivity(uint creature, DateTime now)
+        {
+            return (_lastCombatActivity.TryGetValue(creature, out var lastCombatActivity) &&
+                    (now - lastCombatActivity).TotalSeconds <= 30) ||
+                (_lastHostileAbilityAttemptActivity.TryGetValue(creature, out var lastHostileAbilityAttempt) &&
+                    (now - lastHostileAbilityAttempt).TotalSeconds <= 30);
         }
 
         public static void TrackStealthOpeningWindow(uint creature)
@@ -4619,6 +4636,7 @@ namespace SWLOR.Game.Server.Service
             _recentGuardedHits.Remove(creature);
             _recentDeflections.Remove(creature);
             _lastCombatActivity.Remove(creature);
+            _lastHostileAbilityAttemptActivity.Remove(creature);
             _lastAttackActivity.Remove(creature);
             _lastCombatAbilityUse.Remove(creature);
             foreach (var key in _pendingSuppressionAbilityUses.Keys.Where(x => x.Item1 == creature || x.Item2 == creature).ToList())
@@ -5082,12 +5100,14 @@ namespace SWLOR.Game.Server.Service
             int damage,
             bool statusApplied,
             Type primaryStatusEffect,
-            IEnumerable<Type> additionalStatusEffects)
+            IEnumerable<Type> additionalStatusEffects,
+            bool firstHostileAbilityHitDamageBonusApplied)
         {
             if (!GetIsObjectValid(activator) || !GetIsObjectValid(target) || ability == null)
                 return;
 
-            ApplyFirstHostileAbilityHitCount(activator, ability);
+            if (firstHostileAbilityHitDamageBonusApplied)
+                ApplyFirstHostileAbilityHitCount(activator, ability);
             if (ability.IsHostileAbility && !ability.SuppressesSourceStatusStackRiders)
             {
                 ApplySourceStatusStackEffects(activator, target);
@@ -5968,8 +5988,7 @@ namespace SWLOR.Game.Server.Service
             }
 
             // With stacks remaining, refresh to a full set once the wielder drops out of combat so each new engagement opens with all stacks.
-            if (_lastCombatActivity.TryGetValue(attacker, out var lastActivity) &&
-                (DateTime.UtcNow - lastActivity).TotalSeconds <= 30)
+            if (HasRecentCombatEntryActivity(attacker, DateTime.UtcNow))
             {
                 return;
             }

--- a/SWLOR.Game.Server/Service/Combat.cs
+++ b/SWLOR.Game.Server/Service/Combat.cs
@@ -2838,6 +2838,11 @@ namespace SWLOR.Game.Server.Service
             TrackCombatActivity(creature);
         }
 
+        public static void TrackHostileAbilityActivity(uint creature)
+        {
+            TrackCombatActivity(creature);
+        }
+
         public static void TrackStealthOpeningWindow(uint creature)
         {
             if (!GetIsObjectValid(creature) || !IsStealthedOrInvisible(creature))

--- a/SWLOR.Game.Server/Service/Combat.cs
+++ b/SWLOR.Game.Server/Service/Combat.cs
@@ -2825,11 +2825,7 @@ namespace SWLOR.Game.Server.Service
                 return;
 
             var now = DateTime.UtcNow;
-            var isEnteringCombat = !HasRecentCombatEntryActivity(creature, now);
-
-            if (isEnteringCombat)
-                ReportFirstStrikeCombatEntry(creature, now);
-
+            ReportCombatEntryIfNeeded(creature, now);
             _lastCombatActivity[creature] = now;
         }
 
@@ -2848,9 +2844,7 @@ namespace SWLOR.Game.Server.Service
                 return;
 
             var now = DateTime.UtcNow;
-            if (!HasRecentCombatEntryActivity(creature, now))
-                ReportFirstStrikeCombatEntry(creature, now);
-
+            ReportCombatEntryIfNeeded(creature, now);
             // Keep cast attempts separate from landed combat activity. Opening-hit riders such as
             // Venatic Recovery must still observe the previous landed-combat timestamp.
             _lastHostileAbilityAttemptActivity[creature] = now;
@@ -2862,12 +2856,16 @@ namespace SWLOR.Game.Server.Service
                 return;
 
             var now = DateTime.UtcNow;
-            if (!HasRecentCombatEntryActivity(creature, now))
-                ReportFirstStrikeCombatEntry(creature, now);
-
+            ReportCombatEntryIfNeeded(creature, now);
             // Incoming damage starts combat for First Strike visibility without consuming the
             // landed-opening timestamp that Venatic Recovery reads when the defender retaliates.
             _lastIncomingDamageActivity[creature] = now;
+        }
+
+        private static void ReportCombatEntryIfNeeded(uint creature, DateTime now)
+        {
+            if (!HasRecentCombatEntryActivity(creature, now))
+                ReportFirstStrikeCombatEntry(creature, now);
         }
 
         private static bool HasRecentCombatEntryActivity(uint creature, DateTime now)


### PR DESCRIPTION
## Summary

- make First Strike create and report an explicit ready state when combat begins
- add durable combat-log feedback for each consumed stack, exhaustion, and in-progress recharge
- preserve the Bible-defined cross-skill scope for any successfully landed hostile combat ability
- add regression assertions for ready-state creation, combat-entry ordering, feedback, and cross-skill behavior

## Root cause

Available First Strike stacks were represented by the absence of an internal state entry. The bonus worked, but players had no persistent indication that stacks were ready, consumed, exhausted, or recharged, so the tracker test could not verify the trait or its cross-skill behavior.

## Tracker

First Strike III is updated from `Fail` to `Retest` with testing notes. The tracker and Combat Upgrade Bible descriptions already matched, so no description change was required. The live tracker now has no remaining `Fail` rows.

## Verification

- `dotnet build SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj -p:RunPostBuildEvent=Never`
- `dotnet test SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj --no-build --filter "FullyQualifiedName~GeneratedWeaponPerkBehaviorTests|FullyQualifiedName~CombatDamageTests"` (70 passed)
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added First Strike feedback when entering combat, including stack readiness, remaining stacks, and recharge timing.
  - Added combat-log messages when First Strike stacks are consumed.
  - Improved handling of hostile abilities across different skills, including missed abilities.

- **Bug Fixes**
  - Corrected combat activity ordering and First Strike state resets.
  - Fixed stack consumption so stacks are used only when the damage bonus applies.
  - Improved recharge and timestamp handling for hostile activity, avoided attacks, incoming damage, and combat.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->