### PR TITLE
Fix Hutlar dungeon leashing

### DIFF
--- a/SWLOR.Game.Server.Tests/Feature/HutlarSpawnDefinitionTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/HutlarSpawnDefinitionTests.cs
@@ -1,0 +1,39 @@
+using System.Linq;
+using FluentAssertions;
+using NUnit.Framework;
+using SWLOR.Game.Server.Feature.SpawnDefinition;
+using SWLOR.Game.Server.Service.AIService;
+using SWLOR.NWN.API.NWScript.Enum;
+
+namespace SWLOR.Game.Server.Tests.Feature;
+
+public class HutlarSpawnDefinitionTests
+{
+    private static readonly string[] DungeonSpawnTables =
+    {
+        "HUTLAR_DUNGEON_BROODMOTHER",
+        "HUTLAR_DUNGEON_CHIEFTAIN",
+        "HUTLAR_DUNGEON_SHAMAN",
+        "HUTLAR_DUNGEON_CHAMPION",
+        "HUTLAR_DUNGEON_BYYSKGUARDIAN",
+        "HUTLAR_DUNGEON_SLUG",
+        "HUTLAR_DUNGEON_TUNNELER",
+    };
+
+    [Test]
+    public void HutlarDungeonCreaturesReturnHome()
+    {
+        var tables = new HutlarSpawnDefinition().BuildSpawnTables();
+
+        foreach (var tableId in DungeonSpawnTables)
+        {
+            tables.Should().ContainKey(tableId);
+            tables[tableId].Spawns
+                .Where(spawn => spawn.Type == ObjectType.Creature)
+                .Should()
+                .OnlyContain(
+                    spawn => spawn.AIFlags.HasFlag(AIFlag.ReturnHome),
+                    $"{tableId} creatures must leash home instead of accumulating at area transitions");
+        }
+    }
+}

--- a/SWLOR.Game.Server.Tests/Feature/HutlarSpawnDefinitionTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/HutlarSpawnDefinitionTests.cs
@@ -28,12 +28,14 @@ public class HutlarSpawnDefinitionTests
         foreach (var tableId in DungeonSpawnTables)
         {
             tables.Should().ContainKey(tableId);
-            tables[tableId].Spawns
+            var creatureSpawns = tables[tableId].Spawns
                 .Where(spawn => spawn.Type == ObjectType.Creature)
-                .Should()
-                .OnlyContain(
-                    spawn => spawn.AIFlags.HasFlag(AIFlag.ReturnHome),
-                    $"{tableId} creatures must leash home instead of accumulating at area transitions");
+                .ToList();
+
+            creatureSpawns.Should().NotBeEmpty($"{tableId} must define at least one creature spawn");
+            creatureSpawns.Should().OnlyContain(
+                spawn => spawn.AIFlags.HasFlag(AIFlag.ReturnHome),
+                $"{tableId} creatures must leash home instead of accumulating at area transitions");
         }
     }
 }

--- a/SWLOR.Game.Server/Feature/SpawnDefinition/HutlarSpawnDefinition.cs
+++ b/SWLOR.Game.Server/Feature/SpawnDefinition/HutlarSpawnDefinition.cs
@@ -139,44 +139,52 @@ namespace SWLOR.Game.Server.Feature.SpawnDefinition
             _builder.Create("HUTLAR_DUNGEON_BROODMOTHER")
                 .AddSpawn(ObjectType.Creature, "huthivebroodmoth")
                 .WithFrequency(1)
+                .ReturnsHome()
                 .RespawnDelay(120);
 
             _builder.Create("HUTLAR_DUNGEON_CHIEFTAIN")
                 .AddSpawn(ObjectType.Creature, "byysk_chieftain")
                 .WithFrequency(1)
+                .ReturnsHome()
                 .RespawnDelay(20);
 
             _builder.Create("HUTLAR_DUNGEON_SHAMAN")
                 .AddSpawn(ObjectType.Creature, "byysk_shaman")
                 .WithFrequency(1)
+                .ReturnsHome()
                 .RespawnDelay(20);
 
             _builder.Create("HUTLAR_DUNGEON_CHAMPION")
                 .AddSpawn(ObjectType.Creature, "byysk_champion")
                 .WithFrequency(1)
+                .ReturnsHome()
                 .RespawnDelay(20);
 
             _builder.Create("HUTLAR_DUNGEON_BYYSKGUARDIAN")
                 .AddSpawn(ObjectType.Creature, "byysk_guard001")
                 .RandomlyWalks()
                 .WithFrequency(1)
+                .ReturnsHome()
                 .RespawnDelay(2)
 
                 .AddSpawn(ObjectType.Creature, "byysk_guard002")
                 .RandomlyWalks()
                 .WithFrequency(1)
+                .ReturnsHome()
                 .RespawnDelay(2);
 
             _builder.Create("HUTLAR_DUNGEON_SLUG")
                 .AddSpawn(ObjectType.Creature, "qion_slug001")
                 .RandomlyWalks()
                 .WithFrequency(1)
+                .ReturnsHome()
                 .RespawnDelay(4);
 
             _builder.Create("HUTLAR_DUNGEON_TUNNELER")
                 .AddSpawn(ObjectType.Creature, "qion_hive_tunnel")
                 .RandomlyWalks()
                 .WithFrequency(1)
+                .ReturnsHome()
                 .RespawnDelay(4);
         }
 


### PR DESCRIPTION
## Summary
- Add ReturnHome AI flags to Hutlar Qion dungeon creature spawns so combat leash/evade behavior applies.
- Cover the Hutlar dungeon spawn tables with a regression test that requires creature entries to return home.

## Root Cause
Hutlar outdoor Byysk and capstone-site spawns already use `ReturnsHome()`, but the Qion dungeon spawn tables did not. Those dungeon creatures could keep combat/pursuit state after chasing a player toward an area transition, allowing multiple enemies to accumulate near the transition and greet players when they re-entered.

## Validation
- `dotnet build SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj -p:RunPostBuildEvent=Never`
- `dotnet test SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj --no-build --filter "FullyQualifiedName~HutlarSpawnDefinitionTests"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved creature behavior in the Qion dungeon so spawned creatures return to their home positions before respawning.
  * Applied consistent return-home behavior across all Qion dungeon creature types.

* **Tests**
  * Added coverage to verify that all Qion dungeon creature spawns use the return-home behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->