### PR TITLE
Move property diagnostics out of Manage Staff

### DIFF
--- a/SWLOR.Game.Server.Tests/Service/PropertyOnDemandLoadingTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/PropertyOnDemandLoadingTests.cs
@@ -594,6 +594,12 @@ public class PropertyOnDemandLoadingTests
         var commandBody = ExtractMethod(adminChatSource, "private void PropertyDiagnosticsCommand()");
         commandBody.Should().Contain("_builder.Create(\"propertydiagnostics\")");
         commandBody.Should().Contain(".Permissions(AuthorizationLevel.Admin)");
+        commandBody.Should().Contain("Log.WriteStructured(");
+        commandBody.Should().Contain("LogGroup.Property");
+        commandBody.Should().Contain("GetName(user)");
+        commandBody.Should().Contain("GetObjectUUID(user)");
+        commandBody.IndexOf("Log.WriteStructured(", StringComparison.Ordinal)
+            .Should().BeLessThan(commandBody.IndexOf("Gui.TogglePlayerWindow(user, GuiWindowType.PropertyDiagnostics);", StringComparison.Ordinal));
         commandBody.Should().Contain("Gui.TogglePlayerWindow(user, GuiWindowType.PropertyDiagnostics);");
         staffDefinitionSource.Should().NotContain("OnClickPropertyDiagnostics");
         staffViewModelSource.Should().NotContain("GuiWindowType.PropertyDiagnostics");

--- a/SWLOR.Game.Server.Tests/Service/PropertyOnDemandLoadingTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/PropertyOnDemandLoadingTests.cs
@@ -563,8 +563,13 @@ public class PropertyOnDemandLoadingTests
     }
 
     [Test]
-    public void PropertyDiagnostics_AreNotExposedAsChatCommands()
+    public void PropertyDiagnostics_AreExposedThroughDedicatedAdminCommand()
     {
+        var commands = new SWLOR.Game.Server.Feature.ChatCommandDefinition.AdminChatCommand().BuildChatCommands();
+        commands.Should().ContainKey("propertydiagnostics");
+        commands["propertydiagnostics"].Authorization
+            .Should().Be(SWLOR.Game.Server.Enumeration.AuthorizationLevel.Admin);
+
         var root = FindRepositoryRoot();
         var adminChatSource = File.ReadAllText(Path.Combine(
             root.FullName,
@@ -586,9 +591,12 @@ public class PropertyOnDemandLoadingTests
             "ViewModel",
             "ManageDMsViewModel.cs"));
 
-        adminChatSource.Should().NotContain("PropertyDiagnostics");
-        staffDefinitionSource.Should().Contain("OnClickPropertyDiagnostics");
-        staffViewModelSource.Should().Contain("GuiWindowType.PropertyDiagnostics");
+        var commandBody = ExtractMethod(adminChatSource, "private void PropertyDiagnosticsCommand()");
+        commandBody.Should().Contain("_builder.Create(\"propertydiagnostics\")");
+        commandBody.Should().Contain(".Permissions(AuthorizationLevel.Admin)");
+        commandBody.Should().Contain("Gui.TogglePlayerWindow(user, GuiWindowType.PropertyDiagnostics);");
+        staffDefinitionSource.Should().NotContain("OnClickPropertyDiagnostics");
+        staffViewModelSource.Should().NotContain("GuiWindowType.PropertyDiagnostics");
     }
 
     private static string ExtractMethod(string source, string signature)

--- a/SWLOR.Game.Server.Tests/Service/PropertyOnDemandLoadingTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/PropertyOnDemandLoadingTests.cs
@@ -594,13 +594,19 @@ public class PropertyOnDemandLoadingTests
         var commandBody = ExtractMethod(adminChatSource, "private void PropertyDiagnosticsCommand()");
         commandBody.Should().Contain("_builder.Create(\"propertydiagnostics\")");
         commandBody.Should().Contain(".Permissions(AuthorizationLevel.Admin)");
+        commandBody.Should().Contain("var player = user;");
+        commandBody.Should().Contain("if (GetIsDMPossessed(player))");
+        commandBody.Should().Contain("uiTarget = player;");
+        commandBody.Should().Contain("player = GetMaster(player);");
         commandBody.Should().Contain("Log.WriteStructured(");
         commandBody.Should().Contain("LogGroup.Property");
-        commandBody.Should().Contain("GetName(user)");
-        commandBody.Should().Contain("GetObjectUUID(user)");
+        commandBody.Should().Contain("Property diagnostics toggled:");
+        commandBody.Should().Contain("GetName(player)");
+        commandBody.Should().Contain("GetObjectUUID(player)");
         commandBody.IndexOf("Log.WriteStructured(", StringComparison.Ordinal)
-            .Should().BeLessThan(commandBody.IndexOf("Gui.TogglePlayerWindow(user, GuiWindowType.PropertyDiagnostics);", StringComparison.Ordinal));
-        commandBody.Should().Contain("Gui.TogglePlayerWindow(user, GuiWindowType.PropertyDiagnostics);");
+            .Should().BeLessThan(commandBody.IndexOf("Gui.TogglePlayerWindow(", StringComparison.Ordinal));
+        commandBody.Should().Contain("GuiWindowType.PropertyDiagnostics,");
+        commandBody.Should().Contain("uiTarget);");
         staffDefinitionSource.Should().NotContain("OnClickPropertyDiagnostics");
         staffViewModelSource.Should().NotContain("GuiWindowType.PropertyDiagnostics");
     }

--- a/SWLOR.Game.Server/Feature/ChatCommandDefinition/AdminChatCommand.cs
+++ b/SWLOR.Game.Server/Feature/ChatCommandDefinition/AdminChatCommand.cs
@@ -49,12 +49,25 @@ namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
                 .Permissions(AuthorizationLevel.Admin)
                 .Action((user, target, location, args) =>
                 {
+                    var player = user;
+                    var uiTarget = OBJECT_INVALID;
+                    if (GetIsDMPossessed(player))
+                    {
+                        uiTarget = player;
+                        player = GetMaster(player);
+                    }
+
                     Log.WriteStructured(
                         LogGroup.Property,
-                        "Property diagnostics opened: PlayerName={PlayerName} PlayerId={PlayerId}",
-                        GetName(user),
-                        GetObjectUUID(user));
-                    Gui.TogglePlayerWindow(user, GuiWindowType.PropertyDiagnostics);
+                        "Property diagnostics toggled: PlayerName={PlayerName} PlayerId={PlayerId}",
+                        GetName(player),
+                        GetObjectUUID(player));
+                    Gui.TogglePlayerWindow(
+                        player,
+                        GuiWindowType.PropertyDiagnostics,
+                        null,
+                        OBJECT_INVALID,
+                        uiTarget);
                 });
         }
 

--- a/SWLOR.Game.Server/Feature/ChatCommandDefinition/AdminChatCommand.cs
+++ b/SWLOR.Game.Server/Feature/ChatCommandDefinition/AdminChatCommand.cs
@@ -14,6 +14,7 @@ namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
         {
             ManageStaffCommand();
             ManageBansCommand();
+            PropertyDiagnosticsCommand();
 
             return _builder.Build();
         }
@@ -37,6 +38,17 @@ namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
                 .Action((user, target, location, args) =>
                 {
                     Gui.TogglePlayerWindow(user, GuiWindowType.ManageBans);
+                });
+        }
+
+        private void PropertyDiagnosticsCommand()
+        {
+            _builder.Create("propertydiagnostics")
+                .Description("Toggles the property loading diagnostics window.")
+                .Permissions(AuthorizationLevel.Admin)
+                .Action((user, target, location, args) =>
+                {
+                    Gui.TogglePlayerWindow(user, GuiWindowType.PropertyDiagnostics);
                 });
         }
 

--- a/SWLOR.Game.Server/Feature/ChatCommandDefinition/AdminChatCommand.cs
+++ b/SWLOR.Game.Server/Feature/ChatCommandDefinition/AdminChatCommand.cs
@@ -3,6 +3,7 @@ using SWLOR.Game.Server.Enumeration;
 using SWLOR.Game.Server.Service;
 using SWLOR.Game.Server.Service.ChatCommandService;
 using SWLOR.Game.Server.Service.GuiService;
+using SWLOR.Game.Server.Service.LogService;
 
 namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
 {
@@ -48,6 +49,11 @@ namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
                 .Permissions(AuthorizationLevel.Admin)
                 .Action((user, target, location, args) =>
                 {
+                    Log.WriteStructured(
+                        LogGroup.Property,
+                        "Property diagnostics opened: PlayerName={PlayerName} PlayerId={PlayerId}",
+                        GetName(user),
+                        GetObjectUUID(user));
                     Gui.TogglePlayerWindow(user, GuiWindowType.PropertyDiagnostics);
                 });
         }

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ManageStaffDefinition.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ManageStaffDefinition.cs
@@ -55,10 +55,6 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                             .SetText("Delete User")
                             .BindOnClicked(model => model.OnClickDeleteUser())
                             .BindIsEnabled(model => model.IsDeleteEnabled);
-
-                        row.AddButton()
-                            .SetText("Properties")
-                            .BindOnClicked(model => model.OnClickPropertyDiagnostics());
                     });
                 })
 

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/ManageDMsViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/ManageDMsViewModel.cs
@@ -210,16 +210,5 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             StatusText = string.Empty;
         };
 
-        public Action OnClickPropertyDiagnostics() => () =>
-        {
-            if (Authorization.GetAuthorizationLevel(Player) != AuthorizationLevel.Admin)
-            {
-                StatusText = "Admin authorization required.";
-                StatusColor = GuiColor.Red;
-                return;
-            }
-
-            Gui.TogglePlayerWindow(Player, GuiWindowType.PropertyDiagnostics);
-        };
     }
 }

--- a/design/property-on-demand-loading-checklist.md
+++ b/design/property-on-demand-loading-checklist.md
@@ -134,7 +134,7 @@ Use short, non-technical messages:
 
 ## Admin Diagnostic NUI Checklist
 
-Create an admin-only diagnostic NUI, not chat commands.
+Open the admin-only diagnostic NUI with `/propertydiagnostics`; keep diagnostic and repair operations out of chat-command verbs.
 
 Minimum views:
 

--- a/design/property-on-demand-loading-checklist.md
+++ b/design/property-on-demand-loading-checklist.md
@@ -15,7 +15,7 @@ Reduce server boot time and resource usage by avoiding boot-time loading of priv
 - Player-requested on-demand loads should have priority over remaining startup-load jobs, while still obeying the same batch throttle.
 - Public building doors should not be exposed until their interior property is fully loaded.
 - Load failures must fail closed. Do not mark a partial load as live.
-- Runtime recovery should be available through an admin-only NUI diagnostic window, not through chat commands.
+- Runtime recovery should be available through an admin-only NUI diagnostic window opened with `/propertydiagnostics`; repair actions should remain in the window rather than becoming chat-command verbs.
 - First-pass runtime recovery should be non-destructive only: status, retry, abort, and notify waiters.
 - Do not include destructive repair/quarantine tools in the first pass.
 - Defer idle property unloading to a later, separately reviewed change.


### PR DESCRIPTION
## Summary

- remove the property diagnostics button and handler from the Manage Staff window
- add an admin-only `/propertydiagnostics` command that opens the existing diagnostics NUI
- update the on-demand property loading regression coverage and design checklist

## Why

The property diagnostics UI is an operational recovery tool, not part of staff-account management. Its original placement reused an existing admin-only window but made the Manage Staff interface misleading.

## Impact

Admins now open the diagnostics window with `/propertydiagnostics`. The diagnostic actions and their defense-in-depth authorization checks are unchanged.

## Validation

- `dotnet build SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj -p:RunPostBuildEvent=Never`
- `dotnet test SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj --no-build --filter "FullyQualifiedName~PropertyOnDemandLoadingTests"` (26 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the admin-only `/propertydiagnostics` command to open the property loading diagnostics window.
  * Property repair actions remain available within the diagnostics window.

* **Changes**
  * Removed property diagnostics access from the Staff Management window.
  * Added diagnostic activity logging when the command is used.
  * Updated guidance to reflect the new administrator workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->