### PR TITLE
Reorder character sheet actions

### DIFF
--- a/SWLOR.Game.Server/Feature/GuiDefinition/CharacterSheetDefinition.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/CharacterSheetDefinition.cs
@@ -422,18 +422,18 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                         AddActionButton(actions, "Skills", model => model.OnClickSkills());
                         AddActionButton(actions, "Perks", model => model.OnClickPerks());
                         AddActionButton(actions, "Techniques", model => model.OnClickTechniques(), model => model.IsTechniquesEnabled);
-                        AddActionButton(actions, "Recipes", model => model.OnClickRecipes());
-                        AddActionButton(actions, "Quests", model => model.OnClickQuests());
-                        AddActionButton(actions, "Open Trash", model => model.OnClickOpenTrash());
-                        AddActionButton(actions, "Currencies", model => model.OnClickCurrencies());
-                        AddActionButton(actions, "Achievements", model => model.OnClickAchievements());
-                        AddActionButton(actions, "Notes", model => model.OnClickNotes());
                         AddActionButton(actions, "Appearance", model => model.OnClickAppearance());
                         AddActionButton(actions, "Disguises", model => model.OnClickDisguises());
-                        AddActionButton(actions, "Settings", model => model.OnClickSettings());
+                        AddActionButton(actions, "Quests", model => model.OnClickQuests());
+                        AddActionButton(actions, "Open Trash", model => model.OnClickOpenTrash());
                         AddActionButton(actions, "HoloCom", model => model.OnClickHoloCom(), model => model.IsHolocomEnabled);
+                        AddActionButton(actions, "Recipes", model => model.OnClickRecipes());
+                        AddActionButton(actions, "Currencies", model => model.OnClickCurrencies());
                         AddActionButton(actions, "Key Items", model => model.OnClickKeyItems());
+                        AddActionButton(actions, "Notes", model => model.OnClickNotes());
                         AddActionButton(actions, "Guide", model => model.OnClickGuide());
+                        AddActionButton(actions, "Achievements", model => model.OnClickAchievements());
+                        AddActionButton(actions, "Settings", model => model.OnClickSettings());
                     });
                 })
                     .SetWidth(128f);

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/PlayerGuideViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/PlayerGuideViewModel.cs
@@ -1111,7 +1111,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
                         new ArticleBlock("Guide Button",
                             "The Character Sheet also has a Guide button, so you can return here while reviewing your character."),
                         new ArticleBlock("Character Sheet Actions",
-                            "The Character Sheet action list opens Skills, Perks, Techniques, Recipes, Quests, Open Trash, Currencies, Achievements, Notes, Appearance, Disguises, Settings, HoloCom, Key Items, and this Guide."),
+                            "The Character Sheet action list opens Skills, Perks, Techniques, Appearance, Disguises, Quests, Open Trash, HoloCom, Recipes, Currencies, Key Items, Notes, this Guide, Achievements, and Settings."),
                         new ArticleBlock("Skills and Perks",
                             "Skills shows ranks, XP, XP debt, decay locks, and RP XP distribution. Perks shows player perks and, when you have an active beast, beast perks."),
                         new ArticleBlock("Quests and Progress",


### PR DESCRIPTION
## Summary
- reorder the Character Sheet action rail to match the requested player-facing priority
- update the Player Guide action list to reflect the new ordering

## Testing
- `git diff --check`
- Tests not run (declarative UI ordering and documentation change only)