### PR TITLE
Match crafted saber lights to blade colors

### DIFF
--- a/Module/uti/ls_custom.uti.json
+++ b/Module/uti/ls_custom.uti.json
@@ -97,7 +97,7 @@
         },
         "Subtype": {
           "type": "word",
-          "value": 0
+          "value": 6
         }
       },
       {

--- a/Module/uti/ss_custom.uti.json
+++ b/Module/uti/ss_custom.uti.json
@@ -97,7 +97,7 @@
         },
         "Subtype": {
           "type": "word",
-          "value": 0
+          "value": 6
         }
       },
       {

--- a/SWLOR.Game.Server.Tests/Feature/LightsaberWorkbenchTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/LightsaberWorkbenchTests.cs
@@ -5,6 +5,7 @@ using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using SWLOR.Game.Server.Service;
 using SWLOR.NWN.API.NWScript.Enum.Item;
+using SWLOR.NWN.API.NWScript.Enum.Item.Property;
 
 namespace SWLOR.Game.Server.Tests.Feature;
 
@@ -90,15 +91,14 @@ public class LightsaberWorkbenchTests
         var saberProperties = ExtractProperties(saber);
         var templateProperties = ExtractProperties(template);
 
-        // Workbench sabers receive a free 5m glow: Light (44), no subtype,
-        // iprp_lightcost (18), Dim (1). It is part of the output blueprint rather
-        // than a socketed enhancement, so constructing the weapon cannot charge
-        // or consume an enhancement slot for it.
+        // Workbench sabers receive a free 5m glow: Light (44), White (6),
+        // iprp_lightcost (18), Dim (1). White is the safe blueprint fallback;
+        // construction replaces it with the selected blade's supported color.
         var expectedProperties = templateProperties
-            .Append((PropertyName: 44, Subtype: 0, CostTable: 18, CostValue: 1))
+            .Append((PropertyName: 44, Subtype: 6, CostTable: 18, CostValue: 1))
             .ToList();
         saberProperties.Should().BeEquivalentTo(expectedProperties,
-            $"{Path.GetFileName(saberPath)} must carry the exact property set of {Path.GetFileName(templatePath)} plus a free Dim (5m) Light property");
+            $"{Path.GetFileName(saberPath)} must carry the exact property set of {Path.GetFileName(templatePath)} plus a free Dim (5m) White Light property");
     }
 
     private static List<(int PropertyName, int Subtype, int CostTable, int CostValue)> ExtractProperties(JObject item)
@@ -342,6 +342,49 @@ public class LightsaberWorkbenchTests
             File.Exists(Path.Combine(uiRoot, $"{hilt.PreviewResref}.tga"))
                 .Should().BeTrue($"preview texture {hilt.PreviewResref}.tga must exist in sw_ui");
         }
+    }
+
+    [Test]
+    public void BladeColors_UseMatchingLightColorsOrNeutralWhiteFallback()
+    {
+        var expected = new Dictionary<string, LightColor>
+        {
+            ["Orange"] = LightColor.ORANGE,
+            ["Blue"] = LightColor.BLUE,
+            ["Green 1"] = LightColor.GREEN,
+            ["Red"] = LightColor.RED,
+            ["White"] = LightColor.WHITE,
+            ["Yellow"] = LightColor.YELLOW,
+            ["Purple 1"] = LightColor.PURPLE,
+            ["Teal"] = LightColor.WHITE,
+            ["Pink"] = LightColor.WHITE,
+            ["Brown"] = LightColor.WHITE,
+            ["Green 2"] = LightColor.GREEN,
+            ["Purple 2"] = LightColor.PURPLE,
+            ["Lavender"] = LightColor.WHITE,
+            ["Cyan"] = LightColor.WHITE,
+        };
+
+        var colors = LightsaberWorkbench.GetBladeColors(BaseItem.Lightsaber, false)
+            .ToDictionary(color => color.Name);
+        colors.Keys.Should().BeEquivalentTo(expected.Keys);
+
+        foreach (var (name, lightColor) in expected)
+        {
+            colors[name].LightColor.Should().Be(lightColor);
+        }
+
+        var root = FindRepositoryRoot();
+        var viewModel = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "SWLOR.Game.Server",
+            "Feature",
+            "GuiDefinition",
+            "ViewModel",
+            "LightsaberWorkbenchViewModel.cs"));
+        viewModel.Should().Contain("ApplyBladeLight(item, top.LightColor);");
+        viewModel.Should().Contain("ItemPropertyLight(LightBrightness.LIGHTBRIGHTNESS_DIM, lightColor)");
+        viewModel.Should().Contain("GetItemPropertyType(ip) == ItemPropertyType.Light");
     }
 
     private static Func<string, bool> GetIsCraftableSaberResref()

--- a/SWLOR.Game.Server.Tests/Feature/LightsaberWorkbenchTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/LightsaberWorkbenchTests.cs
@@ -349,20 +349,20 @@ public class LightsaberWorkbenchTests
     {
         var expected = new Dictionary<string, LightColor>
         {
-            ["Orange"] = LightColor.ORANGE,
-            ["Blue"] = LightColor.BLUE,
-            ["Green 1"] = LightColor.GREEN,
-            ["Red"] = LightColor.RED,
-            ["White"] = LightColor.WHITE,
-            ["Yellow"] = LightColor.YELLOW,
-            ["Purple 1"] = LightColor.PURPLE,
-            ["Teal"] = LightColor.WHITE,
-            ["Pink"] = LightColor.WHITE,
-            ["Brown"] = LightColor.WHITE,
-            ["Green 2"] = LightColor.GREEN,
-            ["Purple 2"] = LightColor.PURPLE,
-            ["Lavender"] = LightColor.WHITE,
-            ["Cyan"] = LightColor.WHITE,
+            ["Orange"] = LightColor.Orange,
+            ["Blue"] = LightColor.Blue,
+            ["Green 1"] = LightColor.Green,
+            ["Red"] = LightColor.Red,
+            ["White"] = LightColor.White,
+            ["Yellow"] = LightColor.Yellow,
+            ["Purple 1"] = LightColor.Purple,
+            ["Teal"] = LightColor.White,
+            ["Pink"] = LightColor.White,
+            ["Brown"] = LightColor.White,
+            ["Green 2"] = LightColor.Green,
+            ["Purple 2"] = LightColor.Purple,
+            ["Lavender"] = LightColor.White,
+            ["Cyan"] = LightColor.White,
         };
 
         var colors = LightsaberWorkbench.GetBladeColors(BaseItem.Lightsaber, false)
@@ -383,7 +383,7 @@ public class LightsaberWorkbenchTests
             "ViewModel",
             "LightsaberWorkbenchViewModel.cs"));
         viewModel.Should().Contain("ApplyBladeLight(item, top.LightColor);");
-        viewModel.Should().Contain("ItemPropertyLight(LightBrightness.LIGHTBRIGHTNESS_DIM, lightColor)");
+        viewModel.Should().Contain("ItemPropertyLight(LightBrightness.Dim, lightColor)");
         viewModel.Should().Contain("GetItemPropertyType(ip) == ItemPropertyType.Light");
     }
 

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/LightsaberWorkbenchViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/LightsaberWorkbenchViewModel.cs
@@ -536,6 +536,8 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
                 return;
             }
 
+            ApplyBladeLight(item, top.LightColor);
+
             foreach (var property in _enhancementProperties.SelectMany(x => x))
             {
                 Craft.ApplyCraftedItemProperty(item, property);
@@ -585,6 +587,27 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             FloatingTextStringOnCreature($"You have constructed your {GetName(item)}!", Player, false);
 
             Gui.TogglePlayerWindow(Player, GuiWindowType.LightsaberWorkbench);
+        }
+
+        private static void ApplyBladeLight(uint item, LightColor lightColor)
+        {
+            // The output blueprints carry a neutral white fallback light. Replace it
+            // with the selected blade's supported engine color during construction.
+            // Scan first because removing properties while iterating skips entries.
+            var existingLights = new List<ItemProperty>();
+            for (var ip = GetFirstItemProperty(item); GetIsItemPropertyValid(ip); ip = GetNextItemProperty(item))
+            {
+                if (GetItemPropertyType(ip) == ItemPropertyType.Light)
+                    existingLights.Add(ip);
+            }
+
+            foreach (var light in existingLights)
+            {
+                RemoveItemProperty(item, light);
+            }
+
+            var bladeLight = ItemPropertyLight(LightBrightness.LIGHTBRIGHTNESS_DIM, lightColor);
+            AddItemProperty(DurationType.Permanent, bladeLight, item);
         }
 
         private static uint ModifyWeaponPart(uint item, AppearanceWeapon partSlot, int partValue)

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/LightsaberWorkbenchViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/LightsaberWorkbenchViewModel.cs
@@ -606,7 +606,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
                 RemoveItemProperty(item, light);
             }
 
-            var bladeLight = ItemPropertyLight(LightBrightness.LIGHTBRIGHTNESS_DIM, lightColor);
+            var bladeLight = ItemPropertyLight(LightBrightness.Dim, lightColor);
             AddItemProperty(DurationType.Permanent, bladeLight, item);
         }
 

--- a/SWLOR.Game.Server/Service/LightsaberWorkbench.cs
+++ b/SWLOR.Game.Server/Service/LightsaberWorkbench.cs
@@ -95,20 +95,20 @@ namespace SWLOR.Game.Server.Service
 
         private static readonly List<SaberBladeColor> _bladeColors = new()
         {
-            new SaberBladeColor("Orange", 11, 31, 11, "ui_lsc_orange", LightColor.ORANGE),
-            new SaberBladeColor("Blue", 12, 32, 12, "ui_lsc_blue", LightColor.BLUE),
-            new SaberBladeColor("Green 1", 13, 33, 13, "ui_lsc_green", LightColor.GREEN),
-            new SaberBladeColor("Red", 14, 34, 14, "ui_lsc_red", LightColor.RED),
-            new SaberBladeColor("White", 15, 35, 25, "ui_lsc_white", LightColor.WHITE),
-            new SaberBladeColor("Yellow", 21, 71, 21, "ui_lsc_yellow", LightColor.YELLOW),
-            new SaberBladeColor("Purple 1", 22, 72, 22, "ui_lsc_purple", LightColor.PURPLE),
-            new SaberBladeColor("Teal", 23, 73, 23, "ui_lsc_teal", LightColor.WHITE),
-            new SaberBladeColor("Pink", 24, 74, 24, "ui_lsc_pink", LightColor.WHITE),
-            new SaberBladeColor("Brown", 51, 61, 51, "ui_lsc_brown", LightColor.WHITE),
-            new SaberBladeColor("Green 2", 52, 62, 52, "ui_lsc_rotjgrn", LightColor.GREEN),
-            new SaberBladeColor("Purple 2", 53, 63, 53, "ui_lsc_windu", LightColor.PURPLE),
-            new SaberBladeColor("Lavender", 54, 64, 54, "ui_lsc_lavendr", LightColor.WHITE),
-            new SaberBladeColor("Cyan", 55, 65, 55, "ui_lsc_cyan", LightColor.WHITE),
+            new SaberBladeColor("Orange", 11, 31, 11, "ui_lsc_orange", LightColor.Orange),
+            new SaberBladeColor("Blue", 12, 32, 12, "ui_lsc_blue", LightColor.Blue),
+            new SaberBladeColor("Green 1", 13, 33, 13, "ui_lsc_green", LightColor.Green),
+            new SaberBladeColor("Red", 14, 34, 14, "ui_lsc_red", LightColor.Red),
+            new SaberBladeColor("White", 15, 35, 25, "ui_lsc_white", LightColor.White),
+            new SaberBladeColor("Yellow", 21, 71, 21, "ui_lsc_yellow", LightColor.Yellow),
+            new SaberBladeColor("Purple 1", 22, 72, 22, "ui_lsc_purple", LightColor.Purple),
+            new SaberBladeColor("Teal", 23, 73, 23, "ui_lsc_teal", LightColor.White),
+            new SaberBladeColor("Pink", 24, 74, 24, "ui_lsc_pink", LightColor.White),
+            new SaberBladeColor("Brown", 51, 61, 51, "ui_lsc_brown", LightColor.White),
+            new SaberBladeColor("Green 2", 52, 62, 52, "ui_lsc_rotjgrn", LightColor.Green),
+            new SaberBladeColor("Purple 2", 53, 63, 53, "ui_lsc_windu", LightColor.Purple),
+            new SaberBladeColor("Lavender", 54, 64, 54, "ui_lsc_lavendr", LightColor.White),
+            new SaberBladeColor("Cyan", 55, 65, 55, "ui_lsc_cyan", LightColor.White),
         };
 
         /// <summary>

--- a/SWLOR.Game.Server/Service/LightsaberWorkbench.cs
+++ b/SWLOR.Game.Server/Service/LightsaberWorkbench.cs
@@ -7,6 +7,7 @@ using SWLOR.Game.Server.Service.GuiService;
 using SWLOR.Game.Server.Service.LightsaberWorkbenchService;
 using SWLOR.Game.Server.Service.LogService;
 using SWLOR.NWN.API.NWScript.Enum.Item;
+using SWLOR.NWN.API.NWScript.Enum.Item.Property;
 using Player = SWLOR.Game.Server.Entity.Player;
 
 namespace SWLOR.Game.Server.Service
@@ -94,20 +95,20 @@ namespace SWLOR.Game.Server.Service
 
         private static readonly List<SaberBladeColor> _bladeColors = new()
         {
-            new SaberBladeColor("Orange", 11, 31, 11, "ui_lsc_orange"),
-            new SaberBladeColor("Blue", 12, 32, 12, "ui_lsc_blue"),
-            new SaberBladeColor("Green 1", 13, 33, 13, "ui_lsc_green"),
-            new SaberBladeColor("Red", 14, 34, 14, "ui_lsc_red"),
-            new SaberBladeColor("White", 15, 35, 25, "ui_lsc_white"),
-            new SaberBladeColor("Yellow", 21, 71, 21, "ui_lsc_yellow"),
-            new SaberBladeColor("Purple 1", 22, 72, 22, "ui_lsc_purple"),
-            new SaberBladeColor("Teal", 23, 73, 23, "ui_lsc_teal"),
-            new SaberBladeColor("Pink", 24, 74, 24, "ui_lsc_pink"),
-            new SaberBladeColor("Brown", 51, 61, 51, "ui_lsc_brown"),
-            new SaberBladeColor("Green 2", 52, 62, 52, "ui_lsc_rotjgrn"),
-            new SaberBladeColor("Purple 2", 53, 63, 53, "ui_lsc_windu"),
-            new SaberBladeColor("Lavender", 54, 64, 54, "ui_lsc_lavendr"),
-            new SaberBladeColor("Cyan", 55, 65, 55, "ui_lsc_cyan"),
+            new SaberBladeColor("Orange", 11, 31, 11, "ui_lsc_orange", LightColor.ORANGE),
+            new SaberBladeColor("Blue", 12, 32, 12, "ui_lsc_blue", LightColor.BLUE),
+            new SaberBladeColor("Green 1", 13, 33, 13, "ui_lsc_green", LightColor.GREEN),
+            new SaberBladeColor("Red", 14, 34, 14, "ui_lsc_red", LightColor.RED),
+            new SaberBladeColor("White", 15, 35, 25, "ui_lsc_white", LightColor.WHITE),
+            new SaberBladeColor("Yellow", 21, 71, 21, "ui_lsc_yellow", LightColor.YELLOW),
+            new SaberBladeColor("Purple 1", 22, 72, 22, "ui_lsc_purple", LightColor.PURPLE),
+            new SaberBladeColor("Teal", 23, 73, 23, "ui_lsc_teal", LightColor.WHITE),
+            new SaberBladeColor("Pink", 24, 74, 24, "ui_lsc_pink", LightColor.WHITE),
+            new SaberBladeColor("Brown", 51, 61, 51, "ui_lsc_brown", LightColor.WHITE),
+            new SaberBladeColor("Green 2", 52, 62, 52, "ui_lsc_rotjgrn", LightColor.GREEN),
+            new SaberBladeColor("Purple 2", 53, 63, 53, "ui_lsc_windu", LightColor.PURPLE),
+            new SaberBladeColor("Lavender", 54, 64, 54, "ui_lsc_lavendr", LightColor.WHITE),
+            new SaberBladeColor("Cyan", 55, 65, 55, "ui_lsc_cyan", LightColor.WHITE),
         };
 
         /// <summary>

--- a/SWLOR.Game.Server/Service/LightsaberWorkbenchService/SaberBladeColor.cs
+++ b/SWLOR.Game.Server/Service/LightsaberWorkbenchService/SaberBladeColor.cs
@@ -1,3 +1,5 @@
+using SWLOR.NWN.API.NWScript.Enum.Item.Property;
+
 namespace SWLOR.Game.Server.Service.LightsaberWorkbenchService
 {
     /// <summary>
@@ -33,13 +35,25 @@ namespace SWLOR.Game.Server.Service.LightsaberWorkbenchService
         /// </summary>
         public string PreviewResref { get; }
 
-        public SaberBladeColor(string name, int straightTopValue, int curvedTopValue, int saberstaffTopValue, string previewResref)
+        /// <summary>
+        /// Color of the dim light emitted by a saber built with this blade.
+        /// </summary>
+        public LightColor LightColor { get; }
+
+        public SaberBladeColor(
+            string name,
+            int straightTopValue,
+            int curvedTopValue,
+            int saberstaffTopValue,
+            string previewResref,
+            LightColor lightColor)
         {
             Name = name;
             StraightTopValue = straightTopValue;
             CurvedTopValue = curvedTopValue;
             SaberstaffTopValue = saberstaffTopValue;
             PreviewResref = previewResref;
+            LightColor = lightColor;
         }
     }
 }

--- a/SWLOR.NWN.API/NWScript/Enum/Item/Property/LightBrightness.cs
+++ b/SWLOR.NWN.API/NWScript/Enum/Item/Property/LightBrightness.cs
@@ -2,9 +2,9 @@ namespace SWLOR.NWN.API.NWScript.Enum.Item.Property
 {
     public enum LightBrightness
     {
-        LIGHTBRIGHTNESS_DIM = 1,
-        LIGHTBRIGHTNESS_LOW = 2,
-        LIGHTBRIGHTNESS_NORMAL = 3,
-        LIGHTBRIGHTNESS_BRIGHT = 4
+        Dim = 1,
+        Low = 2,
+        Normal = 3,
+        Bright = 4
     }
 }

--- a/SWLOR.NWN.API/NWScript/Enum/Item/Property/LightColor.cs
+++ b/SWLOR.NWN.API/NWScript/Enum/Item/Property/LightColor.cs
@@ -2,12 +2,12 @@ namespace SWLOR.NWN.API.NWScript.Enum.Item.Property
 {
     public enum LightColor
     {
-        BLUE = 0,
-        YELLOW = 1,
-        PURPLE = 2,
-        RED = 3,
-        GREEN = 4,
-        ORANGE = 5,
-        WHITE = 6
+        Blue = 0,
+        Yellow = 1,
+        Purple = 2,
+        Red = 3,
+        Green = 4,
+        Orange = 5,
+        White = 6
     }
 }


### PR DESCRIPTION
## Summary

- map workbench blade selections to matching NWN dim-light colors
- use neutral white for blade shades without a faithful engine light color
- change workbench saber blueprints to a neutral white fallback and replace that fallback during construction
- add regression coverage for blueprint and blade-color mappings

## Root cause

Both workbench output blueprints carried a fixed Blue light property. Construction changed the weapon-part appearance for the selected blade color but never replaced that property, so a Red lightsaber still displayed `Light Dim (5m) Blue`.

## Validation

- `dotnet build SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj --no-restore -p:RunPostBuildEvent=Never`
- `dotnet test SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj --no-build --filter "FullyQualifiedName~LightsaberWorkbenchTests"` (9 passed, 1 asset-catalog test skipped because the HAK submodule is unavailable)
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Lightsaber construction now applies the selected blade color to the weapon’s glow.
  - Added support for matching light colors across available blade colors, with neutral white used when no direct match is available.

- **Bug Fixes**
  - Updated workbench templates to use white as the safe default glow color before construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->