### PR TITLE
Allow repeated ERF imports

### DIFF
--- a/SWLOR.Toolset.Tests/ErfArchiveServiceTests.cs
+++ b/SWLOR.Toolset.Tests/ErfArchiveServiceTests.cs
@@ -459,6 +459,19 @@ namespace SWLOR.Toolset.Tests
                     extension,
                     $"{resRef}.{extension}.json")).Should().BeTrue();
             }
+
+            importViewModel.ShowImportAction.Should().BeFalse();
+            importViewModel.ShowRestartImportAction.Should().BeTrue();
+            importViewModel.CanGoBack.Should().BeFalse();
+
+            importViewModel.RestartImportCommand.Execute(null);
+
+            importViewModel.CurrentStep.Should().Be(0);
+            importViewModel.IsComplete.Should().BeFalse();
+            importViewModel.ImportArchivePath.Should().BeEmpty();
+            importViewModel.Assets.Should().BeEmpty();
+            importViewModel.CanGoNext.Should().BeFalse();
+            importViewModel.StatusText.Should().Be("Choose an ERF file to begin.");
         }
 
         [Test]

--- a/SWLOR.Toolset.Tests/ErfArchiveWindowRenderTests.cs
+++ b/SWLOR.Toolset.Tests/ErfArchiveWindowRenderTests.cs
@@ -110,6 +110,21 @@ namespace SWLOR.Toolset.Tests
                 viewModel.IsBusy = false;
                 Dispatcher.UIThread.RunJobs();
                 closeButton.IsEnabled.Should().BeTrue();
+
+                viewModel.Mode = ErfArchiveMode.Import;
+                viewModel.CurrentStep = 3;
+                viewModel.IsComplete = true;
+                Dispatcher.UIThread.RunJobs();
+
+                var importAgainButton = window.GetVisualDescendants()
+                    .OfType<Button>()
+                    .Single(button => button.Content?.ToString() == "Import another ERF");
+                importAgainButton.IsVisible.Should().BeTrue();
+                importAgainButton.IsEnabled.Should().BeTrue();
+                window.GetVisualDescendants()
+                    .OfType<Button>()
+                    .Single(button => button.Content?.ToString() == "Import to Module")
+                    .IsVisible.Should().BeFalse();
             }
             finally
             {

--- a/SWLOR.Toolset/Archives/ErfArchiveViewModel.cs
+++ b/SWLOR.Toolset/Archives/ErfArchiveViewModel.cs
@@ -354,6 +354,9 @@ namespace SWLOR.Toolset.Archives
         [NotifyPropertyChangedFor(nameof(StepThreeLabel))]
         [NotifyPropertyChangedFor(nameof(StepFourLabel))]
         [NotifyPropertyChangedFor(nameof(StatusFilters))]
+        [NotifyPropertyChangedFor(nameof(ShowImportAction))]
+        [NotifyPropertyChangedFor(nameof(ShowRestartImportAction))]
+        [NotifyPropertyChangedFor(nameof(CanRestartImport))]
         private ErfArchiveMode _mode = ErfArchiveMode.Import;
 
         [ObservableProperty]
@@ -370,6 +373,8 @@ namespace SWLOR.Toolset.Archives
         [NotifyPropertyChangedFor(nameof(CanGoNext))]
         [NotifyPropertyChangedFor(nameof(ShowNext))]
         [NotifyPropertyChangedFor(nameof(ShowImportAction))]
+        [NotifyPropertyChangedFor(nameof(ShowRestartImportAction))]
+        [NotifyPropertyChangedFor(nameof(CanRestartImport))]
         [NotifyPropertyChangedFor(nameof(ShowExportAction))]
         [NotifyPropertyChangedFor(nameof(StepTitle))]
         [NotifyPropertyChangedFor(nameof(StepDescription))]
@@ -379,6 +384,7 @@ namespace SWLOR.Toolset.Archives
         [NotifyPropertyChangedFor(nameof(CanGoNext))]
         [NotifyPropertyChangedFor(nameof(CanCommit))]
         [NotifyPropertyChangedFor(nameof(CanClose))]
+        [NotifyPropertyChangedFor(nameof(CanRestartImport))]
         private bool _isBusy;
 
         [ObservableProperty]
@@ -392,6 +398,10 @@ namespace SWLOR.Toolset.Archives
 
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(CanCommit))]
+        [NotifyPropertyChangedFor(nameof(CanGoBack))]
+        [NotifyPropertyChangedFor(nameof(ShowImportAction))]
+        [NotifyPropertyChangedFor(nameof(ShowRestartImportAction))]
+        [NotifyPropertyChangedFor(nameof(CanRestartImport))]
         private bool _isComplete;
 
         [ObservableProperty]
@@ -443,10 +453,12 @@ namespace SWLOR.Toolset.Archives
         public bool IsStepFour => CurrentStep == 3;
         public bool CanGoBack =>
             !IsBusy &&
+            !(IsImport && IsComplete) &&
             CurrentStep > 0 &&
             !(IsExport && CurrentStep == 1);
         public bool ShowNext => CurrentStep < 3 && !IsValidatingSelection;
-        public bool ShowImportAction => IsImport && CurrentStep == 3;
+        public bool ShowImportAction => IsImport && CurrentStep == 3 && !IsComplete;
+        public bool ShowRestartImportAction => IsImport && CurrentStep == 3 && IsComplete;
         public bool ShowExportAction => IsExport && CurrentStep == 3;
         public bool ShowImportFile => IsImport && CurrentStep == 0;
         public bool ShowExportSnapshot => IsExport && CurrentStep == 0;
@@ -457,6 +469,7 @@ namespace SWLOR.Toolset.Archives
         public bool ShowExportValidation =>
             IsExport && CurrentStep == 2 && !IsValidatingSelection;
         public bool CanCommit => !IsBusy && !IsComplete;
+        public bool CanRestartImport => !IsBusy && ShowRestartImportAction;
         public bool CanClose => !IsBusy;
         public bool CanGoNext => !IsBusy && CurrentStep < 3 && (CurrentStep != 0 || !IsImport || _session != null);
         public string ModeTitle => IsImport ? "Import ERF" : "Export ERF";
@@ -606,6 +619,26 @@ namespace SWLOR.Toolset.Archives
             StatusText = _session == null
                 ? "Choose an ERF file to begin."
                 : $"{Assets.Count} asset(s) found.";
+        }
+
+        [RelayCommand]
+        private void RestartImport()
+        {
+            if (!CanRestartImport)
+                return;
+
+            var session = _session;
+            _session = null;
+            _explicitImportSelection.Clear();
+            ResetRows();
+            session?.Dispose();
+            ImportArchivePath = string.Empty;
+            SelectedRecentArchive = null;
+            CompletionTitle = string.Empty;
+            CompletionDetail = string.Empty;
+            CurrentStep = 0;
+            IsComplete = false;
+            StatusText = "Choose an ERF file to begin.";
         }
 
         [RelayCommand]
@@ -1120,6 +1153,11 @@ namespace SWLOR.Toolset.Archives
         {
             BackCommand.NotifyCanExecuteChanged();
             NextCommand.NotifyCanExecuteChanged();
+        }
+
+        partial void OnIsCompleteChanged(bool value)
+        {
+            BackCommand.NotifyCanExecuteChanged();
         }
 
         public void Dispose()

--- a/SWLOR.Toolset/Archives/ErfArchiveWindow.axaml
+++ b/SWLOR.Toolset/Archives/ErfArchiveWindow.axaml
@@ -382,6 +382,10 @@
         <Button Grid.Column="4" Classes="primary" Content="Import to Module"
                 Click="OnImportClicked" IsVisible="{Binding ShowImportAction}"
                 IsEnabled="{Binding CanCommit}" />
+        <Button Grid.Column="4" Classes="primary" Content="Import another ERF"
+                Command="{Binding RestartImportCommand}"
+                IsVisible="{Binding ShowRestartImportAction}"
+                IsEnabled="{Binding CanRestartImport}" />
         <Button Grid.Column="5" Classes="primary" Content="Save ERF As..."
                 Click="OnExportClicked" IsVisible="{Binding ShowExportAction}"
                 IsEnabled="{Binding CanCommit}" />


### PR DESCRIPTION
## Summary

- replace the disabled post-import action with an **Import another ERF** button
- release the completed archive session and reset the wizard to a fresh file-selection state
- retain recent ERF history while clearing the prior path, assets, selections, and completion details
- add view-model and rendered-window regression coverage

## Root cause

After a successful import, the wizard remained on its final step with **Import to Module** disabled. There was no action that released the current archive and returned the workflow to step 1, so importing another ERF required closing and reopening the window.

## User impact

Toolset users can now import multiple ERF files in sequence without restarting the archive window.

## Validation

- `dotnet build SWLOR.Toolset.Tests\SWLOR.Toolset.Tests.csproj --no-restore -m:1 -p:RunPostBuildEvent=Never`
- `dotnet test SWLOR.Toolset.Tests\SWLOR.Toolset.Tests.csproj --no-build --filter "FullyQualifiedName~ErfArchiveServiceTests|FullyQualifiedName~ErfArchiveWindowRenderTests" -p:RunPostBuildEvent=Never`
- 45 ERF-focused tests passed