### PR TITLE
Fix smuggler shuttle access and conversation portraits

### DIFF
--- a/Module/git/tat_anc_astropor.git.json
+++ b/Module/git/tat_anc_astropor.git.json
@@ -56210,7 +56210,7 @@
               },
               "Value": {
                 "type": "int",
-                "value": 81
+                "value": 86
               }
             },
             {

--- a/SWLOR.Game.Server.Tests/Feature/TatooineSmugglerTravelTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/TatooineSmugglerTravelTests.cs
@@ -1,0 +1,119 @@
+using System.Text.Json;
+using FluentAssertions;
+using NUnit.Framework;
+using SWLOR.Game.Server.Service.KeyItemService;
+
+namespace SWLOR.Game.Server.Tests.Feature;
+
+public class TatooineSmugglerTravelTests
+{
+    [Test]
+    public void SmugglerShipTeleport_RequiresTheQuestRewardedSmugglerPass()
+    {
+        using var area = LoadModuleJson("git", "tat_anc_astropor.git.json");
+
+        var teleporter = EnumerateObjects(area.RootElement)
+            .Single(element =>
+                GetString(element, "OnUsed") == "teleport" &&
+                GetOptionalLocalString(element, "DESTINATION") == "smuggler_moon");
+
+        GetLocalInt(teleporter, "KEY_ITEM_ID").Should().Be((int)KeyItemType.SmugglerPass);
+        GetLocalString(teleporter, "MISSING_KEY_ITEM_MESSAGE").Should().Contain("key pass");
+    }
+
+    private static JsonDocument LoadModuleJson(string folder, string fileName)
+    {
+        var root = FindRepositoryRoot();
+        return JsonDocument.Parse(File.ReadAllText(Path.Combine(
+            root.FullName,
+            "Module",
+            folder,
+            fileName)));
+    }
+
+    private static int GetLocalInt(JsonElement json, string variableName)
+    {
+        return GetLocal(json, variableName).GetProperty("Value").GetProperty("value").GetInt32();
+    }
+
+    private static string GetLocalString(JsonElement json, string variableName)
+    {
+        return GetLocal(json, variableName).GetProperty("Value").GetProperty("value").GetString()!;
+    }
+
+    private static string GetOptionalLocalString(JsonElement json, string variableName)
+    {
+        return TryGetLocal(json, variableName, out var local)
+            ? local.GetProperty("Value").GetProperty("value").GetString() ?? string.Empty
+            : string.Empty;
+    }
+
+    private static JsonElement GetLocal(JsonElement json, string variableName)
+    {
+        if (!TryGetLocal(json, variableName, out var local))
+            throw new InvalidOperationException($"Missing local variable '{variableName}'.");
+
+        return local;
+    }
+
+    private static bool TryGetLocal(JsonElement json, string variableName, out JsonElement local)
+    {
+        local = default;
+        if (!json.TryGetProperty("VarTable", out var varTable) ||
+            !varTable.TryGetProperty("value", out var variables) ||
+            variables.ValueKind != JsonValueKind.Array)
+        {
+            return false;
+        }
+
+        foreach (var variable in variables.EnumerateArray())
+        {
+            if (variable.GetProperty("Name").GetProperty("value").GetString() == variableName)
+            {
+                local = variable;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string GetString(JsonElement json, string propertyName)
+    {
+        return json.TryGetProperty(propertyName, out var property) &&
+               property.TryGetProperty("value", out var value) &&
+               value.ValueKind == JsonValueKind.String
+            ? value.GetString()!
+            : string.Empty;
+    }
+
+    private static IEnumerable<JsonElement> EnumerateObjects(JsonElement element)
+    {
+        if (element.ValueKind == JsonValueKind.Object)
+        {
+            yield return element;
+            foreach (var property in element.EnumerateObject())
+            {
+                foreach (var nested in EnumerateObjects(property.Value))
+                    yield return nested;
+            }
+        }
+        else if (element.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in element.EnumerateArray())
+            {
+                foreach (var nested in EnumerateObjects(item))
+                    yield return nested;
+            }
+        }
+    }
+
+    private static DirectoryInfo FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(TestContext.CurrentContext.TestDirectory);
+        while (directory != null && !File.Exists(Path.Combine(directory.FullName, "SWLOR.Game.Server.sln")))
+            directory = directory.Parent;
+
+        return directory ?? throw new DirectoryNotFoundException("Could not locate repository root.");
+    }
+}

--- a/SWLOR.Game.Server.Tests/Service/ConversationArchitectureTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/ConversationArchitectureTests.cs
@@ -6,6 +6,7 @@ using SWLOR.Game.Server.Core;
 using SWLOR.Game.Server.Feature.GuiDefinition.ViewModel;
 using SWLOR.Game.Server.Service;
 using SWLOR.Game.Server.Service.ConversationService;
+using SWLOR.NWN.API.NWScript.Enum;
 
 namespace SWLOR.Game.Server.Tests.Service;
 
@@ -196,6 +197,20 @@ public class ConversationArchitectureTests
         segments.Should().HaveCountGreaterThan(1);
         segments.Should().OnlyContain(segment => segment.Length <= 320);
         string.Join(" ", segments).Should().Be(source);
+    }
+
+    [Test]
+    public void AutomaticConversationPortraits_AreLimitedToCreatures()
+    {
+        var method = typeof(ConversationViewModel).GetMethod(
+            "SupportsAutomaticPortrait",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        method.Should().NotBeNull();
+
+        ((bool)method!.Invoke(null, new object[] { ObjectType.Creature })!).Should().BeTrue();
+        ((bool)method.Invoke(null, new object[] { ObjectType.Placeable })!).Should().BeFalse(
+            "placeables such as shuttle status consoles do not have renderable creature portraits");
+        ((bool)method.Invoke(null, new object[] { ObjectType.Door })!).Should().BeFalse();
     }
 
     private static bool IsGeneratedShell(string fileName)

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/ConversationViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/ConversationViewModel.cs
@@ -249,12 +249,15 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             if (!string.IsNullOrWhiteSpace(node.PortraitResref))
                 return _session.ResolveText(node.PortraitResref);
 
-            if (!GetIsObjectValid(speaker))
+            if (!GetIsObjectValid(speaker) || !SupportsAutomaticPortrait(GetObjectType(speaker)))
                 return string.Empty;
 
             var portrait = GetPortraitResRef(speaker);
             return string.IsNullOrWhiteSpace(portrait) ? string.Empty : portrait + "l";
         }
+
+        private static bool SupportsAutomaticPortrait(ObjectType objectType) =>
+            objectType == ObjectType.Creature;
 
         private static void PlayPresentation(
             uint actor,


### PR DESCRIPTION
## Summary

- prevent the NUI conversation window from rendering automatic portraits for non-creature owners such as shuttle consoles
- update Smuggler Joe's ship teleporter to require the existing `SmugglerPass` key item
- add regression coverage for non-creature conversation portraits and the Tatooine smuggler teleporter

## Root cause

The conversation view attempted to resolve creature portraits for every valid conversation owner, including placeables. Separately, the smuggler ship teleporter referenced stale key-item ID `81` while the quest rewards `KeyItemType.SmugglerPass`, ID `86`.

## Impact

The shuttle status conversation no longer shows a broken portrait image, and Smuggler Joe's permanent pass now works consistently at both the flights terminal and the nearby ship teleporter.

## Validation

- `dotnet build SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj -p:RunPostBuildEvent=Never`
- `dotnet test SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj --no-build --filter "FullyQualifiedName~ConversationArchitectureTests|FullyQualifiedName~TatooineSmugglerTravelTests"` (11 passed)
- parsed `Module/git/tat_anc_astropor.git.json` with `ConvertFrom-Json`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted automatic conversation portraits to creature speakers, preventing invalid portraits for placeables and doors.
  * Updated the Tatooine smuggler travel configuration to require the correct smuggler pass.

* **Tests**
  * Added coverage confirming the smuggler ship requires the Smuggler Pass and displays an appropriate message when unavailable.
  * Added validation for supported conversation portrait object types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->