### PR TITLE
Keep ranged NPCs at firing distance

### DIFF
--- a/SWLOR.Game.Server.Tests/AI/AIModelTests.cs
+++ b/SWLOR.Game.Server.Tests/AI/AIModelTests.cs
@@ -519,42 +519,70 @@ public class AIModelTests
             .BeLessThan(pendingAttackBody.IndexOf("pCreature.ResolveAttack(oidTarget, nAttacks, nTimeAnimation);", StringComparison.Ordinal));
     }
 
-    [TestCase(false, false, true)]
-    [TestCase(false, true, false)]
-    [TestCase(true, false, false)]
-    [TestCase(true, true, false)]
-    public void NativeAttackAction_OnlyMeleeAttackersInsideMaximumRangeCloseToPersonalSpace(
+    [TestCase(false, false, 1.5f, 1.5f, true, true)]
+    [TestCase(false, true, 0.25f, 10f, false, false)]
+    [TestCase(true, false, 10f, 10f, true, true)]
+    [TestCase(true, true, 10f, 10f, true, true)]
+    public void NativeAttackAction_BlockedLineMovementPlan_SelectsExecutablePath(
         bool isOutsideAttackRange,
         bool hasRangedWeapon,
-        bool expected)
+        float expectedPathCompletionRange,
+        float expectedAttackCheckRange,
+        bool expectedTrackAttackTarget,
+        bool expectedTargetDestination)
     {
-        var method = typeof(OnAIActionAttackObject).GetMethod(
-            "ShouldUsePersonalSpaceForBlockedLineOfAttack",
-            BindingFlags.Static | BindingFlags.NonPublic);
+        var plan = CreateBlockedLineMovementPlan(
+            10f,
+            0f,
+            0f,
+            0f,
+            0f,
+            0f,
+            2,
+            10f,
+            1.5f,
+            isOutsideAttackRange,
+            hasRangedWeapon);
 
-        method.Should().NotBeNull();
-        method!.Invoke(null, new object[] { isOutsideAttackRange, hasRangedWeapon })
-            .Should()
-            .Be(expected);
+        ReadPlanProperty<float>(plan, "PathCompletionRange").Should().Be(expectedPathCompletionRange);
+        ReadPlanProperty<float>(plan, "AttackCheckRange").Should().Be(expectedAttackCheckRange);
+        ReadPlanProperty<bool>(plan, "TrackAttackTarget").Should().Be(expectedTrackAttackTarget);
+
+        var destinationIsTarget =
+            ReadPlanProperty<float>(plan, "DestinationX") == 0f &&
+            ReadPlanProperty<float>(plan, "DestinationY") == 0f &&
+            ReadPlanProperty<float>(plan, "DestinationZ") == 0f;
+        destinationIsTarget.Should().Be(expectedTargetDestination);
     }
 
     [Test]
-    public void NativeAttackAction_BlockedRangedLinePreservesDesiredAttackRange()
+    public void NativeAttackAction_BlockedRangedLine_ForcesLateralMovementAtFiringDistance()
     {
-        var source = ReadSource("SWLOR.Game.Server", "Native", "OnAIActionAttackObject.cs")
-            .Replace("\r\n", "\n");
-        var movementStart = source.IndexOf(
-            "var fMoveToTargetRange = fDesiredAttackRange;",
-            StringComparison.Ordinal);
-        var movementBody = source.Substring(
-            movementStart,
-            source.IndexOf("var bRunToTarget = true;", movementStart, StringComparison.Ordinal) - movementStart);
+        var plan = CreateBlockedLineMovementPlan(
+            10f,
+            0f,
+            2f,
+            0f,
+            0f,
+            0f,
+            2,
+            10f,
+            1.5f,
+            false,
+            true);
+        var destinationX = ReadPlanProperty<float>(plan, "DestinationX");
+        var destinationY = ReadPlanProperty<float>(plan, "DestinationY");
+        var destinationZ = ReadPlanProperty<float>(plan, "DestinationZ");
 
-        movementBody.Should().Contain(
-            "ShouldUsePersonalSpaceForBlockedLineOfAttack(\n                                    bOutsideAttackRange,\n                                    pCreature.GetRangeWeaponEquipped() == 1)");
-        movementBody.Should().Contain(
-            "fMoveToTargetRange = pCreature.m_pcPathfindInformation.m_fCreaturePersonalSpace;");
-        movementBody.Should().NotContain("if (!bOutsideAttackRange)");
+        destinationX.Should().NotBe(10f);
+        destinationY.Should().NotBe(0f);
+        ReadPlanProperty<float>(plan, "PathCompletionRange").Should().BeLessThan(2f);
+        ReadPlanProperty<float>(plan, "AttackCheckRange").Should().Be(10f);
+        ReadPlanProperty<bool>(plan, "TrackAttackTarget").Should().BeFalse();
+
+        var repositionedRadiusSquared = MathF.Pow(destinationX, 2) + MathF.Pow(destinationY, 2);
+        repositionedRadiusSquared.Should().BeApproximately(100f, 0.001f);
+        destinationZ.Should().Be(2f);
     }
 
     [Test]
@@ -977,6 +1005,47 @@ public class AIModelTests
         return (T)typeof(Enmity)
             .GetField(name, BindingFlags.Static | BindingFlags.NonPublic)!
             .GetValue(null)!;
+    }
+
+    private static object CreateBlockedLineMovementPlan(
+        float attackerX,
+        float attackerY,
+        float attackerZ,
+        float targetX,
+        float targetY,
+        float targetZ,
+        uint attackerId,
+        float desiredAttackRange,
+        float personalSpaceRange,
+        bool isOutsideAttackRange,
+        bool hasRangedWeapon)
+    {
+        var method = typeof(OnAIActionAttackObject).GetMethod(
+            "CreateBlockedLineMovementPlan",
+            BindingFlags.Static | BindingFlags.NonPublic);
+
+        method.Should().NotBeNull();
+        return method!.Invoke(null, new object[]
+        {
+            attackerX,
+            attackerY,
+            attackerZ,
+            targetX,
+            targetY,
+            targetZ,
+            attackerId,
+            desiredAttackRange,
+            personalSpaceRange,
+            isOutsideAttackRange,
+            hasRangedWeapon
+        })!;
+    }
+
+    private static T ReadPlanProperty<T>(object plan, string name)
+    {
+        var property = plan.GetType().GetProperty(name, BindingFlags.Instance | BindingFlags.Public);
+        property.Should().NotBeNull();
+        return (T)property!.GetValue(plan)!;
     }
 
     private static string ReadSource(params string[] pathParts)

--- a/SWLOR.Game.Server.Tests/AI/AIModelTests.cs
+++ b/SWLOR.Game.Server.Tests/AI/AIModelTests.cs
@@ -586,6 +586,30 @@ public class AIModelTests
     }
 
     [Test]
+    public void NativeAttackAction_BlockedRangedLine_OverlapFallbackUsesFiringDistance()
+    {
+        var plan = CreateBlockedLineMovementPlan(
+            0f,
+            0f,
+            2f,
+            0f,
+            0f,
+            0f,
+            3,
+            10f,
+            1.5f,
+            false,
+            true);
+        var destinationX = ReadPlanProperty<float>(plan, "DestinationX");
+        var destinationY = ReadPlanProperty<float>(plan, "DestinationY");
+
+        var destinationRadius = MathF.Sqrt(MathF.Pow(destinationX, 2) + MathF.Pow(destinationY, 2));
+        destinationRadius.Should().BeApproximately(10f, 0.001f);
+        ReadPlanProperty<float>(plan, "AttackCheckRange").Should().Be(10f);
+        ReadPlanProperty<bool>(plan, "TrackAttackTarget").Should().BeFalse();
+    }
+
+    [Test]
     public void CreatureHeartbeat_DoesNotScanForAggroTargets()
     {
         var aiSource = File.ReadAllText(Path.Combine(

--- a/SWLOR.Game.Server.Tests/AI/AIModelTests.cs
+++ b/SWLOR.Game.Server.Tests/AI/AIModelTests.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using System.Text.RegularExpressions;
 using FluentAssertions;
 using NUnit.Framework;
+using SWLOR.Game.Server.Native;
 using SWLOR.Game.Server.Service;
 using SWLOR.Game.Server.Service.AbilityService;
 using SWLOR.Game.Server.Service.AIService;
@@ -516,6 +517,44 @@ public class AIModelTests
         pendingAttackBody.IndexOf("TryCancelAttackForCombatLeash(pCreature, pNode, oidTarget)", StringComparison.Ordinal)
             .Should()
             .BeLessThan(pendingAttackBody.IndexOf("pCreature.ResolveAttack(oidTarget, nAttacks, nTimeAnimation);", StringComparison.Ordinal));
+    }
+
+    [TestCase(false, false, true)]
+    [TestCase(false, true, false)]
+    [TestCase(true, false, false)]
+    [TestCase(true, true, false)]
+    public void NativeAttackAction_OnlyMeleeAttackersInsideMaximumRangeCloseToPersonalSpace(
+        bool isOutsideAttackRange,
+        bool hasRangedWeapon,
+        bool expected)
+    {
+        var method = typeof(OnAIActionAttackObject).GetMethod(
+            "ShouldUsePersonalSpaceForBlockedLineOfAttack",
+            BindingFlags.Static | BindingFlags.NonPublic);
+
+        method.Should().NotBeNull();
+        method!.Invoke(null, new object[] { isOutsideAttackRange, hasRangedWeapon })
+            .Should()
+            .Be(expected);
+    }
+
+    [Test]
+    public void NativeAttackAction_BlockedRangedLinePreservesDesiredAttackRange()
+    {
+        var source = ReadSource("SWLOR.Game.Server", "Native", "OnAIActionAttackObject.cs")
+            .Replace("\r\n", "\n");
+        var movementStart = source.IndexOf(
+            "var fMoveToTargetRange = fDesiredAttackRange;",
+            StringComparison.Ordinal);
+        var movementBody = source.Substring(
+            movementStart,
+            source.IndexOf("var bRunToTarget = true;", movementStart, StringComparison.Ordinal) - movementStart);
+
+        movementBody.Should().Contain(
+            "ShouldUsePersonalSpaceForBlockedLineOfAttack(\n                                    bOutsideAttackRange,\n                                    pCreature.GetRangeWeaponEquipped() == 1)");
+        movementBody.Should().Contain(
+            "fMoveToTargetRange = pCreature.m_pcPathfindInformation.m_fCreaturePersonalSpace;");
+        movementBody.Should().NotContain("if (!bOutsideAttackRange)");
     }
 
     [Test]

--- a/SWLOR.Game.Server.Tests/AI/AIModelTests.cs
+++ b/SWLOR.Game.Server.Tests/AI/AIModelTests.cs
@@ -610,6 +610,75 @@ public class AIModelTests
     }
 
     [Test]
+    public void NativeAttackAction_BlockedRangedLine_NearOverlapStillForcesMovement()
+    {
+        var plan = CreateBlockedLineMovementPlan(
+            0.2f,
+            0f,
+            2f,
+            0f,
+            0f,
+            0f,
+            5,
+            10f,
+            1.5f,
+            false,
+            true);
+        var destinationX = ReadPlanProperty<float>(plan, "DestinationX");
+        var destinationY = ReadPlanProperty<float>(plan, "DestinationY");
+        var distanceFromAttacker = MathF.Sqrt(
+            MathF.Pow(destinationX - 0.2f, 2) +
+            MathF.Pow(destinationY, 2));
+
+        distanceFromAttacker.Should().BeGreaterThan(
+            ReadPlanProperty<float>(plan, "PathCompletionRange"));
+        MathF.Sqrt(MathF.Pow(destinationX, 2) + MathF.Pow(destinationY, 2))
+            .Should()
+            .BeApproximately(10f, 0.001f);
+    }
+
+    [Test]
+    public void NativeAttackAction_BlockedRangedLine_PathFailureAlternatesSidestep()
+    {
+        const uint attackerId = 9001;
+        var firstPlan = CreateBlockedLineMovementPlan(
+            10f,
+            0f,
+            0f,
+            0f,
+            0f,
+            0f,
+            attackerId,
+            10f,
+            1.5f,
+            false,
+            true);
+
+        AlternateRangedRepositionDirection(attackerId);
+
+        var secondPlan = CreateBlockedLineMovementPlan(
+            10f,
+            0f,
+            0f,
+            0f,
+            0f,
+            0f,
+            attackerId,
+            10f,
+            1.5f,
+            false,
+            true);
+
+        ReadPlanProperty<float>(firstPlan, "DestinationX")
+            .Should()
+            .BeApproximately(ReadPlanProperty<float>(secondPlan, "DestinationX"), 0.001f);
+        (ReadPlanProperty<float>(firstPlan, "DestinationY") *
+         ReadPlanProperty<float>(secondPlan, "DestinationY"))
+            .Should()
+            .BeNegative();
+    }
+
+    [Test]
     public void CreatureHeartbeat_DoesNotScanForAggroTargets()
     {
         var aiSource = File.ReadAllText(Path.Combine(
@@ -1070,6 +1139,16 @@ public class AIModelTests
         var property = plan.GetType().GetProperty(name, BindingFlags.Instance | BindingFlags.Public);
         property.Should().NotBeNull();
         return (T)property!.GetValue(plan)!;
+    }
+
+    private static void AlternateRangedRepositionDirection(uint attackerId)
+    {
+        var method = typeof(OnAIActionAttackObject).GetMethod(
+            "AlternateRangedRepositionDirection",
+            BindingFlags.Static | BindingFlags.NonPublic);
+
+        method.Should().NotBeNull();
+        method!.Invoke(null, new object[] { attackerId });
     }
 
     private static string ReadSource(params string[] pathParts)

--- a/SWLOR.Game.Server/Native/OnAIActionAttackObject.cs
+++ b/SWLOR.Game.Server/Native/OnAIActionAttackObject.cs
@@ -294,7 +294,9 @@ namespace SWLOR.Game.Server.Native
 
                         if (bClearLineOfAttack == 0)
                         {
-                            if (!bOutsideAttackRange)
+                            if (ShouldUsePersonalSpaceForBlockedLineOfAttack(
+                                    bOutsideAttackRange,
+                                    pCreature.GetRangeWeaponEquipped() == 1))
                             {
                                 if (pTarget.AsNWSCreature() != null)
                                 {
@@ -667,6 +669,13 @@ namespace SWLOR.Game.Server.Native
 
                 return ACTION_IN_PROGRESS;
             });
+        }
+
+        private static bool ShouldUsePersonalSpaceForBlockedLineOfAttack(
+            bool isOutsideAttackRange,
+            bool hasRangedWeapon)
+        {
+            return !isOutsideAttackRange && !hasRangedWeapon;
         }
 
         private static bool TryCancelAttackForCombatLeash(CNWSCreature pCreature, CNWSObjectActionNode pNode, uint target)

--- a/SWLOR.Game.Server/Native/OnAIActionAttackObject.cs
+++ b/SWLOR.Game.Server/Native/OnAIActionAttackObject.cs
@@ -32,6 +32,10 @@ namespace SWLOR.Game.Server.Native
         private const int CNWSOBJECTACTION_PARAMETER_FLOAT = 2;
         private const int CNWSOBJECTACTION_PARAMETER_OBJECT = 3;
 
+        private const float RANGED_LINE_REPOSITION_ARC_LENGTH = 2.0f;
+        private const float RANGED_LINE_REPOSITION_MAX_ANGLE = 0.7853982f;
+        private const float RANGED_LINE_REPOSITION_COMPLETION_RANGE = 0.25f;
+
         private const int CNWSCOMBATROUND_TYPE_INVALID = 0;
         private const int CNWSCOMBATROUND_TYPE_ATTACK = 1;
         private const int CNWSCOMBATROUND_TYPE_REACTION = 3;
@@ -291,23 +295,42 @@ namespace SWLOR.Game.Server.Native
 
                         var fMoveToTargetRange = fDesiredAttackRange;
                         var fMoveToTargetMaxRange = fMaxAttackRange;
+                        var fPathMoveRange = fMoveToTargetRange;
+                        var vMoveTargetPosition = vTargetPosition;
+                        var bTrackAttackTargetWhileMoving = true;
 
                         if (bClearLineOfAttack == 0)
                         {
-                            if (ShouldUsePersonalSpaceForBlockedLineOfAttack(
-                                    bOutsideAttackRange,
-                                    pCreature.GetRangeWeaponEquipped() == 1))
+                            float fPersonalSpaceRange;
+                            if (pTarget.AsNWSCreature() != null)
                             {
-                                if (pTarget.AsNWSCreature() != null)
-                                {
-                                    fMoveToTargetRange = pCreature.m_pcPathfindInformation.m_fCreaturePersonalSpace;
-                                    fMoveToTargetRange += pTarget.AsNWSCreature().m_pcPathfindInformation.m_fCreaturePersonalSpace;
-                                }
-                                else
-                                {
-                                    fMoveToTargetRange = pCreature.m_pcPathfindInformation.m_fPersonalSpace;
-                                }
+                                fPersonalSpaceRange = pCreature.m_pcPathfindInformation.m_fCreaturePersonalSpace;
+                                fPersonalSpaceRange += pTarget.AsNWSCreature().m_pcPathfindInformation.m_fCreaturePersonalSpace;
                             }
+                            else
+                            {
+                                fPersonalSpaceRange = pCreature.m_pcPathfindInformation.m_fPersonalSpace;
+                            }
+
+                            var movementPlan = CreateBlockedLineMovementPlan(
+                                pCreature.m_vPosition.x,
+                                pCreature.m_vPosition.y,
+                                pCreature.m_vPosition.z,
+                                vTargetPosition.x,
+                                vTargetPosition.y,
+                                vTargetPosition.z,
+                                pCreature.m_idSelf,
+                                fDesiredAttackRange,
+                                fPersonalSpaceRange,
+                                bOutsideAttackRange,
+                                pCreature.GetRangeWeaponEquipped() == 1);
+                            fMoveToTargetRange = movementPlan.AttackCheckRange;
+                            fPathMoveRange = movementPlan.PathCompletionRange;
+                            vMoveTargetPosition = new Vector(
+                                movementPlan.DestinationX,
+                                movementPlan.DestinationY,
+                                movementPlan.DestinationZ);
+                            bTrackAttackTargetWhileMoving = movementPlan.TrackAttackTarget;
 
                             pCreature.m_pcPathfindInformation.m_bUsePlotGridPath = 1;
                         }
@@ -341,21 +364,21 @@ namespace SWLOR.Game.Server.Native
                         {
                             pCreature.AddMoveToPointActionToFront(
                                 pNode.m_nGroupActionId,
-                                vTargetPosition,
+                                vMoveTargetPosition,
                                 oidArea,
                                 OBJECT_INVALID,
                                 bRunToTarget ? 1 : 0,
-                                fMoveToTargetRange);
+                                fPathMoveRange);
                         }
                         else
                         {
                             pCreature.AddMoveToPointActionToFront(
                                 pNode.m_nGroupActionId,
-                                vTargetPosition,
+                                vMoveTargetPosition,
                                 oidArea,
-                                oidAttackTarget,
+                                bTrackAttackTargetWhileMoving ? oidAttackTarget : OBJECT_INVALID,
                                 bRunToTarget ? 1 : 0,
-                                fMoveToTargetRange);
+                                fPathMoveRange);
                         }
 
 
@@ -671,12 +694,99 @@ namespace SWLOR.Game.Server.Native
             });
         }
 
-        private static bool ShouldUsePersonalSpaceForBlockedLineOfAttack(
+        private static BlockedLineMovementPlan CreateBlockedLineMovementPlan(
+            float attackerX,
+            float attackerY,
+            float attackerZ,
+            float targetX,
+            float targetY,
+            float targetZ,
+            uint attackerId,
+            float desiredAttackRange,
+            float personalSpaceRange,
             bool isOutsideAttackRange,
             bool hasRangedWeapon)
         {
-            return !isOutsideAttackRange && !hasRangedWeapon;
+            if (isOutsideAttackRange)
+            {
+                return new BlockedLineMovementPlan(
+                    targetX,
+                    targetY,
+                    targetZ,
+                    desiredAttackRange,
+                    desiredAttackRange,
+                    true);
+            }
+
+            if (!hasRangedWeapon)
+            {
+                return new BlockedLineMovementPlan(
+                    targetX,
+                    targetY,
+                    targetZ,
+                    personalSpaceRange,
+                    personalSpaceRange,
+                    true);
+            }
+
+            var destination = GetRangedLineRepositionDestination(
+                attackerX,
+                attackerY,
+                attackerZ,
+                targetX,
+                targetY,
+                attackerId);
+            return new BlockedLineMovementPlan(
+                destination.X,
+                destination.Y,
+                destination.Z,
+                RANGED_LINE_REPOSITION_COMPLETION_RANGE,
+                desiredAttackRange,
+                false);
         }
+
+        private static RepositionDestination GetRangedLineRepositionDestination(
+            float attackerX,
+            float attackerY,
+            float attackerZ,
+            float targetX,
+            float targetY,
+            uint attackerId)
+        {
+            var x = attackerX - targetX;
+            var y = attackerY - targetY;
+            var radius = MathF.Sqrt(x * x + y * y);
+            var direction = (attackerId & 1) == 0 ? 1f : -1f;
+
+            if (radius <= CNW_PATHFIND_TOLERANCE)
+            {
+                return new RepositionDestination(
+                    attackerX,
+                    attackerY + direction * RANGED_LINE_REPOSITION_ARC_LENGTH,
+                    attackerZ);
+            }
+
+            var angle = MathF.Min(
+                RANGED_LINE_REPOSITION_MAX_ANGLE,
+                RANGED_LINE_REPOSITION_ARC_LENGTH / radius);
+            var cosine = MathF.Cos(angle);
+            var sine = MathF.Sin(angle) * direction;
+
+            return new RepositionDestination(
+                targetX + x * cosine - y * sine,
+                targetY + x * sine + y * cosine,
+                attackerZ);
+        }
+
+        private readonly record struct BlockedLineMovementPlan(
+            float DestinationX,
+            float DestinationY,
+            float DestinationZ,
+            float PathCompletionRange,
+            float AttackCheckRange,
+            bool TrackAttackTarget);
+
+        private readonly record struct RepositionDestination(float X, float Y, float Z);
 
         private static bool TryCancelAttackForCombatLeash(CNWSCreature pCreature, CNWSObjectActionNode pNode, uint target)
         {

--- a/SWLOR.Game.Server/Native/OnAIActionAttackObject.cs
+++ b/SWLOR.Game.Server/Native/OnAIActionAttackObject.cs
@@ -49,6 +49,7 @@ namespace SWLOR.Game.Server.Native
         private const int WEAPON_ATTACK_TYPE_OFFHAND = 2;
 
         private static readonly Dictionary<uint, DateTime> _creatureAttackDelays = new();
+        private static readonly Dictionary<uint, float> _rangedRepositionDirections = new();
 
         internal delegate int AIActionAttackObjectHook(void* pCreature, void* pNode);
 
@@ -81,6 +82,7 @@ namespace SWLOR.Game.Server.Native
                 if (_creatureAttackDelays.ContainsKey(pCreature.m_idSelf) && !GetIsObjectValid(pCreature.m_idSelf))
                 {
                     _creatureAttackDelays.Remove(pCreature.m_idSelf);
+                    _rangedRepositionDirections.Remove(pCreature.m_idSelf);
                     Combat.ClearAttackSwingDebt(pCreature.m_idSelf);
                 }
 
@@ -99,6 +101,8 @@ namespace SWLOR.Game.Server.Native
                     {
                         _creatureAttackDelays.Remove(pCreature.m_idSelf);
                     }
+
+                    _rangedRepositionDirections.Remove(pCreature.m_idSelf);
 
                     Combat.ClearAttackSwingDebt(pCreature.m_idSelf);
 
@@ -268,6 +272,10 @@ namespace SWLOR.Game.Server.Native
                             {
                                 newTarget = pCreature.GetNewCombatTarget(oidAttackTarget);
                             }
+                            else
+                            {
+                                AlternateRangedRepositionDirection(pCreature.m_idSelf);
+                            }
 
                             var bUpdateTarget = false;
                             if (newTarget != null)
@@ -385,6 +393,8 @@ namespace SWLOR.Game.Server.Native
                         return ACTION_COMPLETE;
                     }
                 }
+
+                _rangedRepositionDirections.Remove(pCreature.m_idSelf);
 
 
 
@@ -673,6 +683,7 @@ namespace SWLOR.Game.Server.Native
 
                     if (bTargetActive == false)
                     {
+                        _rangedRepositionDirections.Remove(pCreature.m_idSelf);
                         var newTarget = pCreature.GetNewCombatTarget(oidAttackTarget);
                         oidAttackTarget = OBJECT_INVALID;
 
@@ -758,9 +769,12 @@ namespace SWLOR.Game.Server.Native
             var x = attackerX - targetX;
             var y = attackerY - targetY;
             var radius = MathF.Sqrt(x * x + y * y);
-            var direction = (attackerId & 1) == 0 ? 1f : -1f;
+            var direction = GetRangedRepositionDirection(attackerId);
+            var maximumArcStep =
+                2f * radius * MathF.Sin(RANGED_LINE_REPOSITION_MAX_ANGLE / 2f);
 
-            if (radius <= CNW_PATHFIND_TOLERANCE)
+            if (radius <= CNW_PATHFIND_TOLERANCE ||
+                maximumArcStep <= RANGED_LINE_REPOSITION_COMPLETION_RANGE)
             {
                 return new RepositionDestination(
                     targetX,
@@ -780,6 +794,20 @@ namespace SWLOR.Game.Server.Native
                 attackerZ);
         }
 
+        private static float GetRangedRepositionDirection(uint attackerId)
+        {
+            return _rangedRepositionDirections.TryGetValue(attackerId, out var direction)
+                ? direction
+                : (attackerId & 1) == 0
+                    ? 1f
+                    : -1f;
+        }
+
+        private static void AlternateRangedRepositionDirection(uint attackerId)
+        {
+            _rangedRepositionDirections[attackerId] = -GetRangedRepositionDirection(attackerId);
+        }
+
         private readonly record struct BlockedLineMovementPlan(
             float DestinationX,
             float DestinationY,
@@ -796,6 +824,7 @@ namespace SWLOR.Game.Server.Native
                 return false;
 
             _creatureAttackDelays.Remove(pCreature.m_idSelf);
+            _rangedRepositionDirections.Remove(pCreature.m_idSelf);
             Combat.ClearAttackSwingDebt(pCreature.m_idSelf);
             pCreature.ChangeAttackTarget(pNode, OBJECT_INVALID);
             return true;

--- a/SWLOR.Game.Server/Native/OnAIActionAttackObject.cs
+++ b/SWLOR.Game.Server/Native/OnAIActionAttackObject.cs
@@ -735,7 +735,8 @@ namespace SWLOR.Game.Server.Native
                 attackerZ,
                 targetX,
                 targetY,
-                attackerId);
+                attackerId,
+                desiredAttackRange);
             return new BlockedLineMovementPlan(
                 destination.X,
                 destination.Y,
@@ -751,7 +752,8 @@ namespace SWLOR.Game.Server.Native
             float attackerZ,
             float targetX,
             float targetY,
-            uint attackerId)
+            uint attackerId,
+            float desiredAttackRange)
         {
             var x = attackerX - targetX;
             var y = attackerY - targetY;
@@ -761,8 +763,8 @@ namespace SWLOR.Game.Server.Native
             if (radius <= CNW_PATHFIND_TOLERANCE)
             {
                 return new RepositionDestination(
-                    attackerX,
-                    attackerY + direction * RANGED_LINE_REPOSITION_ARC_LENGTH,
+                    targetX,
+                    targetY + direction * desiredAttackRange,
                     attackerZ);
             }
 


### PR DESCRIPTION
## What changed

- preserve configured firing distance for ranged NPCs instead of forcing them into personal space when line of attack is blocked
- force in-range ranged attackers to sidestep around the target on the same firing radius
- alternate sidestep direction after a failed path so an obstacle on one side does not cause an infinite retry
- handle overlapping and near-overlapping positions with a firing-distance fallback that exceeds the path-completion radius
- retain existing personal-space movement for melee attackers
- add executable regression coverage for all melee/ranged and inside/outside combinations, sidestep geometry, overlap handling, near-overlap handling, and failed-path direction changes

## Root cause

The native attack action replaced the configured desired range with personal space whenever an attacker was inside maximum range but lacked a clear line of attack. Rifle-equipped NPCs therefore closed to melee distance. Simply preserving the desired range was insufficient because an NPC already inside that radius could consider movement complete without changing position.

## Player impact

Ranged NPCs now move to acquire line of sight while maintaining firing distance. They can try the opposite side after a failed path, while melee positioning remains unchanged.

## Validation

- `dotnet build SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj --no-restore -p:RunPostBuildEvent=Never`
- `dotnet test SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj --no-build --filter "FullyQualifiedName~AIModelTests|FullyQualifiedName~EnmityTests"` (68 passed)
- `git diff --check`
- Codex reviewed exact head `0e606ace41` with no major issues
- CodeRabbit exact-head status is successful; all actionable comments are addressed and all review threads are resolved