### PR TITLE
Drive NPC attack range from equipped weapons

### DIFF
--- a/SWLOR.Game.Server.Tests/AI/AIModelTests.cs
+++ b/SWLOR.Game.Server.Tests/AI/AIModelTests.cs
@@ -482,8 +482,8 @@ public class AIModelTests
             .BeGreaterThan(issueBody.LastIndexOf("AI.TryStartCombatLeashEvade(creature, target)", StringComparison.Ordinal));
         issueBody.Should().Contain("ClearAllActions(true);");
         issueBody.Should().Contain("ActionMoveToObject(target, true, GetAttackMoveRange(creature));");
-        enmitySource.Should().Contain("CreaturePlugin.GetPreferredAttackDistance(creature)");
-        enmitySource.Should().Contain("private static float GetAttackMoveRange(SkillType skillType, float preferredAttackDistance)");
+        enmitySource.Should().Contain("Combat.GetWeaponEngagementRange(skillType)");
+        enmitySource.Should().NotContain("GetPreferredAttackDistance");
         attackActionBody.Should().Contain("Enmity.AttackHighestEnmityTarget(context.Self);");
         attackActionBody.Should().NotContain("ClearAllActions");
         attackActionBody.Should().NotContain("ActionAttack");

--- a/SWLOR.Game.Server.Tests/Service/EnmityTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/EnmityTests.cs
@@ -448,44 +448,46 @@ public class EnmityTests
     }
 
     [Test]
-    public void GetAttackMoveRange_UsesPreferredDistanceForRangedWeaponSkills()
+    public void GetWeaponEngagementRange_UsesTheEquippedWeaponSkill()
     {
-        GetAttackMoveRange(SkillType.Rifle, 10f).Should().Be(10f);
-        GetAttackMoveRange(SkillType.Pistol, 12f).Should().Be(12f);
-        GetAttackMoveRange(SkillType.Throwing, 8f).Should().Be(8f);
+        Combat.GetWeaponEngagementRange(SkillType.Rifle).Should().Be(10f);
+        Combat.GetWeaponEngagementRange(SkillType.Pistol).Should().Be(10f);
+        Combat.GetWeaponEngagementRange(SkillType.Throwing).Should().Be(10f);
+        Combat.GetWeaponEngagementRange(SkillType.Lightsaber).Should().Be(1.5f);
+        Combat.GetWeaponEngagementRange(SkillType.Katar).Should().Be(1.5f);
+        Combat.GetWeaponEngagementRange(SkillType.Invalid).Should().Be(1.5f);
     }
 
     [Test]
-    public void GetAttackMoveRange_KeepsRangedEnemiesAtRangeWhenPreferredDistanceIsMissing()
+    public void AttackMovement_UsesWeaponRangeInsteadOfAppearancePreferredDistance()
     {
-        GetAttackMoveRange(SkillType.Rifle, 0f).Should().Be(10f);
-        GetAttackMoveRange(SkillType.Rifle, -1f).Should().Be(10f);
-        GetAttackMoveRange(SkillType.Rifle, float.NaN).Should().Be(10f);
-        GetAttackMoveRange(SkillType.Rifle, float.PositiveInfinity).Should().Be(10f);
-    }
-
-    [Test]
-    public void NativeRangedAttackPath_RepairsInvalidDesiredDistanceBeforePathing()
-    {
-        var source = File.ReadAllText(Path.Combine(
-            FindRepositoryRoot().FullName,
+        var repositoryRoot = FindRepositoryRoot().FullName;
+        var nativeSource = File.ReadAllText(Path.Combine(
+            repositoryRoot,
             "SWLOR.Game.Server",
             "Native",
             "OnAIActionAttackObject.cs"));
+        var enmitySource = File.ReadAllText(Path.Combine(
+            repositoryRoot,
+            "SWLOR.Game.Server",
+            "Service",
+            "Enmity.cs"));
 
-        source.Should().Contain("fDesiredAttackRange = ResolveDesiredAttackRange(");
-        source.Should().Contain("pCreature.GetRangeWeaponEquipped() == 1");
-        source.Should().Contain("private static float ResolveDesiredAttackRange(");
-        source.Should().Contain("fMaxAttackRange = ResolveMaximumAttackRange(");
-        source.Should().Contain("private static float ResolveMaximumAttackRange(");
-        source.Should().Contain("DEFAULT_RANGED_DESIRED_ATTACK_RANGE = 10f");
+        nativeSource.Should().Contain("Combat.GetWeaponEngagementRange(attackSkillType)");
+        nativeSource.Should().Contain("Combat.IsRangedWeaponSkill(attackSkillType)");
+        nativeSource.Should().NotContain("pCreature.DesiredAttackRange(");
+        nativeSource.Should().NotContain("pCreature.GetRangeWeaponEquipped()");
+        enmitySource.Should().Contain("Combat.GetWeaponEngagementRange(skillType)");
+        enmitySource.Should().NotContain("GetPreferredAttackDistance");
 
-        ResolveNativeDesiredAttackRange(0f, 30f, true).Should().Be(10f);
-        ResolveNativeDesiredAttackRange(float.NaN, 5f, true).Should().BeApproximately(4.99f, 0.001f);
-        ResolveNativeDesiredAttackRange(0f, 0f, true).Should().Be(10f,
+        ResolveNativeDesiredAttackRange(10f, 30f, true).Should().Be(10f);
+        ResolveNativeDesiredAttackRange(10f, 5f, true).Should().BeApproximately(4.99f, 0.001f,
+            "a ranged weapon's real maximum range must cap the standard engagement distance");
+        ResolveNativeDesiredAttackRange(10f, 1.5f, true).Should().BeApproximately(1.49f, 0.001f,
+            "even a very short real ranged weapon range must be respected");
+        ResolveNativeDesiredAttackRange(10f, 0f, true).Should().Be(10f,
             "missing ranged metadata must not collapse a ranged creature to melee distance");
-        ResolveNativeDesiredAttackRange(8f, 30f, true).Should().Be(8f);
-        ResolveNativeDesiredAttackRange(0f, 30f, false).Should().Be(0f);
+        ResolveNativeDesiredAttackRange(1.5f, 30f, false).Should().Be(1.5f);
 
         ResolveNativeMaximumAttackRange(10f, 0f, true).Should().Be(10f,
             "missing ranged metadata must repair the maximum range as well as the desired range");
@@ -495,14 +497,7 @@ public class EnmityTests
     }
 
     [Test]
-    public void GetAttackMoveRange_KeepsMeleeEnemiesAtCloseRange()
-    {
-        GetAttackMoveRange(SkillType.Lightsaber, 10f).Should().Be(1.5f);
-        GetAttackMoveRange(SkillType.Katar, 10f).Should().Be(1.5f);
-    }
-
-    [Test]
-    public void ShouldMoveIntoAttackRange_UsesPreferredRangeForRangedEnemies()
+    public void ShouldMoveIntoAttackRange_UsesWeaponRangeForRangedEnemies()
     {
         ShouldMoveIntoAttackRange(10.25f, SkillType.Rifle, 10f).Should().BeFalse();
         ShouldMoveIntoAttackRange(10.26f, SkillType.Rifle, 10f).Should().BeTrue();
@@ -591,16 +586,6 @@ public class EnmityTests
                 hasRecentAttack,
                 recoverySeconds
             })!;
-    }
-
-    private static float GetAttackMoveRange(SkillType skillType, float preferredAttackDistance)
-    {
-        return (float)typeof(Enmity)
-            .GetMethods(BindingFlags.Static | BindingFlags.NonPublic)
-            .Single(method =>
-                method.Name == "GetAttackMoveRange" &&
-                method.GetParameters().Length == 2)
-            .Invoke(null, new object[] { skillType, preferredAttackDistance })!;
     }
 
     private static bool ShouldMoveIntoAttackRange(float distance, SkillType skillType, float moveRange)

--- a/SWLOR.Game.Server.Tests/Service/EnmityTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/EnmityTests.cs
@@ -475,19 +475,26 @@ public class EnmityTests
 
         nativeSource.Should().Contain("Combat.GetWeaponEngagementRange(attackSkillType)");
         nativeSource.Should().Contain("Combat.IsRangedWeaponSkill(attackSkillType)");
-        nativeSource.Should().NotContain("pCreature.DesiredAttackRange(");
-        nativeSource.Should().NotContain("pCreature.GetRangeWeaponEquipped()");
+        nativeSource.Should().Contain("var isPlayerCreature = pCreature.m_bPlayerCharacter == 1");
+        nativeSource.Should().Contain("? pCreature.GetRangeWeaponEquipped() == 1");
+        nativeSource.Should().Contain("? ResolveEngineDesiredAttackRange(");
+        nativeSource.Should().Contain(": ResolveWeaponEngagementRange(");
         enmitySource.Should().Contain("Combat.GetWeaponEngagementRange(skillType)");
         enmitySource.Should().NotContain("GetPreferredAttackDistance");
 
-        ResolveNativeDesiredAttackRange(10f, 30f, true).Should().Be(10f);
-        ResolveNativeDesiredAttackRange(10f, 5f, true).Should().BeApproximately(4.99f, 0.001f,
+        ResolveNativeWeaponEngagementRange(10f, 30f, true).Should().Be(10f);
+        ResolveNativeWeaponEngagementRange(10f, 5f, true).Should().BeApproximately(4.99f, 0.001f,
             "a ranged weapon's real maximum range must cap the standard engagement distance");
-        ResolveNativeDesiredAttackRange(10f, 1.5f, true).Should().BeApproximately(1.49f, 0.001f,
+        ResolveNativeWeaponEngagementRange(10f, 1.5f, true).Should().BeApproximately(1.49f, 0.001f,
             "even a very short real ranged weapon range must be respected");
-        ResolveNativeDesiredAttackRange(10f, 0f, true).Should().Be(10f,
+        ResolveNativeWeaponEngagementRange(10f, 0f, true).Should().Be(10f,
             "missing ranged metadata must not collapse a ranged creature to melee distance");
-        ResolveNativeDesiredAttackRange(1.5f, 30f, false).Should().Be(1.5f);
+        ResolveNativeWeaponEngagementRange(1.5f, 30f, false).Should().Be(1.5f);
+
+        ResolveNativeEngineDesiredAttackRange(8f, 30f, true).Should().Be(8f,
+            "players must retain the engine's weapon- and target-specific desired range");
+        ResolveNativeEngineDesiredAttackRange(0f, 30f, true).Should().Be(10f);
+        ResolveNativeEngineDesiredAttackRange(1.25f, 30f, false).Should().Be(1.25f);
 
         ResolveNativeMaximumAttackRange(10f, 0f, true).Should().Be(10f,
             "missing ranged metadata must repair the maximum range as well as the desired range");
@@ -609,13 +616,23 @@ public class EnmityTests
             .Invoke(null, new object[] { effectiveDelayMilliseconds })!;
     }
 
-    private static float ResolveNativeDesiredAttackRange(
+    private static float ResolveNativeWeaponEngagementRange(
         float desiredAttackRange,
         float maxAttackRange,
         bool hasRangedWeapon)
     {
         return (float)typeof(OnAIActionAttackObject)
-            .GetMethod("ResolveDesiredAttackRange", BindingFlags.Static | BindingFlags.NonPublic)!
+            .GetMethod("ResolveWeaponEngagementRange", BindingFlags.Static | BindingFlags.NonPublic)!
+            .Invoke(null, new object[] { desiredAttackRange, maxAttackRange, hasRangedWeapon })!;
+    }
+
+    private static float ResolveNativeEngineDesiredAttackRange(
+        float desiredAttackRange,
+        float maxAttackRange,
+        bool hasRangedWeapon)
+    {
+        return (float)typeof(OnAIActionAttackObject)
+            .GetMethod("ResolveEngineDesiredAttackRange", BindingFlags.Static | BindingFlags.NonPublic)!
             .Invoke(null, new object[] { desiredAttackRange, maxAttackRange, hasRangedWeapon })!;
     }
 

--- a/SWLOR.Game.Server/Native/OnAIActionAttackObject.cs
+++ b/SWLOR.Game.Server/Native/OnAIActionAttackObject.cs
@@ -16,8 +16,6 @@ namespace SWLOR.Game.Server.Native
 
         private const int SANCTUARY_SAVE_FAILED = 1;
         private const float CNW_PATHFIND_TOLERANCE = 0.01f;
-        private const float DEFAULT_RANGED_DESIRED_ATTACK_RANGE = 10f;
-        private const float MELEE_ATTACK_RANGE = 1.5f;
 
         private const ushort AISTATE_CREATURE_ABLE_TO_GO_HOSTILE = 0x0080;
         private const ushort AISTATE_CREATURE_USE_HANDS = 0x0004;
@@ -79,6 +77,8 @@ namespace SWLOR.Game.Server.Native
                 var pCreature = CNWSCreature.FromPointer(creature);
                 var pNode = CNWSObjectActionNode.FromPointer(node);
                 var pArea = pCreature.GetArea();
+                var attackSkillType = Combat.GetEquippedWeaponSkillType(pCreature.m_idSelf);
+                var usesRangedWeapon = Combat.IsRangedWeaponSkill(attackSkillType);
 
                 // Clean up attack delay entry if creature no longer exists
                 if (_creatureAttackDelays.ContainsKey(pCreature.m_idSelf) && !GetIsObjectValid(pCreature.m_idSelf))
@@ -177,15 +177,15 @@ namespace SWLOR.Game.Server.Native
                     var pTargetArea = pTarget.GetArea();
 
                     var fMaxAttackRange = pCreature.MaxAttackRange(oidAttackTarget);
-                    var fDesiredAttackRange = pCreature.DesiredAttackRange(oidAttackTarget);
+                    var fDesiredAttackRange = Combat.GetWeaponEngagementRange(attackSkillType);
                     fDesiredAttackRange = ResolveDesiredAttackRange(
                         fDesiredAttackRange,
                         fMaxAttackRange,
-                        pCreature.GetRangeWeaponEquipped() == 1);
+                        usesRangedWeapon);
                     fMaxAttackRange = ResolveMaximumAttackRange(
                         fDesiredAttackRange,
                         fMaxAttackRange,
-                        pCreature.GetRangeWeaponEquipped() == 1);
+                        usesRangedWeapon);
                     if (pCreature.m_oidAttemptedAttackTarget == OBJECT_INVALID)
                     {
                         pCreature.m_oidAttemptedAttackTarget = oidAttackTarget;
@@ -278,7 +278,7 @@ namespace SWLOR.Game.Server.Native
 
                             CNWSCreature newTarget = null;
 
-                            if (pCreature.GetRangeWeaponEquipped() == 0)
+                            if (!usesRangedWeapon)
                             {
                                 newTarget = pCreature.GetNewCombatTarget(oidAttackTarget);
                             }
@@ -341,7 +341,7 @@ namespace SWLOR.Game.Server.Native
                                 fDesiredAttackRange,
                                 fPersonalSpaceRange,
                                 bOutsideAttackRange,
-                                pCreature.GetRangeWeaponEquipped() == 1);
+                                usesRangedWeapon);
                             fMoveToTargetRange = movementPlan.AttackCheckRange;
                             fPathMoveRange = movementPlan.PathCompletionRange;
                             vMoveTargetPosition = new Vector(
@@ -433,7 +433,6 @@ namespace SWLOR.Game.Server.Native
                     }
                 }
 
-                var attackSkillType = Combat.GetEquippedWeaponSkillType(pCreature.m_idSelf);
                 var useDefaultMinimumDelay = Combat.HasNextAutoAttackNoDelay(pCreature.m_idSelf, attackSkillType);
                 var calculatedDelay = Combat.CalculateAttackDelay(pCreature.m_idSelf);
                 var effectiveAttackDelay = Combat.CalculateEffectiveAttackDelay(calculatedDelay, useDefaultMinimumDelay);
@@ -829,40 +828,35 @@ namespace SWLOR.Game.Server.Native
         private readonly record struct RepositionDestination(float X, float Y, float Z);
 
         private static float ResolveDesiredAttackRange(
-            float desiredAttackRange,
+            float weaponEngagementRange,
             float maxAttackRange,
-            bool hasRangedWeapon)
+            bool usesRangedWeapon)
         {
-            if (!hasRangedWeapon ||
-                !float.IsNaN(desiredAttackRange) &&
-                !float.IsInfinity(desiredAttackRange) &&
-                desiredAttackRange > MELEE_ATTACK_RANGE)
-            {
-                return desiredAttackRange;
-            }
+            if (!usesRangedWeapon)
+                return weaponEngagementRange;
 
             if (float.IsNaN(maxAttackRange) ||
                 float.IsInfinity(maxAttackRange) ||
-                maxAttackRange <= MELEE_ATTACK_RANGE)
+                maxAttackRange <= CNW_PATHFIND_TOLERANCE)
             {
-                return DEFAULT_RANGED_DESIRED_ATTACK_RANGE;
+                return weaponEngagementRange;
             }
 
             var maximumUsableRange = maxAttackRange - CNW_PATHFIND_TOLERANCE;
-            return Math.Min(DEFAULT_RANGED_DESIRED_ATTACK_RANGE, maximumUsableRange);
+            return Math.Min(weaponEngagementRange, maximumUsableRange);
         }
 
         private static float ResolveMaximumAttackRange(
             float desiredAttackRange,
             float maxAttackRange,
-            bool hasRangedWeapon)
+            bool usesRangedWeapon)
         {
-            if (!hasRangedWeapon)
+            if (!usesRangedWeapon)
                 return maxAttackRange;
 
             if (float.IsNaN(maxAttackRange) ||
                 float.IsInfinity(maxAttackRange) ||
-                maxAttackRange <= MELEE_ATTACK_RANGE)
+                maxAttackRange <= CNW_PATHFIND_TOLERANCE)
             {
                 return desiredAttackRange;
             }

--- a/SWLOR.Game.Server/Native/OnAIActionAttackObject.cs
+++ b/SWLOR.Game.Server/Native/OnAIActionAttackObject.cs
@@ -78,7 +78,10 @@ namespace SWLOR.Game.Server.Native
                 var pNode = CNWSObjectActionNode.FromPointer(node);
                 var pArea = pCreature.GetArea();
                 var attackSkillType = Combat.GetEquippedWeaponSkillType(pCreature.m_idSelf);
-                var usesRangedWeapon = Combat.IsRangedWeaponSkill(attackSkillType);
+                var isPlayerCreature = pCreature.m_bPlayerCharacter == 1;
+                var usesRangedWeapon = isPlayerCreature
+                    ? pCreature.GetRangeWeaponEquipped() == 1
+                    : Combat.IsRangedWeaponSkill(attackSkillType);
 
                 // Clean up attack delay entry if creature no longer exists
                 if (_creatureAttackDelays.ContainsKey(pCreature.m_idSelf) && !GetIsObjectValid(pCreature.m_idSelf))
@@ -177,11 +180,15 @@ namespace SWLOR.Game.Server.Native
                     var pTargetArea = pTarget.GetArea();
 
                     var fMaxAttackRange = pCreature.MaxAttackRange(oidAttackTarget);
-                    var fDesiredAttackRange = Combat.GetWeaponEngagementRange(attackSkillType);
-                    fDesiredAttackRange = ResolveDesiredAttackRange(
-                        fDesiredAttackRange,
-                        fMaxAttackRange,
-                        usesRangedWeapon);
+                    var fDesiredAttackRange = isPlayerCreature
+                        ? ResolveEngineDesiredAttackRange(
+                            pCreature.DesiredAttackRange(oidAttackTarget),
+                            fMaxAttackRange,
+                            usesRangedWeapon)
+                        : ResolveWeaponEngagementRange(
+                            Combat.GetWeaponEngagementRange(attackSkillType),
+                            fMaxAttackRange,
+                            usesRangedWeapon);
                     fMaxAttackRange = ResolveMaximumAttackRange(
                         fDesiredAttackRange,
                         fMaxAttackRange,
@@ -827,7 +834,7 @@ namespace SWLOR.Game.Server.Native
 
         private readonly record struct RepositionDestination(float X, float Y, float Z);
 
-        private static float ResolveDesiredAttackRange(
+        private static float ResolveWeaponEngagementRange(
             float weaponEngagementRange,
             float maxAttackRange,
             bool usesRangedWeapon)
@@ -844,6 +851,30 @@ namespace SWLOR.Game.Server.Native
 
             var maximumUsableRange = maxAttackRange - CNW_PATHFIND_TOLERANCE;
             return Math.Min(weaponEngagementRange, maximumUsableRange);
+        }
+
+        private static float ResolveEngineDesiredAttackRange(
+            float desiredAttackRange,
+            float maxAttackRange,
+            bool usesRangedWeapon)
+        {
+            if (!usesRangedWeapon ||
+                !float.IsNaN(desiredAttackRange) &&
+                !float.IsInfinity(desiredAttackRange) &&
+                desiredAttackRange > Combat.MeleeWeaponEngagementRange)
+            {
+                return desiredAttackRange;
+            }
+
+            if (float.IsNaN(maxAttackRange) ||
+                float.IsInfinity(maxAttackRange) ||
+                maxAttackRange <= Combat.MeleeWeaponEngagementRange)
+            {
+                return Combat.RangedWeaponEngagementRange;
+            }
+
+            var maximumUsableRange = maxAttackRange - CNW_PATHFIND_TOLERANCE;
+            return Math.Min(Combat.RangedWeaponEngagementRange, maximumUsableRange);
         }
 
         private static float ResolveMaximumAttackRange(

--- a/SWLOR.Game.Server/Service/Combat.cs
+++ b/SWLOR.Game.Server/Service/Combat.cs
@@ -4592,6 +4592,16 @@ namespace SWLOR.Game.Server.Service
                    skillType == SkillType.Throwing;
         }
 
+        public static float GetWeaponEngagementRange(SkillType skillType)
+        {
+            const float meleeWeaponRange = 1.5f;
+            const float rangedWeaponRange = 10f;
+
+            return IsRangedWeaponSkill(skillType)
+                ? rangedWeaponRange
+                : meleeWeaponRange;
+        }
+
         public static bool IsMeleeWeaponSkill(SkillType skillType)
         {
             return IsWeaponSkillType(skillType) && !IsRangedWeaponSkill(skillType);

--- a/SWLOR.Game.Server/Service/Combat.cs
+++ b/SWLOR.Game.Server/Service/Combat.cs
@@ -43,6 +43,8 @@ namespace SWLOR.Game.Server.Service
 
         public const int StandardCriticalRating = 2;
         public const int BaseAttackDelayMilliseconds = 1750;
+        public const float MeleeWeaponEngagementRange = 1.5f;
+        public const float RangedWeaponEngagementRange = 10f;
 
         // The engine/client cannot play swing animations faster than the base attack delay.
         // Delays below it are honored by resolving multiple attack rolls within a single swing,
@@ -4594,12 +4596,9 @@ namespace SWLOR.Game.Server.Service
 
         public static float GetWeaponEngagementRange(SkillType skillType)
         {
-            const float meleeWeaponRange = 1.5f;
-            const float rangedWeaponRange = 10f;
-
             return IsRangedWeaponSkill(skillType)
-                ? rangedWeaponRange
-                : meleeWeaponRange;
+                ? RangedWeaponEngagementRange
+                : MeleeWeaponEngagementRange;
         }
 
         public static bool IsMeleeWeaponSkill(SkillType skillType)

--- a/SWLOR.Game.Server/Service/Enmity.cs
+++ b/SWLOR.Game.Server/Service/Enmity.cs
@@ -24,9 +24,7 @@ namespace SWLOR.Game.Server.Service
         private static readonly Dictionary<uint, DateTime> _attackCommandTimes = new();
         private const float MinimumStaleAttackRecoverySeconds = 4.5f;
         private const float AttackMoveRangeTolerance = 0.25f;
-        private const float DefaultRangedAttackMoveRange = 10f;
         private const float MeleeAttackMoveThreshold = 2.25f;
-        private const float MeleeAttackMoveRange = 1.5f;
 
         /// <summary>
         /// When an enemy is damaged, increase enmity toward that creature by the amount of damage dealt.
@@ -661,14 +659,14 @@ namespace SWLOR.Game.Server.Service
             }
 
             var skillType = Combat.GetEquippedWeaponSkillType(creature);
-            var moveRange = GetAttackMoveRange(skillType, CreaturePlugin.GetPreferredAttackDistance(creature));
+            var moveRange = Combat.GetWeaponEngagementRange(skillType);
 
             return ShouldMoveIntoAttackRange(GetDistanceBetween(creature, target), skillType, moveRange);
         }
 
         private static bool ShouldMoveIntoAttackRange(float distance, SkillType skillType, float moveRange)
         {
-            var threshold = Combat.IsRangedDamageSkill(skillType)
+            var threshold = Combat.IsRangedWeaponSkill(skillType)
                 ? moveRange + AttackMoveRangeTolerance
                 : MeleeAttackMoveThreshold;
 
@@ -678,22 +676,7 @@ namespace SWLOR.Game.Server.Service
         private static float GetAttackMoveRange(uint creature)
         {
             var skillType = Combat.GetEquippedWeaponSkillType(creature);
-            return GetAttackMoveRange(skillType, CreaturePlugin.GetPreferredAttackDistance(creature));
-        }
-
-        private static float GetAttackMoveRange(SkillType skillType, float preferredAttackDistance)
-        {
-            if (!Combat.IsRangedDamageSkill(skillType))
-                return MeleeAttackMoveRange;
-
-            if (float.IsNaN(preferredAttackDistance) ||
-                float.IsInfinity(preferredAttackDistance) ||
-                preferredAttackDistance <= MeleeAttackMoveRange)
-            {
-                return DefaultRangedAttackMoveRange;
-            }
-
-            return preferredAttackDistance;
+            return Combat.GetWeaponEngagementRange(skillType);
         }
 
         private static bool ShouldRemoveStaleProximityTarget(uint enemy, uint target)


### PR DESCRIPTION
## Summary

- derive NPC engagement distance from the currently equipped weapon instead of appearance preferred-distance metadata
- use 1.5m for melee weapons and 10m for ranged weapons, capped by a shorter real weapon maximum range
- make the enmity pre-move and native attack hook share the same weapon classification and engagement rule
- add regressions proving the paths do not use appearance preference, NPC-specific data, or the native ranged-weapon shortcut

## Validation

- `dotnet build SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj -p:RunPostBuildEvent=Never`
- `dotnet test SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj --no-build --filter "FullyQualifiedName~EnmityTests|FullyQualifiedName~AIModelTests"` — 67 passed
- full suite: 1,798 passed / 6 unrelated existing failures (Force Burst coverage, NWN Core-dependent stance tests, and pre-existing status-effect naming audit failures)

No NPC blueprints, resrefs, appearance rows, animations, weapon stats, damage, or accuracy were changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved NPC attack positioning based on each equipped weapon’s effective engagement range.
  - Ranged attackers now maintain appropriate distance while respecting maximum attack range limits.
  - Melee attackers use a closer engagement threshold for more reliable movement and attacks.
  - Improved fallback behavior when ranged weapon range information is unavailable.
  - Updated attack movement and target engagement to use consistent weapon-based range calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->