### PR TITLE
Fix HoloCom dialogue relay

### DIFF
--- a/SWLOR.Game.Server.Tests/Feature/PlayerFacingNameBroadcastTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/PlayerFacingNameBroadcastTests.cs
@@ -37,7 +37,7 @@ public class PlayerFacingNameBroadcastTests
         normalizedSource.Should().Contain("if (!GetIsPC(player))");
 
         source.Should().NotContain("finalMessage.Append(\"[Comms] \");");
-        source.Should().Contain("ChatPlugin.SendMessage(channel, message, speaker, receiver)");
+        source.Should().Contain("ChatPlugin.SendMessage(channel, message, transportSpeaker, receiver)");
         source.Should().NotContain("ChatChannel.DMTalk");
     }
 
@@ -166,7 +166,7 @@ public class PlayerFacingNameBroadcastTests
         communicationSource.Should().Contain("else if (channel == ChatChannel.PlayerWhisper)");
         communicationSource.Should().NotContain("finalMessage.Append(\"[Whisper] \");");
         communicationSource.Should().NotContain("finalMessage.Append(\"[Holonet] \");");
-        communicationSource.Should().Contain("SendProcessedChatMessage(channel, receiver, speaker, finalMessageColored);");
+        communicationSource.Should().Contain("SendProcessedChatMessage(channel, receiver, sender, speaker, finalMessageColored);");
         communicationSource.Should().Contain("private static void SendProcessedChatMessage(");
         communicationSource.Should().NotContain("SendMessageToPC(receiver");
         // NWNX_Rename only patches the per-observer name override around the native Party/Shout/Tell
@@ -175,7 +175,7 @@ public class PlayerFacingNameBroadcastTests
         // DM_* channel. Comms must dispatch on the native PlayerParty channel, not DMTalk, or the
         // override never applies and the speaker's true name leaks once they leave the receiver's area.
         communicationSource.Should().NotContain("ChatChannel.DMTalk");
-        communicationSource.Should().Contain("ChatPlugin.SendMessage(channel, message, speaker, receiver)");
+        communicationSource.Should().Contain("ChatPlugin.SendMessage(channel, message, transportSpeaker, receiver)");
         communicationSource.Should().NotContain("PlayerName.SendWithChatNameOverride");
         communicationSource.Should().NotContain("ChatPlugin.SendMessage(ChatChannel.PlayerDM");
         communicationSource.Should().NotContain("ChatChannel.PlayerDM, finalMessageColored");
@@ -418,6 +418,32 @@ public class PlayerFacingNameBroadcastTests
         propertySource.Should().NotContain("**Mayor**:");
         propertySource.Should().NotContain("**New Mayor**:");
         propertySource.Should().NotContain("**Founding Mayor**:");
+    }
+
+    [Test]
+    public void HoloComDialogue_UsesTheAreaLocalHologramAsItsTransportSpeaker()
+    {
+        var root = FindRepositoryRoot();
+        var communicationSource = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "SWLOR.Game.Server",
+            "Service",
+            "Communication.cs"));
+        var normalizedCommunicationSource = communicationSource.Replace("\r\n", "\n");
+
+        communicationSource.Should().Contain("var speaker = GetEffectiveChatSpeaker(sender);");
+        communicationSource.Should().Contain(
+            "SendProcessedChatMessage(channel, receiver, sender, speaker, finalMessageColored);");
+        communicationSource.Should().Contain("uint transportSpeaker,");
+        communicationSource.Should().Contain("uint identitySpeaker,");
+        normalizedCommunicationSource.Should().Contain(
+            "PlayerName.SendChatMessageWithChatNameOverride(\n" +
+            "                receiver,\n" +
+            "                identitySpeaker,");
+        communicationSource.Should().Contain(
+            "ChatPlugin.SendMessage(channel, message, transportSpeaker, receiver)");
+        communicationSource.Should().NotContain(
+            "ChatPlugin.SendMessage(channel, message, identitySpeaker, receiver)");
     }
 
     [Test]

--- a/SWLOR.Game.Server.Tests/Feature/PlayerFacingNameBroadcastTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/PlayerFacingNameBroadcastTests.cs
@@ -37,7 +37,7 @@ public class PlayerFacingNameBroadcastTests
         normalizedSource.Should().Contain("if (!GetIsPC(player))");
 
         source.Should().NotContain("finalMessage.Append(\"[Comms] \");");
-        source.Should().Contain("ChatPlugin.SendMessage(channel, message, transportSpeaker, receiver)");
+        source.Should().Contain("ChatPlugin.SendMessage(channel, message, identitySpeaker, receiver)");
         source.Should().NotContain("ChatChannel.DMTalk");
     }
 
@@ -175,7 +175,7 @@ public class PlayerFacingNameBroadcastTests
         // DM_* channel. Comms must dispatch on the native PlayerParty channel, not DMTalk, or the
         // override never applies and the speaker's true name leaks once they leave the receiver's area.
         communicationSource.Should().NotContain("ChatChannel.DMTalk");
-        communicationSource.Should().Contain("ChatPlugin.SendMessage(channel, message, transportSpeaker, receiver)");
+        communicationSource.Should().Contain("ChatPlugin.SendMessage(channel, message, identitySpeaker, receiver)");
         communicationSource.Should().NotContain("PlayerName.SendWithChatNameOverride");
         communicationSource.Should().NotContain("ChatPlugin.SendMessage(ChatChannel.PlayerDM");
         communicationSource.Should().NotContain("ChatChannel.PlayerDM, finalMessageColored");
@@ -432,18 +432,25 @@ public class PlayerFacingNameBroadcastTests
         var normalizedCommunicationSource = communicationSource.Replace("\r\n", "\n");
 
         communicationSource.Should().Contain("var speaker = GetEffectiveChatSpeaker(sender);");
+        communicationSource.Should().Contain("var isHoloComRelay = sender != speaker;");
         communicationSource.Should().Contain(
             "SendProcessedChatMessage(channel, receiver, sender, speaker, finalMessageColored);");
         communicationSource.Should().Contain("uint transportSpeaker,");
         communicationSource.Should().Contain("uint identitySpeaker,");
+        communicationSource.Should().Contain("if (isHoloComRelay)");
+        communicationSource.Should().Contain(
+            "finalMessage.Append(PlayerName.GetColoredChatDisplayName(receiver, speaker));");
+        communicationSource.Should().Contain("if (transportSpeaker != identitySpeaker)");
+        communicationSource.Should().Contain(
+            "ChatPlugin.SendMessage(ChatChannel.ServerMessage, message, transportSpeaker, receiver);");
         normalizedCommunicationSource.Should().Contain(
             "PlayerName.SendChatMessageWithChatNameOverride(\n" +
             "                receiver,\n" +
             "                identitySpeaker,");
         communicationSource.Should().Contain(
-            "ChatPlugin.SendMessage(channel, message, transportSpeaker, receiver)");
-        communicationSource.Should().NotContain(
             "ChatPlugin.SendMessage(channel, message, identitySpeaker, receiver)");
+        communicationSource.Should().NotContain(
+            "ChatPlugin.SendMessage(channel, message, transportSpeaker, receiver)");
     }
 
     [Test]

--- a/SWLOR.Game.Server.Tests/Feature/PlayerFacingNameBroadcastTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/PlayerFacingNameBroadcastTests.cs
@@ -21,6 +21,7 @@ public class PlayerFacingNameBroadcastTests
         source.Should().Contain("private const int PartyChatMessagePrefixStrRef = 10303;");
         source.Should().Contain("private const string CommsChannelName = \"Comms\";");
         source.Should().Contain("private const string CommsMessagePrefix = \"[Comms] \";");
+        source.Should().Contain("private const string WhisperMessagePrefix = \"[Whisper] \";");
         var moduleEnterHandlerIndex = normalizedSource.IndexOf("[NWNEventHandler(ScriptName.OnModuleEnter)]", StringComparison.Ordinal);
         var applyChannelNameIndex = normalizedSource.IndexOf("public static void ApplyCommsChannelName()", StringComparison.Ordinal);
         var applyChannelNameOverrideIndex = normalizedSource.IndexOf(
@@ -439,7 +440,16 @@ public class PlayerFacingNameBroadcastTests
         communicationSource.Should().Contain("uint identitySpeaker,");
         communicationSource.Should().Contain("if (isHoloComRelay)");
         communicationSource.Should().Contain(
+            "finalMessage.Append(GetHoloComRelayChannelPrefix(channel));");
+        communicationSource.Should().Contain(
             "finalMessage.Append(PlayerName.GetColoredChatDisplayName(receiver, speaker));");
+        communicationSource.Should().Contain(
+            "private static string GetHoloComRelayChannelPrefix(ChatChannel channel)");
+        communicationSource.Should().Contain("if (channel == ChatChannel.PlayerWhisper)");
+        communicationSource.Should().Contain("return WhisperMessagePrefix;");
+        communicationSource.Should().Contain("if (channel == ChatChannel.PlayerParty)");
+        communicationSource.Should().Contain("return CommsMessagePrefix;");
+        communicationSource.Should().Contain("return string.Empty;");
         communicationSource.Should().Contain("if (transportSpeaker != identitySpeaker)");
         communicationSource.Should().Contain(
             "ChatPlugin.SendMessage(ChatChannel.ServerMessage, message, transportSpeaker, receiver);");

--- a/SWLOR.Game.Server/Service/Communication.cs
+++ b/SWLOR.Game.Server/Service/Communication.cs
@@ -451,16 +451,21 @@ namespace SWLOR.Game.Server.Service
                     finalMessageColored = ColorToken.Orange(finalMessageColored);
                 }
 
-                SendProcessedChatMessage(channel, receiver, speaker, finalMessageColored);
+                SendProcessedChatMessage(channel, receiver, sender, speaker, finalMessageColored);
             }
         }
 
         private static void SendProcessedChatMessage(
             ChatChannel channel,
             uint receiver,
-            uint speaker,
+            uint transportSpeaker,
+            uint identitySpeaker,
             string message)
         {
+            // A HoloCom message is spoken by a copied creature in the receiver's area. The hologram's
+            // owner supplies the player-facing identity and language, but the area-local hologram must
+            // remain the native transport speaker or Talk/Whisper packets from the distant owner are
+            // discarded by the engine. Holograms retain their generic, display-safe object name.
             // NWNX_Rename only patches the per-observer PC name override around three native chat
             // functions - Party, Shout, and Tell (see the plugin's HOOK_CHAT registrations). Talk and
             // Whisper are not among them; they render correctly today only because the speaker's
@@ -472,8 +477,8 @@ namespace SWLOR.Game.Server.Service
             // boundaries the same way DMTalk did.
             PlayerName.SendChatMessageWithChatNameOverride(
                 receiver,
-                speaker,
-                () => ChatPlugin.SendMessage(channel, message, speaker, receiver));
+                identitySpeaker,
+                () => ChatPlugin.SendMessage(channel, message, transportSpeaker, receiver));
         }
 
         private static bool IsChatCommandMessage(string message)

--- a/SWLOR.Game.Server/Service/Communication.cs
+++ b/SWLOR.Game.Server/Service/Communication.cs
@@ -29,6 +29,7 @@ namespace SWLOR.Game.Server.Service
         private const int PartyChatMessagePrefixStrRef = 10303;
         private const string CommsChannelName = "Comms";
         private const string CommsMessagePrefix = "[Comms] ";
+        private const string WhisperMessagePrefix = "[Whisper] ";
 
         public static (byte, byte, byte) OOCChatColor { get; } = (64, 64, 64);
         public static (byte, byte, byte) EmoteChatColor { get; } = (0, 255, 0);
@@ -385,6 +386,7 @@ namespace SWLOR.Game.Server.Service
                 // hologram's shared object name or globally renaming it.
                 if (isHoloComRelay)
                 {
+                    finalMessage.Append(GetHoloComRelayChannelPrefix(channel));
                     finalMessage.Append(PlayerName.GetColoredChatDisplayName(receiver, speaker));
                     finalMessage.Append(": ");
                 }
@@ -465,6 +467,17 @@ namespace SWLOR.Game.Server.Service
 
                 SendProcessedChatMessage(channel, receiver, sender, speaker, finalMessageColored);
             }
+        }
+
+        private static string GetHoloComRelayChannelPrefix(ChatChannel channel)
+        {
+            if (channel == ChatChannel.PlayerWhisper)
+                return WhisperMessagePrefix;
+
+            if (channel == ChatChannel.PlayerParty)
+                return CommsMessagePrefix;
+
+            return string.Empty;
         }
 
         private static void SendProcessedChatMessage(

--- a/SWLOR.Game.Server/Service/Communication.cs
+++ b/SWLOR.Game.Server/Service/Communication.cs
@@ -321,6 +321,7 @@ namespace SWLOR.Game.Server.Service
             // them once before dispatching rather than recomputing (and re-writing language state)
             // per receiver.
             var speaker = GetEffectiveChatSpeaker(sender);
+            var isHoloComRelay = sender != speaker;
             var language = Language.GetActiveLanguage(speaker);
 
             // Wookiees cannot speak any other language (but they can understand them).
@@ -377,6 +378,17 @@ namespace SWLOR.Game.Server.Service
                         finalMessage.Append(" } ");
                     }
                 }
+
+                // HoloCom holograms have a deliberately generic object name because the nearby
+                // observers may know their owner by different names. Render the owner's chat name
+                // into the direct relay message separately for each observer instead of exposing the
+                // hologram's shared object name or globally renaming it.
+                if (isHoloComRelay)
+                {
+                    finalMessage.Append(PlayerName.GetColoredChatDisplayName(receiver, speaker));
+                    finalMessage.Append(": ");
+                }
+
                 var (r, g, b) = Language.GetColor(language);
 
                 if (dbReceiver?.Settings?.LanguageChatColors != null &&
@@ -462,10 +474,17 @@ namespace SWLOR.Game.Server.Service
             uint identitySpeaker,
             string message)
         {
-            // A HoloCom message is spoken by a copied creature in the receiver's area. The hologram's
-            // owner supplies the player-facing identity and language, but the area-local hologram must
-            // remain the native transport speaker or Talk/Whisper packets from the distant owner are
-            // discarded by the engine. Holograms retain their generic, display-safe object name.
+            // Native Talk/Whisper packets cannot use the distant HoloCom owner as their sender, while
+            // using the area-local hologram would expose its generic shared object name. The caller has
+            // already rendered the owner's observer-specific chat name into the message, so deliver it
+            // directly without a native sender label. The hologram's ActionSpeakString still supplies
+            // the visible speaking animation that initiated this processed relay.
+            if (transportSpeaker != identitySpeaker)
+            {
+                ChatPlugin.SendMessage(ChatChannel.ServerMessage, message, transportSpeaker, receiver);
+                return;
+            }
+
             // NWNX_Rename only patches the per-observer PC name override around three native chat
             // functions - Party, Shout, and Tell (see the plugin's HOOK_CHAT registrations). Talk and
             // Whisper are not among them; they render correctly today only because the speaker's
@@ -478,7 +497,7 @@ namespace SWLOR.Game.Server.Service
             PlayerName.SendChatMessageWithChatNameOverride(
                 receiver,
                 identitySpeaker,
-                () => ChatPlugin.SendMessage(channel, message, transportSpeaker, receiver));
+                () => ChatPlugin.SendMessage(channel, message, identitySpeaker, receiver));
         }
 
         private static bool IsChatCommandMessage(string message)


### PR DESCRIPTION
## Summary
- keep the HoloCom owner as the identity and language source for relayed dialogue
- use the area-local hologram as the native Talk/Whisper transport speaker so the recipient receives the message
- add regression coverage for the transport/identity split

## Testing
- `dotnet build SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj -p:RunPostBuildEvent=Never`
- `dotnet test SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj --no-build --filter "FullyQualifiedName~PlayerFacingNameBroadcastTests|FullyQualifiedName~CommunicationEmoteParsingTests"`