### PR TITLE
Preserve per-weapon damage when dual wielding

### DIFF
--- a/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
@@ -854,6 +854,11 @@ public class CombatDamageTests
         damageRollSource.Should().Contain("var damageProfile = ExtractWeaponDamageProfile(weapon);");
         damageRollSource.Should().NotContain("ExtractAttackDamageProfile");
         damageRollSource.Should().NotContain("ExtractWeaponDamageProfile(rightHand, leftHand)");
+
+        var extractor = ExtractMethod(damageRollSource, "private static WeaponDamageProfile ExtractWeaponDamageProfile(");
+        extractor.Should().Contain("var hasDamageProperty = false;");
+        extractor.Should().Contain("if (!hasDamageProperty)");
+        extractor.Should().Contain("return new WeaponDamageProfile(CombatDamageType.Physical, DefaultPhysicalDamage);");
     }
 
     [Test]

--- a/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
@@ -845,6 +845,18 @@ public class CombatDamageTests
     }
 
     [Test]
+    public void DamageRoll_DualWieldKeepsDamageProfileOnCurrentAttackWeapon()
+    {
+        var root = FindRepositoryRoot();
+        var damageRollSource = File.ReadAllText(Path.Combine(root.FullName, "SWLOR.Game.Server", "Native", "GetDamageRoll.cs"));
+
+        damageRollSource.Should().Contain("var weapon = pCombatRound.GetCurrentAttackWeapon();");
+        damageRollSource.Should().Contain("var damageProfile = ExtractWeaponDamageProfile(weapon);");
+        damageRollSource.Should().NotContain("ExtractAttackDamageProfile");
+        damageRollSource.Should().NotContain("ExtractWeaponDamageProfile(rightHand, leftHand)");
+    }
+
+    [Test]
     public void ModuleWeaponItems_UseUntypedDmgAndSeparateDamageTypeProperty()
     {
         var root = FindRepositoryRoot();

--- a/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
@@ -850,7 +850,8 @@ public class CombatDamageTests
         var root = FindRepositoryRoot();
         var damageRollSource = File.ReadAllText(Path.Combine(root.FullName, "SWLOR.Game.Server", "Native", "GetDamageRoll.cs"));
 
-        damageRollSource.Should().Contain("var weapon = pCombatRound.GetCurrentAttackWeapon();");
+        damageRollSource.Should().Contain("var weapon = pCombatRound.GetCurrentAttackWeapon(bOffHand);");
+        damageRollSource.Should().NotContain("var weapon = pCombatRound.GetCurrentAttackWeapon();");
         damageRollSource.Should().Contain("var damageProfile = ExtractWeaponDamageProfile(weapon);");
         damageRollSource.Should().NotContain("ExtractAttackDamageProfile");
         damageRollSource.Should().NotContain("ExtractWeaponDamageProfile(rightHand, leftHand)");

--- a/SWLOR.Game.Server/Native/GetDamageRoll.cs
+++ b/SWLOR.Game.Server/Native/GetDamageRoll.cs
@@ -83,7 +83,7 @@ namespace SWLOR.Game.Server.Native
                 var damageFlags = attackerStats.m_pBaseCreature.GetDamageFlags();
                 var pCombatRound = attacker.m_pcCombatRound;
                 var pAttackData = pCombatRound.GetAttack(pCombatRound.m_nCurrentAttack);
-                var weapon = pCombatRound.GetCurrentAttackWeapon();
+                var weapon = pCombatRound.GetCurrentAttackWeapon(bOffHand);
 
                 var attackType = attacker.GetRangeWeaponEquipped() == 1 ? (uint)AttackType.Ranged : (uint)AttackType.Melee;
 

--- a/SWLOR.Game.Server/Native/GetDamageRoll.cs
+++ b/SWLOR.Game.Server/Native/GetDamageRoll.cs
@@ -307,7 +307,7 @@ namespace SWLOR.Game.Server.Native
         {
             var damageType = CombatDamageType.Physical;
             var damage = 0;
-            var foundDMG = false;
+            var hasDamageProperty = false;
 
             if (weapon != null)
             {
@@ -320,42 +320,23 @@ namespace SWLOR.Game.Server.Native
                     if (ip.m_nPropertyName == (ushort)ItemPropertyType.DMG)
                     {
                         damage += ip.m_nCostTableValue;
-                        foundDMG = true;
+                        hasDamageProperty = true;
                     }
                     else if (ip.m_nPropertyName == (ushort)ItemPropertyType.WeaponDamageType)
                     {
                         damageType = ResolveWeaponDamageType(damageType, ip.m_nSubType);
                     }
                 }
-
-                if (!foundDMG && IsWeapon(weapon))
-                {
-                    damage += DefaultPhysicalDamage;
-                    foundDMG = true;
-                }
             }
 
-            if (!foundDMG)
+            // A damage type only selects the type of a real DMG property. Items without DMG use
+            // the unarmed/default physical fallback instead of manufacturing elemental damage.
+            if (!hasDamageProperty)
             {
                 return new WeaponDamageProfile(CombatDamageType.Physical, DefaultPhysicalDamage);
             }
 
             return new WeaponDamageProfile(damageType, damage);
-        }
-
-        private static bool IsWeapon(CNWSItem item)
-        {
-            if (item == null)
-                return false;
-
-            var baseItem = (BaseItem)item.m_nBaseItem;
-            foreach (var weaponType in Item.WeaponBaseItemTypes)
-            {
-                if (weaponType == baseItem)
-                    return true;
-            }
-
-            return false;
         }
 
         private static CombatDamageType ResolveWeaponDamageType(CombatDamageType current, int damageTypeId)

--- a/SWLOR.Game.Server/Native/GetDamageRoll.cs
+++ b/SWLOR.Game.Server/Native/GetDamageRoll.cs
@@ -96,7 +96,10 @@ namespace SWLOR.Game.Server.Native
                 LogAttackInfo(attacker, defender, attackType, weapon);
 
                 // Extract weapon damage properties and get ability stats
-                var damageProfile = ExtractAttackDamageProfile(attacker, weapon);
+                // ResolveAttack already emits distinct main-hand and off-hand rolls. Keep the
+                // damage profile tied to that roll's current weapon so an elemental weapon cannot
+                // re-type or absorb the other hand's DMG.
+                var damageProfile = ExtractWeaponDamageProfile(weapon);
                 var weaponSkillType = weapon == null
                     ? SkillType.Invalid
                     : SWLOR.Game.Server.Service.Skill.GetSkillTypeByBaseItem((BaseItem)weapon.m_nBaseItem);
@@ -263,19 +266,6 @@ namespace SWLOR.Game.Server.Native
             attackData.AddDamage((ushort)damageType.GetNativeDamageType(), damage);
         }
 
-        private static WeaponDamageProfile ExtractAttackDamageProfile(CNWSCreature attacker, CNWSItem currentWeapon)
-        {
-            var rightHand = attacker.m_pInventory.GetItemInSlot((uint)EquipmentSlot.RightHand);
-            var leftHand = attacker.m_pInventory.GetItemInSlot((uint)EquipmentSlot.LeftHand);
-
-            if (HasDelayProperty(rightHand) && HasDelayProperty(leftHand))
-            {
-                return ExtractWeaponDamageProfile(rightHand, leftHand);
-            }
-
-            return ExtractWeaponDamageProfile(currentWeapon);
-        }
-
         // While Imbuement Stance is active, the wearer's hostile weapon auto-attacks deal Force damage instead of
         // their normal type and cost FP per swing. This only affects real auto-attacks against creatures; queued
         // weapon abilities apply their own damage and are excluded so they are neither converted nor charged.
@@ -313,18 +303,14 @@ namespace SWLOR.Game.Server.Native
             return new WeaponDamageProfile(CombatDamageType.Force, damageProfile.Damage);
         }
 
-        private static WeaponDamageProfile ExtractWeaponDamageProfile(params CNWSItem[] weapons)
+        private static WeaponDamageProfile ExtractWeaponDamageProfile(CNWSItem weapon)
         {
             var damageType = CombatDamageType.Physical;
             var damage = 0;
             var foundDMG = false;
 
-            foreach (var weapon in weapons)
+            if (weapon != null)
             {
-                if (weapon == null)
-                    continue;
-
-                var foundWeaponDMG = false;
                 for (var index = 0; index < weapon.m_lstPassiveProperties.Count; index++)
                 {
                     var ip = weapon.GetPassiveProperty(index);
@@ -334,7 +320,6 @@ namespace SWLOR.Game.Server.Native
                     if (ip.m_nPropertyName == (ushort)ItemPropertyType.DMG)
                     {
                         damage += ip.m_nCostTableValue;
-                        foundWeaponDMG = true;
                         foundDMG = true;
                     }
                     else if (ip.m_nPropertyName == (ushort)ItemPropertyType.WeaponDamageType)
@@ -343,7 +328,7 @@ namespace SWLOR.Game.Server.Native
                     }
                 }
 
-                if (!foundWeaponDMG && IsWeapon(weapon))
+                if (!foundDMG && IsWeapon(weapon))
                 {
                     damage += DefaultPhysicalDamage;
                     foundDMG = true;
@@ -356,21 +341,6 @@ namespace SWLOR.Game.Server.Native
             }
 
             return new WeaponDamageProfile(damageType, damage);
-        }
-
-        private static bool HasDelayProperty(CNWSItem weapon)
-        {
-            if (!IsWeapon(weapon))
-                return false;
-
-            for (var index = 0; index < weapon.m_lstPassiveProperties.Count; index++)
-            {
-                var ip = weapon.GetPassiveProperty(index);
-                if (ip?.m_nPropertyName == (ushort)ItemPropertyType.Delay)
-                    return true;
-            }
-
-            return false;
         }
 
         private static bool IsWeapon(CNWSItem item)


### PR DESCRIPTION
## Summary

- keep each native main-hand and off-hand damage roll tied to its current weapon
- prevent one weapon's elemental damage type from re-typing or absorbing the other hand's DMG
- remove the obsolete dual-wield aggregation path
- add regression coverage for current-weapon damage profile selection

## Root cause

The damage hook received the engine's current attack weapon but replaced it with a profile built from both equipped weapons whenever both had a Delay property. Because that aggregate profile can only carry one damage type, a Fire weapon caused the other hand's DMG to be resolved as Fire as well. The combat-upgrade attack loop already emits distinct main-hand and off-hand rolls, so aggregating both weapons again also inflated every dual-wield roll.

## Player impact

Mixed-type dual wielding now produces independent weapon attacks. Each hand uses its own DMG, damage type, skill/stat calculation, defenses, critical handling, and combat-log entry. Swapping hands no longer converts the other weapon's damage.

## Validation

- `dotnet build SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj -p:RunPostBuildEvent=Never`
- `dotnet test SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj --no-build --filter "FullyQualifiedName~CombatDamageTests|FullyQualifiedName~CombatAttackDelayTests"` (89 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected dual-wield damage calculations to consistently use the currently attacking weapon’s damage profile.
  * Improved fallback handling when a weapon’s physical damage profile is unavailable, ensuring damage rolls remain accurate.

* **Tests**
  * Added regression coverage to verify accurate damage rolls during dual-wield attacks and confirm correct handling of missing damage profiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->