### PR TITLE
Fix ranged NPC recovery after area abilities

### DIFF
--- a/SWLOR.Game.Server.Tests/AI/AIModelTests.cs
+++ b/SWLOR.Game.Server.Tests/AI/AIModelTests.cs
@@ -270,6 +270,27 @@ public class AIModelTests
     }
 
     [Test]
+    public void AITarget_SelfCenteredHostileAreasEvaluateEnemiesAroundTheCaster()
+    {
+        var source = ReadSource("SWLOR.Game.Server", "Service", "AIService", "AITarget.cs")
+            .Replace("\r\n", "\n");
+        var selfCenteredBody = source.Substring(
+            source.IndexOf("private static AITargetSelector SelfCenteredHostileArea", StringComparison.Ordinal),
+            source.IndexOf("public static AITargetSelector AllyAttacker", StringComparison.Ordinal) -
+            source.IndexOf("private static AITargetSelector SelfCenteredHostileArea", StringComparison.Ordinal));
+        var inferDefaultBody = source.Substring(
+            source.IndexOf("public static AITargetSelector InferDefault", StringComparison.Ordinal));
+
+        selfCenteredBody.Should().Contain("GetIsObjectValid(context.CurrentEnmityTarget)");
+        selfCenteredBody.Should().Contain("ability.Targeting?.ResolveSizeX(context.Self, true)");
+        selfCenteredBody.Should().Contain("context.SetEvaluatedTarget(context.Self);");
+        selfCenteredBody.Should().Contain("context.CountHostilesNearTarget(radius) >= minimumTargets");
+        selfCenteredBody.Should().Contain("? context.Self");
+        inferDefaultBody.Should().Contain("AbilityTargetingFlags.OriginOnSelf");
+        inferDefaultBody.Should().Contain("SelfCenteredHostileArea(ability, 2)");
+    }
+
+    [Test]
     public void CreatureAggroEnter_EnforcesAggroRangeBeforeAddingProximityEnmity()
     {
         var aiSource = File.ReadAllText(Path.Combine(
@@ -426,8 +447,19 @@ public class AIModelTests
             source.IndexOf("void CompleteActivation", StringComparison.Ordinal),
             source.IndexOf("// Begin the main process", StringComparison.Ordinal) -
             source.IndexOf("void CompleteActivation", StringComparison.Ordinal));
+        var delayedResumeBody = source.Substring(
+            source.IndexOf("private static void ResumeAttackAfterDelay", StringComparison.Ordinal),
+            source.IndexOf("/// <summary>\n        /// Breaks stealth", StringComparison.Ordinal) -
+            source.IndexOf("private static void ResumeAttackAfterDelay", StringComparison.Ordinal));
 
         resumeBody.Should().Contain("Enmity.IssueAttackCommand(activator, target, clearActions);");
+        resumeBody.Should().Contain("var enmityTarget = Enmity.GetHighestEnmityTarget(activator);");
+        resumeBody.IndexOf("if (GetIsObjectValid(enmityTarget))", StringComparison.Ordinal)
+            .Should()
+            .BeLessThan(resumeBody.IndexOf("target = enmityTarget;", StringComparison.Ordinal),
+                "a valid saved cast target must survive a transiently empty enmity table");
+        delayedResumeBody.Should().Contain("GetIsPC(activator) || GetIsPC(GetMaster(activator))");
+        delayedResumeBody.Should().Contain("DelayCommand(delay, () =>");
         animationBody.Should().Contain("if (GetIsPC(activator))");
         animationBody.Should().Contain("ClearAllActions(true);");
         completeBody.Should().Contain("ResumeAttackAfterDelay(activator, resumeAttackTarget, 0.1f);");

--- a/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
@@ -854,6 +854,11 @@ public class CombatDamageTests
         damageRollSource.Should().Contain("var damageProfile = ExtractWeaponDamageProfile(weapon);");
         damageRollSource.Should().NotContain("ExtractAttackDamageProfile");
         damageRollSource.Should().NotContain("ExtractWeaponDamageProfile(rightHand, leftHand)");
+
+        var extractor = ExtractMethod(damageRollSource, "private static WeaponDamageProfile ExtractWeaponDamageProfile(");
+        extractor.Should().Contain("var hasDamageProperty = false;");
+        extractor.Should().Contain("if (!hasDamageProperty)");
+        extractor.Should().Contain("return new WeaponDamageProfile(CombatDamageType.Physical, DefaultPhysicalDamage);");
     }
 
     [Test]

--- a/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
@@ -845,6 +845,18 @@ public class CombatDamageTests
     }
 
     [Test]
+    public void DamageRoll_DualWieldKeepsDamageProfileOnCurrentAttackWeapon()
+    {
+        var root = FindRepositoryRoot();
+        var damageRollSource = File.ReadAllText(Path.Combine(root.FullName, "SWLOR.Game.Server", "Native", "GetDamageRoll.cs"));
+
+        damageRollSource.Should().Contain("var weapon = pCombatRound.GetCurrentAttackWeapon();");
+        damageRollSource.Should().Contain("var damageProfile = ExtractWeaponDamageProfile(weapon);");
+        damageRollSource.Should().NotContain("ExtractAttackDamageProfile");
+        damageRollSource.Should().NotContain("ExtractWeaponDamageProfile(rightHand, leftHand)");
+    }
+
+    [Test]
     public void ModuleWeaponItems_UseUntypedDmgAndSeparateDamageTypeProperty()
     {
         var root = FindRepositoryRoot();

--- a/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
@@ -850,7 +850,8 @@ public class CombatDamageTests
         var root = FindRepositoryRoot();
         var damageRollSource = File.ReadAllText(Path.Combine(root.FullName, "SWLOR.Game.Server", "Native", "GetDamageRoll.cs"));
 
-        damageRollSource.Should().Contain("var weapon = pCombatRound.GetCurrentAttackWeapon();");
+        damageRollSource.Should().Contain("var weapon = pCombatRound.GetCurrentAttackWeapon(bOffHand);");
+        damageRollSource.Should().NotContain("var weapon = pCombatRound.GetCurrentAttackWeapon();");
         damageRollSource.Should().Contain("var damageProfile = ExtractWeaponDamageProfile(weapon);");
         damageRollSource.Should().NotContain("ExtractAttackDamageProfile");
         damageRollSource.Should().NotContain("ExtractWeaponDamageProfile(rightHand, leftHand)");

--- a/SWLOR.Game.Server/Feature/UsePerkFeat.cs
+++ b/SWLOR.Game.Server/Feature/UsePerkFeat.cs
@@ -97,7 +97,11 @@ namespace SWLOR.Game.Server.Feature
             }
 
             if (!GetIsPC(activator) && !GetIsPC(GetMaster(activator)))
-                target = Enmity.GetHighestEnmityTarget(activator);
+            {
+                var enmityTarget = Enmity.GetHighestEnmityTarget(activator);
+                if (GetIsObjectValid(enmityTarget))
+                    target = enmityTarget;
+            }
 
             if (!GetIsObjectValid(target) ||
                 GetCurrentHitPoints(target) <= 0 ||
@@ -172,8 +176,13 @@ namespace SWLOR.Game.Server.Feature
 
         private static void ResumeAttackAfterDelay(uint activator, uint target, float delay, bool clearActions = true)
         {
-            if (!GetIsObjectValid(target))
+            // Autonomous NPCs reacquire their highest-enmity target inside ResumeAttack. Schedule
+            // the callback even when the target saved before the cast has since become invalid.
+            if (!GetIsObjectValid(target) &&
+                (GetIsPC(activator) || GetIsPC(GetMaster(activator))))
+            {
                 return;
+            }
 
             DelayCommand(delay, () =>
             {

--- a/SWLOR.Game.Server/Native/GetDamageRoll.cs
+++ b/SWLOR.Game.Server/Native/GetDamageRoll.cs
@@ -83,7 +83,7 @@ namespace SWLOR.Game.Server.Native
                 var damageFlags = attackerStats.m_pBaseCreature.GetDamageFlags();
                 var pCombatRound = attacker.m_pcCombatRound;
                 var pAttackData = pCombatRound.GetAttack(pCombatRound.m_nCurrentAttack);
-                var weapon = pCombatRound.GetCurrentAttackWeapon();
+                var weapon = pCombatRound.GetCurrentAttackWeapon(bOffHand);
 
                 var attackType = attacker.GetRangeWeaponEquipped() == 1 ? (uint)AttackType.Ranged : (uint)AttackType.Melee;
 

--- a/SWLOR.Game.Server/Native/GetDamageRoll.cs
+++ b/SWLOR.Game.Server/Native/GetDamageRoll.cs
@@ -307,7 +307,7 @@ namespace SWLOR.Game.Server.Native
         {
             var damageType = CombatDamageType.Physical;
             var damage = 0;
-            var foundDMG = false;
+            var hasDamageProperty = false;
 
             if (weapon != null)
             {
@@ -320,42 +320,23 @@ namespace SWLOR.Game.Server.Native
                     if (ip.m_nPropertyName == (ushort)ItemPropertyType.DMG)
                     {
                         damage += ip.m_nCostTableValue;
-                        foundDMG = true;
+                        hasDamageProperty = true;
                     }
                     else if (ip.m_nPropertyName == (ushort)ItemPropertyType.WeaponDamageType)
                     {
                         damageType = ResolveWeaponDamageType(damageType, ip.m_nSubType);
                     }
                 }
-
-                if (!foundDMG && IsWeapon(weapon))
-                {
-                    damage += DefaultPhysicalDamage;
-                    foundDMG = true;
-                }
             }
 
-            if (!foundDMG)
+            // A damage type only selects the type of a real DMG property. Items without DMG use
+            // the unarmed/default physical fallback instead of manufacturing elemental damage.
+            if (!hasDamageProperty)
             {
                 return new WeaponDamageProfile(CombatDamageType.Physical, DefaultPhysicalDamage);
             }
 
             return new WeaponDamageProfile(damageType, damage);
-        }
-
-        private static bool IsWeapon(CNWSItem item)
-        {
-            if (item == null)
-                return false;
-
-            var baseItem = (BaseItem)item.m_nBaseItem;
-            foreach (var weaponType in Item.WeaponBaseItemTypes)
-            {
-                if (weaponType == baseItem)
-                    return true;
-            }
-
-            return false;
         }
 
         private static CombatDamageType ResolveWeaponDamageType(CombatDamageType current, int damageTypeId)

--- a/SWLOR.Game.Server/Native/GetDamageRoll.cs
+++ b/SWLOR.Game.Server/Native/GetDamageRoll.cs
@@ -96,7 +96,10 @@ namespace SWLOR.Game.Server.Native
                 LogAttackInfo(attacker, defender, attackType, weapon);
 
                 // Extract weapon damage properties and get ability stats
-                var damageProfile = ExtractAttackDamageProfile(attacker, weapon);
+                // ResolveAttack already emits distinct main-hand and off-hand rolls. Keep the
+                // damage profile tied to that roll's current weapon so an elemental weapon cannot
+                // re-type or absorb the other hand's DMG.
+                var damageProfile = ExtractWeaponDamageProfile(weapon);
                 var weaponSkillType = weapon == null
                     ? SkillType.Invalid
                     : SWLOR.Game.Server.Service.Skill.GetSkillTypeByBaseItem((BaseItem)weapon.m_nBaseItem);
@@ -263,19 +266,6 @@ namespace SWLOR.Game.Server.Native
             attackData.AddDamage((ushort)damageType.GetNativeDamageType(), damage);
         }
 
-        private static WeaponDamageProfile ExtractAttackDamageProfile(CNWSCreature attacker, CNWSItem currentWeapon)
-        {
-            var rightHand = attacker.m_pInventory.GetItemInSlot((uint)EquipmentSlot.RightHand);
-            var leftHand = attacker.m_pInventory.GetItemInSlot((uint)EquipmentSlot.LeftHand);
-
-            if (HasDelayProperty(rightHand) && HasDelayProperty(leftHand))
-            {
-                return ExtractWeaponDamageProfile(rightHand, leftHand);
-            }
-
-            return ExtractWeaponDamageProfile(currentWeapon);
-        }
-
         // While Imbuement Stance is active, the wearer's hostile weapon auto-attacks deal Force damage instead of
         // their normal type and cost FP per swing. This only affects real auto-attacks against creatures; queued
         // weapon abilities apply their own damage and are excluded so they are neither converted nor charged.
@@ -313,18 +303,14 @@ namespace SWLOR.Game.Server.Native
             return new WeaponDamageProfile(CombatDamageType.Force, damageProfile.Damage);
         }
 
-        private static WeaponDamageProfile ExtractWeaponDamageProfile(params CNWSItem[] weapons)
+        private static WeaponDamageProfile ExtractWeaponDamageProfile(CNWSItem weapon)
         {
             var damageType = CombatDamageType.Physical;
             var damage = 0;
             var foundDMG = false;
 
-            foreach (var weapon in weapons)
+            if (weapon != null)
             {
-                if (weapon == null)
-                    continue;
-
-                var foundWeaponDMG = false;
                 for (var index = 0; index < weapon.m_lstPassiveProperties.Count; index++)
                 {
                     var ip = weapon.GetPassiveProperty(index);
@@ -334,7 +320,6 @@ namespace SWLOR.Game.Server.Native
                     if (ip.m_nPropertyName == (ushort)ItemPropertyType.DMG)
                     {
                         damage += ip.m_nCostTableValue;
-                        foundWeaponDMG = true;
                         foundDMG = true;
                     }
                     else if (ip.m_nPropertyName == (ushort)ItemPropertyType.WeaponDamageType)
@@ -343,7 +328,7 @@ namespace SWLOR.Game.Server.Native
                     }
                 }
 
-                if (!foundWeaponDMG && IsWeapon(weapon))
+                if (!foundDMG && IsWeapon(weapon))
                 {
                     damage += DefaultPhysicalDamage;
                     foundDMG = true;
@@ -356,21 +341,6 @@ namespace SWLOR.Game.Server.Native
             }
 
             return new WeaponDamageProfile(damageType, damage);
-        }
-
-        private static bool HasDelayProperty(CNWSItem weapon)
-        {
-            if (!IsWeapon(weapon))
-                return false;
-
-            for (var index = 0; index < weapon.m_lstPassiveProperties.Count; index++)
-            {
-                var ip = weapon.GetPassiveProperty(index);
-                if (ip?.m_nPropertyName == (ushort)ItemPropertyType.Delay)
-                    return true;
-            }
-
-            return false;
         }
 
         private static bool IsWeapon(CNWSItem item)

--- a/SWLOR.Game.Server/Service/AIService/AITarget.cs
+++ b/SWLOR.Game.Server/Service/AIService/AITarget.cs
@@ -53,6 +53,27 @@ namespace SWLOR.Game.Server.Service.AIService
             };
         }
 
+        private static AITargetSelector SelfCenteredHostileArea(AbilityDetail ability, int minimumTargets)
+        {
+            return context =>
+            {
+                if (!GetIsObjectValid(context.CurrentEnmityTarget))
+                    return OBJECT_INVALID;
+
+                var radius = ability.Targeting?.ResolveSizeX(context.Self, true) ?? 0f;
+                if (radius <= 0f)
+                    radius = ability.MaxRange;
+
+                // Self-centered areas must evaluate the creatures actually inside the caster's
+                // effect, not a cluster around the current target. Returning self also keeps the
+                // activation location anchored on the caster.
+                context.SetEvaluatedTarget(context.Self);
+                return radius > 0f && context.CountHostilesNearTarget(radius) >= minimumTargets
+                    ? context.Self
+                    : OBJECT_INVALID;
+            };
+        }
+
         public static AITargetSelector AllyAttacker(float maxRange = 10f)
         {
             return context =>
@@ -93,9 +114,12 @@ namespace SWLOR.Game.Server.Service.AIService
         {
             if (ability.IsHostileAbility)
             {
-                return ability.IsAreaAbility
-                    ? HostileCluster(ability.MaxRange, 2)
-                    : HighestEnmity();
+                if (!ability.IsAreaAbility)
+                    return HighestEnmity();
+
+                return ability.Targeting?.Flags.HasFlag(AbilityTargetingFlags.OriginOnSelf) == true
+                    ? SelfCenteredHostileArea(ability, 2)
+                    : HostileCluster(ability.MaxRange, 2);
             }
 
             if (ability.RequiresTarget)


### PR DESCRIPTION
## Summary

- evaluate self-centered hostile AOEs around the caster using the ability's actual targeting radius
- preserve a valid pre-cast target when NPC enmity is transiently empty
- allow autonomous NPCs to reacquire targets after delayed ability recovery
- resume attacks through the existing ranged stand-off logic so rifle and pistol users do not run into melee

## Root cause

All hostile area abilities used target-centered cluster selection, including abilities whose area originates on the caster. Ranged NPCs could therefore choose an AOE because enemies were clustered around their current target even when nobody was inside the caster-centered effect. Afterward, recovery could discard a valid saved target when enmity was briefly empty, leaving the NPC idle or falling back into bad movement behavior.

## Validation

- `dotnet build SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj -p:RunPostBuildEvent=Never`
- `dotnet test SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj --no-build --filter "FullyQualifiedName~AIModelTests|FullyQualifiedName~AIProfileValidationTests|FullyQualifiedName~AbilityDamageQueueTests|FullyQualifiedName~EnmityTests"` (87 passed)

No HAK submodule files changed.