### PR TITLE
Normalize NPC HP budgets against native Vitality

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,12 @@ This file is the shared rule set for all coding agents. Codex reads it natively;
 - `StatType` classification, polarity, or category decisions must be declared with `StatTypeAttribute` on the enum entry. Do not add large `if`/`switch` lists elsewhere to infer stat meaning; shared systems should read the enum metadata instead.
 - Attack Deflection, Shield Deflection, and Guard are separate combat mechanics. Attack Deflection and Shield Deflection are attack-roll outcomes that negate the hit and do not stack with each other; Guard is a damage-stage outcome that reduces damage and increases enmity. Do not implement one by reusing the state, stats, logs, or triggers of another.
 
+## NPC Hit Point Budgets
+
+- A stat skin's `NPCHP` is the NPC's final maximum HP budget. NWN stores `HitPoints` as base HP, then derives maximum HP by applying the Constitution modifier (SWLOR Vitality) once per class level, Toughness once per level, and 20 HP for each Epic Toughness feat. Do not set UTC `HitPoints` directly to `NPCHP`: set `CurrentHitPoints` and `MaxHitPoints` to `NPCHP`, and set `HitPoints` to `NPCHP` minus those native bonuses.
+- Apply runtime NPC HP budgets through `Stat.SetNPCMaxHitPoints` only, after the raw Vitality score has been finalized. `ObjectPlugin.SetMaxHitPoints` writes native base HP and therefore must not receive an `NPCHP` final budget directly.
+- After adding or restatting NPCHP-backed creatures, run `powershell -ExecutionPolicy Bypass -File tools/NormalizeNpcHitPoints.ps1`. Use `-CheckOnly` in audits. `NPCEnemyBalanceAuditTests.AllNpcHpBudgets_AccountForNativeVitalityAndToughnessRules` protects the complete corpus.
+
 ## Player Identity
 
 - Player-facing surfaces must use the `PlayerName` service instead of raw player names. For live player objects, use `PlayerName.GetDisplayName(observer, target)` or `PlayerName.GetColoredDisplayName(observer, target)`. For offline/persisted player records, use `PlayerName.GetDisplayNameByPlayerId(observer, playerId, fallbackName)`.

--- a/Module/utc/ancientsandwor.utc.json
+++ b/Module/utc/ancientsandwor.utc.json
@@ -192,7 +192,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 8367
+    "value": 7917
   },
   "Int": {
     "type": "byte",
@@ -226,7 +226,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 8817
+    "value": 8367
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/banecaller.utc.json
+++ b/Module/utc/banecaller.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2075
+    "value": 2012
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/barrieroverse.utc.json
+++ b/Module/utc/barrieroverse.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2075
+    "value": 2012
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/beaconmarks.utc.json
+++ b/Module/utc/beaconmarks.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2197
+    "value": 2089
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/bf_butcher.utc.json
+++ b/Module/utc/bf_butcher.utc.json
@@ -276,7 +276,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2441
+    "value": 2333
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/bf_duelist.utc.json
+++ b/Module/utc/bf_duelist.utc.json
@@ -269,7 +269,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1573
+    "value": 1474
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/bf_kess.utc.json
+++ b/Module/utc/bf_kess.utc.json
@@ -297,7 +297,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 5425
+    "value": 5317
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/bf_pulsedroid.utc.json
+++ b/Module/utc/bf_pulsedroid.utc.json
@@ -199,7 +199,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 977
+    "value": 537
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/bf_scavenger.utc.json
+++ b/Module/utc/bf_scavenger.utc.json
@@ -262,7 +262,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1085
+    "value": 986
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/blackoutwrd.utc.json
+++ b/Module/utc/blackoutwrd.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2075
+    "value": 2012
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/blastbreaker.utc.json
+++ b/Module/utc/blastbreaker.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2441
+    "value": 2333
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/bolboss.utc.json
+++ b/Module/utc/bolboss.utc.json
@@ -157,7 +157,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 922
+    "value": 682
   },
   "Int": {
     "type": "byte",
@@ -191,7 +191,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1162
+    "value": 922
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/bulwark.utc.json
+++ b/Module/utc/bulwark.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 3296
+    "value": 3152
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/bunkerbreak.utc.json
+++ b/Module/utc/bunkerbreak.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2441
+    "value": 2333
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/byysk_champion.utc.json
+++ b/Module/utc/byysk_champion.utc.json
@@ -297,7 +297,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2197
+    "value": 2089
   },
   "Int": {
     "type": "byte",
@@ -331,7 +331,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2305
+    "value": 2197
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/byysk_chieftain.utc.json
+++ b/Module/utc/byysk_chieftain.utc.json
@@ -339,7 +339,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4883
+    "value": 4775
   },
   "Int": {
     "type": "byte",
@@ -373,7 +373,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4991
+    "value": 4883
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/byysk_cryoadept.utc.json
+++ b/Module/utc/byysk_cryoadept.utc.json
@@ -255,7 +255,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2319
+    "value": 2211
   },
   "Int": {
     "type": "byte",
@@ -289,7 +289,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2427
+    "value": 2319
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/byysk_guard001.utc.json
+++ b/Module/utc/byysk_guard001.utc.json
@@ -262,7 +262,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2197
+    "value": 2089
   },
   "Int": {
     "type": "byte",
@@ -296,7 +296,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2305
+    "value": 2197
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/byysk_guard002.utc.json
+++ b/Module/utc/byysk_guard002.utc.json
@@ -276,7 +276,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2441
+    "value": 2333
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/byysk_shaman.utc.json
+++ b/Module/utc/byysk_shaman.utc.json
@@ -248,7 +248,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2319
+    "value": 2211
   },
   "Int": {
     "type": "byte",
@@ -282,7 +282,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2427
+    "value": 2319
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/byysk_warrior.utc.json
+++ b/Module/utc/byysk_warrior.utc.json
@@ -227,7 +227,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 553
+    "value": 526
   },
   "Int": {
     "type": "byte",
@@ -261,7 +261,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 580
+    "value": 553
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/byysk_warrior2.utc.json
+++ b/Module/utc/byysk_warrior2.utc.json
@@ -241,7 +241,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 586
+    "value": 523
   },
   "Int": {
     "type": "byte",
@@ -275,7 +275,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 649
+    "value": 586
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/canyonbulwrk.utc.json
+++ b/Module/utc/canyonbulwrk.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2441
+    "value": 2333
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/chemslinger.utc.json
+++ b/Module/utc/chemslinger.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2197
+    "value": 2089
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/colicoidexp.utc.json
+++ b/Module/utc/colicoidexp.utc.json
@@ -141,7 +141,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 85
+    "value": 95
   },
   "Int": {
     "type": "byte",
@@ -175,7 +175,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 75
+    "value": 85
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/conduitmatrn.utc.json
+++ b/Module/utc/conduitmatrn.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2075
+    "value": 2012
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/cp_absdef_ad.utc.json
+++ b/Module/utc/cp_absdef_ad.utc.json
@@ -276,7 +276,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2124
+    "value": 1989
   },
   "Int": {
     "type": "byte",
@@ -310,7 +310,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2259
+    "value": 2124
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_absdef_ic.utc.json
+++ b/Module/utc/cp_absdef_ic.utc.json
@@ -283,7 +283,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2802
+    "value": 2658
   },
   "Int": {
     "type": "byte",
@@ -317,7 +317,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2946
+    "value": 2802
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_absdef_ms.utc.json
+++ b/Module/utc/cp_absdef_ms.utc.json
@@ -304,7 +304,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 10254
+    "value": 10110
   },
   "Int": {
     "type": "byte",
@@ -338,7 +338,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 10398
+    "value": 10254
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_absdef_sp.utc.json
+++ b/Module/utc/cp_absdef_sp.utc.json
@@ -220,7 +220,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4614
+    "value": 3974
   },
   "Int": {
     "type": "byte",
@@ -254,7 +254,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 5254
+    "value": 4614
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_absdef_wd.utc.json
+++ b/Module/utc/cp_absdef_wd.utc.json
@@ -297,7 +297,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 10254
+    "value": 10110
   },
   "Int": {
     "type": "byte",
@@ -331,7 +331,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 10398
+    "value": 10254
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_adamguard_ad.utc.json
+++ b/Module/utc/cp_adamguard_ad.utc.json
@@ -276,7 +276,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2124
+    "value": 1989
   },
   "Int": {
     "type": "byte",
@@ -310,7 +310,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2259
+    "value": 2124
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_adamguard_ic.utc.json
+++ b/Module/utc/cp_adamguard_ic.utc.json
@@ -283,7 +283,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 3296
+    "value": 3152
   },
   "Int": {
     "type": "byte",
@@ -317,7 +317,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 3440
+    "value": 3296
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_adamguard_ms.utc.json
+++ b/Module/utc/cp_adamguard_ms.utc.json
@@ -304,7 +304,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 10254
+    "value": 10110
   },
   "Int": {
     "type": "byte",
@@ -338,7 +338,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 10398
+    "value": 10254
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_adamguard_sp.utc.json
+++ b/Module/utc/cp_adamguard_sp.utc.json
@@ -220,7 +220,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4614
+    "value": 3974
   },
   "Int": {
     "type": "byte",
@@ -254,7 +254,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 5254
+    "value": 4614
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_adamguard_wd.utc.json
+++ b/Module/utc/cp_adamguard_wd.utc.json
@@ -297,7 +297,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 10254
+    "value": 10110
   },
   "Int": {
     "type": "byte",
@@ -331,7 +331,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 10398
+    "value": 10254
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_alpharhy_ad.utc.json
+++ b/Module/utc/cp_alpharhy_ad.utc.json
@@ -157,7 +157,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1495
+    "value": 1055
   },
   "Int": {
     "type": "byte",
@@ -191,7 +191,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1935
+    "value": 1495
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_alpharhy_ic.utc.json
+++ b/Module/utc/cp_alpharhy_ic.utc.json
@@ -164,7 +164,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1971
+    "value": 1491
   },
   "Int": {
     "type": "byte",
@@ -198,7 +198,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2451
+    "value": 1971
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_alpharhy_ms.utc.json
+++ b/Module/utc/cp_alpharhy_ms.utc.json
@@ -192,7 +192,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 5154
+    "value": 5046
   },
   "Int": {
     "type": "byte",
@@ -226,7 +226,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 5262
+    "value": 5154
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_alpharhy_sp.utc.json
+++ b/Module/utc/cp_alpharhy_sp.utc.json
@@ -164,7 +164,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2319
+    "value": 1839
   },
   "Int": {
     "type": "byte",
@@ -198,7 +198,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2799
+    "value": 2319
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_alpharhy_wd.utc.json
+++ b/Module/utc/cp_alpharhy_wd.utc.json
@@ -185,7 +185,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 5154
+    "value": 5046
   },
   "Int": {
     "type": "byte",
@@ -219,7 +219,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 5262
+    "value": 5154
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_apexbite_ad.utc.json
+++ b/Module/utc/cp_apexbite_ad.utc.json
@@ -157,7 +157,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1573
+    "value": 1133
   },
   "Int": {
     "type": "byte",
@@ -191,7 +191,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2013
+    "value": 1573
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_apexbite_ic.utc.json
+++ b/Module/utc/cp_apexbite_ic.utc.json
@@ -164,7 +164,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2441
+    "value": 1961
   },
   "Int": {
     "type": "byte",
@@ -198,7 +198,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2921
+    "value": 2441
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_apexbite_ms.utc.json
+++ b/Module/utc/cp_apexbite_ms.utc.json
@@ -192,7 +192,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4611
+    "value": 4503
   },
   "Int": {
     "type": "byte",
@@ -226,7 +226,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4719
+    "value": 4611
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_apexbite_sp.utc.json
+++ b/Module/utc/cp_apexbite_sp.utc.json
@@ -164,7 +164,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2075
+    "value": 1595
   },
   "Int": {
     "type": "byte",
@@ -198,7 +198,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2555
+    "value": 2075
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_apexbite_wd.utc.json
+++ b/Module/utc/cp_apexbite_wd.utc.json
@@ -185,7 +185,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4611
+    "value": 4503
   },
   "Int": {
     "type": "byte",
@@ -219,7 +219,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4719
+    "value": 4611
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_cripdef_ad.utc.json
+++ b/Module/utc/cp_cripdef_ad.utc.json
@@ -276,7 +276,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2124
+    "value": 1989
   },
   "Int": {
     "type": "byte",
@@ -310,7 +310,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2259
+    "value": 2124
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_cripdef_ic.utc.json
+++ b/Module/utc/cp_cripdef_ic.utc.json
@@ -283,7 +283,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 3296
+    "value": 3152
   },
   "Int": {
     "type": "byte",
@@ -317,7 +317,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 3440
+    "value": 3296
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_cripdef_ms.utc.json
+++ b/Module/utc/cp_cripdef_ms.utc.json
@@ -304,7 +304,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 10254
+    "value": 10110
   },
   "Int": {
     "type": "byte",
@@ -338,7 +338,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 10398
+    "value": 10254
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_cripdef_sp.utc.json
+++ b/Module/utc/cp_cripdef_sp.utc.json
@@ -220,7 +220,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4614
+    "value": 3974
   },
   "Int": {
     "type": "byte",
@@ -254,7 +254,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 5254
+    "value": 4614
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_cripdef_wd.utc.json
+++ b/Module/utc/cp_cripdef_wd.utc.json
@@ -297,7 +297,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 10254
+    "value": 10110
   },
   "Int": {
     "type": "byte",
@@ -331,7 +331,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 10398
+    "value": 10254
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_darkhung_ad.utc.json
+++ b/Module/utc/cp_darkhung_ad.utc.json
@@ -276,7 +276,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1337
+    "value": 1283
   },
   "Int": {
     "type": "byte",
@@ -310,7 +310,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1391
+    "value": 1337
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_darkhung_ic.utc.json
+++ b/Module/utc/cp_darkhung_ic.utc.json
@@ -283,7 +283,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2075
+    "value": 2012
   },
   "Int": {
     "type": "byte",
@@ -317,7 +317,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2138
+    "value": 2075
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_darkhung_ms.utc.json
+++ b/Module/utc/cp_darkhung_ms.utc.json
@@ -304,7 +304,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4611
+    "value": 4548
   },
   "Int": {
     "type": "byte",
@@ -338,7 +338,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4674
+    "value": 4611
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_darkhung_sp.utc.json
+++ b/Module/utc/cp_darkhung_sp.utc.json
@@ -220,7 +220,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2075
+    "value": 1795
   },
   "Int": {
     "type": "byte",
@@ -254,7 +254,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2355
+    "value": 2075
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_darkhung_wd.utc.json
+++ b/Module/utc/cp_darkhung_wd.utc.json
@@ -297,7 +297,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4611
+    "value": 4548
   },
   "Int": {
     "type": "byte",
@@ -331,7 +331,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4674
+    "value": 4611
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_deadhand_ad.utc.json
+++ b/Module/utc/cp_deadhand_ad.utc.json
@@ -276,7 +276,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1416
+    "value": 1317
   },
   "Int": {
     "type": "byte",
@@ -310,7 +310,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1515
+    "value": 1416
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_deadhand_ic.utc.json
+++ b/Module/utc/cp_deadhand_ic.utc.json
@@ -283,7 +283,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2197
+    "value": 2089
   },
   "Int": {
     "type": "byte",
@@ -317,7 +317,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2305
+    "value": 2197
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_deadhand_ms.utc.json
+++ b/Module/utc/cp_deadhand_ms.utc.json
@@ -304,7 +304,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4151
+    "value": 4043
   },
   "Int": {
     "type": "byte",
@@ -338,7 +338,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4259
+    "value": 4151
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_deadhand_sp.utc.json
+++ b/Module/utc/cp_deadhand_sp.utc.json
@@ -220,7 +220,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1867
+    "value": 1387
   },
   "Int": {
     "type": "byte",
@@ -254,7 +254,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2347
+    "value": 1867
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_deadhand_wd.utc.json
+++ b/Module/utc/cp_deadhand_wd.utc.json
@@ -297,7 +297,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4151
+    "value": 4043
   },
   "Int": {
     "type": "byte",
@@ -331,7 +331,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4259
+    "value": 4151
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_deccommand_ad.utc.json
+++ b/Module/utc/cp_deccommand_ad.utc.json
@@ -276,7 +276,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1495
+    "value": 1396
   },
   "Int": {
     "type": "byte",
@@ -310,7 +310,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1594
+    "value": 1495
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_deccommand_ic.utc.json
+++ b/Module/utc/cp_deccommand_ic.utc.json
@@ -283,7 +283,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2319
+    "value": 2211
   },
   "Int": {
     "type": "byte",
@@ -317,7 +317,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2427
+    "value": 2319
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_deccommand_ms.utc.json
+++ b/Module/utc/cp_deccommand_ms.utc.json
@@ -304,7 +304,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 5154
+    "value": 5046
   },
   "Int": {
     "type": "byte",
@@ -338,7 +338,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 5262
+    "value": 5154
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_deccommand_sp.utc.json
+++ b/Module/utc/cp_deccommand_sp.utc.json
@@ -220,7 +220,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2319
+    "value": 1839
   },
   "Int": {
     "type": "byte",
@@ -254,7 +254,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2799
+    "value": 2319
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_deccommand_wd.utc.json
+++ b/Module/utc/cp_deccommand_wd.utc.json
@@ -297,7 +297,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 5154
+    "value": 5046
   },
   "Int": {
     "type": "byte",
@@ -331,7 +331,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 5262
+    "value": 5154
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_eclipse_ad.utc.json
+++ b/Module/utc/cp_eclipse_ad.utc.json
@@ -276,7 +276,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1337
+    "value": 1283
   },
   "Int": {
     "type": "byte",
@@ -310,7 +310,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1391
+    "value": 1337
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_eclipse_ic.utc.json
+++ b/Module/utc/cp_eclipse_ic.utc.json
@@ -283,7 +283,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1764
+    "value": 1701
   },
   "Int": {
     "type": "byte",
@@ -317,7 +317,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1827
+    "value": 1764
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_eclipse_ms.utc.json
+++ b/Module/utc/cp_eclipse_ms.utc.json
@@ -304,7 +304,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 3919
+    "value": 3856
   },
   "Int": {
     "type": "byte",
@@ -338,7 +338,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 3982
+    "value": 3919
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_eclipse_sp.utc.json
+++ b/Module/utc/cp_eclipse_sp.utc.json
@@ -220,7 +220,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2075
+    "value": 1795
   },
   "Int": {
     "type": "byte",
@@ -254,7 +254,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2355
+    "value": 2075
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_eclipse_wd.utc.json
+++ b/Module/utc/cp_eclipse_wd.utc.json
@@ -297,7 +297,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4611
+    "value": 4548
   },
   "Int": {
     "type": "byte",
@@ -331,7 +331,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4674
+    "value": 4611
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_embunker_ad.utc.json
+++ b/Module/utc/cp_embunker_ad.utc.json
@@ -276,7 +276,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1495
+    "value": 1396
   },
   "Int": {
     "type": "byte",
@@ -310,7 +310,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1594
+    "value": 1495
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_embunker_ic.utc.json
+++ b/Module/utc/cp_embunker_ic.utc.json
@@ -283,7 +283,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2319
+    "value": 2211
   },
   "Int": {
     "type": "byte",
@@ -317,7 +317,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2427
+    "value": 2319
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_embunker_ms.utc.json
+++ b/Module/utc/cp_embunker_ms.utc.json
@@ -304,7 +304,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 5154
+    "value": 5046
   },
   "Int": {
     "type": "byte",
@@ -338,7 +338,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 5262
+    "value": 5154
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_embunker_sp.utc.json
+++ b/Module/utc/cp_embunker_sp.utc.json
@@ -220,7 +220,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2319
+    "value": 1839
   },
   "Int": {
     "type": "byte",
@@ -254,7 +254,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2799
+    "value": 2319
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_embunker_wd.utc.json
+++ b/Module/utc/cp_embunker_wd.utc.json
@@ -297,7 +297,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 5154
+    "value": 5046
   },
   "Int": {
     "type": "byte",
@@ -331,7 +331,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 5262
+    "value": 5154
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_emcocktail_ad.utc.json
+++ b/Module/utc/cp_emcocktail_ad.utc.json
@@ -276,7 +276,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1495
+    "value": 1396
   },
   "Int": {
     "type": "byte",
@@ -310,7 +310,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1594
+    "value": 1495
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_emcocktail_ic.utc.json
+++ b/Module/utc/cp_emcocktail_ic.utc.json
@@ -283,7 +283,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1971
+    "value": 1863
   },
   "Int": {
     "type": "byte",
@@ -317,7 +317,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2079
+    "value": 1971
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_emcocktail_ms.utc.json
+++ b/Module/utc/cp_emcocktail_ms.utc.json
@@ -304,7 +304,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 5154
+    "value": 5046
   },
   "Int": {
     "type": "byte",
@@ -338,7 +338,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 5262
+    "value": 5154
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_emcocktail_sp.utc.json
+++ b/Module/utc/cp_emcocktail_sp.utc.json
@@ -220,7 +220,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2319
+    "value": 1839
   },
   "Int": {
     "type": "byte",
@@ -254,7 +254,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2799
+    "value": 2319
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_emcocktail_wd.utc.json
+++ b/Module/utc/cp_emcocktail_wd.utc.json
@@ -297,7 +297,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 5154
+    "value": 5046
   },
   "Int": {
     "type": "byte",
@@ -331,7 +331,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 5262
+    "value": 5154
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_forcebane_ad.utc.json
+++ b/Module/utc/cp_forcebane_ad.utc.json
@@ -276,7 +276,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1337
+    "value": 1283
   },
   "Int": {
     "type": "byte",
@@ -310,7 +310,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1391
+    "value": 1337
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_forcebane_ic.utc.json
+++ b/Module/utc/cp_forcebane_ic.utc.json
@@ -283,7 +283,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2075
+    "value": 2012
   },
   "Int": {
     "type": "byte",
@@ -317,7 +317,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2138
+    "value": 2075
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_forcebane_ms.utc.json
+++ b/Module/utc/cp_forcebane_ms.utc.json
@@ -304,7 +304,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 3919
+    "value": 3856
   },
   "Int": {
     "type": "byte",
@@ -338,7 +338,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 3982
+    "value": 3919
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_forcebane_sp.utc.json
+++ b/Module/utc/cp_forcebane_sp.utc.json
@@ -220,7 +220,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2075
+    "value": 1795
   },
   "Int": {
     "type": "byte",
@@ -254,7 +254,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2355
+    "value": 2075
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_forcebane_wd.utc.json
+++ b/Module/utc/cp_forcebane_wd.utc.json
@@ -297,7 +297,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4611
+    "value": 4548
   },
   "Int": {
     "type": "byte",
@@ -331,7 +331,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4674
+    "value": 4611
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_forcebeast_ad.utc.json
+++ b/Module/utc/cp_forcebeast_ad.utc.json
@@ -157,7 +157,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1337
+    "value": 1097
   },
   "Int": {
     "type": "byte",
@@ -191,7 +191,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1577
+    "value": 1337
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_forcebeast_ic.utc.json
+++ b/Module/utc/cp_forcebeast_ic.utc.json
@@ -164,7 +164,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1764
+    "value": 1484
   },
   "Int": {
     "type": "byte",
@@ -198,7 +198,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2044
+    "value": 1764
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_forcebeast_ms.utc.json
+++ b/Module/utc/cp_forcebeast_ms.utc.json
@@ -192,7 +192,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4611
+    "value": 4548
   },
   "Int": {
     "type": "byte",
@@ -226,7 +226,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4674
+    "value": 4611
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_forcebeast_sp.utc.json
+++ b/Module/utc/cp_forcebeast_sp.utc.json
@@ -164,7 +164,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2075
+    "value": 1795
   },
   "Int": {
     "type": "byte",
@@ -198,7 +198,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2355
+    "value": 2075
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_forcebeast_wd.utc.json
+++ b/Module/utc/cp_forcebeast_wd.utc.json
@@ -185,7 +185,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4611
+    "value": 4548
   },
   "Int": {
     "type": "byte",
@@ -219,7 +219,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4674
+    "value": 4611
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_guardmst_ad.utc.json
+++ b/Module/utc/cp_guardmst_ad.utc.json
@@ -276,7 +276,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2124
+    "value": 1989
   },
   "Int": {
     "type": "byte",
@@ -310,7 +310,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2259
+    "value": 2124
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_guardmst_ic.utc.json
+++ b/Module/utc/cp_guardmst_ic.utc.json
@@ -283,7 +283,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 3296
+    "value": 3152
   },
   "Int": {
     "type": "byte",
@@ -317,7 +317,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 3440
+    "value": 3296
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_guardmst_ms.utc.json
+++ b/Module/utc/cp_guardmst_ms.utc.json
@@ -304,7 +304,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 10254
+    "value": 10110
   },
   "Int": {
     "type": "byte",
@@ -338,7 +338,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 10398
+    "value": 10254
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_guardmst_sp.utc.json
+++ b/Module/utc/cp_guardmst_sp.utc.json
@@ -220,7 +220,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4614
+    "value": 3974
   },
   "Int": {
     "type": "byte",
@@ -254,7 +254,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 5254
+    "value": 4614
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_guardmst_wd.utc.json
+++ b/Module/utc/cp_guardmst_wd.utc.json
@@ -297,7 +297,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 10254
+    "value": 10110
   },
   "Int": {
     "type": "byte",
@@ -331,7 +331,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 10398
+    "value": 10254
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_holdline_ad.utc.json
+++ b/Module/utc/cp_holdline_ad.utc.json
@@ -276,7 +276,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2124
+    "value": 1989
   },
   "Int": {
     "type": "byte",
@@ -310,7 +310,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2259
+    "value": 2124
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_holdline_ic.utc.json
+++ b/Module/utc/cp_holdline_ic.utc.json
@@ -283,7 +283,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2802
+    "value": 2658
   },
   "Int": {
     "type": "byte",
@@ -317,7 +317,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2946
+    "value": 2802
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_holdline_ms.utc.json
+++ b/Module/utc/cp_holdline_ms.utc.json
@@ -304,7 +304,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 10254
+    "value": 10110
   },
   "Int": {
     "type": "byte",
@@ -338,7 +338,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 10398
+    "value": 10254
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_holdline_sp.utc.json
+++ b/Module/utc/cp_holdline_sp.utc.json
@@ -220,7 +220,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4614
+    "value": 3974
   },
   "Int": {
     "type": "byte",
@@ -254,7 +254,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 5254
+    "value": 4614
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_holdline_wd.utc.json
+++ b/Module/utc/cp_holdline_wd.utc.json
@@ -297,7 +297,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 10254
+    "value": 10110
   },
   "Int": {
     "type": "byte",
@@ -331,7 +331,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 10398
+    "value": 10254
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_infconduit_ad.utc.json
+++ b/Module/utc/cp_infconduit_ad.utc.json
@@ -276,7 +276,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1495
+    "value": 1396
   },
   "Int": {
     "type": "byte",
@@ -310,7 +310,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1594
+    "value": 1495
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_infconduit_ic.utc.json
+++ b/Module/utc/cp_infconduit_ic.utc.json
@@ -283,7 +283,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2319
+    "value": 2211
   },
   "Int": {
     "type": "byte",
@@ -317,7 +317,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2427
+    "value": 2319
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_infconduit_ms.utc.json
+++ b/Module/utc/cp_infconduit_ms.utc.json
@@ -304,7 +304,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 5154
+    "value": 5046
   },
   "Int": {
     "type": "byte",
@@ -338,7 +338,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 5262
+    "value": 5154
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_infconduit_sp.utc.json
+++ b/Module/utc/cp_infconduit_sp.utc.json
@@ -220,7 +220,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2319
+    "value": 1839
   },
   "Int": {
     "type": "byte",
@@ -254,7 +254,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2799
+    "value": 2319
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_infconduit_wd.utc.json
+++ b/Module/utc/cp_infconduit_wd.utc.json
@@ -297,7 +297,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 5154
+    "value": 5046
   },
   "Int": {
     "type": "byte",
@@ -331,7 +331,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 5262
+    "value": 5154
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_invinc_ad.utc.json
+++ b/Module/utc/cp_invinc_ad.utc.json
@@ -276,7 +276,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2124
+    "value": 1989
   },
   "Int": {
     "type": "byte",
@@ -310,7 +310,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2259
+    "value": 2124
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_invinc_ic.utc.json
+++ b/Module/utc/cp_invinc_ic.utc.json
@@ -283,7 +283,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 3296
+    "value": 3152
   },
   "Int": {
     "type": "byte",
@@ -317,7 +317,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 3440
+    "value": 3296
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_invinc_ms.utc.json
+++ b/Module/utc/cp_invinc_ms.utc.json
@@ -304,7 +304,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 10254
+    "value": 10110
   },
   "Int": {
     "type": "byte",
@@ -338,7 +338,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 10398
+    "value": 10254
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_invinc_sp.utc.json
+++ b/Module/utc/cp_invinc_sp.utc.json
@@ -220,7 +220,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4614
+    "value": 3974
   },
   "Int": {
     "type": "byte",
@@ -254,7 +254,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 5254
+    "value": 4614
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_invinc_wd.utc.json
+++ b/Module/utc/cp_invinc_wd.utc.json
@@ -297,7 +297,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 10254
+    "value": 10110
   },
   "Int": {
     "type": "byte",
@@ -331,7 +331,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 10398
+    "value": 10254
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_killbeacon_ad.utc.json
+++ b/Module/utc/cp_killbeacon_ad.utc.json
@@ -276,7 +276,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1337
+    "value": 1283
   },
   "Int": {
     "type": "byte",
@@ -310,7 +310,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1391
+    "value": 1337
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_killbeacon_ic.utc.json
+++ b/Module/utc/cp_killbeacon_ic.utc.json
@@ -283,7 +283,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1764
+    "value": 1701
   },
   "Int": {
     "type": "byte",
@@ -317,7 +317,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1827
+    "value": 1764
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_killbeacon_ms.utc.json
+++ b/Module/utc/cp_killbeacon_ms.utc.json
@@ -304,7 +304,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 3919
+    "value": 3856
   },
   "Int": {
     "type": "byte",
@@ -338,7 +338,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 3982
+    "value": 3919
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_killbeacon_sp.utc.json
+++ b/Module/utc/cp_killbeacon_sp.utc.json
@@ -220,7 +220,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2075
+    "value": 1795
   },
   "Int": {
     "type": "byte",
@@ -254,7 +254,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2355
+    "value": 2075
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_killbeacon_wd.utc.json
+++ b/Module/utc/cp_killbeacon_wd.utc.json
@@ -297,7 +297,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4611
+    "value": 4548
   },
   "Int": {
     "type": "byte",
@@ -331,7 +331,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4674
+    "value": 4611
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_killbox_ad.utc.json
+++ b/Module/utc/cp_killbox_ad.utc.json
@@ -276,7 +276,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1416
+    "value": 1317
   },
   "Int": {
     "type": "byte",
@@ -310,7 +310,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1515
+    "value": 1416
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_killbox_ic.utc.json
+++ b/Module/utc/cp_killbox_ic.utc.json
@@ -283,7 +283,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1867
+    "value": 1759
   },
   "Int": {
     "type": "byte",
@@ -317,7 +317,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1975
+    "value": 1867
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_killbox_ms.utc.json
+++ b/Module/utc/cp_killbox_ms.utc.json
@@ -304,7 +304,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4151
+    "value": 4043
   },
   "Int": {
     "type": "byte",
@@ -338,7 +338,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4259
+    "value": 4151
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_killbox_sp.utc.json
+++ b/Module/utc/cp_killbox_sp.utc.json
@@ -220,7 +220,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1867
+    "value": 1387
   },
   "Int": {
     "type": "byte",
@@ -254,7 +254,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2347
+    "value": 1867
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_killbox_wd.utc.json
+++ b/Module/utc/cp_killbox_wd.utc.json
@@ -297,7 +297,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4151
+    "value": 4043
   },
   "Int": {
     "type": "byte",
@@ -331,7 +331,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4259
+    "value": 4151
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_lastword_ad.utc.json
+++ b/Module/utc/cp_lastword_ad.utc.json
@@ -276,7 +276,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1416
+    "value": 1317
   },
   "Int": {
     "type": "byte",
@@ -310,7 +310,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1515
+    "value": 1416
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_lastword_ic.utc.json
+++ b/Module/utc/cp_lastword_ic.utc.json
@@ -283,7 +283,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2197
+    "value": 2089
   },
   "Int": {
     "type": "byte",
@@ -317,7 +317,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2305
+    "value": 2197
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_lastword_ms.utc.json
+++ b/Module/utc/cp_lastword_ms.utc.json
@@ -304,7 +304,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4151
+    "value": 4043
   },
   "Int": {
     "type": "byte",
@@ -338,7 +338,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4259
+    "value": 4151
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_lastword_sp.utc.json
+++ b/Module/utc/cp_lastword_sp.utc.json
@@ -220,7 +220,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1867
+    "value": 1387
   },
   "Int": {
     "type": "byte",
@@ -254,7 +254,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2347
+    "value": 1867
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_lastword_wd.utc.json
+++ b/Module/utc/cp_lastword_wd.utc.json
@@ -297,7 +297,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4151
+    "value": 4043
   },
   "Int": {
     "type": "byte",
@@ -331,7 +331,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4259
+    "value": 4151
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_lightstand_ad.utc.json
+++ b/Module/utc/cp_lightstand_ad.utc.json
@@ -276,7 +276,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1495
+    "value": 1396
   },
   "Int": {
     "type": "byte",
@@ -310,7 +310,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1594
+    "value": 1495
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_lightstand_ic.utc.json
+++ b/Module/utc/cp_lightstand_ic.utc.json
@@ -283,7 +283,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2319
+    "value": 2211
   },
   "Int": {
     "type": "byte",
@@ -317,7 +317,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2427
+    "value": 2319
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_lightstand_ms.utc.json
+++ b/Module/utc/cp_lightstand_ms.utc.json
@@ -304,7 +304,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 5154
+    "value": 5046
   },
   "Int": {
     "type": "byte",
@@ -338,7 +338,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 5262
+    "value": 5154
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_lightstand_sp.utc.json
+++ b/Module/utc/cp_lightstand_sp.utc.json
@@ -220,7 +220,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2319
+    "value": 1839
   },
   "Int": {
     "type": "byte",
@@ -254,7 +254,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2799
+    "value": 2319
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_lightstand_wd.utc.json
+++ b/Module/utc/cp_lightstand_wd.utc.json
@@ -297,7 +297,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 5154
+    "value": 5046
   },
   "Int": {
     "type": "byte",
@@ -331,7 +331,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 5262
+    "value": 5154
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_oneshot_ad.utc.json
+++ b/Module/utc/cp_oneshot_ad.utc.json
@@ -276,7 +276,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1416
+    "value": 1317
   },
   "Int": {
     "type": "byte",
@@ -310,7 +310,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1515
+    "value": 1416
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_oneshot_ic.utc.json
+++ b/Module/utc/cp_oneshot_ic.utc.json
@@ -283,7 +283,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1867
+    "value": 1759
   },
   "Int": {
     "type": "byte",
@@ -317,7 +317,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1975
+    "value": 1867
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_oneshot_ms.utc.json
+++ b/Module/utc/cp_oneshot_ms.utc.json
@@ -304,7 +304,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4151
+    "value": 4043
   },
   "Int": {
     "type": "byte",
@@ -338,7 +338,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4259
+    "value": 4151
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_oneshot_sp.utc.json
+++ b/Module/utc/cp_oneshot_sp.utc.json
@@ -220,7 +220,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1867
+    "value": 1387
   },
   "Int": {
     "type": "byte",
@@ -254,7 +254,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2347
+    "value": 1867
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_oneshot_wd.utc.json
+++ b/Module/utc/cp_oneshot_wd.utc.json
@@ -297,7 +297,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4151
+    "value": 4043
   },
   "Int": {
     "type": "byte",
@@ -331,7 +331,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4259
+    "value": 4151
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_overbarr_ad.utc.json
+++ b/Module/utc/cp_overbarr_ad.utc.json
@@ -276,7 +276,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1416
+    "value": 1317
   },
   "Int": {
     "type": "byte",
@@ -310,7 +310,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1515
+    "value": 1416
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_overbarr_ic.utc.json
+++ b/Module/utc/cp_overbarr_ic.utc.json
@@ -283,7 +283,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1867
+    "value": 1759
   },
   "Int": {
     "type": "byte",
@@ -317,7 +317,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1975
+    "value": 1867
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_overbarr_ms.utc.json
+++ b/Module/utc/cp_overbarr_ms.utc.json
@@ -304,7 +304,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4151
+    "value": 4043
   },
   "Int": {
     "type": "byte",
@@ -338,7 +338,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4259
+    "value": 4151
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_overbarr_sp.utc.json
+++ b/Module/utc/cp_overbarr_sp.utc.json
@@ -220,7 +220,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1867
+    "value": 1387
   },
   "Int": {
     "type": "byte",
@@ -254,7 +254,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2347
+    "value": 1867
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_overbarr_wd.utc.json
+++ b/Module/utc/cp_overbarr_wd.utc.json
@@ -297,7 +297,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4151
+    "value": 4043
   },
   "Int": {
     "type": "byte",
@@ -331,7 +331,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4259
+    "value": 4151
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_perflurry_ad.utc.json
+++ b/Module/utc/cp_perflurry_ad.utc.json
@@ -276,7 +276,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1573
+    "value": 1474
   },
   "Int": {
     "type": "byte",
@@ -310,7 +310,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1672
+    "value": 1573
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_perflurry_ic.utc.json
+++ b/Module/utc/cp_perflurry_ic.utc.json
@@ -283,7 +283,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2441
+    "value": 2333
   },
   "Int": {
     "type": "byte",
@@ -317,7 +317,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2549
+    "value": 2441
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_perflurry_ms.utc.json
+++ b/Module/utc/cp_perflurry_ms.utc.json
@@ -304,7 +304,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4611
+    "value": 4503
   },
   "Int": {
     "type": "byte",
@@ -338,7 +338,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4719
+    "value": 4611
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_perflurry_sp.utc.json
+++ b/Module/utc/cp_perflurry_sp.utc.json
@@ -220,7 +220,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2075
+    "value": 1595
   },
   "Int": {
     "type": "byte",
@@ -254,7 +254,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2555
+    "value": 2075
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_perflurry_wd.utc.json
+++ b/Module/utc/cp_perflurry_wd.utc.json
@@ -297,7 +297,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4611
+    "value": 4503
   },
   "Int": {
     "type": "byte",
@@ -331,7 +331,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4719
+    "value": 4611
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_primover_ad.utc.json
+++ b/Module/utc/cp_primover_ad.utc.json
@@ -157,7 +157,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1573
+    "value": 1133
   },
   "Int": {
     "type": "byte",
@@ -191,7 +191,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2013
+    "value": 1573
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_primover_ic.utc.json
+++ b/Module/utc/cp_primover_ic.utc.json
@@ -164,7 +164,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2441
+    "value": 1961
   },
   "Int": {
     "type": "byte",
@@ -198,7 +198,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2921
+    "value": 2441
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_primover_ms.utc.json
+++ b/Module/utc/cp_primover_ms.utc.json
@@ -192,7 +192,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4611
+    "value": 4503
   },
   "Int": {
     "type": "byte",
@@ -226,7 +226,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4719
+    "value": 4611
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_primover_sp.utc.json
+++ b/Module/utc/cp_primover_sp.utc.json
@@ -164,7 +164,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2075
+    "value": 1595
   },
   "Int": {
     "type": "byte",
@@ -198,7 +198,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2555
+    "value": 2075
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_primover_wd.utc.json
+++ b/Module/utc/cp_primover_wd.utc.json
@@ -185,7 +185,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4611
+    "value": 4503
   },
   "Int": {
     "type": "byte",
@@ -219,7 +219,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4719
+    "value": 4611
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_rainsteel_ad.utc.json
+++ b/Module/utc/cp_rainsteel_ad.utc.json
@@ -276,7 +276,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1416
+    "value": 1317
   },
   "Int": {
     "type": "byte",
@@ -310,7 +310,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1515
+    "value": 1416
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_rainsteel_ic.utc.json
+++ b/Module/utc/cp_rainsteel_ic.utc.json
@@ -283,7 +283,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2197
+    "value": 2089
   },
   "Int": {
     "type": "byte",
@@ -317,7 +317,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2305
+    "value": 2197
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_rainsteel_ms.utc.json
+++ b/Module/utc/cp_rainsteel_ms.utc.json
@@ -304,7 +304,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4151
+    "value": 4043
   },
   "Int": {
     "type": "byte",
@@ -338,7 +338,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4259
+    "value": 4151
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_rainsteel_sp.utc.json
+++ b/Module/utc/cp_rainsteel_sp.utc.json
@@ -220,7 +220,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1867
+    "value": 1387
   },
   "Int": {
     "type": "byte",
@@ -254,7 +254,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2347
+    "value": 1867
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_rainsteel_wd.utc.json
+++ b/Module/utc/cp_rainsteel_wd.utc.json
@@ -297,7 +297,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4151
+    "value": 4043
   },
   "Int": {
     "type": "byte",
@@ -331,7 +331,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4259
+    "value": 4151
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_redbloom_ad.utc.json
+++ b/Module/utc/cp_redbloom_ad.utc.json
@@ -276,7 +276,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1573
+    "value": 1474
   },
   "Int": {
     "type": "byte",
@@ -310,7 +310,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1672
+    "value": 1573
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_redbloom_ic.utc.json
+++ b/Module/utc/cp_redbloom_ic.utc.json
@@ -283,7 +283,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2075
+    "value": 1967
   },
   "Int": {
     "type": "byte",
@@ -317,7 +317,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2183
+    "value": 2075
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_redbloom_ms.utc.json
+++ b/Module/utc/cp_redbloom_ms.utc.json
@@ -304,7 +304,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4611
+    "value": 4503
   },
   "Int": {
     "type": "byte",
@@ -338,7 +338,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4719
+    "value": 4611
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_redbloom_sp.utc.json
+++ b/Module/utc/cp_redbloom_sp.utc.json
@@ -220,7 +220,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2075
+    "value": 1595
   },
   "Int": {
     "type": "byte",
@@ -254,7 +254,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2555
+    "value": 2075
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_redbloom_wd.utc.json
+++ b/Module/utc/cp_redbloom_wd.utc.json
@@ -297,7 +297,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4611
+    "value": 4503
   },
   "Int": {
     "type": "byte",
@@ -331,7 +331,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4719
+    "value": 4611
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_sabcycl_ad.utc.json
+++ b/Module/utc/cp_sabcycl_ad.utc.json
@@ -276,7 +276,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1573
+    "value": 1474
   },
   "Int": {
     "type": "byte",
@@ -310,7 +310,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1672
+    "value": 1573
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_sabcycl_ic.utc.json
+++ b/Module/utc/cp_sabcycl_ic.utc.json
@@ -283,7 +283,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2441
+    "value": 2333
   },
   "Int": {
     "type": "byte",
@@ -317,7 +317,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2549
+    "value": 2441
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_sabcycl_ms.utc.json
+++ b/Module/utc/cp_sabcycl_ms.utc.json
@@ -304,7 +304,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4611
+    "value": 4503
   },
   "Int": {
     "type": "byte",
@@ -338,7 +338,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4719
+    "value": 4611
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_sabcycl_sp.utc.json
+++ b/Module/utc/cp_sabcycl_sp.utc.json
@@ -220,7 +220,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2075
+    "value": 1595
   },
   "Int": {
     "type": "byte",
@@ -254,7 +254,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2555
+    "value": 2075
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_sabcycl_wd.utc.json
+++ b/Module/utc/cp_sabcycl_wd.utc.json
@@ -297,7 +297,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4611
+    "value": 4503
   },
   "Int": {
     "type": "byte",
@@ -331,7 +331,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4719
+    "value": 4611
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_sabstorm_ad.utc.json
+++ b/Module/utc/cp_sabstorm_ad.utc.json
@@ -276,7 +276,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1573
+    "value": 1474
   },
   "Int": {
     "type": "byte",
@@ -310,7 +310,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1672
+    "value": 1573
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_sabstorm_ic.utc.json
+++ b/Module/utc/cp_sabstorm_ic.utc.json
@@ -283,7 +283,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2075
+    "value": 1967
   },
   "Int": {
     "type": "byte",
@@ -317,7 +317,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2183
+    "value": 2075
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_sabstorm_ms.utc.json
+++ b/Module/utc/cp_sabstorm_ms.utc.json
@@ -304,7 +304,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4611
+    "value": 4503
   },
   "Int": {
     "type": "byte",
@@ -338,7 +338,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4719
+    "value": 4611
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_sabstorm_sp.utc.json
+++ b/Module/utc/cp_sabstorm_sp.utc.json
@@ -220,7 +220,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2075
+    "value": 1595
   },
   "Int": {
     "type": "byte",
@@ -254,7 +254,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2555
+    "value": 2075
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_sabstorm_wd.utc.json
+++ b/Module/utc/cp_sabstorm_wd.utc.json
@@ -297,7 +297,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4611
+    "value": 4503
   },
   "Int": {
     "type": "byte",
@@ -331,7 +331,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4719
+    "value": 4611
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_scraplock_ad.utc.json
+++ b/Module/utc/cp_scraplock_ad.utc.json
@@ -276,7 +276,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1337
+    "value": 1283
   },
   "Int": {
     "type": "byte",
@@ -310,7 +310,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1391
+    "value": 1337
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_scraplock_ic.utc.json
+++ b/Module/utc/cp_scraplock_ic.utc.json
@@ -283,7 +283,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2075
+    "value": 2012
   },
   "Int": {
     "type": "byte",
@@ -317,7 +317,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2138
+    "value": 2075
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_scraplock_ms.utc.json
+++ b/Module/utc/cp_scraplock_ms.utc.json
@@ -304,7 +304,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 3919
+    "value": 3856
   },
   "Int": {
     "type": "byte",
@@ -338,7 +338,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 3982
+    "value": 3919
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_scraplock_sp.utc.json
+++ b/Module/utc/cp_scraplock_sp.utc.json
@@ -220,7 +220,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2075
+    "value": 1795
   },
   "Int": {
     "type": "byte",
@@ -254,7 +254,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2355
+    "value": 2075
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_scraplock_wd.utc.json
+++ b/Module/utc/cp_scraplock_wd.utc.json
@@ -297,7 +297,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4611
+    "value": 4548
   },
   "Int": {
     "type": "byte",
@@ -331,7 +331,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4674
+    "value": 4611
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_soulasc_ad.utc.json
+++ b/Module/utc/cp_soulasc_ad.utc.json
@@ -276,7 +276,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1573
+    "value": 1474
   },
   "Int": {
     "type": "byte",
@@ -310,7 +310,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1672
+    "value": 1573
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_soulasc_ic.utc.json
+++ b/Module/utc/cp_soulasc_ic.utc.json
@@ -283,7 +283,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2075
+    "value": 1967
   },
   "Int": {
     "type": "byte",
@@ -317,7 +317,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2183
+    "value": 2075
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_soulasc_ms.utc.json
+++ b/Module/utc/cp_soulasc_ms.utc.json
@@ -304,7 +304,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4611
+    "value": 4503
   },
   "Int": {
     "type": "byte",
@@ -338,7 +338,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4719
+    "value": 4611
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_soulasc_sp.utc.json
+++ b/Module/utc/cp_soulasc_sp.utc.json
@@ -220,7 +220,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2075
+    "value": 1595
   },
   "Int": {
     "type": "byte",
@@ -254,7 +254,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2555
+    "value": 2075
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_soulasc_wd.utc.json
+++ b/Module/utc/cp_soulasc_wd.utc.json
@@ -297,7 +297,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4611
+    "value": 4503
   },
   "Int": {
     "type": "byte",
@@ -331,7 +331,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4719
+    "value": 4611
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_sysshut_ad.utc.json
+++ b/Module/utc/cp_sysshut_ad.utc.json
@@ -276,7 +276,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1337
+    "value": 1283
   },
   "Int": {
     "type": "byte",
@@ -310,7 +310,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1391
+    "value": 1337
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_sysshut_ic.utc.json
+++ b/Module/utc/cp_sysshut_ic.utc.json
@@ -283,7 +283,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1764
+    "value": 1701
   },
   "Int": {
     "type": "byte",
@@ -317,7 +317,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1827
+    "value": 1764
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_sysshut_ms.utc.json
+++ b/Module/utc/cp_sysshut_ms.utc.json
@@ -304,7 +304,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 3919
+    "value": 3856
   },
   "Int": {
     "type": "byte",
@@ -338,7 +338,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 3982
+    "value": 3919
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_sysshut_sp.utc.json
+++ b/Module/utc/cp_sysshut_sp.utc.json
@@ -220,7 +220,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2075
+    "value": 1795
   },
   "Int": {
     "type": "byte",
@@ -254,7 +254,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2355
+    "value": 2075
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_sysshut_wd.utc.json
+++ b/Module/utc/cp_sysshut_wd.utc.json
@@ -297,7 +297,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4611
+    "value": 4548
   },
   "Int": {
     "type": "byte",
@@ -331,7 +331,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4674
+    "value": 4611
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_tempbloom_ad.utc.json
+++ b/Module/utc/cp_tempbloom_ad.utc.json
@@ -276,7 +276,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1573
+    "value": 1474
   },
   "Int": {
     "type": "byte",
@@ -310,7 +310,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1672
+    "value": 1573
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_tempbloom_ic.utc.json
+++ b/Module/utc/cp_tempbloom_ic.utc.json
@@ -283,7 +283,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2075
+    "value": 1967
   },
   "Int": {
     "type": "byte",
@@ -317,7 +317,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2183
+    "value": 2075
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_tempbloom_ms.utc.json
+++ b/Module/utc/cp_tempbloom_ms.utc.json
@@ -304,7 +304,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4611
+    "value": 4503
   },
   "Int": {
     "type": "byte",
@@ -338,7 +338,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4719
+    "value": 4611
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_tempbloom_sp.utc.json
+++ b/Module/utc/cp_tempbloom_sp.utc.json
@@ -220,7 +220,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2075
+    "value": 1595
   },
   "Int": {
     "type": "byte",
@@ -254,7 +254,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2555
+    "value": 2075
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_tempbloom_wd.utc.json
+++ b/Module/utc/cp_tempbloom_wd.utc.json
@@ -297,7 +297,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4611
+    "value": 4503
   },
   "Int": {
     "type": "byte",
@@ -331,7 +331,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4719
+    "value": 4611
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_thermdet_ad.utc.json
+++ b/Module/utc/cp_thermdet_ad.utc.json
@@ -276,7 +276,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1416
+    "value": 1317
   },
   "Int": {
     "type": "byte",
@@ -310,7 +310,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1515
+    "value": 1416
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_thermdet_ic.utc.json
+++ b/Module/utc/cp_thermdet_ic.utc.json
@@ -283,7 +283,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1867
+    "value": 1759
   },
   "Int": {
     "type": "byte",
@@ -317,7 +317,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1975
+    "value": 1867
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_thermdet_ms.utc.json
+++ b/Module/utc/cp_thermdet_ms.utc.json
@@ -304,7 +304,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4151
+    "value": 4043
   },
   "Int": {
     "type": "byte",
@@ -338,7 +338,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4259
+    "value": 4151
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_thermdet_sp.utc.json
+++ b/Module/utc/cp_thermdet_sp.utc.json
@@ -220,7 +220,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1867
+    "value": 1387
   },
   "Int": {
     "type": "byte",
@@ -254,7 +254,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2347
+    "value": 1867
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_thermdet_wd.utc.json
+++ b/Module/utc/cp_thermdet_wd.utc.json
@@ -297,7 +297,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4151
+    "value": 4043
   },
   "Int": {
     "type": "byte",
@@ -331,7 +331,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4259
+    "value": 4151
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_unbrbeast_ad.utc.json
+++ b/Module/utc/cp_unbrbeast_ad.utc.json
@@ -157,7 +157,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2124
+    "value": 1524
   },
   "Int": {
     "type": "byte",
@@ -191,7 +191,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2724
+    "value": 2124
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_unbrbeast_ic.utc.json
+++ b/Module/utc/cp_unbrbeast_ic.utc.json
@@ -164,7 +164,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2802
+    "value": 2162
   },
   "Int": {
     "type": "byte",
@@ -198,7 +198,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 3442
+    "value": 2802
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_unbrbeast_ms.utc.json
+++ b/Module/utc/cp_unbrbeast_ms.utc.json
@@ -192,7 +192,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 10254
+    "value": 10110
   },
   "Int": {
     "type": "byte",
@@ -226,7 +226,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 10398
+    "value": 10254
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_unbrbeast_sp.utc.json
+++ b/Module/utc/cp_unbrbeast_sp.utc.json
@@ -164,7 +164,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4614
+    "value": 3974
   },
   "Int": {
     "type": "byte",
@@ -198,7 +198,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 5254
+    "value": 4614
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_unbrbeast_wd.utc.json
+++ b/Module/utc/cp_unbrbeast_wd.utc.json
@@ -185,7 +185,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 10254
+    "value": 10110
   },
   "Int": {
     "type": "byte",
@@ -219,7 +219,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 10398
+    "value": 10254
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_unmovctr_ad.utc.json
+++ b/Module/utc/cp_unmovctr_ad.utc.json
@@ -276,7 +276,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2124
+    "value": 1989
   },
   "Int": {
     "type": "byte",
@@ -310,7 +310,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2259
+    "value": 2124
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_unmovctr_ic.utc.json
+++ b/Module/utc/cp_unmovctr_ic.utc.json
@@ -283,7 +283,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2802
+    "value": 2658
   },
   "Int": {
     "type": "byte",
@@ -317,7 +317,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2946
+    "value": 2802
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_unmovctr_ms.utc.json
+++ b/Module/utc/cp_unmovctr_ms.utc.json
@@ -304,7 +304,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 10254
+    "value": 10110
   },
   "Int": {
     "type": "byte",
@@ -338,7 +338,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 10398
+    "value": 10254
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_unmovctr_sp.utc.json
+++ b/Module/utc/cp_unmovctr_sp.utc.json
@@ -220,7 +220,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4614
+    "value": 3974
   },
   "Int": {
     "type": "byte",
@@ -254,7 +254,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 5254
+    "value": 4614
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_unmovctr_wd.utc.json
+++ b/Module/utc/cp_unmovctr_wd.utc.json
@@ -297,7 +297,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 10254
+    "value": 10110
   },
   "Int": {
     "type": "byte",
@@ -331,7 +331,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 10398
+    "value": 10254
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_untinst_ad.utc.json
+++ b/Module/utc/cp_untinst_ad.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 708
+    "value": 468
   },
   "Int": {
     "type": "byte",
@@ -184,7 +184,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 948
+    "value": 708
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_untinst_ic.utc.json
+++ b/Module/utc/cp_untinst_ic.utc.json
@@ -157,7 +157,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1099
+    "value": 819
   },
   "Int": {
     "type": "byte",
@@ -191,7 +191,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1379
+    "value": 1099
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_untinst_ms.utc.json
+++ b/Module/utc/cp_untinst_ms.utc.json
@@ -178,7 +178,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4611
+    "value": 4503
   },
   "Int": {
     "type": "byte",
@@ -212,7 +212,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4719
+    "value": 4611
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_untinst_sp.utc.json
+++ b/Module/utc/cp_untinst_sp.utc.json
@@ -157,7 +157,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 934
+    "value": 654
   },
   "Int": {
     "type": "byte",
@@ -191,7 +191,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1214
+    "value": 934
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_untinst_wd.utc.json
+++ b/Module/utc/cp_untinst_wd.utc.json
@@ -171,7 +171,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4611
+    "value": 4503
   },
   "Int": {
     "type": "byte",
@@ -205,7 +205,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4719
+    "value": 4611
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_vitrupt_ad.utc.json
+++ b/Module/utc/cp_vitrupt_ad.utc.json
@@ -276,7 +276,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1573
+    "value": 1474
   },
   "Int": {
     "type": "byte",
@@ -310,7 +310,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1672
+    "value": 1573
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_vitrupt_ic.utc.json
+++ b/Module/utc/cp_vitrupt_ic.utc.json
@@ -283,7 +283,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2441
+    "value": 2333
   },
   "Int": {
     "type": "byte",
@@ -317,7 +317,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2549
+    "value": 2441
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_vitrupt_ms.utc.json
+++ b/Module/utc/cp_vitrupt_ms.utc.json
@@ -304,7 +304,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4611
+    "value": 4503
   },
   "Int": {
     "type": "byte",
@@ -338,7 +338,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4719
+    "value": 4611
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_vitrupt_sp.utc.json
+++ b/Module/utc/cp_vitrupt_sp.utc.json
@@ -220,7 +220,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2075
+    "value": 1595
   },
   "Int": {
     "type": "byte",
@@ -254,7 +254,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2555
+    "value": 2075
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_vitrupt_wd.utc.json
+++ b/Module/utc/cp_vitrupt_wd.utc.json
@@ -297,7 +297,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4611
+    "value": 4503
   },
   "Int": {
     "type": "byte",
@@ -331,7 +331,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4719
+    "value": 4611
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_worldbrk_ad.utc.json
+++ b/Module/utc/cp_worldbrk_ad.utc.json
@@ -276,7 +276,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1573
+    "value": 1474
   },
   "Int": {
     "type": "byte",
@@ -310,7 +310,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1672
+    "value": 1573
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_worldbrk_ic.utc.json
+++ b/Module/utc/cp_worldbrk_ic.utc.json
@@ -283,7 +283,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2075
+    "value": 1967
   },
   "Int": {
     "type": "byte",
@@ -317,7 +317,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2183
+    "value": 2075
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_worldbrk_ms.utc.json
+++ b/Module/utc/cp_worldbrk_ms.utc.json
@@ -304,7 +304,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4611
+    "value": 4503
   },
   "Int": {
     "type": "byte",
@@ -338,7 +338,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4719
+    "value": 4611
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_worldbrk_sp.utc.json
+++ b/Module/utc/cp_worldbrk_sp.utc.json
@@ -220,7 +220,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2075
+    "value": 1595
   },
   "Int": {
     "type": "byte",
@@ -254,7 +254,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2555
+    "value": 2075
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cp_worldbrk_wd.utc.json
+++ b/Module/utc/cp_worldbrk_wd.utc.json
@@ -297,7 +297,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4611
+    "value": 4503
   },
   "Int": {
     "type": "byte",
@@ -331,7 +331,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4719
+    "value": 4611
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/crycrazewarocas.utc.json
+++ b/Module/utc/crycrazewarocas.utc.json
@@ -141,7 +141,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 380
+    "value": 370
   },
   "Int": {
     "type": "byte",
@@ -175,7 +175,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 390
+    "value": 380
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cryptwarden.utc.json
+++ b/Module/utc/cryptwarden.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2441
+    "value": 2333
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/crystalspider.utc.json
+++ b/Module/utc/crystalspider.utc.json
@@ -164,7 +164,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 156
+    "value": 154
   },
   "Int": {
     "type": "byte",
@@ -198,7 +198,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 158
+    "value": 156
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/cycloneadpt.utc.json
+++ b/Module/utc/cycloneadpt.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2075
+    "value": 2012
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/czcryo_mynock.utc.json
+++ b/Module/utc/czcryo_mynock.utc.json
@@ -136,7 +136,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 40
+    "value": 42
   },
   "Int": {
     "type": "byte",
@@ -170,7 +170,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 38
+    "value": 40
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/dantarihunter.utc.json
+++ b/Module/utc/dantarihunter.utc.json
@@ -256,7 +256,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 911
+    "value": 551
   },
   "Int": {
     "type": "byte",
@@ -290,7 +290,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1271
+    "value": 911
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/dantarishaman.utc.json
+++ b/Module/utc/dantarishaman.utc.json
@@ -263,7 +263,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1889
+    "value": 1449
   },
   "Int": {
     "type": "byte",
@@ -297,7 +297,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2329
+    "value": 1889
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/deadhandzeph.utc.json
+++ b/Module/utc/deadhandzeph.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2075
+    "value": 2012
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/decurioncmd.utc.json
+++ b/Module/utc/decurioncmd.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2075
+    "value": 2012
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/demolisherzr9.utc.json
+++ b/Module/utc/demolisherzr9.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2197
+    "value": 2089
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/dgraul.utc.json
+++ b/Module/utc/dgraul.utc.json
@@ -178,7 +178,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4611
+    "value": 4548
   },
   "Int": {
     "type": "byte",
@@ -212,7 +212,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4674
+    "value": 4611
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/dunedeadeye.utc.json
+++ b/Module/utc/dunedeadeye.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2197
+    "value": 2089
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/eclipseshade.utc.json
+++ b/Module/utc/eclipseshade.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2075
+    "value": 2012
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/ecoterr_1.utc.json
+++ b/Module/utc/ecoterr_1.utc.json
@@ -340,7 +340,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 490
+    "value": 430
   },
   "Int": {
     "type": "byte",
@@ -374,7 +374,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 550
+    "value": 490
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/ecoterr_2.utc.json
+++ b/Module/utc/ecoterr_2.utc.json
@@ -340,7 +340,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 490
+    "value": 442
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/ecoterr_ldr.utc.json
+++ b/Module/utc/ecoterr_ldr.utc.json
@@ -382,7 +382,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1128
+    "value": 1044
   },
   "Int": {
     "type": "byte",
@@ -416,7 +416,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1212
+    "value": 1128
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/elite_sith_troop.utc.json
+++ b/Module/utc/elite_sith_troop.utc.json
@@ -382,7 +382,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 626
+    "value": 566
   },
   "Int": {
     "type": "byte",
@@ -436,7 +436,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 686
+    "value": 626
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/enclavesentl.utc.json
+++ b/Module/utc/enclavesentl.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2197
+    "value": 2089
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/exchangeenfor001.utc.json
+++ b/Module/utc/exchangeenfor001.utc.json
@@ -394,7 +394,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 321
+    "value": 285
   },
   "Int": {
     "type": "byte",
@@ -448,7 +448,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 357
+    "value": 321
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/exchangeenforcer.utc.json
+++ b/Module/utc/exchangeenforcer.utc.json
@@ -387,7 +387,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 289
+    "value": 253
   },
   "Int": {
     "type": "byte",
@@ -441,7 +441,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 325
+    "value": 289
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/ext_tusken_tr001.utc.json
+++ b/Module/utc/ext_tusken_tr001.utc.json
@@ -337,7 +337,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 77
+    "value": 74
   },
   "Int": {
     "type": "byte",
@@ -371,7 +371,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 80
+    "value": 77
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/ext_tusken_tr003.utc.json
+++ b/Module/utc/ext_tusken_tr003.utc.json
@@ -420,7 +420,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 617
+    "value": 573
   },
   "Int": {
     "type": "byte",
@@ -454,7 +454,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 661
+    "value": 617
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/flameweaver.utc.json
+++ b/Module/utc/flameweaver.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2197
+    "value": 2089
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/flurrychamp.utc.json
+++ b/Module/utc/flurrychamp.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2441
+    "value": 2333
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/forcewitch001.utc.json
+++ b/Module/utc/forcewitch001.utc.json
@@ -373,7 +373,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2419
+    "value": 2289
   },
   "Int": {
     "type": "byte",
@@ -407,7 +407,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2549
+    "value": 2419
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/forest_king.utc.json
+++ b/Module/utc/forest_king.utc.json
@@ -206,7 +206,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4611
+    "value": 4506
   },
   "Int": {
     "type": "byte",
@@ -240,7 +240,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4716
+    "value": 4611
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/forgewright.utc.json
+++ b/Module/utc/forgewright.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2441
+    "value": 2333
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/frogboss.utc.json
+++ b/Module/utc/frogboss.utc.json
@@ -281,7 +281,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 7467
+    "value": 7067
   },
   "Int": {
     "type": "byte",
@@ -315,7 +315,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 7867
+    "value": 7467
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/garkaniandragon.utc.json
+++ b/Module/utc/garkaniandragon.utc.json
@@ -197,7 +197,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4148
+    "value": 4138
   },
   "Int": {
     "type": "byte",
@@ -231,7 +231,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4158
+    "value": 4148
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/gerogoon002.utc.json
+++ b/Module/utc/gerogoon002.utc.json
@@ -387,7 +387,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 289
+    "value": 253
   },
   "Int": {
     "type": "byte",
@@ -441,7 +441,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 325
+    "value": 289
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/gerogoon003.utc.json
+++ b/Module/utc/gerogoon003.utc.json
@@ -387,7 +387,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 321
+    "value": 285
   },
   "Int": {
     "type": "byte",
@@ -441,7 +441,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 357
+    "value": 321
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/gerogoon005.utc.json
+++ b/Module/utc/gerogoon005.utc.json
@@ -387,7 +387,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 321
+    "value": 285
   },
   "Int": {
     "type": "byte",
@@ -421,7 +421,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 357
+    "value": 321
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/ghostviperking.utc.json
+++ b/Module/utc/ghostviperking.utc.json
@@ -162,7 +162,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 735
+    "value": 695
   },
   "Int": {
     "type": "byte",
@@ -196,7 +196,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 775
+    "value": 735
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/gizka.utc.json
+++ b/Module/utc/gizka.utc.json
@@ -141,7 +141,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 940
+    "value": 790
   },
   "Int": {
     "type": "byte",
@@ -175,7 +175,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1090
+    "value": 940
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/glassjaw.utc.json
+++ b/Module/utc/glassjaw.utc.json
@@ -164,7 +164,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1128
+    "value": 1086
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/greyspine.utc.json
+++ b/Module/utc/greyspine.utc.json
@@ -157,7 +157,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 461
+    "value": 413
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/grottoalpha.utc.json
+++ b/Module/utc/grottoalpha.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2441
+    "value": 1961
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/harrek_voss.utc.json
+++ b/Module/utc/harrek_voss.utc.json
@@ -354,7 +354,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 483
+    "value": 427
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/hexcaller.utc.json
+++ b/Module/utc/hexcaller.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2075
+    "value": 2012
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/hkinrath.utc.json
+++ b/Module/utc/hkinrath.utc.json
@@ -141,7 +141,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 723
+    "value": 363
   },
   "Int": {
     "type": "byte",
@@ -175,7 +175,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1083
+    "value": 723
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/holo_gimpassa.utc.json
+++ b/Module/utc/holo_gimpassa.utc.json
@@ -143,7 +143,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 173
+    "value": 161
   },
   "Int": {
     "type": "byte",
@@ -177,7 +177,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 185
+    "value": 173
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/holo_kathhound.utc.json
+++ b/Module/utc/holo_kathhound.utc.json
@@ -143,7 +143,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 85
+    "value": 87
   },
   "Int": {
     "type": "byte",
@@ -177,7 +177,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 83
+    "value": 85
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/hologimpassa_lo.utc.json
+++ b/Module/utc/hologimpassa_lo.utc.json
@@ -143,7 +143,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 113
+    "value": 107
   },
   "Int": {
     "type": "byte",
@@ -177,7 +177,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 119
+    "value": 113
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/holokath_lo.utc.json
+++ b/Module/utc/holokath_lo.utc.json
@@ -143,7 +143,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 40
+    "value": 44
   },
   "Int": {
     "type": "byte",
@@ -177,7 +177,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 36
+    "value": 40
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/huthivebroodmoth.utc.json
+++ b/Module/utc/huthivebroodmoth.utc.json
@@ -185,7 +185,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4485
+    "value": 4205
   },
   "Int": {
     "type": "byte",
@@ -219,7 +219,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4765
+    "value": 4485
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/inkveil.utc.json
+++ b/Module/utc/inkveil.utc.json
@@ -164,7 +164,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1109
+    "value": 1085
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/invictus.utc.json
+++ b/Module/utc/invictus.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2441
+    "value": 2333
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/iriaz.utc.json
+++ b/Module/utc/iriaz.utc.json
@@ -141,7 +141,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 857
+    "value": 758
   },
   "Int": {
     "type": "byte",
@@ -175,7 +175,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 956
+    "value": 857
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/ironjaw.utc.json
+++ b/Module/utc/ironjaw.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2441
+    "value": 2333
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/kael_drox.utc.json
+++ b/Module/utc/kael_drox.utc.json
@@ -375,7 +375,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1270
+    "value": 1174
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/kath_hound.utc.json
+++ b/Module/utc/kath_hound.utc.json
@@ -143,7 +143,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 86
+    "value": 84
   },
   "Int": {
     "type": "byte",
@@ -177,7 +177,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 88
+    "value": 86
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/korr_frostbind.utc.json
+++ b/Module/utc/korr_frostbind.utc.json
@@ -319,7 +319,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 363
+    "value": 351
   },
   "Int": {
     "type": "byte",
@@ -353,7 +353,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 375
+    "value": 363
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/korr_klorslug.utc.json
+++ b/Module/utc/korr_klorslug.utc.json
@@ -143,7 +143,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 386
+    "value": 361
   },
   "Int": {
     "type": "byte",
@@ -177,7 +177,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 411
+    "value": 386
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/korr_wraid.utc.json
+++ b/Module/utc/korr_wraid.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 604
+    "value": 564
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/korriinitiate.utc.json
+++ b/Module/utc/korriinitiate.utc.json
@@ -305,7 +305,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 217
+    "value": 211
   },
   "Int": {
     "type": "byte",
@@ -339,7 +339,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 223
+    "value": 217
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/looter_1.utc.json
+++ b/Module/utc/looter_1.utc.json
@@ -312,7 +312,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 102
+    "value": 98
   },
   "Int": {
     "type": "byte",
@@ -346,7 +346,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 106
+    "value": 102
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/looter_2.utc.json
+++ b/Module/utc/looter_2.utc.json
@@ -312,7 +312,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 102
+    "value": 98
   },
   "Int": {
     "type": "byte",
@@ -346,7 +346,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 106
+    "value": 102
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/lordneph.utc.json
+++ b/Module/utc/lordneph.utc.json
@@ -452,7 +452,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 12899
+    "value": 12599
   },
   "Int": {
     "type": "byte",
@@ -486,7 +486,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 13199
+    "value": 12899
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/lordsirtu.utc.json
+++ b/Module/utc/lordsirtu.utc.json
@@ -765,7 +765,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 8611
+    "value": 7931
   },
   "Int": {
     "type": "byte",
@@ -799,7 +799,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 9091
+    "value": 8611
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/lordvalerius.utc.json
+++ b/Module/utc/lordvalerius.utc.json
@@ -452,7 +452,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 12899
+    "value": 12599
   },
   "Int": {
     "type": "byte",
@@ -486,7 +486,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 13199
+    "value": 12899
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/malechef.utc.json
+++ b/Module/utc/malechef.utc.json
@@ -331,7 +331,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 86
+    "value": 81
   },
   "Int": {
     "type": "byte",
@@ -365,7 +365,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 91
+    "value": 86
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/man_hunter.utc.json
+++ b/Module/utc/man_hunter.utc.json
@@ -347,7 +347,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 214
+    "value": 202
   },
   "Int": {
     "type": "byte",
@@ -381,7 +381,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 226
+    "value": 214
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/man_leader.utc.json
+++ b/Module/utc/man_leader.utc.json
@@ -396,7 +396,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 589
+    "value": 585
   },
   "Int": {
     "type": "byte",
@@ -430,7 +430,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 593
+    "value": 589
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/man_ranger_1.utc.json
+++ b/Module/utc/man_ranger_1.utc.json
@@ -347,7 +347,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 199
+    "value": 187
   },
   "Int": {
     "type": "byte",
@@ -381,7 +381,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 211
+    "value": 199
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/man_ranger_2.utc.json
+++ b/Module/utc/man_ranger_2.utc.json
@@ -347,7 +347,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 199
+    "value": 187
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/man_scout.utc.json
+++ b/Module/utc/man_scout.utc.json
@@ -333,7 +333,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 311
+    "value": 296
   },
   "Int": {
     "type": "byte",
@@ -367,7 +367,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 326
+    "value": 311
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/man_warrior_1.utc.json
+++ b/Module/utc/man_warrior_1.utc.json
@@ -340,7 +340,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 214
+    "value": 199
   },
   "Int": {
     "type": "byte",
@@ -374,7 +374,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 229
+    "value": 214
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/markahunger.utc.json
+++ b/Module/utc/markahunger.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2197
+    "value": 2089
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/maw_ghal.utc.json
+++ b/Module/utc/maw_ghal.utc.json
@@ -164,7 +164,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 557
+    "value": 523
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/mc_amphihydrus.utc.json
+++ b/Module/utc/mc_amphihydrus.utc.json
@@ -157,7 +157,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 380
+    "value": 362
   },
   "Int": {
     "type": "byte",
@@ -191,7 +191,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 398
+    "value": 380
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/mc_aradile.utc.json
+++ b/Module/utc/mc_aradile.utc.json
@@ -143,7 +143,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 380
+    "value": 368
   },
   "Int": {
     "type": "byte",
@@ -177,7 +177,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 392
+    "value": 380
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/mc_microtench.utc.json
+++ b/Module/utc/mc_microtench.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 512
+    "value": 476
   },
   "Int": {
     "type": "byte",
@@ -184,7 +184,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 548
+    "value": 512
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/mc_octotench.utc.json
+++ b/Module/utc/mc_octotench.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 534
+    "value": 498
   },
   "Int": {
     "type": "byte",
@@ -184,7 +184,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 570
+    "value": 534
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/mc_scorchys.utc.json
+++ b/Module/utc/mc_scorchys.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 473
+    "value": 455
   },
   "Int": {
     "type": "byte",
@@ -184,7 +184,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 491
+    "value": 473
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/mirevein.utc.json
+++ b/Module/utc/mirevein.utc.json
@@ -204,7 +204,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 461
+    "value": 413
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/mossback.utc.json
+++ b/Module/utc/mossback.utc.json
@@ -157,7 +157,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 461
+    "value": 413
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/mynock.utc.json
+++ b/Module/utc/mynock.utc.json
@@ -143,7 +143,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 40
+    "value": 42
   },
   "Int": {
     "type": "byte",
@@ -177,7 +177,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 38
+    "value": 40
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/nar_arenafight.utc.json
+++ b/Module/utc/nar_arenafight.utc.json
@@ -312,7 +312,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 627
+    "value": 599
   },
   "Int": {
     "type": "byte",
@@ -346,7 +346,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 655
+    "value": 627
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/nar_cmd_droid.utc.json
+++ b/Module/utc/nar_cmd_droid.utc.json
@@ -164,7 +164,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1270
+    "value": 1238
   },
   "Int": {
     "type": "byte",
@@ -198,7 +198,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1302
+    "value": 1270
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/nar_hiddenblade.utc.json
+++ b/Module/utc/nar_hiddenblade.utc.json
@@ -319,7 +319,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 627
+    "value": 599
   },
   "Int": {
     "type": "byte",
@@ -353,7 +353,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 655
+    "value": 627
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/nar_pirate.utc.json
+++ b/Module/utc/nar_pirate.utc.json
@@ -319,7 +319,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 627
+    "value": 599
   },
   "Int": {
     "type": "byte",
@@ -353,7 +353,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 655
+    "value": 627
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/nar_redblade.utc.json
+++ b/Module/utc/nar_redblade.utc.json
@@ -319,7 +319,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 627
+    "value": 599
   },
   "Int": {
     "type": "byte",
@@ -353,7 +353,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 655
+    "value": 627
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/nar_rogue_droid.utc.json
+++ b/Module/utc/nar_rogue_droid.utc.json
@@ -63,7 +63,7 @@
   "Description": {
     "type": "cexolocstring",
     "value": {
-      "0": "A malfunctioning combat unit left to roam the moon�s industrial districts. Its targeting protocols are unstable and it attacks anything nearby."
+      "0": "A malfunctioning combat unit left to roam the moon’s industrial districts. Its targeting protocols are unstable and it attacks anything nearby."
     }
   },
   "Dex": {

--- a/Module/utc/nar_rogue_droid.utc.json
+++ b/Module/utc/nar_rogue_droid.utc.json
@@ -63,7 +63,7 @@
   "Description": {
     "type": "cexolocstring",
     "value": {
-      "0": "A malfunctioning combat unit left to roam the moon’s industrial districts. Its targeting protocols are unstable and it attacks anything nearby."
+      "0": "A malfunctioning combat unit left to roam the moonï¿½s industrial districts. Its targeting protocols are unstable and it attacks anything nearby."
     }
   },
   "Dex": {
@@ -157,7 +157,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 818
+    "value": 786
   },
   "Int": {
     "type": "byte",
@@ -191,7 +191,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 850
+    "value": 818
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/nar_scavenger.utc.json
+++ b/Module/utc/nar_scavenger.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 564
+    "value": 536
   },
   "Int": {
     "type": "byte",
@@ -184,7 +184,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 592
+    "value": 564
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/nar_serp_leader.utc.json
+++ b/Module/utc/nar_serp_leader.utc.json
@@ -326,7 +326,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1680
+    "value": 1640
   },
   "Int": {
     "type": "byte",
@@ -360,7 +360,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1720
+    "value": 1680
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/nar_serpent.utc.json
+++ b/Module/utc/nar_serpent.utc.json
@@ -312,7 +312,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 627
+    "value": 599
   },
   "Int": {
     "type": "byte",
@@ -346,7 +346,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 655
+    "value": 627
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/nar_slavercaptn.utc.json
+++ b/Module/utc/nar_slavercaptn.utc.json
@@ -155,7 +155,7 @@
   "Description": {
     "type": "cexolocstring",
     "value": {
-      "0": "Leader of a slaver convoy cell operating out of Nar Shaddaa’s shadow ports. Experienced, well-equipped, and protected by hired muscle."
+      "0": "Leader of a slaver convoy cell operating out of Nar Shaddaaï¿½s shadow ports. Experienced, well-equipped, and protected by hired muscle."
     }
   },
   "Dex": {
@@ -326,7 +326,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1680
+    "value": 1640
   },
   "Int": {
     "type": "byte",
@@ -360,7 +360,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1720
+    "value": 1680
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/nar_slavercaptn.utc.json
+++ b/Module/utc/nar_slavercaptn.utc.json
@@ -155,7 +155,7 @@
   "Description": {
     "type": "cexolocstring",
     "value": {
-      "0": "Leader of a slaver convoy cell operating out of Nar Shaddaa�s shadow ports. Experienced, well-equipped, and protected by hired muscle."
+      "0": "Leader of a slaver convoy cell operating out of Nar Shaddaa’s shadow ports. Experienced, well-equipped, and protected by hired muscle."
     }
   },
   "Dex": {

--- a/Module/utc/nar_sniper.utc.json
+++ b/Module/utc/nar_sniper.utc.json
@@ -326,7 +326,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1680
+    "value": 1640
   },
   "Int": {
     "type": "byte",
@@ -360,7 +360,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1720
+    "value": 1680
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/nar_thief.utc.json
+++ b/Module/utc/nar_thief.utc.json
@@ -312,7 +312,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 564
+    "value": 536
   },
   "Int": {
     "type": "byte",
@@ -346,7 +346,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 592
+    "value": 564
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/nar_troublemaker.utc.json
+++ b/Module/utc/nar_troublemaker.utc.json
@@ -312,7 +312,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 747
+    "value": 711
   },
   "Int": {
     "type": "byte",
@@ -346,7 +346,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 783
+    "value": 747
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/nara_venn.utc.json
+++ b/Module/utc/nara_venn.utc.json
@@ -326,7 +326,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 230
+    "value": 218
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/oldscar_kath.utc.json
+++ b/Module/utc/oldscar_kath.utc.json
@@ -157,7 +157,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 193
+    "value": 185
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/overwatch.utc.json
+++ b/Module/utc/overwatch.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2197
+    "value": 2089
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/pelko.utc.json
+++ b/Module/utc/pelko.utc.json
@@ -136,7 +136,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 165
+    "value": 163
   },
   "Int": {
     "type": "byte",
@@ -170,7 +170,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 167
+    "value": 165
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/pho.utc.json
+++ b/Module/utc/pho.utc.json
@@ -331,7 +331,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 86
+    "value": 81
   },
   "Int": {
     "type": "byte",
@@ -365,7 +365,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 91
+    "value": 86
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/psychoticpris001.utc.json
+++ b/Module/utc/psychoticpris001.utc.json
@@ -331,7 +331,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 262
+    "value": 247
   },
   "Int": {
     "type": "byte",
@@ -365,7 +365,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 277
+    "value": 262
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/psychoticpris002.utc.json
+++ b/Module/utc/psychoticpris002.utc.json
@@ -331,7 +331,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 262
+    "value": 247
   },
   "Int": {
     "type": "byte",
@@ -365,7 +365,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 277
+    "value": 262
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/psychoticpris004.utc.json
+++ b/Module/utc/psychoticpris004.utc.json
@@ -345,7 +345,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 247
+    "value": 242
   },
   "Int": {
     "type": "byte",
@@ -379,7 +379,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 252
+    "value": 247
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/psychoticpris005.utc.json
+++ b/Module/utc/psychoticpris005.utc.json
@@ -331,7 +331,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 262
+    "value": 247
   },
   "Int": {
     "type": "byte",
@@ -365,7 +365,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 277
+    "value": 262
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/pthune.utc.json
+++ b/Module/utc/pthune.utc.json
@@ -143,7 +143,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 823
+    "value": 748
   },
   "Int": {
     "type": "byte",
@@ -177,7 +177,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 898
+    "value": 823
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/qion_hive_tunnel.utc.json
+++ b/Module/utc/qion_hive_tunnel.utc.json
@@ -164,7 +164,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 897
+    "value": 843
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/qion_larvae.utc.json
+++ b/Module/utc/qion_larvae.utc.json
@@ -157,7 +157,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 373
+    "value": 337
   },
   "Int": {
     "type": "byte",
@@ -191,7 +191,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 409
+    "value": 373
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/qion_slug.utc.json
+++ b/Module/utc/qion_slug.utc.json
@@ -164,7 +164,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 522
+    "value": 468
   },
   "Int": {
     "type": "byte",
@@ -198,7 +198,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 576
+    "value": 522
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/qion_slug001.utc.json
+++ b/Module/utc/qion_slug001.utc.json
@@ -171,7 +171,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 493
+    "value": 466
   },
   "Int": {
     "type": "byte",
@@ -205,7 +205,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 520
+    "value": 493
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/qion_tiger.utc.json
+++ b/Module/utc/qion_tiger.utc.json
@@ -164,7 +164,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 513
+    "value": 486
   },
   "Int": {
     "type": "byte",
@@ -198,7 +198,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 540
+    "value": 513
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/qionhivebugswarm.utc.json
+++ b/Module/utc/qionhivebugswarm.utc.json
@@ -143,7 +143,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 462
+    "value": 452
   },
   "Int": {
     "type": "byte",
@@ -177,7 +177,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 472
+    "value": 462
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/qionmut_lo.utc.json
+++ b/Module/utc/qionmut_lo.utc.json
@@ -289,7 +289,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 47
+    "value": 2
   },
   "Int": {
     "type": "byte",
@@ -323,7 +323,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 72
+    "value": 47
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/qionmutationbeas.utc.json
+++ b/Module/utc/qionmutationbeas.utc.json
@@ -296,7 +296,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 676
+    "value": 431
   },
   "Int": {
     "type": "byte",
@@ -330,7 +330,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 901
+    "value": 676
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/quickdraw.utc.json
+++ b/Module/utc/quickdraw.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2197
+    "value": 2089
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/quillstalker.utc.json
+++ b/Module/utc/quillstalker.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2197
+    "value": 1717
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/rancor.utc.json
+++ b/Module/utc/rancor.utc.json
@@ -171,7 +171,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 3191
+    "value": 3141
   },
   "Int": {
     "type": "byte",
@@ -205,7 +205,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 3241
+    "value": 3191
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/redtail_kor.utc.json
+++ b/Module/utc/redtail_kor.utc.json
@@ -157,7 +157,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 536
+    "value": 480
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/reefmaw.utc.json
+++ b/Module/utc/reefmaw.utc.json
@@ -157,7 +157,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1103
+    "value": 1061
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/revmynock.utc.json
+++ b/Module/utc/revmynock.utc.json
@@ -143,7 +143,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 51
+    "value": 53
   },
   "Int": {
     "type": "byte",
@@ -177,7 +177,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 49
+    "value": 51
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/rhydelalpha.utc.json
+++ b/Module/utc/rhydelalpha.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2075
+    "value": 1795
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/ritestalker.utc.json
+++ b/Module/utc/ritestalker.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2075
+    "value": 1795
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/rootcoil.utc.json
+++ b/Module/utc/rootcoil.utc.json
@@ -204,7 +204,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 461
+    "value": 413
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/ruptorvane.utc.json
+++ b/Module/utc/ruptorvane.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2197
+    "value": 2089
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/s_app.utc.json
+++ b/Module/utc/s_app.utc.json
@@ -312,7 +312,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 363
+    "value": 351
   },
   "Int": {
     "type": "byte",
@@ -346,7 +346,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 375
+    "value": 363
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/s_app_m.utc.json
+++ b/Module/utc/s_app_m.utc.json
@@ -319,7 +319,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 363
+    "value": 351
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/sable_quarr.utc.json
+++ b/Module/utc/sable_quarr.utc.json
@@ -347,7 +347,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1082
+    "value": 1026
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/sabraetrial.utc.json
+++ b/Module/utc/sabraetrial.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2441
+    "value": 2333
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/sandbeetle.utc.json
+++ b/Module/utc/sandbeetle.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 683
+    "value": 623
   },
   "Int": {
     "type": "byte",
@@ -184,7 +184,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 743
+    "value": 683
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/sanddemon.utc.json
+++ b/Module/utc/sanddemon.utc.json
@@ -213,7 +213,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 3993
+    "value": 3923
   },
   "Int": {
     "type": "byte",
@@ -247,7 +247,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4063
+    "value": 3993
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/sandswimmer.utc.json
+++ b/Module/utc/sandswimmer.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 777
+    "value": 657
   },
   "Int": {
     "type": "byte",
@@ -184,7 +184,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 897
+    "value": 777
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/sandworm.utc.json
+++ b/Module/utc/sandworm.utc.json
@@ -157,7 +157,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 7324
+    "value": 6924
   },
   "Int": {
     "type": "byte",
@@ -191,7 +191,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 7724
+    "value": 7324
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/sewerpatroldroid.utc.json
+++ b/Module/utc/sewerpatroldroid.utc.json
@@ -197,7 +197,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 90
+    "value": 86
   },
   "Int": {
     "type": "byte",
@@ -231,7 +231,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 94
+    "value": 90
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/shardeye.utc.json
+++ b/Module/utc/shardeye.utc.json
@@ -178,7 +178,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 350
+    "value": 320
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/shyrack.utc.json
+++ b/Module/utc/shyrack.utc.json
@@ -143,7 +143,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 345
+    "value": 341
   },
   "Int": {
     "type": "byte",
@@ -177,7 +177,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 349
+    "value": 345
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/silkshade.utc.json
+++ b/Module/utc/silkshade.utc.json
@@ -164,7 +164,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 259
+    "value": 245
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/sirtulieut.utc.json
+++ b/Module/utc/sirtulieut.utc.json
@@ -513,7 +513,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 90
+    "value": 85
   },
   "Int": {
     "type": "byte",
@@ -547,7 +547,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 55
+    "value": 90
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/sith_cmdr.utc.json
+++ b/Module/utc/sith_cmdr.utc.json
@@ -361,7 +361,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 592
+    "value": 568
   },
   "Int": {
     "type": "byte",
@@ -415,7 +415,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 616
+    "value": 592
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/sith_commando.utc.json
+++ b/Module/utc/sith_commando.utc.json
@@ -459,7 +459,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 398
+    "value": 366
   },
   "Int": {
     "type": "byte",
@@ -528,7 +528,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 430
+    "value": 398
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/sith_hogu.utc.json
+++ b/Module/utc/sith_hogu.utc.json
@@ -361,7 +361,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1037
+    "value": 925
   },
   "Int": {
     "type": "byte",
@@ -430,7 +430,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1149
+    "value": 1037
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/sith_siegetroop.utc.json
+++ b/Module/utc/sith_siegetroop.utc.json
@@ -354,7 +354,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 246
+    "value": 198
   },
   "Int": {
     "type": "byte",
@@ -388,7 +388,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 294
+    "value": 246
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/sith_troop.utc.json
+++ b/Module/utc/sith_troop.utc.json
@@ -347,7 +347,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 256
+    "value": 220
   },
   "Int": {
     "type": "byte",
@@ -381,7 +381,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 292
+    "value": 256
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/sithofficer001.utc.json
+++ b/Module/utc/sithofficer001.utc.json
@@ -415,7 +415,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 352
+    "value": 292
   },
   "Int": {
     "type": "byte",
@@ -449,7 +449,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 412
+    "value": 352
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/sithsnake.utc.json
+++ b/Module/utc/sithsnake.utc.json
@@ -143,7 +143,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 384
+    "value": 359
   },
   "Int": {
     "type": "byte",
@@ -177,7 +177,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 409
+    "value": 384
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/slagborn.utc.json
+++ b/Module/utc/slagborn.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2441
+    "value": 2333
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/soot_rusk.utc.json
+++ b/Module/utc/soot_rusk.utc.json
@@ -326,7 +326,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 230
+    "value": 218
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/spinequill.utc.json
+++ b/Module/utc/spinequill.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2197
+    "value": 1717
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/suppressor.utc.json
+++ b/Module/utc/suppressor.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2075
+    "value": 2012
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/swampvines.utc.json
+++ b/Module/utc/swampvines.utc.json
@@ -190,7 +190,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 205
+    "value": 190
   },
   "Int": {
     "type": "byte",
@@ -224,7 +224,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 225
+    "value": 205
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/tarn_kyric.utc.json
+++ b/Module/utc/tarn_kyric.utc.json
@@ -340,7 +340,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 483
+    "value": 427
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/tarnapexmaw.utc.json
+++ b/Module/utc/tarnapexmaw.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2441
+    "value": 1961
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/thermlancer.utc.json
+++ b/Module/utc/thermlancer.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2197
+    "value": 2089
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/thune.utc.json
+++ b/Module/utc/thune.utc.json
@@ -169,7 +169,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1906
+    "value": 1666
   },
   "Int": {
     "type": "byte",
@@ -203,7 +203,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2146
+    "value": 1906
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/triagewarden.utc.json
+++ b/Module/utc/triagewarden.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2441
+    "value": 2333
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/tukata.utc.json
+++ b/Module/utc/tukata.utc.json
@@ -136,7 +136,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 595
+    "value": 515
   },
   "Int": {
     "type": "byte",
@@ -170,7 +170,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 675
+    "value": 595
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/tusken_elite1.utc.json
+++ b/Module/utc/tusken_elite1.utc.json
@@ -448,7 +448,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1587
+    "value": 1532
   },
   "Int": {
     "type": "byte",
@@ -482,7 +482,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1642
+    "value": 1587
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/tusken_elite2.utc.json
+++ b/Module/utc/tusken_elite2.utc.json
@@ -471,7 +471,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1587
+    "value": 1482
   },
   "Int": {
     "type": "byte",
@@ -505,7 +505,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1692
+    "value": 1587
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/tusken_melee.utc.json
+++ b/Module/utc/tusken_melee.utc.json
@@ -443,7 +443,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 617
+    "value": 533
   },
   "Int": {
     "type": "byte",
@@ -477,7 +477,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 701
+    "value": 617
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/v_flesheater.utc.json
+++ b/Module/utc/v_flesheater.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 247
+    "value": 239
   },
   "Int": {
     "type": "byte",
@@ -184,7 +184,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 255
+    "value": 247
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/v_flesheater2.utc.json
+++ b/Module/utc/v_flesheater2.utc.json
@@ -157,7 +157,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 291
+    "value": 267
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/v_fleshleader.utc.json
+++ b/Module/utc/v_fleshleader.utc.json
@@ -252,7 +252,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 664
+    "value": 644
   },
   "Int": {
     "type": "byte",
@@ -286,7 +286,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 684
+    "value": 664
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/v_raivor.utc.json
+++ b/Module/utc/v_raivor.utc.json
@@ -143,7 +143,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 238
+    "value": 223
   },
   "Int": {
     "type": "byte",
@@ -177,7 +177,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 253
+    "value": 238
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/v_raivor2.utc.json
+++ b/Module/utc/v_raivor2.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 238
+    "value": 223
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/vall_nashtah.utc.json
+++ b/Module/utc/vall_nashtah.utc.json
@@ -143,7 +143,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 189
+    "value": 179
   },
   "Int": {
     "type": "byte",
@@ -177,7 +177,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 199
+    "value": 189
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/valley_cairnmog.utc.json
+++ b/Module/utc/valley_cairnmog.utc.json
@@ -143,7 +143,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 173
+    "value": 161
   },
   "Int": {
     "type": "byte",
@@ -177,7 +177,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 185
+    "value": 173
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/valley_cairnmog2.utc.json
+++ b/Module/utc/valley_cairnmog2.utc.json
@@ -171,7 +171,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 392
+    "value": 387
   },
   "Int": {
     "type": "byte",
@@ -205,7 +205,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 397
+    "value": 392
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/valnpcsi4.utc.json
+++ b/Module/utc/valnpcsi4.utc.json
@@ -354,7 +354,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 795
+    "value": 435
   },
   "Int": {
     "type": "byte",
@@ -388,7 +388,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1155
+    "value": 795
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/valnpcswar4.utc.json
+++ b/Module/utc/valnpcswar4.utc.json
@@ -389,7 +389,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1573
+    "value": 1213
   },
   "Int": {
     "type": "byte",
@@ -423,7 +423,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1933
+    "value": 1573
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/valnpcswarmong.utc.json
+++ b/Module/utc/valnpcswarmong.utc.json
@@ -375,7 +375,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1790
+    "value": 1390
   },
   "Int": {
     "type": "byte",
@@ -409,7 +409,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2190
+    "value": 1790
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/varo_skeld.utc.json
+++ b/Module/utc/varo_skeld.utc.json
@@ -361,7 +361,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 483
+    "value": 427
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/vdathchirodac.utc.json
+++ b/Module/utc/vdathchirodac.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1085
+    "value": 645
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/vdathdarkadept.utc.json
+++ b/Module/utc/vdathdarkadept.utc.json
@@ -319,7 +319,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4611
+    "value": 4513
   },
   "Int": {
     "type": "byte",
@@ -353,7 +353,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4709
+    "value": 4611
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vdathguard.utc.json
+++ b/Module/utc/vdathguard.utc.json
@@ -171,7 +171,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1902
+    "value": 1462
   },
   "Int": {
     "type": "byte",
@@ -205,7 +205,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2342
+    "value": 1902
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vdathpurbole.utc.json
+++ b/Module/utc/vdathpurbole.utc.json
@@ -143,7 +143,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 705
+    "value": 545
   },
   "Int": {
     "type": "byte",
@@ -177,7 +177,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 865
+    "value": 705
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vdathshaman.utc.json
+++ b/Module/utc/vdathshaman.utc.json
@@ -164,7 +164,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1948
+    "value": 1548
   },
   "Int": {
     "type": "byte",
@@ -198,7 +198,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2348
+    "value": 1948
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vdathshear.utc.json
+++ b/Module/utc/vdathshear.utc.json
@@ -143,7 +143,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 857
+    "value": 497
   },
   "Int": {
     "type": "byte",
@@ -177,7 +177,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1217
+    "value": 857
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vdathsprantal.utc.json
+++ b/Module/utc/vdathsprantal.utc.json
@@ -143,7 +143,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 968
+    "value": 568
   },
   "Int": {
     "type": "byte",
@@ -177,7 +177,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1368
+    "value": 968
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vdathsquell.utc.json
+++ b/Module/utc/vdathsquell.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 897
+    "value": 497
   },
   "Int": {
     "type": "byte",
@@ -184,7 +184,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1297
+    "value": 897
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vdathssurian.utc.json
+++ b/Module/utc/vdathssurian.utc.json
@@ -143,7 +143,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1026
+    "value": 626
   },
   "Int": {
     "type": "byte",
@@ -177,7 +177,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1426
+    "value": 1026
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vdathswampland.utc.json
+++ b/Module/utc/vdathswampland.utc.json
@@ -183,7 +183,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 683
+    "value": 523
   },
   "Int": {
     "type": "byte",
@@ -217,11 +217,11 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 843
+    "value": 683
   },
   "NaturalAC": {
     "type": "byte",
-    "value": 12
+    "value": 0
   },
   "NoPermDeath": {
     "type": "byte",

--- a/Module/utc/vdathtribal.utc.json
+++ b/Module/utc/vdathtribal.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 795
+    "value": 435
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/vdathturtle.utc.json
+++ b/Module/utc/vdathturtle.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4485
+    "value": 4205
   },
   "Int": {
     "type": "byte",
@@ -184,7 +184,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4765
+    "value": 4485
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vdatthrancor.utc.json
+++ b/Module/utc/vdatthrancor.utc.json
@@ -178,7 +178,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4611
+    "value": 4548
   },
   "Int": {
     "type": "byte",
@@ -212,7 +212,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4674
+    "value": 4611
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vellen_raptor.utc.json
+++ b/Module/utc/vellen_raptor.utc.json
@@ -169,7 +169,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 380
+    "value": 360
   },
   "Int": {
     "type": "byte",
@@ -203,7 +203,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 400
+    "value": 380
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vellenrap_lo.utc.json
+++ b/Module/utc/vellenrap_lo.utc.json
@@ -169,7 +169,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 96
+    "value": 106
   },
   "Int": {
     "type": "byte",
@@ -203,7 +203,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 86
+    "value": 96
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vgapingspider.utc.json
+++ b/Module/utc/vgapingspider.utc.json
@@ -148,7 +148,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 728
+    "value": 723
   },
   "Int": {
     "type": "byte",
@@ -182,7 +182,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 733
+    "value": 728
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/viper.utc.json
+++ b/Module/utc/viper.utc.json
@@ -162,7 +162,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 448
+    "value": 400
   },
   "Int": {
     "type": "byte",
@@ -196,7 +196,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 496
+    "value": 448
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vkorrdun1rifle.utc.json
+++ b/Module/utc/vkorrdun1rifle.utc.json
@@ -326,7 +326,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1116
+    "value": 636
   },
   "Int": {
     "type": "byte",
@@ -360,7 +360,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1596
+    "value": 1116
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vkorrdun1sword.utc.json
+++ b/Module/utc/vkorrdun1sword.utc.json
@@ -326,7 +326,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1116
+    "value": 636
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/vkorrdun4boss.utc.json
+++ b/Module/utc/vkorrdun4boss.utc.json
@@ -375,7 +375,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 7467
+    "value": 7067
   },
   "Int": {
     "type": "byte",
@@ -409,7 +409,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 7867
+    "value": 7467
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vkorrduncouncilg.utc.json
+++ b/Module/utc/vkorrduncouncilg.utc.json
@@ -382,7 +382,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 7467
+    "value": 7067
   },
   "Int": {
     "type": "byte",
@@ -416,7 +416,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 7867
+    "value": 7467
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vkorrdundroidhvy.utc.json
+++ b/Module/utc/vkorrdundroidhvy.utc.json
@@ -220,7 +220,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2548
+    "value": 2308
   },
   "Int": {
     "type": "byte",
@@ -254,7 +254,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2788
+    "value": 2548
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vkorrdungate.utc.json
+++ b/Module/utc/vkorrdungate.utc.json
@@ -361,7 +361,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 3360
+    "value": 2960
   },
   "Int": {
     "type": "byte",
@@ -395,7 +395,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 3760
+    "value": 3360
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vkorrduninquis.utc.json
+++ b/Module/utc/vkorrduninquis.utc.json
@@ -375,7 +375,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2166
+    "value": 1806
   },
   "Int": {
     "type": "byte",
@@ -409,7 +409,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2526
+    "value": 2166
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vkorrdunmarauder.utc.json
+++ b/Module/utc/vkorrdunmarauder.utc.json
@@ -375,7 +375,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1528
+    "value": 1248
   },
   "Int": {
     "type": "byte",
@@ -409,7 +409,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1808
+    "value": 1528
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vkorrdunsorc.utc.json
+++ b/Module/utc/vkorrdunsorc.utc.json
@@ -380,7 +380,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1528
+    "value": 1248
   },
   "Int": {
     "type": "byte",
@@ -414,7 +414,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1808
+    "value": 1528
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vkorrdunwarform.utc.json
+++ b/Module/utc/vkorrdunwarform.utc.json
@@ -248,7 +248,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 8785
+    "value": 8105
   },
   "Int": {
     "type": "byte",
@@ -282,7 +282,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 9465
+    "value": 8785
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vnpcdarklord.utc.json
+++ b/Module/utc/vnpcdarklord.utc.json
@@ -366,7 +366,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 12899
+    "value": 12299
   },
   "Int": {
     "type": "byte",
@@ -400,7 +400,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 13499
+    "value": 12899
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vnpcscons1.utc.json
+++ b/Module/utc/vnpcscons1.utc.json
@@ -291,7 +291,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 21
+    "value": 41
   },
   "Int": {
     "type": "byte",
@@ -345,7 +345,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 10
+    "value": 21
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vnpcscons3.utc.json
+++ b/Module/utc/vnpcscons3.utc.json
@@ -298,7 +298,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1116
+    "value": 636
   },
   "Int": {
     "type": "byte",
@@ -352,7 +352,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1596
+    "value": 1116
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vnpcshvygun.utc.json
+++ b/Module/utc/vnpcshvygun.utc.json
@@ -340,7 +340,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1153
+    "value": 753
   },
   "Int": {
     "type": "byte",
@@ -374,7 +374,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1553
+    "value": 1153
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vnpcsi1.utc.json
+++ b/Module/utc/vnpcsi1.utc.json
@@ -333,7 +333,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 687
+    "value": 567
   },
   "Int": {
     "type": "byte",
@@ -367,7 +367,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 807
+    "value": 687
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vnpcsi2.utc.json
+++ b/Module/utc/vnpcsi2.utc.json
@@ -347,7 +347,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 863
+    "value": 703
   },
   "Int": {
     "type": "byte",
@@ -381,7 +381,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1023
+    "value": 863
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vnpcsi3.utc.json
+++ b/Module/utc/vnpcsi3.utc.json
@@ -333,7 +333,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1158
+    "value": 918
   },
   "Int": {
     "type": "byte",
@@ -367,7 +367,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1398
+    "value": 1158
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vnpcsinvade.utc.json
+++ b/Module/utc/vnpcsinvade.utc.json
@@ -312,7 +312,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 823
+    "value": 748
   },
   "Int": {
     "type": "byte",
@@ -366,7 +366,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 898
+    "value": 823
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vnpcsmedic.utc.json
+++ b/Module/utc/vnpcsmedic.utc.json
@@ -326,7 +326,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 763
+    "value": 403
   },
   "Int": {
     "type": "byte",
@@ -360,7 +360,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1123
+    "value": 763
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vnpcsofficer.utc.json
+++ b/Module/utc/vnpcsofficer.utc.json
@@ -347,7 +347,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1106
+    "value": 746
   },
   "Int": {
     "type": "byte",
@@ -401,7 +401,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1466
+    "value": 1106
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vnpcssabot.utc.json
+++ b/Module/utc/vnpcssabot.utc.json
@@ -361,7 +361,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 846
+    "value": 446
   },
   "Int": {
     "type": "byte",
@@ -395,7 +395,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1246
+    "value": 846
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vnpcssnipe1.utc.json
+++ b/Module/utc/vnpcssnipe1.utc.json
@@ -312,7 +312,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 612
+    "value": 522
   },
   "Int": {
     "type": "byte",
@@ -346,7 +346,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 702
+    "value": 612
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vnpcssnipe2.utc.json
+++ b/Module/utc/vnpcssnipe2.utc.json
@@ -305,7 +305,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 564
+    "value": 459
   },
   "Int": {
     "type": "byte",
@@ -339,7 +339,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 669
+    "value": 564
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vnpcssnipe3.utc.json
+++ b/Module/utc/vnpcssnipe3.utc.json
@@ -305,7 +305,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 699
+    "value": 579
   },
   "Int": {
     "type": "byte",
@@ -339,7 +339,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 819
+    "value": 699
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vnpcssorc1.utc.json
+++ b/Module/utc/vnpcssorc1.utc.json
@@ -319,7 +319,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 435
+    "value": 415
   },
   "Int": {
     "type": "byte",
@@ -353,7 +353,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 455
+    "value": 435
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vnpcssorc2.utc.json
+++ b/Module/utc/vnpcssorc2.utc.json
@@ -319,7 +319,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 553
+    "value": 523
   },
   "Int": {
     "type": "byte",
@@ -353,7 +353,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 583
+    "value": 553
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vnpcssorc3.utc.json
+++ b/Module/utc/vnpcssorc3.utc.json
@@ -347,7 +347,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 823
+    "value": 748
   },
   "Int": {
     "type": "byte",
@@ -381,7 +381,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 898
+    "value": 823
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vnpcssorc4.utc.json
+++ b/Module/utc/vnpcssorc4.utc.json
@@ -347,7 +347,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 847
+    "value": 647
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/vnpcstroop1.utc.json
+++ b/Module/utc/vnpcstroop1.utc.json
@@ -305,7 +305,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 230
+    "value": 110
   },
   "Int": {
     "type": "byte",
@@ -359,7 +359,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 350
+    "value": 230
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vnpcstroop2.utc.json
+++ b/Module/utc/vnpcstroop2.utc.json
@@ -298,7 +298,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 295
+    "value": 285
   },
   "Int": {
     "type": "byte",
@@ -352,7 +352,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 305
+    "value": 295
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vnpcstroop3.utc.json
+++ b/Module/utc/vnpcstroop3.utc.json
@@ -326,7 +326,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 744
+    "value": 584
   },
   "Int": {
     "type": "byte",
@@ -380,7 +380,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 904
+    "value": 744
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vnpcstroop4.utc.json
+++ b/Module/utc/vnpcstroop4.utc.json
@@ -354,7 +354,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1436
+    "value": 1236
   },
   "Int": {
     "type": "byte",
@@ -408,7 +408,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1636
+    "value": 1436
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vnpcstroop5.utc.json
+++ b/Module/utc/vnpcstroop5.utc.json
@@ -340,7 +340,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2075
+    "value": 1795
   },
   "Int": {
     "type": "byte",
@@ -394,7 +394,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2355
+    "value": 2075
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vnpcsvan1.utc.json
+++ b/Module/utc/vnpcsvan1.utc.json
@@ -305,7 +305,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 476
+    "value": 446
   },
   "Int": {
     "type": "byte",
@@ -359,7 +359,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 506
+    "value": 476
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vnpcsvan3.utc.json
+++ b/Module/utc/vnpcsvan3.utc.json
@@ -340,7 +340,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 1867
+    "value": 1467
   },
   "Int": {
     "type": "byte",
@@ -394,7 +394,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 2267
+    "value": 1867
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vnpcswar1.utc.json
+++ b/Module/utc/vnpcswar1.utc.json
@@ -319,7 +319,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 640
+    "value": 550
   },
   "Int": {
     "type": "byte",
@@ -353,7 +353,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 730
+    "value": 640
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vnpcswar2.utc.json
+++ b/Module/utc/vnpcswar2.utc.json
@@ -326,7 +326,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 926
+    "value": 766
   },
   "Int": {
     "type": "byte",
@@ -360,7 +360,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1086
+    "value": 926
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vnpcswar3.utc.json
+++ b/Module/utc/vnpcswar3.utc.json
@@ -361,7 +361,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 676
+    "value": 596
   },
   "Int": {
     "type": "byte",
@@ -395,7 +395,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 756
+    "value": 676
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/voritorlizard.utc.json
+++ b/Module/utc/voritorlizard.utc.json
@@ -148,7 +148,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 997
+    "value": 527
   },
   "Int": {
     "type": "byte",
@@ -182,7 +182,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1467
+    "value": 997
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vqueenkin.utc.json
+++ b/Module/utc/vqueenkin.utc.json
@@ -176,7 +176,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4883
+    "value": 4403
   },
   "Int": {
     "type": "byte",
@@ -210,7 +210,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 5363
+    "value": 4883
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vrix7.utc.json
+++ b/Module/utc/vrix7.utc.json
@@ -213,7 +213,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 2197
+    "value": 1717
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/vsithbot1.utc.json
+++ b/Module/utc/vsithbot1.utc.json
@@ -199,7 +199,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 184
+    "value": 169
   },
   "Int": {
     "type": "byte",
@@ -233,7 +233,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 199
+    "value": 184
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vsithbot2.utc.json
+++ b/Module/utc/vsithbot2.utc.json
@@ -199,7 +199,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 295
+    "value": 255
   },
   "Int": {
     "type": "byte",
@@ -233,7 +233,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 335
+    "value": 295
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vsithbot3.utc.json
+++ b/Module/utc/vsithbot3.utc.json
@@ -206,7 +206,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 747
+    "value": 387
   },
   "Int": {
     "type": "byte",
@@ -240,7 +240,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1107
+    "value": 747
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vsithbot4.utc.json
+++ b/Module/utc/vsithbot4.utc.json
@@ -234,7 +234,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 977
+    "value": 812
   },
   "Int": {
     "type": "byte",
@@ -268,7 +268,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 1142
+    "value": 977
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vsithbot5.utc.json
+++ b/Module/utc/vsithbot5.utc.json
@@ -241,7 +241,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4228
+    "value": 3788
   },
   "Int": {
     "type": "byte",
@@ -275,7 +275,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4668
+    "value": 4228
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vtattbountyhunt.utc.json
+++ b/Module/utc/vtattbountyhunt.utc.json
@@ -340,7 +340,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 5425
+    "value": 4945
   },
   "Int": {
     "type": "byte",
@@ -394,7 +394,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 5905
+    "value": 5425
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vtattkrayt.utc.json
+++ b/Module/utc/vtattkrayt.utc.json
@@ -185,7 +185,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 4611
+    "value": 4548
   },
   "Int": {
     "type": "byte",
@@ -219,7 +219,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 4674
+    "value": 4611
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vtdrakebruiser.utc.json
+++ b/Module/utc/vtdrakebruiser.utc.json
@@ -298,7 +298,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 73
+    "value": 83
   },
   "Int": {
     "type": "byte",
@@ -332,7 +332,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 63
+    "value": 73
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/vtdrakegrunt.utc.json
+++ b/Module/utc/vtdrakegrunt.utc.json
@@ -291,7 +291,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 73
+    "value": 83
   },
   "Int": {
     "type": "byte",
@@ -325,7 +325,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 63
+    "value": 73
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/warocas.utc.json
+++ b/Module/utc/warocas.utc.json
@@ -143,7 +143,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 62
+    "value": 64
   },
   "Int": {
     "type": "byte",
@@ -177,7 +177,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 60
+    "value": 62
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/weequay_pirate.utc.json
+++ b/Module/utc/weequay_pirate.utc.json
@@ -317,7 +317,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 62
+    "value": 65
   },
   "Int": {
     "type": "byte",
@@ -351,7 +351,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 59
+    "value": 62
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/womprat.utc.json
+++ b/Module/utc/womprat.utc.json
@@ -143,7 +143,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 676
+    "value": 596
   },
   "Int": {
     "type": "byte",
@@ -177,7 +177,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 756
+    "value": 676
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/ww_gimpassa.utc.json
+++ b/Module/utc/ww_gimpassa.utc.json
@@ -143,7 +143,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 205
+    "value": 187
   },
   "Int": {
     "type": "byte",
@@ -177,7 +177,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 223
+    "value": 205
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/ww_kinrath.utc.json
+++ b/Module/utc/ww_kinrath.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 115
+    "value": 114
   },
   "Int": {
     "type": "byte",

--- a/Module/utc/zomb_guard.utc.json
+++ b/Module/utc/zomb_guard.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 417
+    "value": 401
   },
   "Int": {
     "type": "byte",
@@ -184,7 +184,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 433
+    "value": 417
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/zomb_rancor.utc.json
+++ b/Module/utc/zomb_rancor.utc.json
@@ -171,7 +171,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 3191
+    "value": 3141
   },
   "Int": {
     "type": "byte",
@@ -205,7 +205,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 3241
+    "value": 3191
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/zomb_scientist1.utc.json
+++ b/Module/utc/zomb_scientist1.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 417
+    "value": 401
   },
   "Int": {
     "type": "byte",
@@ -184,7 +184,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 433
+    "value": 417
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/zomb_worker1.utc.json
+++ b/Module/utc/zomb_worker1.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 417
+    "value": 401
   },
   "Int": {
     "type": "byte",
@@ -184,7 +184,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 433
+    "value": 417
   },
   "NaturalAC": {
     "type": "byte",

--- a/Module/utc/zomb_worker2.utc.json
+++ b/Module/utc/zomb_worker2.utc.json
@@ -150,7 +150,7 @@
   },
   "HitPoints": {
     "type": "short",
-    "value": 417
+    "value": 401
   },
   "Int": {
     "type": "byte",
@@ -184,7 +184,7 @@
   },
   "MaxHitPoints": {
     "type": "short",
-    "value": 433
+    "value": 417
   },
   "NaturalAC": {
     "type": "byte",

--- a/SWLOR.Game.Server.Tests/Feature/NPCEnemyBalanceAuditTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/NPCEnemyBalanceAuditTests.cs
@@ -1,5 +1,7 @@
+using System.Diagnostics;
 using System.Globalization;
 using System.IO.Compression;
+using System.Text;
 using System.Text.Json;
 using System.Xml.Linq;
 using FluentAssertions;
@@ -483,6 +485,120 @@ public class NPCEnemyBalanceAuditTests
         audited.Should().BeGreaterThan(450, "every terrestrial combat creature with an NPCHP stat skin should be audited");
         failures.Should().BeEmpty(
             "UTC HitPoints must exclude NWN's native Vitality/Constitution and Toughness bonuses while CurrentHitPoints and MaxHitPoints remain the final NPCHP budget");
+    }
+
+    [Test]
+    public async Task NpcHpNormalizer_PreservesWindows1252AssetText()
+    {
+        var root = FindRepositoryRoot();
+        var temporaryRoot = Path.Combine(Path.GetTempPath(), $"swlor-npc-hp-{Guid.NewGuid():N}");
+        var toolsDirectory = Path.Combine(temporaryRoot, "tools");
+        var utcDirectory = Path.Combine(temporaryRoot, "Module", "utc");
+        var utiDirectory = Path.Combine(temporaryRoot, "Module", "uti");
+
+        Directory.CreateDirectory(toolsDirectory);
+        Directory.CreateDirectory(utcDirectory);
+        Directory.CreateDirectory(utiDirectory);
+
+        try
+        {
+            var script = Path.Combine(toolsDirectory, "NormalizeNpcHitPoints.ps1");
+            File.Copy(Path.Combine(root.FullName, "tools", "NormalizeNpcHitPoints.ps1"), script);
+
+            const string utcText = """
+                                   {
+                                     "Equip_ItemList": {
+                                       "value": [
+                                         {
+                                           "__struct_id": 131072,
+                                           "EquippedRes": { "value": "legacy_skin" }
+                                         }
+                                       ]
+                                     },
+                                     "ClassList": { "value": [{ "ClassLevel": { "value": 2 } }] },
+                                     "Con": { "value": 14 },
+                                     "FeatList": { "value": [] },
+                                     "Description": { "value": { "0": "Nar Shaddaa’s shadow ports" } },
+                                     "CurrentHitPoints": { "type": "short", "value": 1 },
+                                     "HitPoints": { "type": "short", "value": 1 },
+                                     "MaxHitPoints": { "type": "short", "value": 1 }
+                                   }
+                                   """;
+            const string skinText = """
+                                    {
+                                      "PropertiesList": {
+                                        "value": [
+                                          {
+                                            "PropertyName": { "value": 96 },
+                                            "CostValue": { "value": 100 }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                    """;
+
+            var utcPath = Path.Combine(utcDirectory, "legacy.utc.json");
+            File.WriteAllBytes(utcPath, EncodeWindows1252Fixture(utcText));
+            File.WriteAllText(Path.Combine(utiDirectory, "legacy_skin.uti.json"), skinText);
+
+            var startInfo = new ProcessStartInfo("powershell.exe")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+            startInfo.ArgumentList.Add("-NoProfile");
+            startInfo.ArgumentList.Add("-ExecutionPolicy");
+            startInfo.ArgumentList.Add("Bypass");
+            startInfo.ArgumentList.Add("-File");
+            startInfo.ArgumentList.Add(script);
+
+            string output;
+            string error;
+            int exitCode;
+            using (var process = Process.Start(startInfo)!)
+            {
+                var outputTask = process.StandardOutput.ReadToEndAsync();
+                var errorTask = process.StandardError.ReadToEndAsync();
+                await process.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(30));
+                output = await outputTask;
+                error = await errorTask;
+                exitCode = process.ExitCode;
+            }
+
+            exitCode.Should().Be(0, $"the normalizer should succeed. Output: {output} Error: {error}");
+
+            var normalizedBytes = File.ReadAllBytes(utcPath);
+            normalizedBytes.Should().Contain((byte)0x92,
+                "the original Windows-1252 apostrophe must remain encoded as 0x92");
+            normalizedBytes.AsSpan().IndexOf(new byte[] { 0xEF, 0xBF, 0xBD }).Should().Be(-1,
+                "the normalizer must not write an encoded Unicode replacement character");
+
+            var normalizedAscii = Encoding.ASCII.GetString(normalizedBytes);
+            normalizedAscii.Should().Contain("\"CurrentHitPoints\": { \"type\": \"short\", \"value\": 100 }");
+            normalizedAscii.Should().Contain("\"HitPoints\": { \"type\": \"short\", \"value\": 96 }");
+            normalizedAscii.Should().Contain("\"MaxHitPoints\": { \"type\": \"short\", \"value\": 100 }");
+        }
+        finally
+        {
+            Directory.Delete(temporaryRoot, true);
+        }
+    }
+
+    private static byte[] EncodeWindows1252Fixture(string text)
+    {
+        var bytes = new List<byte>();
+        var segments = text.Split('’');
+
+        for (var index = 0; index < segments.Length; index++)
+        {
+            bytes.AddRange(Encoding.ASCII.GetBytes(segments[index]));
+            if (index < segments.Length - 1)
+                bytes.Add(0x92);
+        }
+
+        return bytes.ToArray();
     }
 
     [Test]

--- a/SWLOR.Game.Server.Tests/Feature/NPCEnemyBalanceAuditTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/NPCEnemyBalanceAuditTests.cs
@@ -36,6 +36,10 @@ public class NPCEnemyBalanceAuditTests
     private const int ResistanceCostTable = 54;
     private const int PhysicalDefenseSubtype = 1;
     private const int ForceDefenseSubtype = 2;
+    private const int ToughnessFeatId = 40;
+    private const int FirstEpicToughnessFeatId = 754;
+    private const int LastEpicToughnessFeatId = 763;
+    private const int EpicToughnessHitPoints = 20;
 
     private static readonly int[] ResistanceSubtypes = { 1, 2, 3, 4, 100, 101, 102, 103 };
 
@@ -434,6 +438,195 @@ public class NPCEnemyBalanceAuditTests
         source.Should().Contain("_builder.Create(\"FrogBoss\", \"Alchemized Frog Boss\")");
         source.Should().Contain(".AddSpawn(ObjectType.Creature, \"frogboss\")");
         source.Should().Contain(".RespawnDelay(120)");
+    }
+
+    [Test]
+    public void AllNpcHpBudgets_AccountForNativeVitalityAndToughnessRules()
+    {
+        var root = FindRepositoryRoot();
+        var utcDirectory = Path.Combine(root.FullName, "Module", "utc");
+        var failures = new List<string>();
+        var audited = 0;
+
+        foreach (var utcPath in Directory.EnumerateFiles(utcDirectory, "*.utc.json").OrderBy(path => path))
+        {
+            using var utc = JsonDocument.Parse(File.ReadAllText(utcPath));
+            var skinResref = GetEquippedResref(utc.RootElement, CreatureArmorSlot);
+            if (string.IsNullOrWhiteSpace(skinResref))
+                continue;
+
+            var skinPath = Path.Combine(root.FullName, "Module", "uti", $"{skinResref}.uti.json");
+            if (!File.Exists(skinPath))
+                continue;
+
+            using var skin = JsonDocument.Parse(File.ReadAllText(skinPath));
+            var finalHp = GetNpcHpBudget(skin.RootElement);
+            if (!finalHp.HasValue)
+                continue;
+
+            var resref = Path.GetFileNameWithoutExtension(Path.GetFileNameWithoutExtension(utcPath));
+            var expectedBaseHp = GetExpectedNpcBaseHitPoints(utc.RootElement, finalHp.Value);
+            var currentHp = GetInt(utc.RootElement, "CurrentHitPoints");
+            var baseHp = GetInt(utc.RootElement, "HitPoints");
+            var maxHp = GetInt(utc.RootElement, "MaxHitPoints");
+
+            if (currentHp != finalHp.Value || baseHp != expectedBaseHp || maxHp != finalHp.Value)
+            {
+                failures.Add(
+                    $"{resref}: CurrentHitPoints={currentHp}, HitPoints={baseHp}, MaxHitPoints={maxHp}; " +
+                    $"expected final NPCHP={finalHp.Value} and native-adjusted base={expectedBaseHp}.");
+            }
+
+            audited++;
+        }
+
+        audited.Should().BeGreaterThan(450, "every terrestrial combat creature with an NPCHP stat skin should be audited");
+        failures.Should().BeEmpty(
+            "UTC HitPoints must exclude NWN's native Vitality/Constitution and Toughness bonuses while CurrentHitPoints and MaxHitPoints remain the final NPCHP budget");
+    }
+
+    [Test]
+    public void WorldNpcAssets_MatchBibleRuntimeHpAndEvasionBudgets()
+    {
+        var root = FindRepositoryRoot();
+        using var archive = ZipFile.OpenRead(Path.Combine(
+            root.FullName,
+            "design",
+            "bible",
+            "SWLOR Design Bible - Combat Upgrade.xlsx"));
+        var worldNpcs = ReadWorksheetByName(archive, "World NPCs");
+        var sharedStrings = ReadSharedStrings(archive);
+        XNamespace ns = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+        var lastRow = worldNpcs
+            .Descendants(ns + "row")
+            .Select(row => int.Parse(row.Attribute("r")!.Value, CultureInfo.InvariantCulture))
+            .Max();
+
+        var failures = new List<string>();
+        var auditedAssets = 0;
+        var bibleHpBudgets = 0;
+        var bibleEvasionBudgets = 0;
+
+        for (var row = 2; row <= lastRow; row++)
+        {
+            var resref = GetWorkbookCellText(worldNpcs, sharedStrings, $"C{row}");
+            if (string.IsNullOrWhiteSpace(resref))
+                continue;
+
+            var utcPath = Path.Combine(root.FullName, "Module", "utc", $"{resref}.utc.json");
+            if (!File.Exists(utcPath))
+            {
+                failures.Add($"World NPCs row {row} ({resref}) has no UTC blueprint.");
+                continue;
+            }
+
+            using var utc = JsonDocument.Parse(File.ReadAllText(utcPath));
+            var skinResref = GetEquippedResref(utc.RootElement, CreatureArmorSlot);
+            if (string.IsNullOrWhiteSpace(skinResref))
+            {
+                failures.Add($"World NPCs row {row} ({resref}) has no equipped stat skin.");
+                continue;
+            }
+
+            var skinPath = Path.Combine(root.FullName, "Module", "uti", $"{skinResref}.uti.json");
+            if (!File.Exists(skinPath))
+            {
+                failures.Add($"World NPCs row {row} ({resref}) references missing stat skin {skinResref}.");
+                continue;
+            }
+
+            using var skin = JsonDocument.Parse(File.ReadAllText(skinPath));
+            var skinHp = GetNpcHpBudget(skin.RootElement);
+            var currentHp = GetInt(utc.RootElement, "CurrentHitPoints");
+            var baseHp = GetInt(utc.RootElement, "HitPoints");
+            var maxHp = GetInt(utc.RootElement, "MaxHitPoints");
+            if (!skinHp.HasValue)
+            {
+                failures.Add($"World NPCs row {row} ({resref}) stat skin {skinResref} has no NPCHP budget.");
+            }
+            else
+            {
+                var expectedBaseHp = GetExpectedNpcBaseHitPoints(utc.RootElement, skinHp.Value);
+                if (currentHp != skinHp.Value || baseHp != expectedBaseHp || maxHp != skinHp.Value)
+                {
+                    failures.Add(
+                        $"World NPCs row {row} ({resref}) HP sources disagree: " +
+                        $"CurrentHitPoints={currentHp}, HitPoints={baseHp}, MaxHitPoints={maxHp}, " +
+                        $"{skinResref}.NPCHP={skinHp.Value}, expected native-adjusted base={expectedBaseHp}.");
+                }
+            }
+
+            var bibleHpText = GetWorkbookCellText(worldNpcs, sharedStrings, $"N{row}");
+            if (decimal.TryParse(bibleHpText, NumberStyles.Number, CultureInfo.InvariantCulture, out var bibleHpValue) &&
+                bibleHpValue > 0)
+            {
+                var bibleHp = decimal.ToInt32(bibleHpValue);
+                bibleHpBudgets++;
+                if (currentHp != bibleHp || maxHp != bibleHp || skinHp != bibleHp)
+                {
+                    failures.Add(
+                        $"World NPCs row {row} ({resref}) does not match Bible HP {bibleHp}: " +
+                        $"CurrentHitPoints={currentHp}, MaxHitPoints={maxHp}, {skinResref}.NPCHP={skinHp?.ToString() ?? "missing"}.");
+                }
+            }
+
+            var bibleEvasionText = GetWorkbookCellText(worldNpcs, sharedStrings, $"T{row}");
+            if (decimal.TryParse(bibleEvasionText, NumberStyles.Number, CultureInfo.InvariantCulture, out var bibleEvasionValue) &&
+                bibleEvasionValue > 0)
+            {
+                var bibleEvasion = decimal.ToInt32(bibleEvasionValue);
+                var skinEvasion = GetItemPropertyCost(skin.RootElement, ItemPropertyEvasion);
+                bibleEvasionBudgets++;
+                if (skinEvasion != bibleEvasion)
+                {
+                    failures.Add(
+                        $"World NPCs row {row} ({resref}) does not match Bible Evasion {bibleEvasion}: " +
+                        $"{skinResref}.Evasion={skinEvasion?.ToString() ?? "missing"}.");
+                }
+            }
+
+            auditedAssets++;
+        }
+
+        auditedAssets.Should().BeGreaterThan(400, "the complete World NPC corpus should remain under asset audit");
+        bibleHpBudgets.Should().BeGreaterThan(350, "formula-backed World NPC HP rows should remain under Bible audit");
+        bibleEvasionBudgets.Should().BeGreaterThan(350, "formula-backed World NPC Evasion rows should remain under Bible audit");
+        failures.Should().BeEmpty("World NPC runtime HP and Evasion sources must agree with the Design Bible");
+    }
+
+    [Test]
+    public void ReportedDathomirForceCasterTargets_MatchReviewedHpAndEffectiveEvasionBudgets()
+    {
+        var root = FindRepositoryRoot();
+        var targets = new[]
+        {
+            new { Resref = "vdathswampland", Skin = "junglebug_sk", Level = 40, HP = 683, Agility = 28, Evasion = 10, EffectiveEvasion = 126 },
+            new { Resref = "vdathpurbole", Skin = "purbole_sk", Level = 41, HP = 705, Agility = 28, Evasion = 10, EffectiveEvasion = 128 },
+            new { Resref = "vdathtribal", Skin = "kwitribal_sk", Level = 43, HP = 795, Agility = 29, Evasion = 11, EffectiveEvasion = 134 },
+            new { Resref = "vdathguard", Skin = "kwiguardian_sk", Level = 45, HP = 1902, Agility = 32, Evasion = 13, EffectiveEvasion = 143 },
+        };
+
+        foreach (var target in targets)
+        {
+            using var utc = ReadJson(root, "Module", "utc", $"{target.Resref}.utc.json");
+            using var skin = ReadJson(root, "Module", "uti", $"{target.Skin}.uti.json");
+
+            GetEquippedResref(utc.RootElement, CreatureArmorSlot).Should().Be(target.Skin, target.Resref);
+            GetInt(utc.RootElement, "CurrentHitPoints").Should().Be(target.HP, target.Resref);
+            GetInt(utc.RootElement, "HitPoints").Should().Be(
+                GetExpectedNpcBaseHitPoints(utc.RootElement, target.HP),
+                $"{target.Resref} must exclude native Vitality HP from its UTC base");
+            GetInt(utc.RootElement, "MaxHitPoints").Should().Be(target.HP, target.Resref);
+            GetItemPropertyCost(skin.RootElement, ItemPropertyNPCHP).Should().Be(target.HP, target.Skin);
+            GetItemPropertyCost(skin.RootElement, ItemPropertyNPCLevel).Should().Be(target.Level, target.Skin);
+            GetItemPropertyCost(skin.RootElement, ItemPropertyEvasion).Should().Be(target.Evasion, target.Skin);
+
+            var naturalAc = GetInt(utc.RootElement, "NaturalAC");
+            naturalAc.Should().Be(0, $"{target.Resref} must not hide extra Evasion outside its Bible stat skin");
+            Stat.GetEvasion(target.Level, target.Agility, target.Evasion + naturalAc * 5)
+                .Should()
+                .Be(target.EffectiveEvasion, $"{target.Resref} effective Evasion must include any serialized NaturalAC contribution");
+        }
     }
 
     [Test]
@@ -1381,7 +1574,9 @@ public class NPCEnemyBalanceAuditTests
     private static void AssertCreatureHitPoints(JsonElement utc, ExpectedEnemy expected)
     {
         GetInt(utc, "CurrentHitPoints").Should().Be(expected.HP, expected.Resref);
-        GetInt(utc, "HitPoints").Should().Be(expected.HP, expected.Resref);
+        GetInt(utc, "HitPoints").Should().Be(
+            GetExpectedNpcBaseHitPoints(utc, expected.HP),
+            $"{expected.Resref} must exclude native Vitality HP from its UTC base");
         GetInt(utc, "MaxHitPoints").Should().Be(expected.HP, expected.Resref);
     }
 
@@ -1472,6 +1667,26 @@ public class NPCEnemyBalanceAuditTests
             .ToArray();
     }
 
+    private static int GetExpectedNpcBaseHitPoints(JsonElement utc, int finalHp)
+    {
+        var level = utc
+            .GetProperty("ClassList")
+            .GetProperty("value")
+            .EnumerateArray()
+            .Sum(entry => GetInt(entry, "ClassLevel"));
+        var constitutionModifier = (int)Math.Floor((GetInt(utc, "Con") - 10) / 2m);
+        var feats = GetCreatureFeats(utc);
+        var nativeAdjustment = constitutionModifier * level;
+
+        if (feats.Contains(ToughnessFeatId))
+            nativeAdjustment += level;
+
+        nativeAdjustment += feats.Count(feat =>
+            feat >= FirstEpicToughnessFeatId && feat <= LastEpicToughnessFeatId) * EpicToughnessHitPoints;
+
+        return finalHp - nativeAdjustment;
+    }
+
     private static int GetJsonLocalInt(JsonElement utc, string variableName)
     {
         return utc
@@ -1507,6 +1722,16 @@ public class NPCEnemyBalanceAuditTests
                 (!subtype.HasValue || GetInt(property, "Subtype") == subtype.Value))
             .Select(property => (int?)GetInt(property, "CostValue"))
             .SingleOrDefault();
+    }
+
+    private static int? GetNpcHpBudget(JsonElement skin)
+    {
+        var values = GetItemProperties(skin)
+            .Where(property => GetInt(property, "PropertyName") == ItemPropertyNPCHP)
+            .Select(property => GetInt(property, "CostValue"))
+            .ToArray();
+
+        return values.Length == 0 ? null : values.Sum();
     }
 
     private static int[] GetItemPropertySubtypes(JsonElement item, int propertyName)

--- a/SWLOR.Game.Server.Tests/Feature/StablesWindowTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/StablesWindowTests.cs
@@ -30,6 +30,21 @@ public class StablesWindowTests
         }
     }
 
+    [Test]
+    public void BeastHpDisplay_UsesTheFinalLevelBudgetWithoutReapplyingVitality()
+    {
+        var source = File.ReadAllText(Path.Combine(
+            FindRepositoryRoot().FullName,
+            "SWLOR.Game.Server",
+            "Feature",
+            "GuiDefinition",
+            "ViewModel",
+            "StablesViewModel.cs"));
+
+        source.Should().Contain("HP = $\"{level.HP}\";");
+        source.Should().NotContain("level.HP +");
+    }
+
     private static string ExtractMethod(string source, string signature)
     {
         var signatureIndex = source.IndexOf(signature, StringComparison.Ordinal);

--- a/SWLOR.Game.Server/Feature/EquipmentStats.cs
+++ b/SWLOR.Game.Server/Feature/EquipmentStats.cs
@@ -189,7 +189,7 @@ namespace SWLOR.Game.Server.Feature
 
                 if (maxHP > 0)
                 {
-                    ObjectPlugin.SetMaxHitPoints(creature, maxHP);
+                    Stat.SetNPCMaxHitPoints(creature, maxHP);
                 }
 
                 if (GetCurrentHitPoints(creature) > GetMaxHitPoints(creature))

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/StablesViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/StablesViewModel.cs
@@ -492,7 +492,6 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             Name = dbBeast.Name;
             XPTooltip = $"XP: {dbBeast.XP} / {BeastMastery.GetRequiredXP(dbBeast.Level, dbBeast.XPPenaltyPercent)}";
 
-            var hp = level.HP + 1 * ((level.Stats[AbilityType.Vitality] - 10) / 2);
             var fp = Stat.GetMaxFP(level.FP, level.Stats[AbilityType.Willpower], 0);
             if (fp < 0)
                 fp = 0;
@@ -501,7 +500,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             if (stm < 0)
                 stm = 0;
 
-            HP = $"{hp}";
+            HP = $"{level.HP}";
             FP = $"{fp}";
             STM = $"{stm}";
             SP = $"{dbBeast.Level} / {BeastMastery.MaxLevel} ({dbBeast.UnallocatedSP})";

--- a/SWLOR.Game.Server/Readmes/WorldNpcBalanceAudit.md
+++ b/SWLOR.Game.Server/Readmes/WorldNpcBalanceAudit.md
@@ -1,6 +1,6 @@
 # World NPC Balance Audit
 
-Last full audit: 2026-07-09 (feature/combat-upgrade)
+Last full audit: 2026-08-15 (feature/combat-upgrade)
 
 ## What the audit verifies
 
@@ -8,7 +8,13 @@ Every `World NPCs` Bible row must match its module assets exactly:
 
 - UTC `Str/Dex/Wis/Con/Int` = Bible `MGT/PER/WIL/VIT/AGI` (runtime mapping:
   Might=STR, Perception=DEX, Vitality=CON, Agility=INT, Willpower=WIS).
-- UTC `HitPoints`/`CurrentHitPoints`/`MaxHitPoints` = Bible `HP`.
+- The stat skin's `NPCHP`, UTC `CurrentHitPoints`, and UTC `MaxHitPoints` = Bible
+  `HP`, which is the final combat budget. UTC `HitPoints` is deliberately lower:
+  NWN treats it as base HP and adds the Constitution modifier (SWLOR Vitality) once
+  per class level, one HP per level for Toughness, and 20 HP per Epic Toughness feat.
+  Its required value is `NPCHP - native HP bonuses`. `LoadNPCStats` applies the same
+  final budget through `Stat.SetNPCMaxHitPoints`, which compensates the engine-derived
+  bonuses instead of passing the final budget to NWNX as though it were base HP.
 - Stat skin item properties (`NPCLevel`, `NPCHP`, `STM`, `FP`, `Attack`,
   `Force Attack`, `Evasion`, `Defense` physical/force, all 8 `Resistance`
   subtypes) = Bible columns. Negative resistances encode as `100 + abs(value)`.
@@ -32,6 +38,12 @@ Every `World NPCs` Bible row must match its module assets exactly:
 Regression coverage lives in `NPCEnemyBalanceAuditTests`,
 `CombatAttackDelayTests`, and `CapstoneQuestDefinitionTests`.
 
+`NPCEnemyBalanceAuditTests` also audits every NPCHP-backed creature in the module,
+not only the documented World NPC rows, against the native-adjusted UTC base and
+final HP budget. Focused effective-Evasion coverage includes UTC `NaturalAC`, which
+contributes five Evasion rating per point through the native AC term and must not
+silently inflate reviewed NPC profiles.
+
 ## Intentionally out of scope for the World NPCs tab
 
 - Starship combat NPCs (`t1bomber`..`t6platform`, `mandocap1-3`, `sithcap1-7`):
@@ -50,8 +62,10 @@ Regression coverage lives in `NPCEnemyBalanceAuditTests`,
 ## 2026-07 audit outcomes
 
 - 120 NPCs had Perception/Agility (DEX/INT) transposed on their UTCs.
-- 70 NPCs had stale `MaxHitPoints` (engine Con-bonus values) above the NPC-HP
-  budget; all three HP fields now match the Bible.
+- HP serialization was later strengthened module-wide: every NPCHP-backed UTC now
+  stores native-adjusted base `HitPoints`, while `CurrentHitPoints`/`MaxHitPoints`
+  match the final NPCHP budget. This prevents Vitality and Toughness from being
+  counted a second time by NWN and is enforced by the normalization tool and corpus test.
 - ~50 NPCs carried delay-pressure-nerfed weapon damage below preset; restored
   to preset values (matching the earlier fast-cadence restoration pass).
 - Five named rares (`reefmaw`, `sable_quarr`, `kael_drox`, `inkveil`,

--- a/SWLOR.Game.Server/Service/BeastMastery.cs
+++ b/SWLOR.Game.Server/Service/BeastMastery.cs
@@ -339,13 +339,13 @@ namespace SWLOR.Game.Server.Service
             BiowareXP2.IPSafeAddItemProperty(claw, ItemPropertyCustom(ItemPropertyType.DamageStat, (int)beastDetail.DamageStat), 0f, AddItemPropertyPolicy.ReplaceExisting, false, false);
             BiowareXP2.IPSafeAddItemProperty(claw, ItemPropertyCustom(ItemPropertyType.AccuracyStat, (int)beastDetail.AccuracyStat), 0f, AddItemPropertyPolicy.ReplaceExisting, false, false);
 
-            ObjectPlugin.SetMaxHitPoints(beast, beastDetail.Levels[dbBeast.Level].HP);
             CreaturePlugin.SetRawAbilityScore(beast, AbilityType.Might, level.Stats[AbilityType.Might]);
             CreaturePlugin.SetRawAbilityScore(beast, AbilityType.Perception, level.Stats[AbilityType.Perception]);
             CreaturePlugin.SetRawAbilityScore(beast, AbilityType.Vitality, level.Stats[AbilityType.Vitality]);
             CreaturePlugin.SetRawAbilityScore(beast, AbilityType.Willpower, level.Stats[AbilityType.Willpower]);
             CreaturePlugin.SetRawAbilityScore(beast, AbilityType.Agility, level.Stats[AbilityType.Agility]);
             CreaturePlugin.SetRawAbilityScore(beast, AbilityType.Social, level.Stats[AbilityType.Social]);
+            Stat.SetNPCMaxHitPoints(beast, level.HP);
 
             var attackBonus = (int)(level.MaxAttackBonus * (dbBeast.AttackPurity * 0.01f));
             var accuracyBonus = (int)(level.MaxAccuracyBonus * (dbBeast.AccuracyPurity * 0.01f));

--- a/SWLOR.Game.Server/Service/Droid.cs
+++ b/SWLOR.Game.Server/Service/Droid.cs
@@ -610,14 +610,13 @@ namespace SWLOR.Game.Server.Service
                 : details.CustomName);
 
             // Raw stats
-            ObjectPlugin.SetMaxHitPoints(droid, details.HP);
-            ObjectPlugin.SetCurrentHitPoints(droid, details.HP);
             CreaturePlugin.SetRawAbilityScore(droid, AbilityType.Might, details.MGT);
             CreaturePlugin.SetRawAbilityScore(droid, AbilityType.Perception, details.PER);
             CreaturePlugin.SetRawAbilityScore(droid, AbilityType.Vitality, details.VIT);
             CreaturePlugin.SetRawAbilityScore(droid, AbilityType.Willpower, details.WIL);
             CreaturePlugin.SetRawAbilityScore(droid, AbilityType.Agility, details.AGI);
             CreaturePlugin.SetRawAbilityScore(droid, AbilityType.Social, details.SOC);
+            Stat.SetNPCMaxHitPoints(droid, details.HP, true);
             CreaturePlugin.SetBaseAC(droid, 10);
             CreaturePlugin.SetBaseAttackBonus(droid, 1);
 

--- a/SWLOR.Game.Server/Service/Stat.cs
+++ b/SWLOR.Game.Server/Service/Stat.cs
@@ -32,6 +32,8 @@ namespace SWLOR.Game.Server.Service
         private const float DefaultPlayerMovementSpeedIncrease = 0.25f;
         private const float DefaultCompanionMovementSpeedIncrease = 0.25f;
         private const float DefaultNPCMovementSpeedIncrease = 0.30f;
+        private const int MaximumNPCHitPoints = 30000;
+        private const int MaximumNPCHitPointAlignmentPasses = 4;
         public const int DefaultMeleeDeflectionChanceCap = 50;
         public const int DefaultRangedDeflectionChanceCap = 50;
         public const int MaximumDeflectionChanceCap = 100;
@@ -2446,17 +2448,67 @@ namespace SWLOR.Game.Server.Service
                 }
             }
 
-            if (maxHP > 30000)
-                maxHP = 30000;
+            if (maxHP > MaximumNPCHitPoints)
+                maxHP = MaximumNPCHitPoints;
 
             if (maxHP > 0)
             {
-                ObjectPlugin.SetMaxHitPoints(self, maxHP);
-                ObjectPlugin.SetCurrentHitPoints(self, maxHP);
+                SetNPCMaxHitPoints(self, maxHP, true);
             }
 
             SetLocalInt(self, "FP", GetMaxFP(self));
             SetLocalInt(self, "STAMINA", GetMaxStamina(self));
+        }
+
+        /// <summary>
+        /// Sets an NPC's final maximum HP after accounting for the native NWN bonuses
+        /// derived from Constitution (SWLOR Vitality), Toughness, and similar rules.
+        /// ObjectPlugin.SetMaxHitPoints writes the engine's base HP, not its final maximum.
+        /// </summary>
+        /// <param name="creature">The NPC whose HP budget is being applied.</param>
+        /// <param name="desiredMaxHitPoints">The final maximum HP the NPC should have.</param>
+        /// <param name="restoreToFull">If true, restore current HP to the final maximum.</param>
+        public static void SetNPCMaxHitPoints(uint creature, int desiredMaxHitPoints, bool restoreToFull = false)
+        {
+            desiredMaxHitPoints = System.Math.Clamp(desiredMaxHitPoints, 1, MaximumNPCHitPoints);
+            var originalCurrentHitPoints = GetCurrentHitPoints(creature);
+
+            // Probe with the final budget, observe the engine-derived adjustment, then
+            // compensate the base value. Repeating also handles NWN's one-HP-per-level
+            // floor for creatures with a negative Constitution modifier.
+            var baseHitPoints = desiredMaxHitPoints;
+            for (var pass = 0; pass < MaximumNPCHitPointAlignmentPasses; pass++)
+            {
+                ObjectPlugin.SetMaxHitPoints(creature, baseHitPoints);
+                var actualMaxHitPoints = GetMaxHitPoints(creature);
+                if (actualMaxHitPoints == desiredMaxHitPoints)
+                    break;
+
+                baseHitPoints = System.Math.Clamp(
+                    baseHitPoints + desiredMaxHitPoints - actualMaxHitPoints,
+                    1,
+                    short.MaxValue);
+            }
+
+            var alignedMaxHitPoints = GetMaxHitPoints(creature);
+            if (alignedMaxHitPoints != desiredMaxHitPoints)
+            {
+                Log.Write(
+                    LogGroup.Error,
+                    $"Unable to align NPC HP budget for {GetResRef(creature)}. " +
+                    $"Expected {desiredMaxHitPoints}, received {alignedMaxHitPoints}.");
+            }
+
+            if (restoreToFull)
+            {
+                ObjectPlugin.SetCurrentHitPoints(creature, alignedMaxHitPoints);
+            }
+            else
+            {
+                ObjectPlugin.SetCurrentHitPoints(
+                    creature,
+                    System.Math.Min(originalCurrentHitPoints, alignedMaxHitPoints));
+            }
         }
 
         /// <summary>

--- a/tools/NormalizeNpcHitPoints.ps1
+++ b/tools/NormalizeNpcHitPoints.ps1
@@ -1,0 +1,129 @@
+param(
+    [switch]$CheckOnly
+)
+
+$ErrorActionPreference = "Stop"
+
+$repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$utcDirectory = Join-Path $repositoryRoot "Module\utc"
+$utiDirectory = Join-Path $repositoryRoot "Module\uti"
+$utf8NoBom = [Text.UTF8Encoding]::new($false)
+
+function Get-EquippedStatSkinResref($utc) {
+    $skin = @($utc.Equip_ItemList.value | Where-Object { $_.__struct_id -eq 131072 }) |
+        Select-Object -First 1
+
+    if ($null -eq $skin) {
+        return ""
+    }
+
+    return [string]$skin.EquippedRes.value
+}
+
+function Get-NpcHpBudget($skin) {
+    $hpProperties = @($skin.PropertiesList.value | Where-Object {
+        $null -ne $_.PropertyName -and [int]$_.PropertyName.value -eq 96
+    })
+
+    if ($hpProperties.Count -eq 0) {
+        return 0
+    }
+
+    $budget = 0
+    foreach ($property in $hpProperties) {
+        $budget += [int]$property.CostValue.value
+    }
+
+    return $budget
+}
+
+function Get-NativeHitPointAdjustment($utc) {
+    $level = 0
+    foreach ($classEntry in @($utc.ClassList.value)) {
+        $level += [int]$classEntry.ClassLevel.value
+    }
+
+    $constitution = [int]$utc.Con.value
+    $constitutionModifier = [int][Math]::Floor(($constitution - 10) / 2)
+    $adjustment = $constitutionModifier * $level
+
+    $featIds = @($utc.FeatList.value | ForEach-Object { [int]$_.Feat.value })
+    if ($featIds -contains 40) {
+        # Toughness grants one HP per character level.
+        $adjustment += $level
+    }
+
+    # Each separately possessed Epic Toughness feat grants 20 HP.
+    $adjustment += 20 * @($featIds | Where-Object { $_ -ge 754 -and $_ -le 763 }).Count
+
+    return $adjustment
+}
+
+function Set-TypedShortValue([string]$text, [string]$fieldName, [int]$value) {
+    $escapedFieldName = [Regex]::Escape($fieldName)
+    $pattern = "(?ms)(^\s*`"$escapedFieldName`"\s*:\s*\{\s*`"type`"\s*:\s*`"short`"\s*,\s*`"value`"\s*:\s*)-?\d+"
+    $matches = [Regex]::Matches($text, $pattern)
+
+    if ($matches.Count -ne 1) {
+        throw "Expected exactly one $fieldName short field, found $($matches.Count)."
+    }
+
+    return [Regex]::Replace(
+        $text,
+        $pattern,
+        { param($match) $match.Groups[1].Value + $value },
+        1)
+}
+
+$audited = 0
+$changed = New-Object System.Collections.Generic.List[string]
+$failures = New-Object System.Collections.Generic.List[string]
+
+foreach ($utcFile in Get-ChildItem -LiteralPath $utcDirectory -Filter "*.utc.json" | Sort-Object Name) {
+    $utcText = [IO.File]::ReadAllText($utcFile.FullName)
+    $utc = $utcText | ConvertFrom-Json
+    $skinResref = Get-EquippedStatSkinResref $utc
+    if ([string]::IsNullOrWhiteSpace($skinResref)) {
+        continue
+    }
+
+    $skinPath = Join-Path $utiDirectory "$skinResref.uti.json"
+    if (-not (Test-Path -LiteralPath $skinPath)) {
+        continue
+    }
+
+    $skin = [IO.File]::ReadAllText($skinPath) | ConvertFrom-Json
+    $finalHp = Get-NpcHpBudget $skin
+    if ($finalHp -le 0) {
+        continue
+    }
+
+    $audited++
+    $baseHp = $finalHp - (Get-NativeHitPointAdjustment $utc)
+    if ($baseHp -lt 1 -or $baseHp -gt [int16]::MaxValue) {
+        $failures.Add("$($utcFile.Name): calculated base HP $baseHp is outside the UTC short range.")
+        continue
+    }
+
+    $normalizedText = Set-TypedShortValue $utcText "CurrentHitPoints" $finalHp
+    $normalizedText = Set-TypedShortValue $normalizedText "HitPoints" $baseHp
+    $normalizedText = Set-TypedShortValue $normalizedText "MaxHitPoints" $finalHp
+
+    if ($normalizedText -ne $utcText) {
+        $changed.Add($utcFile.Name)
+        if (-not $CheckOnly) {
+            [IO.File]::WriteAllText($utcFile.FullName, $normalizedText, $utf8NoBom)
+        }
+    }
+}
+
+if ($failures.Count -gt 0) {
+    throw "NPC HP normalization failed:`n$($failures -join "`n")"
+}
+
+if ($CheckOnly -and $changed.Count -gt 0) {
+    throw "$($changed.Count) of $audited NPCHP-backed UTCs are not normalized:`n$($changed -join "`n")"
+}
+
+$verb = if ($CheckOnly) { "Verified" } else { "Normalized" }
+Write-Host "$verb $audited NPCHP-backed UTCs; $($changed.Count) required changes."

--- a/tools/NormalizeNpcHitPoints.ps1
+++ b/tools/NormalizeNpcHitPoints.ps1
@@ -8,6 +8,25 @@ $repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
 $utcDirectory = Join-Path $repositoryRoot "Module\utc"
 $utiDirectory = Join-Path $repositoryRoot "Module\uti"
 $utf8NoBom = [Text.UTF8Encoding]::new($false)
+$strictUtf8NoBom = [Text.UTF8Encoding]::new($false, $true)
+$windows1252 = [Text.Encoding]::GetEncoding(1252)
+
+function Read-TextFilePreservingEncoding([string]$path) {
+    $bytes = [IO.File]::ReadAllBytes($path)
+
+    try {
+        return [PSCustomObject]@{
+            Text = $strictUtf8NoBom.GetString($bytes)
+            Encoding = $utf8NoBom
+        }
+    }
+    catch [Text.DecoderFallbackException] {
+        return [PSCustomObject]@{
+            Text = $windows1252.GetString($bytes)
+            Encoding = $windows1252
+        }
+    }
+}
 
 function Get-EquippedStatSkinResref($utc) {
     $skin = @($utc.Equip_ItemList.value | Where-Object { $_.__struct_id -eq 131072 }) |
@@ -80,7 +99,8 @@ $changed = New-Object System.Collections.Generic.List[string]
 $failures = New-Object System.Collections.Generic.List[string]
 
 foreach ($utcFile in Get-ChildItem -LiteralPath $utcDirectory -Filter "*.utc.json" | Sort-Object Name) {
-    $utcText = [IO.File]::ReadAllText($utcFile.FullName)
+    $utcDocument = Read-TextFilePreservingEncoding $utcFile.FullName
+    $utcText = $utcDocument.Text
     $utc = $utcText | ConvertFrom-Json
     $skinResref = Get-EquippedStatSkinResref $utc
     if ([string]::IsNullOrWhiteSpace($skinResref)) {
@@ -92,7 +112,8 @@ foreach ($utcFile in Get-ChildItem -LiteralPath $utcDirectory -Filter "*.utc.jso
         continue
     }
 
-    $skin = [IO.File]::ReadAllText($skinPath) | ConvertFrom-Json
+    $skinDocument = Read-TextFilePreservingEncoding $skinPath
+    $skin = $skinDocument.Text | ConvertFrom-Json
     $finalHp = Get-NpcHpBudget $skin
     if ($finalHp -le 0) {
         continue
@@ -112,7 +133,7 @@ foreach ($utcFile in Get-ChildItem -LiteralPath $utcDirectory -Filter "*.utc.jso
     if ($normalizedText -ne $utcText) {
         $changed.Add($utcFile.Name)
         if (-not $CheckOnly) {
-            [IO.File]::WriteAllText($utcFile.FullName, $normalizedText, $utf8NoBom)
+            [IO.File]::WriteAllText($utcFile.FullName, $normalizedText, $utcDocument.Encoding)
         }
     }
 }

--- a/tools/UpdateCapstoneEnemyIdentity.ps1
+++ b/tools/UpdateCapstoneEnemyIdentity.ps1
@@ -1871,6 +1871,24 @@ function Get-GeneratedEnemyItemName($row, [string]$itemKind) {
     return "Level 50 $($row.Role) $($row.StepLabel) $itemKind"
 }
 
+function Get-NativeNpcHitPointAdjustment($utc) {
+    $level = 0
+    foreach ($classEntry in @($utc.ClassList.value)) {
+        $level += [int]$classEntry.ClassLevel.value
+    }
+
+    $constitutionModifier = [int][Math]::Floor(([int]$utc.Con.value - 10) / 2)
+    $adjustment = $constitutionModifier * $level
+    $featIds = @($utc.FeatList.value | ForEach-Object { [int]$_.Feat.value })
+
+    if ($featIds -contains 40) {
+        $adjustment += $level
+    }
+
+    $adjustment += 20 * @($featIds | Where-Object { $_ -ge 754 -and $_ -le 763 }).Count
+    return $adjustment
+}
+
 function Get-AbilityPackageText($package, [string]$signatureDisplayName = "", [string]$capstoneDisplayName = "") {
     $names = New-Object System.Collections.Generic.List[string]
     if (-not [string]::IsNullOrWhiteSpace($signatureDisplayName)) {
@@ -1919,9 +1937,6 @@ function Update-ModuleAssets($rows, $featMap) {
         Set-JsonTypedValue $utc "Int" $stats.PER
         Set-JsonTypedValue $utc "Wis" $stats.WIL
         Set-JsonTypedValue $utc "Cha" $stats.WIL
-        Set-JsonTypedValue $utc "CurrentHitPoints" $stats.HP
-        Set-JsonTypedValue $utc "HitPoints" $stats.HP
-        Set-JsonTypedValue $utc "MaxHitPoints" $stats.HP
 
         $keptFeats = New-Object System.Collections.Generic.List[object]
         foreach ($feat in @($utc.FeatList.value)) {
@@ -1954,6 +1969,10 @@ function Update-ModuleAssets($rows, $featMap) {
             }
         })
         $utc.FeatList.value = @($keptFeats.ToArray())
+
+        Set-JsonTypedValue $utc "CurrentHitPoints" $stats.HP
+        Set-JsonTypedValue $utc "HitPoints" ($stats.HP - (Get-NativeNpcHitPointAdjustment $utc))
+        Set-JsonTypedValue $utc "MaxHitPoints" $stats.HP
 
         Set-ItemPropertyCost $skin 99 43 50
         Set-ItemPropertyCost $skin 96 39 $stats.HP


### PR DESCRIPTION
## Summary
- normalize every NPCHP-backed creature blueprint so UTC base HP excludes native NWN Vitality and Toughness bonuses
- route runtime enemy, beast, droid, and NPC equipment HP updates through a native-aware final-HP helper
- add reusable normalization tooling, generator support, repository guidance, and corpus regression coverage

## Root cause
NWN treats UTC HitPoints and NWNX ObjectPlugin.SetMaxHitPoints as base HP, then applies Constitution/Vitality per class level and Toughness bonuses. The combat-upgrade NPCHP values are authored as final budgets, so assigning them as base HP double-counted the native bonuses.

## Impact
All 480 NPCHP-backed creatures are audited; 462 blueprints required correction. CurrentHitPoints and MaxHitPoints remain the authored final NPCHP values, while HitPoints stores the engine-adjusted base. Runtime spawning and companion restatting now land on that same final budget.

## Validation
- `powershell -ExecutionPolicy Bypass -File tools/NormalizeNpcHitPoints.ps1 -CheckOnly` — 480 audited, 0 drift
- `dotnet build SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj --no-restore -p:RunPostBuildEvent=Never` — succeeded
- focused NPC balance, beastmaster, droid rebuild, and release audit tests — 44/44 passed
- `git diff --cached --check` — clean

Deployment note: repack the module so the corrected UTC blueprints ship.