### PR TITLE
Audit disguise identity mutations

### DIFF
--- a/SWLOR.Game.Server.Tests/Feature/PlayerNameRecognitionTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/PlayerNameRecognitionTests.cs
@@ -512,6 +512,54 @@ public class PlayerNameRecognitionTests
     }
 
     [Test]
+    public void DisguiseIdentityMutations_AreAuditedWithCanonicalIdentityAndRelevantState()
+    {
+        var root = FindRepositoryRoot();
+        var source = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "SWLOR.Game.Server",
+            "Service",
+            "Disguise.cs"));
+
+        var createMethod = ExtractMethod(source, "public static PlayerDisguise CreateDisguise(uint player)");
+        createMethod.Should().Contain("Disguise created: PlayerId={PlayerId} PlayerName={PlayerName} DisguiseId={DisguiseId}");
+        createMethod.Should().Contain("LogGroup.PlayerName");
+        createMethod.Should().Contain("GetName(player)");
+
+        var saveMethod = ExtractMethod(source, "public static SaveDisguiseResult SaveDisguise(");
+        saveMethod.Should().Contain("var previousPrivateName = disguise.PrivateName;");
+        saveMethod.Should().Contain("var previousDescriptor = disguise.Descriptor;");
+        saveMethod.Should().Contain("Disguise saved: PlayerId={PlayerId} PlayerName={PlayerName} DisguiseId={DisguiseId}");
+        saveMethod.Should().Contain("PreviousPrivateName={PreviousPrivateName} PrivateName={PrivateName}");
+        saveMethod.Should().Contain("PreviousDescriptor={PreviousDescriptor} Descriptor={Descriptor}");
+        saveMethod.Should().Contain("PreviousPortraitInternalId={PreviousPortraitInternalId} PortraitInternalId={PortraitInternalId}");
+        saveMethod.Should().Contain("PreviousSoundSetId={PreviousSoundSetId} SoundSetId={SoundSetId}");
+        saveMethod.Should().Contain("PreviousScrambleAccountId={PreviousScrambleAccountId} ScrambleAccountId={ScrambleAccountId}");
+        saveMethod.Should().Contain("LogGroup.PlayerName");
+        saveMethod.Should().Contain("GetName(player)");
+
+        var activateMethod = ExtractMethod(source, "public static ActivateDisguiseResult Activate(uint player, string disguiseId)");
+        activateMethod.Should().Contain("var previousDisguiseId = dbPlayer.ActiveDisguiseId;");
+        activateMethod.Should().Contain("Disguise activated: PlayerId={PlayerId} PlayerName={PlayerName} PreviousDisguiseId={PreviousDisguiseId} DisguiseId={DisguiseId}");
+        activateMethod.Should().Contain("LogGroup.PlayerName");
+        activateMethod.Should().Contain("GetName(player)");
+        activateMethod.IndexOf("return ActivateDisguiseResult.Success();", StringComparison.Ordinal)
+            .Should().BeLessThan(activateMethod.IndexOf("Disguise activated:", StringComparison.Ordinal));
+
+        var deactivateMethod = ExtractMethod(source, "public static bool Deactivate(uint player)");
+        deactivateMethod.Should().Contain("var activeDisguiseId = dbPlayer.ActiveDisguiseId;");
+        deactivateMethod.Should().Contain("var activeDisguise = GetActiveDisguise(dbPlayer);");
+        deactivateMethod.Should().Contain("Disguise deactivated: PlayerId={PlayerId} PlayerName={PlayerName} DisguiseId={DisguiseId}");
+        deactivateMethod.Should().Contain("activeDisguise?.PrivateName ?? string.Empty");
+        deactivateMethod.Should().Contain("activeDisguise?.Descriptor ?? string.Empty");
+        deactivateMethod.Should().Contain("activeDisguise?.PortraitInternalId ?? -1");
+        deactivateMethod.Should().Contain("activeDisguise?.SoundSetId ?? -1");
+        deactivateMethod.Should().Contain("activeDisguise?.ScrambleAccountId ?? false");
+        deactivateMethod.Should().Contain("LogGroup.PlayerName");
+        deactivateMethod.Should().Contain("GetName(player)");
+    }
+
+    [Test]
     public void Disguises_UseDisguiseIdentityKeysAndHardDeleteRetiredIdentities()
     {
         var root = FindRepositoryRoot();

--- a/SWLOR.Game.Server/Service/Disguise.cs
+++ b/SWLOR.Game.Server/Service/Disguise.cs
@@ -201,6 +201,19 @@ namespace SWLOR.Game.Server.Service
             };
 
             DB.Set(disguise);
+
+            Log.WriteStructured(
+                LogGroup.PlayerName,
+                "Disguise created: PlayerId={PlayerId} PlayerName={PlayerName} DisguiseId={DisguiseId} PrivateName={PrivateName} Descriptor={Descriptor} PortraitInternalId={PortraitInternalId} SoundSetId={SoundSetId} ScrambleAccountId={ScrambleAccountId}",
+                playerId,
+                GetName(player),
+                disguise.Id,
+                disguise.PrivateName,
+                disguise.Descriptor,
+                disguise.PortraitInternalId,
+                disguise.SoundSetId,
+                disguise.ScrambleAccountId);
+
             return disguise;
         }
 
@@ -232,12 +245,35 @@ namespace SWLOR.Game.Server.Service
             portraitInternalId = Math.Clamp(portraitInternalId, 1, GetMaxPortraitCount());
             soundSetId = ResolveSoundSetId(soundSetId);
 
+            var previousPrivateName = disguise.PrivateName;
+            var previousDescriptor = disguise.Descriptor;
+            var previousPortraitInternalId = disguise.PortraitInternalId;
+            var previousSoundSetId = disguise.SoundSetId;
+            var previousScrambleAccountId = disguise.ScrambleAccountId;
+
             disguise.PrivateName = PlayerName.SanitizeKnownName(privateName);
             disguise.Descriptor = PlayerName.SanitizeKnownName(descriptor);
             disguise.PortraitInternalId = portraitInternalId;
             disguise.SoundSetId = soundSetId;
             disguise.ScrambleAccountId = scrambleAccountId;
             DB.Set(disguise);
+
+            Log.WriteStructured(
+                LogGroup.PlayerName,
+                "Disguise saved: PlayerId={PlayerId} PlayerName={PlayerName} DisguiseId={DisguiseId} PreviousPrivateName={PreviousPrivateName} PrivateName={PrivateName} PreviousDescriptor={PreviousDescriptor} Descriptor={Descriptor} PreviousPortraitInternalId={PreviousPortraitInternalId} PortraitInternalId={PortraitInternalId} PreviousSoundSetId={PreviousSoundSetId} SoundSetId={SoundSetId} PreviousScrambleAccountId={PreviousScrambleAccountId} ScrambleAccountId={ScrambleAccountId}",
+                playerId,
+                GetName(player),
+                disguise.Id,
+                previousPrivateName,
+                disguise.PrivateName,
+                previousDescriptor,
+                disguise.Descriptor,
+                previousPortraitInternalId,
+                disguise.PortraitInternalId,
+                previousSoundSetId,
+                disguise.SoundSetId,
+                previousScrambleAccountId,
+                disguise.ScrambleAccountId);
 
             if (IsActiveDisguise(player, disguise.Id))
             {
@@ -275,6 +311,8 @@ namespace SWLOR.Game.Server.Service
             if (!string.IsNullOrWhiteSpace(delayError))
                 return ActivateDisguiseResult.Failure(delayError);
 
+            var previousDisguiseId = dbPlayer.ActiveDisguiseId;
+
             // Only snapshot the undisguised baseline when transitioning from no active disguise.
             // Keying off the stored id (rather than a resolved disguise) avoids capturing an
             // already-applied disguise appearance as the baseline if the stored id is ever stale.
@@ -289,6 +327,19 @@ namespace SWLOR.Game.Server.Service
             disguise.DateLastActivated = DateTime.UtcNow;
             DB.Set(disguise);
             DB.Set(dbPlayer);
+
+            Log.WriteStructured(
+                LogGroup.PlayerName,
+                "Disguise activated: PlayerId={PlayerId} PlayerName={PlayerName} PreviousDisguiseId={PreviousDisguiseId} DisguiseId={DisguiseId} PrivateName={PrivateName} Descriptor={Descriptor} PortraitInternalId={PortraitInternalId} SoundSetId={SoundSetId} ScrambleAccountId={ScrambleAccountId}",
+                playerId,
+                GetName(player),
+                previousDisguiseId,
+                disguise.Id,
+                disguise.PrivateName,
+                disguise.Descriptor,
+                disguise.PortraitInternalId,
+                disguise.SoundSetId,
+                disguise.ScrambleAccountId);
 
             ApplyAppearance(player, disguise);
             RefreshDisguiseDisplay(player);
@@ -305,6 +356,9 @@ namespace SWLOR.Game.Server.Service
                 return false;
             }
 
+            var activeDisguiseId = dbPlayer.ActiveDisguiseId;
+            var activeDisguise = GetActiveDisguise(dbPlayer);
+
             if (!string.IsNullOrWhiteSpace(dbPlayer.UndisguisedPortraitResref))
                 SetPortraitResRef(player, dbPlayer.UndisguisedPortraitResref);
             else if (dbPlayer.UndisguisedPortraitId >= 0)
@@ -318,6 +372,18 @@ namespace SWLOR.Game.Server.Service
             dbPlayer.UndisguisedPortraitResref = string.Empty;
             dbPlayer.UndisguisedSoundSetId = -1;
             DB.Set(dbPlayer);
+
+            Log.WriteStructured(
+                LogGroup.PlayerName,
+                "Disguise deactivated: PlayerId={PlayerId} PlayerName={PlayerName} DisguiseId={DisguiseId} PrivateName={PrivateName} Descriptor={Descriptor} PortraitInternalId={PortraitInternalId} SoundSetId={SoundSetId} ScrambleAccountId={ScrambleAccountId}",
+                playerId,
+                GetName(player),
+                activeDisguiseId,
+                activeDisguise?.PrivateName ?? string.Empty,
+                activeDisguise?.Descriptor ?? string.Empty,
+                activeDisguise?.PortraitInternalId ?? -1,
+                activeDisguise?.SoundSetId ?? -1,
+                activeDisguise?.ScrambleAccountId ?? false);
 
             RefreshDisguiseDisplay(player);
             return true;


### PR DESCRIPTION
## Summary

- audit successful disguise creation, save, activation, and deactivation
- retain canonical player identity plus the disguise state needed to reconstruct identity history
- capture before/after values for edits and the previous identity when switching disguises
- cover the new audit contract with a focused regression test

## Testing

- `dotnet build SWLOR.Game.Server.Tests\\SWLOR.Game.Server.Tests.csproj -p:RunPostBuildEvent=Never`
- `dotnet test SWLOR.Game.Server.Tests\\SWLOR.Game.Server.Tests.csproj --no-build --filter "FullyQualifiedName~DisguiseIdentityMutations_AreAuditedWithCanonicalIdentityAndRelevantState"`

The broader `PlayerNameRecognitionTests` run passed 16 tests and encountered one unrelated worktree fixture failure because `SWLOR_Haks/sw_2da/appearance.2da` is unavailable in this checkout.