### PR TITLE
Address post-merge combat review findings

### DIFF
--- a/SWLOR.Game.Server.Tests/Feature/CharacterSheetStatCoverageTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/CharacterSheetStatCoverageTests.cs
@@ -112,6 +112,9 @@ public class CharacterSheetStatCoverageTests
         statusEffects.Should().Contain(
             "Gui.PublishCharacterSheetRefreshEvent(creature, new StatusEffectRemovedRefreshEvent())");
         statusEffects.Should().Contain("if (!isReplacement)");
+        statusEffects.Should().Contain("isReplacement: true");
+        statusEffects.Should().Contain("bool isReplacement = false");
+        statusEffects.Should().MatchRegex(@"removeNativeEffect,\s+isReplacement\);");
 
         var gui = ReadService("Gui.cs");
         gui.Should().Contain("public static void PublishCharacterSheetRefreshEvent<T>(uint target, T payload)");

--- a/SWLOR.Game.Server.Tests/Feature/CharacterSheetStatCoverageTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/CharacterSheetStatCoverageTests.cs
@@ -58,7 +58,8 @@ public class CharacterSheetStatCoverageTests
         var viewModel = ReadViewModel();
 
         viewModel.Should().Contain("AddHighResourceAbilityDamageStats(AddStat);");
-        viewModel.Should().Contain("\"Balanced Current\"");
+        viewModel.Should().Contain("\"High-Resource Ability DMG\"");
+        viewModel.Should().NotContain("\"Balanced Current\"");
         viewModel.Should().Contain("StatType.HighFPAndStaminaAbilityDamageBonusThresholdPercent");
         viewModel.Should().Contain("\"Balanced Attunement\"");
         viewModel.Should().Contain("StatType.HighFPAndStaminaAbilityDamagePercentAdjustmentThresholdPercent");
@@ -94,6 +95,23 @@ public class CharacterSheetStatCoverageTests
         viewModel.Should().Contain("public void Refresh(StatAdjustmentRefreshEvent payload)");
         temporaryModifiers.Should().Contain("Gui.PublishRefreshEvent(creature, new StatAdjustmentRefreshEvent())");
         temporaryModifiers.Should().Contain("if (PurgeExpired(creature))");
+    }
+
+    [Test]
+    public void CharacterSheet_RefreshesWhenStatusEffectStatsChange()
+    {
+        var viewModel = ReadViewModel();
+        var statusEffects = ReadService("StatusEffect.cs");
+
+        viewModel.Should().Contain("IGuiRefreshable<StatusEffectReceivedRefreshEvent>");
+        viewModel.Should().Contain("IGuiRefreshable<StatusEffectRemovedRefreshEvent>");
+        viewModel.Should().Contain("public void Refresh(StatusEffectReceivedRefreshEvent payload)");
+        viewModel.Should().Contain("public void Refresh(StatusEffectRemovedRefreshEvent payload)");
+        statusEffects.Should().Contain(
+            "Gui.PublishRefreshEvent(creature, new StatusEffectReceivedRefreshEvent())");
+        statusEffects.Should().Contain(
+            "Gui.PublishRefreshEvent(creature, new StatusEffectRemovedRefreshEvent())");
+        statusEffects.Should().Contain("if (!isReplacement)");
     }
 
     [Test]

--- a/SWLOR.Game.Server.Tests/Feature/CharacterSheetStatCoverageTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/CharacterSheetStatCoverageTests.cs
@@ -108,10 +108,15 @@ public class CharacterSheetStatCoverageTests
         viewModel.Should().Contain("public void Refresh(StatusEffectReceivedRefreshEvent payload)");
         viewModel.Should().Contain("public void Refresh(StatusEffectRemovedRefreshEvent payload)");
         statusEffects.Should().Contain(
-            "Gui.PublishRefreshEvent(creature, new StatusEffectReceivedRefreshEvent())");
+            "Gui.PublishCharacterSheetRefreshEvent(creature, new StatusEffectReceivedRefreshEvent())");
         statusEffects.Should().Contain(
-            "Gui.PublishRefreshEvent(creature, new StatusEffectRemovedRefreshEvent())");
+            "Gui.PublishCharacterSheetRefreshEvent(creature, new StatusEffectRemovedRefreshEvent())");
         statusEffects.Should().Contain("if (!isReplacement)");
+
+        var gui = ReadService("Gui.cs");
+        gui.Should().Contain("public static void PublishCharacterSheetRefreshEvent<T>(uint target, T payload)");
+        gui.Should().Contain("for (var observer = GetFirstPC(); GetIsObjectValid(observer); observer = GetNextPC())");
+        gui.Should().Contain("!viewModel.IsViewingTarget(target)");
     }
 
     [Test]

--- a/SWLOR.Game.Server.Tests/Feature/CombatBibleSelectiveCorrectionTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/CombatBibleSelectiveCorrectionTests.cs
@@ -11,6 +11,7 @@ namespace SWLOR.Game.Server.Tests.Feature;
 public class CombatBibleSelectiveCorrectionTests
 {
     private static readonly TimeSpan CorrectionTimeout = TimeSpan.FromMinutes(2);
+    private static readonly TimeSpan ProcessTerminationTimeout = TimeSpan.FromSeconds(10);
 
     private static readonly XNamespace SpreadsheetNs =
         "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
@@ -154,6 +155,18 @@ public class CombatBibleSelectiveCorrectionTests
             catch (InvalidOperationException)
             {
                 // The process exited after the timeout fired but before it could be killed.
+            }
+
+            try
+            {
+                await completionTask.WaitAsync(ProcessTerminationTimeout);
+            }
+            catch (TimeoutException terminationTimeoutException)
+            {
+                throw new TimeoutException(
+                    $"Combat Bible correction exceeded its {CorrectionTimeout.TotalSeconds:0}-second limit " +
+                    $"and did not terminate within {ProcessTerminationTimeout.TotalSeconds:0} seconds after being killed.",
+                    new AggregateException(timeoutException, terminationTimeoutException));
             }
 
             throw new TimeoutException(

--- a/SWLOR.Game.Server.Tests/Feature/CombatBibleSelectiveCorrectionTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/CombatBibleSelectiveCorrectionTests.cs
@@ -7,8 +7,11 @@ using NUnit.Framework;
 
 namespace SWLOR.Game.Server.Tests.Feature;
 
+[Platform(Include = "Win")]
 public class CombatBibleSelectiveCorrectionTests
 {
+    private static readonly TimeSpan CorrectionTimeout = TimeSpan.FromMinutes(2);
+
     private static readonly XNamespace SpreadsheetNs =
         "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
     private static readonly XNamespace DocumentRelationshipNs =
@@ -17,7 +20,7 @@ public class CombatBibleSelectiveCorrectionTests
         "http://schemas.openxmlformats.org/package/2006/relationships";
 
     [Test]
-    public void SelectivePerkMode_ChangesOnlyOneSelectedPerk()
+    public async Task SelectivePerkMode_ChangesOnlyOneSelectedPerk()
     {
         var workbook = CopyBibleToTemporaryFile();
         try
@@ -27,7 +30,7 @@ public class CombatBibleSelectiveCorrectionTests
             var characterStatsBefore = ReadSheetXml(workbook, "Character Stats");
             var auditBefore = ReadSheetXml(workbook, "Combat Balance Findings");
 
-            var result = RunCorrection(workbook, new[] { "Force Sheath II" });
+            var result = await RunCorrection(workbook, new[] { "Force Sheath II" });
 
             result.ExitCode.Should().Be(0, result.Error);
             ReadPerkDescription(workbook, "Lightsaber", "Force Sheath II")
@@ -44,7 +47,7 @@ public class CombatBibleSelectiveCorrectionTests
     }
 
     [Test]
-    public void SelectivePerkMode_ChangesOnlyMultipleSelectedPerks()
+    public async Task SelectivePerkMode_ChangesOnlyMultipleSelectedPerks()
     {
         var workbook = CopyBibleToTemporaryFile();
         try
@@ -55,7 +58,7 @@ public class CombatBibleSelectiveCorrectionTests
             var characterStatsBefore = ReadSheetXml(workbook, "Character Stats");
             var auditBefore = ReadSheetXml(workbook, "Combat Balance Findings");
 
-            var result = RunCorrection(workbook, new[] { "Force Sheath II", "Force Sheath III" });
+            var result = await RunCorrection(workbook, new[] { "Force Sheath II", "Force Sheath III" });
 
             result.ExitCode.Should().Be(0, result.Error);
             ReadPerkDescription(workbook, "Lightsaber", "Force Sheath II")
@@ -75,15 +78,15 @@ public class CombatBibleSelectiveCorrectionTests
 
     [TestCase(false)]
     [TestCase(true)]
-    public void SelectivePerkMode_InvalidOrConflictingArgumentsDoNotModifyWorkbook(bool conflictingModes)
+    public async Task SelectivePerkMode_InvalidOrConflictingArgumentsDoNotModifyWorkbook(bool conflictingModes)
     {
         var workbook = CopyBibleToTemporaryFile();
         try
         {
             var before = File.ReadAllBytes(workbook);
             var result = conflictingModes
-                ? RunCorrection(workbook, new[] { "Force Sheath II" }, espionageStealthOnly: true)
-                : RunCorrection(workbook, new[] { "Not A Real Perk" });
+                ? await RunCorrection(workbook, new[] { "Force Sheath II" }, espionageStealthOnly: true)
+                : await RunCorrection(workbook, new[] { "Not A Real Perk" });
 
             result.ExitCode.Should().NotBe(0);
             File.ReadAllBytes(workbook).Should().Equal(before,
@@ -104,7 +107,7 @@ public class CombatBibleSelectiveCorrectionTests
         return destination;
     }
 
-    private static (int ExitCode, string Output, string Error) RunCorrection(
+    private static async Task<(int ExitCode, string Output, string Error)> RunCorrection(
         string workbook,
         IReadOnlyCollection<string> perkNames,
         bool espionageStealthOnly = false)
@@ -134,9 +137,32 @@ public class CombatBibleSelectiveCorrectionTests
         startInfo.ArgumentList.Add(command);
 
         using var process = Process.Start(startInfo)!;
-        var output = process.StandardOutput.ReadToEnd();
-        var error = process.StandardError.ReadToEnd();
-        process.WaitForExit();
+        var outputTask = process.StandardOutput.ReadToEndAsync();
+        var errorTask = process.StandardError.ReadToEndAsync();
+        var completionTask = Task.WhenAll(process.WaitForExitAsync(), outputTask, errorTask);
+
+        try
+        {
+            await completionTask.WaitAsync(CorrectionTimeout);
+        }
+        catch (TimeoutException timeoutException)
+        {
+            try
+            {
+                process.Kill(entireProcessTree: true);
+            }
+            catch (InvalidOperationException)
+            {
+                // The process exited after the timeout fired but before it could be killed.
+            }
+
+            throw new TimeoutException(
+                $"Combat Bible correction exceeded its {CorrectionTimeout.TotalSeconds:0}-second limit.",
+                timeoutException);
+        }
+
+        var output = await outputTask;
+        var error = await errorTask;
         return (process.ExitCode, output, error);
     }
 

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/CharacterSheetViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/CharacterSheetViewModel.cs
@@ -47,6 +47,11 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
         private uint _target;
         private bool _isSynchronizingTabRows;
 
+        public bool IsViewingTarget(uint target)
+        {
+            return _target == target;
+        }
+
         public int SelectedTabId
         {
             get => Get<int>();

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/CharacterSheetViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/CharacterSheetViewModel.cs
@@ -969,9 +969,9 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             {
                 var active = Combat.IsCurrentFPAndStaminaAtOrAbovePercent(_target, flatThreshold);
                 addStat(
-                    "Balanced Current",
+                    "High-Resource Ability DMG",
                     active ? $"Active (+{flatBonus} DMG)" : $"Inactive ({flatThreshold}% required)",
-                    $"Hostile combat abilities gain +{flatBonus} DMG while FP and STM are both at least {flatThreshold}%.");
+                    $"Combined conditional bonus: hostile combat abilities gain +{flatBonus} DMG while FP and STM are both at least {flatThreshold}%.");
             }
 
             var percentBonus = Stat.GetStatAdjustment(

--- a/SWLOR.Game.Server/Service/Gui.cs
+++ b/SWLOR.Game.Server/Service/Gui.cs
@@ -4,6 +4,7 @@ using SWLOR.Game.Server.Core;
 using SWLOR.Game.Server.Entity;
 using SWLOR.Game.Server.Feature.GuiDefinition.Payload;
 using SWLOR.Game.Server.Feature.GuiDefinition.RefreshEvent;
+using SWLOR.Game.Server.Feature.GuiDefinition.ViewModel;
 using SWLOR.Game.Server.Service.GuiService;
 using SWLOR.Game.Server.Service.GuiService.Component;
 using SWLOR.NWN.API.NWScript.Enum;
@@ -372,6 +373,32 @@ namespace SWLOR.Game.Server.Service
 
                 if(NuiFindWindow(player, windowId) != 0)
                     ((IGuiRefreshable<T>)playerWindow.ViewModel).Refresh(payload);
+            }
+        }
+
+        /// <summary>
+        /// Refreshes every open character sheet currently displaying the supplied target.
+        /// This includes sheets opened by another player, such as DM-inspected creatures.
+        /// </summary>
+        public static void PublishCharacterSheetRefreshEvent<T>(uint target, T payload)
+            where T : IGuiRefreshEvent
+        {
+            var windowId = BuildWindowId(GuiWindowType.CharacterSheet);
+
+            for (var observer = GetFirstPC(); GetIsObjectValid(observer); observer = GetNextPC())
+            {
+                var observerId = GetObjectUUID(observer);
+                if (!_playerWindows.TryGetValue(observerId, out var windows) ||
+                    !windows.TryGetValue(GuiWindowType.CharacterSheet, out var playerWindow) ||
+                    NuiFindWindow(observer, windowId) == 0 ||
+                    playerWindow.ViewModel is not CharacterSheetViewModel viewModel ||
+                    !viewModel.IsViewingTarget(target) ||
+                    viewModel is not IGuiRefreshable<T> refreshable)
+                {
+                    continue;
+                }
+
+                refreshable.Refresh(payload);
             }
         }
 

--- a/SWLOR.Game.Server/Service/StatusEffect.cs
+++ b/SWLOR.Game.Server/Service/StatusEffect.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using SWLOR.Game.Server.Core;
+using SWLOR.Game.Server.Feature.GuiDefinition.RefreshEvent;
 using SWLOR.Game.Server.Feature.StatusEffectDefinition;
 using SWLOR.Game.Server.Service.CombatService;
 using SWLOR.Game.Server.Service.StatService;
@@ -570,6 +571,7 @@ namespace SWLOR.Game.Server.Service
 
             ApplyTrackedNWNEffect(creature, statusEffect, durationTicks, isPermanent);
             Combat.ApplyStatusAppliedTargetStaminaDrain(source, creature, statusEffect.Categories);
+            PublishStatusEffectReceivedRefresh(creature);
 
             if (!string.IsNullOrWhiteSpace(durationResistanceMessage) &&
                 (GetIsPC(source) || GetIsDM(source)))
@@ -1556,6 +1558,11 @@ namespace SWLOR.Game.Server.Service
             {
                 DelayCommand(0.1f, () => Stat.ApplyCreatureMovementRate(creature));
             }
+
+            if (!isReplacement)
+            {
+                PublishStatusEffectRemovedRefresh(creature);
+            }
         }
 
         /// <summary>
@@ -1640,6 +1647,24 @@ namespace SWLOR.Game.Server.Service
         private static bool HasStatAdjustment(IStatusEffect statusEffect)
         {
             return statusEffect.StatGroup.Stats.Any(stat => stat.Value != 0);
+        }
+
+        private static void PublishStatusEffectReceivedRefresh(uint creature)
+        {
+            if (GetIsPC(creature))
+            {
+                DelayCommand(0.0f, () =>
+                    Gui.PublishRefreshEvent(creature, new StatusEffectReceivedRefreshEvent()));
+            }
+        }
+
+        private static void PublishStatusEffectRemovedRefresh(uint creature)
+        {
+            if (GetIsPC(creature))
+            {
+                DelayCommand(0.0f, () =>
+                    Gui.PublishRefreshEvent(creature, new StatusEffectRemovedRefreshEvent()));
+            }
         }
 
         private static void RemoveNativeStatusEffect(uint creature, string statusEffectId)

--- a/SWLOR.Game.Server/Service/StatusEffect.cs
+++ b/SWLOR.Game.Server/Service/StatusEffect.cs
@@ -1394,7 +1394,8 @@ namespace SWLOR.Game.Server.Service
                 sendsWornOffMessage,
                 statusEffectType,
                 removeNativeEffect,
-                source);
+                source,
+                isReplacement: true);
         }
 
         public static List<Type> GetStatusEffectsFromIcon(EffectIconType effectIcon)
@@ -1684,7 +1685,8 @@ namespace SWLOR.Game.Server.Service
             bool sendsWornOffMessage = true,
             Type excludedStatusEffectType = null,
             bool removeNativeEffect = true,
-            uint filterBySource = OBJECT_INVALID)
+            uint filterBySource = OBJECT_INVALID,
+            bool isReplacement = false)
         {
             var creatureEffects = GetCreatureStatusEffects(creature);
             var effects = creatureEffects.GetAllBySourceType(sourceType);
@@ -1696,7 +1698,13 @@ namespace SWLOR.Game.Server.Service
                 if (filterBySource != OBJECT_INVALID && effect.Source != filterBySource)
                     continue;
 
-                RemoveStatusEffect(effect.GetType(), creature, effect.Source, sendsWornOffMessage, removeNativeEffect);
+                RemoveStatusEffect(
+                    effect.GetType(),
+                    creature,
+                    effect.Source,
+                    sendsWornOffMessage,
+                    removeNativeEffect,
+                    isReplacement);
             }
         }
 

--- a/SWLOR.Game.Server/Service/StatusEffect.cs
+++ b/SWLOR.Game.Server/Service/StatusEffect.cs
@@ -1651,18 +1651,12 @@ namespace SWLOR.Game.Server.Service
 
         private static void PublishStatusEffectReceivedRefresh(uint creature)
         {
-            if (GetIsPC(creature))
-            {
-                Gui.PublishRefreshEvent(creature, new StatusEffectReceivedRefreshEvent());
-            }
+            Gui.PublishCharacterSheetRefreshEvent(creature, new StatusEffectReceivedRefreshEvent());
         }
 
         private static void PublishStatusEffectRemovedRefresh(uint creature)
         {
-            if (GetIsPC(creature))
-            {
-                Gui.PublishRefreshEvent(creature, new StatusEffectRemovedRefreshEvent());
-            }
+            Gui.PublishCharacterSheetRefreshEvent(creature, new StatusEffectRemovedRefreshEvent());
         }
 
         private static void RemoveNativeStatusEffect(uint creature, string statusEffectId)

--- a/SWLOR.Game.Server/Service/StatusEffect.cs
+++ b/SWLOR.Game.Server/Service/StatusEffect.cs
@@ -1653,8 +1653,7 @@ namespace SWLOR.Game.Server.Service
         {
             if (GetIsPC(creature))
             {
-                DelayCommand(0.0f, () =>
-                    Gui.PublishRefreshEvent(creature, new StatusEffectReceivedRefreshEvent()));
+                Gui.PublishRefreshEvent(creature, new StatusEffectReceivedRefreshEvent());
             }
         }
 
@@ -1662,8 +1661,7 @@ namespace SWLOR.Game.Server.Service
         {
             if (GetIsPC(creature))
             {
-                DelayCommand(0.0f, () =>
-                    Gui.PublishRefreshEvent(creature, new StatusEffectRemovedRefreshEvent()));
+                Gui.PublishRefreshEvent(creature, new StatusEffectRemovedRefreshEvent());
             }
         }
 


### PR DESCRIPTION
## Summary

- drain PowerShell stdout and stderr concurrently in the combat Bible selective-correction tests
- enforce a two-minute process timeout, terminate the full process tree on timeout, and skip the fixture on non-Windows hosts
- refresh open character sheets when status effects that back live stats are applied, replaced, stacked, or removed
- use a source-neutral `High-Resource Ability DMG` label for the combined Balanced Current / Infinite Conduit flat bonus

Follow-up to merged PR #2164. Addresses:

- https://github.com/zunath/SWLOR_NWN/pull/2164#discussion_r3771660108
- https://github.com/zunath/SWLOR_NWN/pull/2164#discussion_r3771694499
- https://github.com/zunath/SWLOR_NWN/pull/2164#discussion_r3771694509

The associated merged Haks PR #375 has no unresolved review findings and requires no follow-up asset change.

## Validation

- `dotnet build SWLOR.Game.Server.Tests\\SWLOR.Game.Server.Tests.csproj -p:RunPostBuildEvent=Never`
- 42 focused character-sheet, status-effect, combat Bible, saberstaff, and cross-skill regression tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Character sheets now refresh automatically when status effects are applied or removed.
  * Status-effect replacement avoids unnecessary intermediate refreshes.

* **Improvements**
  * Updated the flat-damage stat label to “High-Resource Ability DMG” with clearer tooltip information.

* **Tests**
  * Expanded coverage for character-sheet updates and high-resource ability labels.
  * Improved reliability and timeout handling for Windows-only combat correction tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->