### PR TITLE
Restore pistol blaster shot audio

### DIFF
--- a/SWLOR.Game.Server.Tests/Feature/EquipmentRestrictionsTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/EquipmentRestrictionsTests.cs
@@ -216,7 +216,7 @@ public class EquipmentRestrictionsTests
             "wamar_001",
             "pistol bullets use the existing single-emitter arrow blaster model");
         ammunitionRows[2]["ShotSound"].Should().Be(
-            "cb_sh_blstrfire1",
+            PistolAnimationRemap.PistolShotSound,
             "pistol bullets use the existing single-shot blaster sound");
 
         rows[514]["label"].Should().Be("legacy_smallarms");

--- a/SWLOR.Game.Server.Tests/Feature/PistolAnimationRemapTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/PistolAnimationRemapTests.cs
@@ -83,20 +83,24 @@ public class PistolAnimationRemapTests
     /// <summary>
     /// Verifies only an active replacement animation needs a scripted pistol shot sound.
     /// </summary>
-    [TestCase(true, BaseItem.Pistol, null, true)]
-    [TestCase(true, BaseItem.LegacyPistol, null, true)]
-    [TestCase(true, BaseItem.Sling, null, true)]
-    [TestCase(false, BaseItem.Pistol, null, false)]
-    [TestCase(true, BaseItem.Pistol, BaseItem.SmallShield, false)]
-    [TestCase(true, BaseItem.Rifle, null, false)]
+    [TestCase(true, 0, BaseItem.Pistol, null, true)]
+    [TestCase(true, 0, BaseItem.LegacyPistol, null, true)]
+    [TestCase(true, 0, BaseItem.Sling, null, true)]
+    [TestCase(true, 1, BaseItem.Pistol, null, false)]
+    [TestCase(true, 2, BaseItem.Pistol, null, false)]
+    [TestCase(false, 0, BaseItem.Pistol, null, false)]
+    [TestCase(true, 0, BaseItem.Pistol, BaseItem.SmallShield, false)]
+    [TestCase(true, 0, BaseItem.Rifle, null, false)]
     public void ReplacementShotSound_PlaysOnlyForAnActiveEligiblePistolRemap(
         bool isRemapActive,
+        int explicitThrowSuspendCount,
         BaseItem? rightHandBaseItem,
         BaseItem? leftHandBaseItem,
         bool expected)
     {
         var result = PistolAnimationRemap.ShouldPlayRemappedPistolShotSound(
             isRemapActive,
+            explicitThrowSuspendCount,
             rightHandBaseItem,
             leftHandBaseItem);
 

--- a/SWLOR.Game.Server.Tests/Feature/PistolAnimationRemapTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/PistolAnimationRemapTests.cs
@@ -17,6 +17,7 @@ public class PistolAnimationRemapTests
     {
         PistolAnimationRemap.SlingAttackAnimation.Should().Be("throwr");
         PistolAnimationRemap.FormerPistolAttackAnimation.Should().Be("bowshot");
+        PistolAnimationRemap.PistolShotSound.Should().Be("cb_sh_blstrfire1");
     }
 
     /// <summary>
@@ -77,6 +78,62 @@ public class PistolAnimationRemapTests
             null);
 
         result.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// Verifies only an active replacement animation needs a scripted pistol shot sound.
+    /// </summary>
+    [TestCase(true, BaseItem.Pistol, null, true)]
+    [TestCase(true, BaseItem.LegacyPistol, null, true)]
+    [TestCase(true, BaseItem.Sling, null, true)]
+    [TestCase(false, BaseItem.Pistol, null, false)]
+    [TestCase(true, BaseItem.Pistol, BaseItem.SmallShield, false)]
+    [TestCase(true, BaseItem.Rifle, null, false)]
+    public void ReplacementShotSound_PlaysOnlyForAnActiveEligiblePistolRemap(
+        bool isRemapActive,
+        BaseItem? rightHandBaseItem,
+        BaseItem? leftHandBaseItem,
+        bool expected)
+    {
+        var result = PistolAnimationRemap.ShouldPlayRemappedPistolShotSound(
+            isRemapActive,
+            rightHandBaseItem,
+            leftHandBaseItem);
+
+        result.Should().Be(expected);
+    }
+
+    /// <summary>
+    /// Verifies weapon projectile launches use the handler that restores the remapped pistol shot sound.
+    /// </summary>
+    [Test]
+    public void WeaponProjectiles_RestoreTheRemappedPistolShotSound()
+    {
+        var method = typeof(PistolAnimationRemap).GetMethod(nameof(PistolAnimationRemap.OnWeaponProjectileCreated));
+        var scripts = method!
+            .GetCustomAttributes(typeof(NWNEventHandler), false)
+            .Cast<NWNEventHandler>()
+            .Select(attribute => attribute.Script);
+
+        scripts.Should().Contain(ScriptName.OnBroadcastSafeProjectileBefore);
+
+        var root = FindRepositoryRoot();
+        var source = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "SWLOR.Game.Server",
+            "Feature",
+            "PistolAnimationRemap.cs"));
+        source.Should().Contain("AssignCommand(attacker, () => PlaySound(PistolShotSound));");
+
+        var registrationSource = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "SWLOR.Game.Server",
+            "Feature",
+            "EventRegistration.cs")).ReplaceLineEndings("\n");
+        registrationSource.Should().Contain(
+            "EventsPlugin.SubscribeEvent(\n                \"NWNX_ON_BROADCAST_SAFE_PROJECTILE_BEFORE\",\n                ScriptName.OnBroadcastSafeProjectileBefore);");
+        registrationSource.Should().Contain(
+            "EventsPlugin.AddIDToWhitelist(\n                    \"NWNX_ON_BROADCAST_SAFE_PROJECTILE_TYPE\",\n                    projectileType);");
     }
 
     /// <summary>

--- a/SWLOR.Game.Server.Tests/Feature/PistolAnimationRemapTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/PistolAnimationRemapTests.cs
@@ -134,6 +134,8 @@ public class PistolAnimationRemapTests
             "EventsPlugin.SubscribeEvent(\n                \"NWNX_ON_BROADCAST_SAFE_PROJECTILE_BEFORE\",\n                ScriptName.OnBroadcastSafeProjectileBefore);");
         registrationSource.Should().Contain(
             "EventsPlugin.AddIDToWhitelist(\n                    \"NWNX_ON_BROADCAST_SAFE_PROJECTILE_TYPE\",\n                    projectileType);");
+        registrationSource.Should().Contain(
+            "EventsPlugin.ToggleIDWhitelist(\"NWNX_ON_BROADCAST_SAFE_PROJECTILE_TYPE\", true);");
     }
 
     /// <summary>

--- a/SWLOR.Game.Server.Tests/Feature/PistolAnimationRemapTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/PistolAnimationRemapTests.cs
@@ -133,7 +133,16 @@ public class PistolAnimationRemapTests
         registrationSource.Should().Contain(
             "EventsPlugin.SubscribeEvent(\n                \"NWNX_ON_BROADCAST_SAFE_PROJECTILE_BEFORE\",\n                ScriptName.OnBroadcastSafeProjectileBefore);");
         registrationSource.Should().Contain(
-            "EventsPlugin.AddIDToWhitelist(\n                    \"NWNX_ON_BROADCAST_SAFE_PROJECTILE_TYPE\",\n                    projectileType);");
+            "foreach (var projectileType in WeaponProjectileTypes)");
+        registrationSource.Should().Contain(
+            "EventsPlugin.AddIDToWhitelist(\n                    \"NWNX_ON_BROADCAST_SAFE_PROJECTILE_TYPE\",\n                    (int)projectileType);");
+        registrationSource.Should().ContainAll(
+            "BroadcastSafeProjectileType.WeaponVfxNone",
+            "BroadcastSafeProjectileType.WeaponVfxAcid",
+            "BroadcastSafeProjectileType.WeaponVfxCold",
+            "BroadcastSafeProjectileType.WeaponVfxElectrical",
+            "BroadcastSafeProjectileType.WeaponVfxFire",
+            "BroadcastSafeProjectileType.WeaponVfxSonic");
         registrationSource.Should().Contain(
             "EventsPlugin.ToggleIDWhitelist(\"NWNX_ON_BROADCAST_SAFE_PROJECTILE_TYPE\", true);");
     }

--- a/SWLOR.Game.Server/Core/ScriptName.cs
+++ b/SWLOR.Game.Server/Core/ScriptName.cs
@@ -645,6 +645,7 @@ namespace SWLOR.Game.Server.Core
         // NWNX Events - Broadcast spell cast events
         public const string OnBroadcastCastSpellBefore = "cast_spell_bef";
         public const string OnBroadcastCastSpellAfter = "cast_spell_aft";
+        public const string OnBroadcastSafeProjectileBefore = "safe_proj_bef";
 
         // NWNX Events - Debug events
         public const string OnDebugRunScriptBefore = "debug_script_bef";

--- a/SWLOR.Game.Server/Feature/EventRegistration.cs
+++ b/SWLOR.Game.Server/Feature/EventRegistration.cs
@@ -1,4 +1,5 @@
 using SWLOR.Game.Server.Core;
+using SWLOR.Game.Server.Core.NWNX.Enum;
 using SWLOR.Game.Server.Entity;
 using SWLOR.Game.Server.Service;
 using SWLOR.NWN.API.NWNX;
@@ -8,6 +9,16 @@ namespace SWLOR.Game.Server.Feature
 {
     public static class EventRegistration
     {
+        private static readonly BroadcastSafeProjectileType[] WeaponProjectileTypes =
+        {
+            BroadcastSafeProjectileType.WeaponVfxNone,
+            BroadcastSafeProjectileType.WeaponVfxAcid,
+            BroadcastSafeProjectileType.WeaponVfxCold,
+            BroadcastSafeProjectileType.WeaponVfxElectrical,
+            BroadcastSafeProjectileType.WeaponVfxFire,
+            BroadcastSafeProjectileType.WeaponVfxSonic
+        };
+
         /// <summary>
         /// Fires on the module PreLoad event. This event should be specified in the environment variables.
         /// This will hook all module/global events.
@@ -533,11 +544,11 @@ namespace SWLOR.Game.Server.Feature
             EventsPlugin.SubscribeEvent(
                 "NWNX_ON_BROADCAST_SAFE_PROJECTILE_BEFORE",
                 ScriptName.OnBroadcastSafeProjectileBefore);
-            for (var projectileType = 0; projectileType <= 5; projectileType++)
+            foreach (var projectileType in WeaponProjectileTypes)
             {
                 EventsPlugin.AddIDToWhitelist(
                     "NWNX_ON_BROADCAST_SAFE_PROJECTILE_TYPE",
-                    projectileType);
+                    (int)projectileType);
             }
             EventsPlugin.ToggleIDWhitelist("NWNX_ON_BROADCAST_SAFE_PROJECTILE_TYPE", true);
 

--- a/SWLOR.Game.Server/Feature/EventRegistration.cs
+++ b/SWLOR.Game.Server/Feature/EventRegistration.cs
@@ -529,6 +529,17 @@ namespace SWLOR.Game.Server.Feature
             EventsPlugin.SubscribeEvent("NWNX_ON_BROADCAST_CAST_SPELL_BEFORE", ScriptName.OnBroadcastCastSpellBefore);
             EventsPlugin.SubscribeEvent("NWNX_ON_BROADCAST_CAST_SPELL_AFTER", ScriptName.OnBroadcastCastSpellAfter);
 
+            // Weapon projectile events
+            EventsPlugin.SubscribeEvent(
+                "NWNX_ON_BROADCAST_SAFE_PROJECTILE_BEFORE",
+                ScriptName.OnBroadcastSafeProjectileBefore);
+            for (var projectileType = 0; projectileType <= 5; projectileType++)
+            {
+                EventsPlugin.AddIDToWhitelist(
+                    "NWNX_ON_BROADCAST_SAFE_PROJECTILE_TYPE",
+                    projectileType);
+            }
+
             // RunScript Debug Events
             EventsPlugin.SubscribeEvent("NWNX_ON_DEBUG_RUN_SCRIPT_BEFORE", ScriptName.OnDebugRunScriptBefore);
             EventsPlugin.SubscribeEvent("NWNX_ON_DEBUG_RUN_SCRIPT_AFTER", ScriptName.OnDebugRunScriptAfter);

--- a/SWLOR.Game.Server/Feature/EventRegistration.cs
+++ b/SWLOR.Game.Server/Feature/EventRegistration.cs
@@ -539,6 +539,7 @@ namespace SWLOR.Game.Server.Feature
                     "NWNX_ON_BROADCAST_SAFE_PROJECTILE_TYPE",
                     projectileType);
             }
+            EventsPlugin.ToggleIDWhitelist("NWNX_ON_BROADCAST_SAFE_PROJECTILE_TYPE", true);
 
             // RunScript Debug Events
             EventsPlugin.SubscribeEvent("NWNX_ON_DEBUG_RUN_SCRIPT_BEFORE", ScriptName.OnDebugRunScriptBefore);

--- a/SWLOR.Game.Server/Feature/PistolAnimationRemap.cs
+++ b/SWLOR.Game.Server/Feature/PistolAnimationRemap.cs
@@ -21,6 +21,7 @@ namespace SWLOR.Game.Server.Feature
         private const float MinimumExplicitThrowRestoreDelaySeconds = 1.1f;
         public const string SlingAttackAnimation = "throwr";
         public const string FormerPistolAttackAnimation = "bowshot";
+        public const string PistolShotSound = "cb_sh_blstrfire1";
 
         /// <summary>
         /// Synchronizes a player creature's pistol animation when it enters the module.
@@ -68,6 +69,26 @@ namespace SWLOR.Game.Server.Feature
         }
 
         /// <summary>
+        /// Restores the ammunition shot sound skipped by the replacement bow animation.
+        /// Native sling attacks continue to play their configured sound and must not be doubled.
+        /// </summary>
+        [NWNEventHandler(ScriptName.OnBroadcastSafeProjectileBefore)]
+        public static void OnWeaponProjectileCreated()
+        {
+            var attacker = OBJECT_SELF;
+            if (!GetIsObjectValid(attacker) ||
+                !ShouldPlayRemappedPistolShotSound(
+                    GetLocalBool(attacker, PistolAnimationRemapActiveVariable),
+                    GetEquippedBaseItem(attacker, InventorySlot.RightHand),
+                    GetEquippedBaseItem(attacker, InventorySlot.LeftHand)))
+            {
+                return;
+            }
+
+            AssignCommand(attacker, () => PlaySound(PistolShotSound));
+        }
+
+        /// <summary>
         /// Determines whether the equipped loadout can safely use the former two-handed pistol attack.
         /// </summary>
         public static bool ShouldUseFormerPistolAttackAnimation(
@@ -77,6 +98,18 @@ namespace SWLOR.Game.Server.Feature
             return rightHandBaseItem.HasValue &&
                    Item.PistolBaseItemTypes.Contains(rightHandBaseItem.Value) &&
                    !leftHandBaseItem.HasValue;
+        }
+
+        /// <summary>
+        /// Determines whether an attack needs the shot sound normally emitted by the sling animation.
+        /// </summary>
+        public static bool ShouldPlayRemappedPistolShotSound(
+            bool isRemapActive,
+            BaseItem? rightHandBaseItem,
+            BaseItem? leftHandBaseItem)
+        {
+            return isRemapActive &&
+                   ShouldUseFormerPistolAttackAnimation(rightHandBaseItem, leftHandBaseItem);
         }
 
         /// <summary>
@@ -228,18 +261,20 @@ namespace SWLOR.Game.Server.Feature
         /// </summary>
         private static bool ShouldUseFormerPistolAttackAnimation(uint creature)
         {
-            var rightHand = GetItemInSlot(InventorySlot.RightHand, creature);
-            var leftHand = GetItemInSlot(InventorySlot.LeftHand, creature);
-            var rightHandBaseItem = GetIsObjectValid(rightHand)
-                ? GetBaseItemType(rightHand)
-                : (BaseItem?)null;
-            var leftHandBaseItem = GetIsObjectValid(leftHand)
-                ? GetBaseItemType(leftHand)
-                : (BaseItem?)null;
-
             return ShouldUseFormerPistolAttackAnimation(
-                rightHandBaseItem,
-                leftHandBaseItem);
+                GetEquippedBaseItem(creature, InventorySlot.RightHand),
+                GetEquippedBaseItem(creature, InventorySlot.LeftHand));
+        }
+
+        /// <summary>
+        /// Returns the equipped base item in a slot, or null when the slot is empty.
+        /// </summary>
+        private static BaseItem? GetEquippedBaseItem(uint creature, InventorySlot slot)
+        {
+            var item = GetItemInSlot(slot, creature);
+            return GetIsObjectValid(item)
+                ? GetBaseItemType(item)
+                : (BaseItem?)null;
         }
 
         /// <summary>

--- a/SWLOR.Game.Server/Feature/PistolAnimationRemap.cs
+++ b/SWLOR.Game.Server/Feature/PistolAnimationRemap.cs
@@ -79,6 +79,7 @@ namespace SWLOR.Game.Server.Feature
             if (!GetIsObjectValid(attacker) ||
                 !ShouldPlayRemappedPistolShotSound(
                     GetLocalBool(attacker, PistolAnimationRemapActiveVariable),
+                    GetLocalInt(attacker, ExplicitThrowSuspendCountVariable),
                     GetEquippedBaseItem(attacker, InventorySlot.RightHand),
                     GetEquippedBaseItem(attacker, InventorySlot.LeftHand)))
             {
@@ -105,10 +106,12 @@ namespace SWLOR.Game.Server.Feature
         /// </summary>
         public static bool ShouldPlayRemappedPistolShotSound(
             bool isRemapActive,
+            int explicitThrowSuspendCount,
             BaseItem? rightHandBaseItem,
             BaseItem? leftHandBaseItem)
         {
             return isRemapActive &&
+                   explicitThrowSuspendCount == 0 &&
                    ShouldUseFormerPistolAttackAnimation(rightHandBaseItem, leftHandBaseItem);
         }
 

--- a/SWLOR.NWN.API/NWNX/Enum/BroadcastSafeProjectileType.cs
+++ b/SWLOR.NWN.API/NWNX/Enum/BroadcastSafeProjectileType.cs
@@ -1,0 +1,14 @@
+namespace SWLOR.Game.Server.Core.NWNX.Enum
+{
+    public enum BroadcastSafeProjectileType
+    {
+        WeaponVfxNone = global::NWN.Core.NWNX.EventsPlugin.NWNX_EVENTS_BROADCAST_SAFE_PROJECTILE_TYPE_WEAPON_VFX_NONE,
+        WeaponVfxAcid = global::NWN.Core.NWNX.EventsPlugin.NWNX_EVENTS_BROADCAST_SAFE_PROJECTILE_TYPE_WEAPON_VFX_ACID,
+        WeaponVfxCold = global::NWN.Core.NWNX.EventsPlugin.NWNX_EVENTS_BROADCAST_SAFE_PROJECTILE_TYPE_WEAPON_VFX_COLD,
+        WeaponVfxElectrical = global::NWN.Core.NWNX.EventsPlugin.NWNX_EVENTS_BROADCAST_SAFE_PROJECTILE_TYPE_WEAPON_VFX_ELECTRICAL,
+        WeaponVfxFire = global::NWN.Core.NWNX.EventsPlugin.NWNX_EVENTS_BROADCAST_SAFE_PROJECTILE_TYPE_WEAPON_VFX_FIRE,
+        WeaponVfxSonic = global::NWN.Core.NWNX.EventsPlugin.NWNX_EVENTS_BROADCAST_SAFE_PROJECTILE_TYPE_WEAPON_VFX_SONIC,
+        SpellDefault = global::NWN.Core.NWNX.EventsPlugin.NWNX_EVENTS_BROADCAST_SAFE_PROJECTILE_TYPE_SPELL_DEFAULT,
+        SpellUsePath = global::NWN.Core.NWNX.EventsPlugin.NWNX_EVENTS_BROADCAST_SAFE_PROJECTILE_TYPE_SPELL_USE_PATH
+    }
+}


### PR DESCRIPTION
## Summary

- restore the single-shot blaster sound suppressed by the unshielded pistol animation remap
- play the cue from the weapon projectile launch event so hits, misses, and every target type are covered
- whitelist the named NWNX weapon projectile types while excluding spell projectiles
- guard the fallback so native shielded-pistol and explicitly suspended throw audio is not doubled
- tie regression coverage to the configured pistol ammunition sound

## Testing

- `dotnet build SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj --no-restore -p:RunPostBuildEvent=Never -nodeReuse:false`
- `dotnet test SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj --no-build --filter "FullyQualifiedName~PistolAnimationRemapTests|FullyQualifiedName~EquipmentRestrictionsTests" -p:RunPostBuildEvent=Never` (83 passed)
