### PR TITLE
Add Edit Copy for toolset blueprints

### DIFF
--- a/SWLOR.NWN.Formats.Tests/NwnResRefTests.cs
+++ b/SWLOR.NWN.Formats.Tests/NwnResRefTests.cs
@@ -1,0 +1,39 @@
+using FluentAssertions;
+using NUnit.Framework;
+using SWLOR.NWN.Formats.Common;
+
+namespace SWLOR.NWN.Formats.Tests;
+
+public sealed class NwnResRefTests
+{
+    [TestCase("a")]
+    [TestCase("abcdefghijklmnop")]
+    [TestCase("mixed_CASE_123")]
+    public void ValidShapeAcceptsLegalAuroraResourceReferences(string value)
+    {
+        NwnResRef.IsValid(value).Should().BeTrue();
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("abcdefghijklmnopq")]
+    [TestCase("bad-name")]
+    [TestCase("bad name")]
+    public void ValidShapeRejectsInvalidAuroraResourceReferences(string? value)
+    {
+        NwnResRef.IsValid(value).Should().BeFalse();
+    }
+
+    [Test]
+    public void CanonicalShapeRequiresLowercase()
+    {
+        NwnResRef.IsCanonical("lower_case_123").Should().BeTrue();
+        NwnResRef.IsCanonical("UPPER_CASE").Should().BeFalse();
+    }
+
+    [Test]
+    public void SharedLimitMatchesTheEngineFieldWidth()
+    {
+        NwnResRef.MaxLength.Should().Be(16);
+    }
+}

--- a/SWLOR.NWN.Formats/Common/NwnResRef.cs
+++ b/SWLOR.NWN.Formats/Common/NwnResRef.cs
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+
+namespace SWLOR.NWN.Formats.Common;
+
+/// <summary>Shared engine limits and shape checks for Aurora resource references.</summary>
+public static class NwnResRef
+{
+    /// <summary>
+    /// Maximum resource-reference length imposed by NWN's fixed-width resource indexes and GFF
+    /// CResRef storage.
+    /// </summary>
+    public const int MaxLength = 16;
+
+    /// <summary>Whether a non-empty value is a legal case-insensitive Aurora resource reference.</summary>
+    public static bool IsValid(string? value) =>
+        value is { Length: >= 1 and <= MaxLength } &&
+        value.All(character =>
+            char.IsAsciiLetterOrDigit(character) ||
+            character == '_');
+
+    /// <summary>Whether a non-empty value is in the lowercase canonical form used by module files.</summary>
+    public static bool IsCanonical(string? value) =>
+        value is { Length: >= 1 and <= MaxLength } &&
+        value.All(character =>
+            character is >= 'a' and <= 'z' or >= '0' and <= '9' or '_');
+}

--- a/SWLOR.NWN.Formats/Gff/GffReader.cs
+++ b/SWLOR.NWN.Formats/Gff/GffReader.cs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 
+using SWLOR.NWN.Formats.Common;
 using SWLOR.NWN.Formats.Internal;
 
 namespace SWLOR.NWN.Formats.Gff;
@@ -228,7 +229,8 @@ public static class GffReader
                 GffField.FLOAT => BitConverter.Int32BitsToSingle(unchecked((int)data)),
                 GffField.DOUBLE => ReadFieldDouble(data, $"GFF DOUBLE field {index}"),
                 GffField.CExoString => ReadLengthPrefixedString(data, 4, int.MaxValue, $"GFF string field {index}"),
-                GffField.CResRef => ReadLengthPrefixedString(data, 1, 16, $"GFF ResRef field {index}"),
+                GffField.CResRef => ReadLengthPrefixedString(
+                    data, 1, NwnResRef.MaxLength, $"GFF ResRef field {index}"),
                 GffField.CExoLocString => ReadLocString(data, index),
                 GffField.VOID => ReadVoid(data, index),
                 GffField.Struct => ReadStruct(data, depth + 1),
@@ -255,7 +257,8 @@ public static class GffReader
                 case GffField.CExoString:
                     return EstimateLengthPrefixedString(data, 4, int.MaxValue, $"GFF string field {fieldIndex}");
                 case GffField.CResRef:
-                    return EstimateLengthPrefixedString(data, 1, 16, $"GFF ResRef field {fieldIndex}");
+                    return EstimateLengthPrefixedString(
+                        data, 1, NwnResRef.MaxLength, $"GFF ResRef field {fieldIndex}");
                 case GffField.CExoLocString:
                 {
                     ValidateRelativeRange(data, 12, _fieldDataCount, $"GFF locstring field {fieldIndex}");

--- a/SWLOR.NWN.Formats/Key/KeyReader.cs
+++ b/SWLOR.NWN.Formats/Key/KeyReader.cs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 
+using SWLOR.NWN.Formats.Common;
 using SWLOR.NWN.Formats.Internal;
 
 namespace SWLOR.NWN.Formats.Key;
@@ -87,8 +88,8 @@ public static class KeyReader
         for (var index = 0; index < resourceCount; index++)
         {
             var offset = resourceTableOffset + (long)index * ResourceEntrySize;
-            var resRef = reader.ReadAscii(offset, 16, $"KEY ResRef {index}", trimNull: true);
-            var resourceType = reader.ReadUInt16(offset + 16);
+            var resRef = reader.ReadAscii(offset, NwnResRef.MaxLength, $"KEY ResRef {index}", trimNull: true);
+            var resourceType = reader.ReadUInt16(offset + NwnResRef.MaxLength);
             var resourceId = reader.ReadUInt32(offset + 18);
             var entry = new KeyResourceEntry(resRef, resourceType, resourceId);
             if (entry.BifIndex >= bifs.Count)

--- a/SWLOR.NWN.Formats/Tlk/TlkReader.cs
+++ b/SWLOR.NWN.Formats/Tlk/TlkReader.cs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 
+using SWLOR.NWN.Formats.Common;
 using SWLOR.NWN.Formats.Internal;
 
 namespace SWLOR.NWN.Formats.Tlk;
@@ -59,7 +60,8 @@ public static class TlkReader
             var flags = reader.ReadUInt32(entryOffset);
             var soundResRef = (flags & SoundPresent) == 0
                 ? string.Empty
-                : reader.ReadAscii(entryOffset + 4, 16, "TLK sound ResRef", trimNull: true);
+                : reader.ReadAscii(
+                    entryOffset + 4, NwnResRef.MaxLength, "TLK sound ResRef", trimNull: true);
             var relativeTextOffset = reader.ReadUInt32(entryOffset + 28);
             var textLength = reader.ReadUInt32(entryOffset + 32);
             var soundLength = (flags & SoundLengthPresent) == 0 ? 0f : reader.ReadSingle(entryOffset + 36);

--- a/SWLOR.Toolset.Domain/Documents/BlueprintCopyFactory.cs
+++ b/SWLOR.Toolset.Domain/Documents/BlueprintCopyFactory.cs
@@ -1,0 +1,147 @@
+using SWLOR.Toolset.Domain.Editing;
+using SWLOR.Toolset.Domain.Gff;
+using SWLOR.Toolset.Domain.Workspace;
+
+namespace SWLOR.Toolset.Domain.Documents
+{
+    /// <summary>
+    /// Builds an independent custom blueprint from an existing blueprint, matching Aurora's
+    /// Edit Copy operation.
+    /// </summary>
+    public static class BlueprintCopyFactory
+    {
+        private const int MaximumResRefLength = 16;
+        private const int InitialCopyNumberWidth = 3;
+
+        /// <summary>
+        /// Returns the next available Aurora-style copy ResRef. A source without a three-or-more digit
+        /// suffix gets <c>001</c>; an already numbered copy increments its suffix.
+        /// </summary>
+        public static string NextResRef(string sourceResRef, IEnumerable<string> existingResRefs)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(sourceResRef);
+            ArgumentNullException.ThrowIfNull(existingResRefs);
+
+            var normalized = NormalizeSourceResRef(sourceResRef);
+            if (normalized.Length == 0)
+                throw new ArgumentException("The source ResRef has no legal ResRef characters.", nameof(sourceResRef));
+
+            var digitStart = normalized.Length;
+            while (digitStart > 0 && char.IsAsciiDigit(normalized[digitStart - 1]))
+                digitStart--;
+
+            var trailingDigitCount = normalized.Length - digitStart;
+            var prefix = normalized;
+            ulong copyNumber = 1;
+            var minimumNumberWidth = InitialCopyNumberWidth;
+
+            if (trailingDigitCount >= InitialCopyNumberWidth &&
+                ulong.TryParse(normalized[digitStart..], out var parsedNumber))
+            {
+                prefix = normalized[..digitStart];
+                copyNumber = parsedNumber + 1;
+                minimumNumberWidth = trailingDigitCount;
+            }
+
+            var existing = existingResRefs.ToHashSet(StringComparer.OrdinalIgnoreCase);
+            var fellBackFromOversizedNumber = false;
+            for (var attempt = 0; attempt < 1_000_000; attempt++, copyNumber++)
+            {
+                var digits = copyNumber.ToString(System.Globalization.CultureInfo.InvariantCulture);
+                if (digits.Length < minimumNumberWidth)
+                    digits = digits.PadLeft(minimumNumberWidth, '0');
+
+                // An all-numeric 16-character ResRef can overflow to 17 digits. At that point it is no
+                // longer useful as a numeric sequence, so start a conventional 001 suffix from it.
+                if (digits.Length > MaximumResRefLength)
+                {
+                    if (fellBackFromOversizedNumber)
+                        break;
+
+                    fellBackFromOversizedNumber = true;
+                    prefix = normalized;
+                    copyNumber = 1;
+                    minimumNumberWidth = InitialCopyNumberWidth;
+                    attempt--;
+                    continue;
+                }
+
+                var prefixLength = Math.Min(prefix.Length, MaximumResRefLength - digits.Length);
+                var candidate = prefix[..prefixLength] + digits;
+                if (!existing.Contains(candidate))
+                    return candidate;
+            }
+
+            throw new InvalidOperationException($"Could not generate an available copy ResRef for '{sourceResRef}'.");
+        }
+
+        /// <summary>
+        /// Deep-copies the source document and changes only its blueprint identity. Tag, name, scripts,
+        /// inventory, variables, unknown fields, and every other authored value are preserved.
+        /// </summary>
+        public static byte[] CreateFileContent(
+            ResourceType type,
+            JsonGffDocument source,
+            string copyResRef)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+            if (!ModuleWorkspace.BlueprintTypes.Contains(type))
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(type), type, "Edit Copy is only available for blueprint resource types.");
+            }
+
+            if (!IsValidResRef(copyResRef))
+            {
+                throw new ArgumentException(
+                    "The copy ResRef must be 1-16 characters of a-z, 0-9, or underscore.",
+                    nameof(copyResRef));
+            }
+
+            // Serializing and parsing produces an independent document while retaining the source's
+            // unknown fields and JSON formatting characteristics. The copy is not on an undo stack yet.
+            var copy = JsonGffDocument.Parse(source.ToBytes());
+            using (EditScope.EnterConstruction())
+            {
+                copy.Root.SetString(
+                    IdentityFieldName(type),
+                    GffFieldType.ResRef,
+                    copyResRef);
+            }
+
+            return copy.ToBytes();
+        }
+
+        /// <summary>The root field which identifies a blueprint of this type.</summary>
+        public static string IdentityFieldName(ResourceType type)
+        {
+            if (!ModuleWorkspace.BlueprintTypes.Contains(type))
+                throw new ArgumentOutOfRangeException(nameof(type), type, "Not a blueprint resource type.");
+
+            return type == ResourceType.Utm ? "ResRef" : "TemplateResRef";
+        }
+
+        private static string NormalizeSourceResRef(string sourceResRef)
+        {
+            var builder = new System.Text.StringBuilder(MaximumResRefLength);
+            foreach (var character in sourceResRef.Trim())
+            {
+                if (char.IsAsciiLetterOrDigit(character) || character == '_')
+                    builder.Append(char.ToLowerInvariant(character));
+
+                if (builder.Length == MaximumResRefLength)
+                    break;
+            }
+
+            return builder.ToString();
+        }
+
+        private static bool IsValidResRef(string resRef) =>
+            !string.IsNullOrWhiteSpace(resRef) &&
+            resRef.Length <= MaximumResRefLength &&
+            resRef.All(character =>
+                char.IsAsciiDigit(character) ||
+                character == '_' ||
+                character is >= 'a' and <= 'z');
+    }
+}

--- a/SWLOR.Toolset.Domain/Documents/BlueprintCopyFactory.cs
+++ b/SWLOR.Toolset.Domain/Documents/BlueprintCopyFactory.cs
@@ -1,4 +1,5 @@
 using SWLOR.Toolset.Domain.Editing;
+using SWLOR.Toolset.Domain.GameData.Resources;
 using SWLOR.Toolset.Domain.Gff;
 using SWLOR.Toolset.Domain.Workspace;
 
@@ -14,6 +15,32 @@ namespace SWLOR.Toolset.Domain.Documents
         private const int InitialCopyNumberWidth = 3;
 
         /// <summary>
+        /// Returns the next available copy ResRef across the module and every indexed Standard/HAK
+        /// layer. A module blueprint with an indexed identity overrides that resource, so excluding the
+        /// index could silently retarget existing instances when the copy is created.
+        /// </summary>
+        public static string NextResRef(
+            ModuleWorkspace workspace,
+            ResourceType type,
+            string sourceResRef)
+        {
+            ArgumentNullException.ThrowIfNull(workspace);
+            if (!ModuleWorkspace.BlueprintTypes.Contains(type))
+                throw new ArgumentOutOfRangeException(nameof(type), type, "Not a blueprint resource type.");
+
+            var moduleResRefs = workspace.EnumerateResRefs(type)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            var indexedType = ResourceIdentity.TypeFromExtension(type.Extension());
+
+            return NextResRef(
+                sourceResRef,
+                candidate =>
+                    moduleResRefs.Contains(candidate) ||
+                    workspace.ResourceIndex?.TryLookup(
+                        new ResourceIdentity(candidate, indexedType), out _) == true);
+        }
+
+        /// <summary>
         /// Returns the next available Aurora-style copy ResRef. A source without a three-or-more digit
         /// suffix gets <c>001</c>; an already numbered copy increments its suffix.
         /// </summary>
@@ -21,6 +48,15 @@ namespace SWLOR.Toolset.Domain.Documents
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(sourceResRef);
             ArgumentNullException.ThrowIfNull(existingResRefs);
+
+            var existing = existingResRefs.ToHashSet(StringComparer.OrdinalIgnoreCase);
+            return NextResRef(sourceResRef, existing.Contains);
+        }
+
+        private static string NextResRef(string sourceResRef, Func<string, bool> exists)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(sourceResRef);
+            ArgumentNullException.ThrowIfNull(exists);
 
             var normalized = NormalizeSourceResRef(sourceResRef);
             if (normalized.Length == 0)
@@ -43,7 +79,6 @@ namespace SWLOR.Toolset.Domain.Documents
                 minimumNumberWidth = trailingDigitCount;
             }
 
-            var existing = existingResRefs.ToHashSet(StringComparer.OrdinalIgnoreCase);
             var fellBackFromOversizedNumber = false;
             for (var attempt = 0; attempt < 1_000_000; attempt++, copyNumber++)
             {
@@ -68,7 +103,7 @@ namespace SWLOR.Toolset.Domain.Documents
 
                 var prefixLength = Math.Min(prefix.Length, MaximumResRefLength - digits.Length);
                 var candidate = prefix[..prefixLength] + digits;
-                if (!existing.Contains(candidate))
+                if (!exists(candidate))
                     return candidate;
             }
 

--- a/SWLOR.Toolset.Domain/Documents/BlueprintCopyFactory.cs
+++ b/SWLOR.Toolset.Domain/Documents/BlueprintCopyFactory.cs
@@ -1,3 +1,4 @@
+using SWLOR.NWN.Formats.Common;
 using SWLOR.Toolset.Domain.Editing;
 using SWLOR.Toolset.Domain.GameData.Resources;
 using SWLOR.Toolset.Domain.Gff;
@@ -11,7 +12,6 @@ namespace SWLOR.Toolset.Domain.Documents
     /// </summary>
     public static class BlueprintCopyFactory
     {
-        private const int MaximumResRefLength = 16;
         private const int InitialCopyNumberWidth = 3;
 
         /// <summary>
@@ -88,7 +88,7 @@ namespace SWLOR.Toolset.Domain.Documents
 
                 // An all-numeric 16-character ResRef can overflow to 17 digits. At that point it is no
                 // longer useful as a numeric sequence, so start a conventional 001 suffix from it.
-                if (digits.Length > MaximumResRefLength)
+                if (digits.Length > NwnResRef.MaxLength)
                 {
                     if (fellBackFromOversizedNumber)
                         break;
@@ -101,7 +101,7 @@ namespace SWLOR.Toolset.Domain.Documents
                     continue;
                 }
 
-                var prefixLength = Math.Min(prefix.Length, MaximumResRefLength - digits.Length);
+                var prefixLength = Math.Min(prefix.Length, NwnResRef.MaxLength - digits.Length);
                 var candidate = prefix[..prefixLength] + digits;
                 if (!exists(candidate))
                     return candidate;
@@ -126,10 +126,11 @@ namespace SWLOR.Toolset.Domain.Documents
                     nameof(type), type, "Edit Copy is only available for blueprint resource types.");
             }
 
-            if (!IsValidResRef(copyResRef))
+            if (!NwnResRef.IsCanonical(copyResRef))
             {
                 throw new ArgumentException(
-                    "The copy ResRef must be 1-16 characters of a-z, 0-9, or underscore.",
+                    $"The copy ResRef must be 1-{NwnResRef.MaxLength} characters " +
+                    "of a-z, 0-9, or underscore.",
                     nameof(copyResRef));
             }
 
@@ -158,25 +159,18 @@ namespace SWLOR.Toolset.Domain.Documents
 
         private static string NormalizeSourceResRef(string sourceResRef)
         {
-            var builder = new System.Text.StringBuilder(MaximumResRefLength);
+            var builder = new System.Text.StringBuilder(NwnResRef.MaxLength);
             foreach (var character in sourceResRef.Trim())
             {
                 if (char.IsAsciiLetterOrDigit(character) || character == '_')
                     builder.Append(char.ToLowerInvariant(character));
 
-                if (builder.Length == MaximumResRefLength)
+                if (builder.Length == NwnResRef.MaxLength)
                     break;
             }
 
             return builder.ToString();
         }
 
-        private static bool IsValidResRef(string resRef) =>
-            !string.IsNullOrWhiteSpace(resRef) &&
-            resRef.Length <= MaximumResRefLength &&
-            resRef.All(character =>
-                char.IsAsciiDigit(character) ||
-                character == '_' ||
-                character is >= 'a' and <= 'z');
     }
 }

--- a/SWLOR.Toolset.Domain/Documents/ModuleResourceTemplateFactory.cs
+++ b/SWLOR.Toolset.Domain/Documents/ModuleResourceTemplateFactory.cs
@@ -1,3 +1,4 @@
+using SWLOR.NWN.Formats.Common;
 using SWLOR.Toolset.Domain.Gff;
 using SWLOR.Toolset.Domain.Script;
 using SWLOR.Toolset.Domain.Workspace;
@@ -78,7 +79,7 @@ namespace SWLOR.Toolset.Domain.Documents
                 '_',
                 new string(characters).Split('_', StringSplitOptions.RemoveEmptyEntries));
             return cleaned.Length > 0
-                ? cleaned[..Math.Min(16, cleaned.Length)]
+                ? cleaned[..Math.Min(NwnResRef.MaxLength, cleaned.Length)]
                 : string.Empty;
         }
 

--- a/SWLOR.Toolset.Domain/Editors/Creatures/CreatureEditorLayout.cs
+++ b/SWLOR.Toolset.Domain/Editors/Creatures/CreatureEditorLayout.cs
@@ -1,3 +1,4 @@
+using SWLOR.NWN.Formats.Common;
 using SWLOR.Toolset.Domain.Editors.Behaviors;
 using SWLOR.Toolset.Domain.Gff;
 
@@ -6,7 +7,6 @@ namespace SWLOR.Toolset.Domain.Editors.Creatures
     /// <summary>The stable field layout of the creature editor's direct UTC surfaces.</summary>
     public static class CreatureEditorLayout
     {
-        public const int MaxResRefLength = 16;
         public const int MaxTagLength = 32;
         public const int MaxNameLength = 64;
 
@@ -18,7 +18,7 @@ namespace SWLOR.Toolset.Domain.Editors.Creatures
                 maxLength: MaxNameLength),
             Field("Tag", "Tag", BehaviorFieldKind.Text, GffFieldType.CExoString, maxLength: MaxTagLength),
             Field("ResRef", "TemplateResRef", BehaviorFieldKind.Text, GffFieldType.ResRef,
-                maxLength: MaxResRefLength, readOnly: true),
+                maxLength: NwnResRef.MaxLength, readOnly: true),
             Choice("Category", "PaletteID", GffFieldType.Byte, CreatureChoiceKeys.PaletteCategories,
                 searchable: true, inlineSearch: true),
             Choice("Movement", "WalkRate", GffFieldType.Int, CreatureChoiceKeys.MovementRates),

--- a/SWLOR.Toolset.Domain/Editors/Doors/DoorBehaviorCatalog.cs
+++ b/SWLOR.Toolset.Domain/Editors/Doors/DoorBehaviorCatalog.cs
@@ -1,3 +1,4 @@
+using SWLOR.NWN.Formats.Common;
 using SWLOR.Toolset.Domain.Documents;
 using SWLOR.Toolset.Domain.Editors.Behaviors;
 using SWLOR.Toolset.Domain.Gff;
@@ -305,7 +306,7 @@ namespace SWLOR.Toolset.Domain.Editors.Doors
                 new DoorFieldDefinition
                 {
                     Label = "Conversation", Name = "Conversation", Kind = BehaviorFieldKind.Text,
-                    FieldType = GffFieldType.ResRef, MaxLength = DoorEditorLayout.MaxResRefLength
+                    FieldType = GffFieldType.ResRef, MaxLength = NwnResRef.MaxLength
                 },
                 Check("Plot", "Plot"),
                 Check("Locked", "Locked"),
@@ -365,7 +366,7 @@ namespace SWLOR.Toolset.Domain.Editors.Doors
             new()
             {
                 Label = label, Name = name, Kind = BehaviorFieldKind.Script,
-                FieldType = GffFieldType.ResRef, MaxLength = DoorEditorLayout.MaxResRefLength
+                FieldType = GffFieldType.ResRef, MaxLength = NwnResRef.MaxLength
             };
 
         private static BehaviorManagedValue Pinned(

--- a/SWLOR.Toolset.Domain/Editors/Doors/DoorEditorLayout.cs
+++ b/SWLOR.Toolset.Domain/Editors/Doors/DoorEditorLayout.cs
@@ -1,3 +1,4 @@
+using SWLOR.NWN.Formats.Common;
 using SWLOR.Toolset.Domain.Editors.Behaviors;
 using SWLOR.Toolset.Domain.Gff;
 
@@ -6,7 +7,6 @@ namespace SWLOR.Toolset.Domain.Editors.Doors
     /// <summary>The fixed Basic rows shared by every door behavior.</summary>
     public static class DoorEditorLayout
     {
-        public const int MaxResRefLength = 16;
         public const int MaxTagLength = 32;
         public const int MaxNameLength = 64;
 
@@ -48,7 +48,7 @@ namespace SWLOR.Toolset.Domain.Editors.Doors
             new DoorFieldDefinition
             {
                 Label = "ResRef", Name = "TemplateResRef", Kind = BehaviorFieldKind.Text,
-                FieldType = GffFieldType.ResRef, MaxLength = MaxResRefLength, IsRequired = true
+                FieldType = GffFieldType.ResRef, MaxLength = NwnResRef.MaxLength, IsRequired = true
             },
             new DoorFieldDefinition
             {

--- a/SWLOR.Toolset.Domain/Editors/Items/ItemEditorLayout.cs
+++ b/SWLOR.Toolset.Domain/Editors/Items/ItemEditorLayout.cs
@@ -1,3 +1,4 @@
+using SWLOR.NWN.Formats.Common;
 using SWLOR.Toolset.Domain.Editors.Behaviors;
 using SWLOR.Toolset.Domain.Gff;
 
@@ -6,7 +7,6 @@ namespace SWLOR.Toolset.Domain.Editors.Items
     /// <summary>The fixed Basic rows every item shows regardless of family or role.</summary>
     public static class ItemEditorLayout
     {
-        public const int MaxResRefLength = 16;
         public const int MaxTagLength = 32;
         public const int MaxNameLength = 64;
 
@@ -30,7 +30,7 @@ namespace SWLOR.Toolset.Domain.Editors.Items
             new BehaviorFieldDefinition
             {
                 Label = "ResRef", Name = "TemplateResRef", Kind = BehaviorFieldKind.Text,
-                FieldType = GffFieldType.ResRef, MaxLength = MaxResRefLength, IsRequired = true
+                FieldType = GffFieldType.ResRef, MaxLength = NwnResRef.MaxLength, IsRequired = true
             },
             new BehaviorFieldDefinition
             {

--- a/SWLOR.Toolset.Domain/Editors/Merchants/MerchantEditorLayout.cs
+++ b/SWLOR.Toolset.Domain/Editors/Merchants/MerchantEditorLayout.cs
@@ -1,3 +1,4 @@
+using SWLOR.NWN.Formats.Common;
 using SWLOR.Toolset.Domain.Editors.Behaviors;
 using SWLOR.Toolset.Domain.Gff;
 
@@ -8,7 +9,6 @@ namespace SWLOR.Toolset.Domain.Editors.Merchants
     {
         public const int MaxNameLength = 64;
         public const int MaxTagLength = 32;
-        public const int MaxResRefLength = 16;
 
         public static IReadOnlyList<BehaviorFieldDefinition> Details { get; } = new[]
         {
@@ -25,7 +25,7 @@ namespace SWLOR.Toolset.Domain.Editors.Merchants
             new BehaviorFieldDefinition
             {
                 Label = "ResRef", Name = "ResRef", Kind = BehaviorFieldKind.Text,
-                FieldType = GffFieldType.ResRef, MaxLength = MaxResRefLength,
+                FieldType = GffFieldType.ResRef, MaxLength = NwnResRef.MaxLength,
                 IsRequired = true
             },
             new BehaviorFieldDefinition

--- a/SWLOR.Toolset.Domain/Editors/Sounds/SoundEditorLayout.cs
+++ b/SWLOR.Toolset.Domain/Editors/Sounds/SoundEditorLayout.cs
@@ -1,3 +1,4 @@
+using SWLOR.NWN.Formats.Common;
 using SWLOR.Toolset.Domain.Editors.Behaviors;
 using SWLOR.Toolset.Domain.Gff;
 
@@ -13,7 +14,6 @@ namespace SWLOR.Toolset.Domain.Editors.Sounds
     /// </remarks>
     public static class SoundEditorLayout
     {
-        public const int MaxResRefLength = 16;
         public const int MaxNameLength = 64;
 
         public static IReadOnlyList<BehaviorFieldDefinition> Basic { get; } = new[]
@@ -31,7 +31,7 @@ namespace SWLOR.Toolset.Domain.Editors.Sounds
             new BehaviorFieldDefinition
             {
                 Label = "ResRef", Name = "TemplateResRef", Kind = BehaviorFieldKind.Text,
-                FieldType = GffFieldType.ResRef, MaxLength = MaxResRefLength, IsRequired = true
+                FieldType = GffFieldType.ResRef, MaxLength = NwnResRef.MaxLength, IsRequired = true
             },
             new BehaviorFieldDefinition
             {

--- a/SWLOR.Toolset.Domain/Editors/Triggers/TriggerEditorLayout.cs
+++ b/SWLOR.Toolset.Domain/Editors/Triggers/TriggerEditorLayout.cs
@@ -1,3 +1,4 @@
+using SWLOR.NWN.Formats.Common;
 using SWLOR.Toolset.Domain.Gff;
 using SWLOR.Toolset.Domain.Editors.Behaviors;
 
@@ -29,13 +30,6 @@ namespace SWLOR.Toolset.Domain.Editors.Triggers
     /// </remarks>
     public static class TriggerEditorLayout
     {
-        /// <summary>
-        /// A resref is 16 characters. This is a real engine limit rather than a convention: the GFF
-        /// ResRef field is a fixed 16 bytes, the longest resref anywhere in the module is exactly 16,
-        /// and <c>ResRefLengthRule</c> already validates against the same number.
-        /// </summary>
-        public const int MaxResRefLength = 16;
-
         /// <summary>
         /// A tag is a CExoString, so the <b>engine imposes no maximum</b> — this is the base
         /// toolset's own editor limit, adopted here for parity. Every trigger tag in the module fits
@@ -76,7 +70,7 @@ namespace SWLOR.Toolset.Domain.Editors.Triggers
             new BehaviorFieldDefinition
             {
                 Label = "ResRef", Name = "TemplateResRef", Kind = BehaviorFieldKind.Text,
-                FieldType = GffFieldType.ResRef, MaxLength = MaxResRefLength, IsRequired = true
+                FieldType = GffFieldType.ResRef, MaxLength = NwnResRef.MaxLength, IsRequired = true
             },
             new BehaviorFieldDefinition
             {

--- a/SWLOR.Toolset.Domain/Editors/Waypoints/WaypointEditorLayout.cs
+++ b/SWLOR.Toolset.Domain/Editors/Waypoints/WaypointEditorLayout.cs
@@ -1,3 +1,4 @@
+using SWLOR.NWN.Formats.Common;
 using SWLOR.Toolset.Domain.Editors.Behaviors;
 using SWLOR.Toolset.Domain.Gff;
 
@@ -5,8 +6,6 @@ namespace SWLOR.Toolset.Domain.Editors.Waypoints
 {
     public static class WaypointEditorLayout
     {
-        public const int MaxResRefLength = 16;
-
         public static IReadOnlyList<BehaviorFieldDefinition> Basic { get; } = new[]
         {
             new BehaviorFieldDefinition
@@ -17,7 +16,7 @@ namespace SWLOR.Toolset.Domain.Editors.Waypoints
             new BehaviorFieldDefinition
             {
                 Label = "ResRef", Name = "TemplateResRef", Kind = BehaviorFieldKind.Text,
-                FieldType = GffFieldType.ResRef, MaxLength = MaxResRefLength, IsRequired = true
+                FieldType = GffFieldType.ResRef, MaxLength = NwnResRef.MaxLength, IsRequired = true
             },
             new BehaviorFieldDefinition
             {

--- a/SWLOR.Toolset.Domain/GameData/Resources/HakArchiveCatalog.cs
+++ b/SWLOR.Toolset.Domain/GameData/Resources/HakArchiveCatalog.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using SWLOR.NWN.Formats;
+using SWLOR.NWN.Formats.Common;
 
 namespace SWLOR.Toolset.Domain.GameData.Resources
 {
@@ -84,7 +85,7 @@ namespace SWLOR.Toolset.Domain.GameData.Resources
             stream.Position = keyOffset;
             for (var index = 0; index < entryCount; index++)
             {
-                var rawResRef = reader.ReadBytes(16);
+                var rawResRef = reader.ReadBytes(NwnResRef.MaxLength);
                 var terminator = Array.IndexOf(rawResRef, (byte)0);
                 var length = terminator < 0 ? rawResRef.Length : terminator;
                 var resRef = Encoding.ASCII.GetString(rawResRef, 0, length);

--- a/SWLOR.Toolset.Domain/Gff/JsonGffField.cs
+++ b/SWLOR.Toolset.Domain/Gff/JsonGffField.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Text;
+using SWLOR.NWN.Formats.Common;
 using SWLOR.Toolset.Domain.Editing;
 
 namespace SWLOR.Toolset.Domain.Gff
@@ -180,21 +181,19 @@ namespace SWLOR.Toolset.Domain.Gff
             if (type != GffFieldType.ResRef)
                 return;
 
-            if (value.Length > 16)
-                throw new ArgumentOutOfRangeException(nameof(value), value, "A ResRef cannot exceed 16 characters.");
-
-            foreach (var character in value)
+            if (value.Length > NwnResRef.MaxLength)
             {
-                var isValid = character is >= 'a' and <= 'z'
-                    or >= 'A' and <= 'Z'
-                    or >= '0' and <= '9'
-                    or '_';
-                if (!isValid)
-                {
-                    throw new ArgumentException(
-                        "A ResRef may contain only ASCII letters, digits, and underscores.",
-                        nameof(value));
-                }
+                throw new ArgumentOutOfRangeException(
+                    nameof(value),
+                    value,
+                    $"A ResRef cannot exceed {NwnResRef.MaxLength} characters.");
+            }
+
+            if (value.Length > 0 && !NwnResRef.IsValid(value))
+            {
+                throw new ArgumentException(
+                    "A ResRef may contain only ASCII letters, digits, and underscores.",
+                    nameof(value));
             }
         }
 

--- a/SWLOR.Toolset.Domain/Validation/ResRefLengthRule.cs
+++ b/SWLOR.Toolset.Domain/Validation/ResRefLengthRule.cs
@@ -1,4 +1,4 @@
-using System.Text.RegularExpressions;
+using SWLOR.NWN.Formats.Common;
 using SWLOR.Toolset.Domain.Workspace;
 
 namespace SWLOR.Toolset.Domain.Validation
@@ -8,14 +8,8 @@ namespace SWLOR.Toolset.Domain.Validation
     /// (NWN's resref limit) and lowercase. Purely file-name based - no file is parsed, so this
     /// rule is cheap to run over the entire corpus.
     /// </summary>
-    public sealed partial class ResRefLengthRule : IValidationRule
+    public sealed class ResRefLengthRule : IValidationRule
     {
-        private const int MaxResRefLength = 16;
-
-        /// <summary>The character set NWN can address: the same one <c>NewAreaWriter</c> enforces.</summary>
-        [GeneratedRegex("^[a-z0-9_]{1,16}$")]
-        private static partial Regex LegalResRef();
-
         public string RuleId => "ResRefLength";
 
         public IEnumerable<ValidationIssue> Validate(ValidationContext context)
@@ -28,12 +22,12 @@ namespace SWLOR.Toolset.Domain.Validation
                 {
                     var path = GetPathSafely(context, type, resRef);
 
-                    if (resRef.Length > MaxResRefLength)
+                    if (resRef.Length > NwnResRef.MaxLength)
                     {
                         issues.Add(new ValidationIssue(
                             ValidationSeverity.Error,
                             RuleId,
-                            $"ResRef '{resRef}' ({type}) is {resRef.Length} characters, exceeding NWN's {MaxResRefLength}-character limit.",
+                            $"ResRef '{resRef}' ({type}) is {resRef.Length} characters, exceeding NWN's {NwnResRef.MaxLength}-character limit.",
                             path,
                             resRef));
                     }
@@ -47,7 +41,7 @@ namespace SWLOR.Toolset.Domain.Validation
                             path,
                             resRef));
                     }
-                    else if (!LegalResRef().IsMatch(resRef))
+                    else if (!NwnResRef.IsCanonical(resRef))
                     {
                         // The length and case checks pass for a short lowercase name like
                         // "bad-name", and nothing else in the default rule set looks at the

--- a/SWLOR.Toolset.Domain/Workspace/NewAreaWriter.cs
+++ b/SWLOR.Toolset.Domain/Workspace/NewAreaWriter.cs
@@ -1,4 +1,3 @@
-using System.Text.RegularExpressions;
 using System.Security.Cryptography;
 using System.Text.Json;
 using SWLOR.NWN.Formats.Common;
@@ -26,8 +25,6 @@ namespace SWLOR.Toolset.Domain.Workspace
         /// <summary>The largest area NWN accepts on a side.</summary>
         public const int MaxDimension = 32;
 
-        /// <summary>NWN resource names are at most 16 characters, lowercase, alphanumeric/underscore.</summary>
-        private static readonly Regex ResRefPattern = new("^[a-z0-9_]{1,16}$", RegexOptions.Compiled);
         private const string PendingMarkerPrefix = ".swlor-toolset-new-area-";
 
         /// <summary>
@@ -57,9 +54,11 @@ namespace SWLOR.Toolset.Domain.Workspace
             error = string.Empty;
 
             resRef = (resRef ?? string.Empty).Trim().ToLowerInvariant();
-            if (!ResRefPattern.IsMatch(resRef))
+            if (!NwnResRef.IsCanonical(resRef))
             {
-                error = "ResRef must be 1-16 characters, lowercase letters/digits/underscore only.";
+                error =
+                    $"ResRef must be 1-{NwnResRef.MaxLength} characters, " +
+                    "lowercase letters/digits/underscore only.";
                 return false;
             }
 

--- a/SWLOR.Toolset.Tests/AreaContentsTests.cs
+++ b/SWLOR.Toolset.Tests/AreaContentsTests.cs
@@ -9,6 +9,7 @@ using NUnit.Framework;
 using SWLOR.NWN.Formats.Common;
 using SWLOR.Toolset.Domain.Documents;
 using SWLOR.Toolset.Domain.Gff;
+using SWLOR.Toolset.Domain.Render;
 using SWLOR.Toolset.Domain.Workspace;
 using SWLOR.Toolset.Editors;
 using SWLOR.Toolset.Services;
@@ -60,7 +61,10 @@ namespace SWLOR.Toolset.Tests
                 Directory.Delete(_moduleRoot, recursive: true);
         }
 
-        private AreaEditorViewModel CreateEditor(IEditorPromptService? prompts = null)
+        private AreaEditorViewModel CreateEditor(
+            IEditorPromptService? prompts = null,
+            Func<ResourceType, string, string?>? editCopyBlueprint = null,
+            ModuleMutationLock? mutationLock = null)
         {
             var log = new OutputLogService();
             return new AreaEditorViewModel(
@@ -69,7 +73,9 @@ namespace SWLOR.Toolset.Tests
                 new LookupOptionProvider(new WorkspaceContext(_ => throw new NotSupportedException(), log)),
                 gameCodeIndex: null,
                 log,
-                prompts: prompts ?? new StubPrompts());
+                prompts: prompts ?? new StubPrompts(),
+                editCopyBlueprint: editCopyBlueprint,
+                mutationLock: mutationLock);
         }
 
         private static AreaContentsViewModel CreatePanel(
@@ -99,6 +105,40 @@ namespace SWLOR.Toolset.Tests
             placeables.Children.Count.Should().BeLessThan(
                 instances / 4,
                 "grouping exists so the branch is readable - a row per instance is what it replaces");
+        }
+
+        [Test]
+        public void ViewportEditCopyRoutesTheSelectedBlueprintWithoutChangingTheInstance()
+        {
+            (ResourceType Type, string ResRef)? request = null;
+            var mutationLock = new ModuleMutationLock();
+            var editor = CreateEditor(
+                editCopyBlueprint: (type, resRef) =>
+                {
+                    request = (type, resRef);
+                    return "source_plc001";
+                },
+                mutationLock: mutationLock);
+            var marker = new InstanceMarker
+            {
+                Kind = InstanceMarkerKind.Placeable,
+                TemplateResRef = "source_plc",
+                Tag = "placed_instance",
+                Position = Vector3.Zero,
+                Orientation = Vector2.UnitX
+            };
+            editor.SelectSceneInstance(marker);
+
+            editor.EditCopySelectedBlueprintCommand.CanExecute(null).Should().BeTrue();
+            editor.EditCopySelectedBlueprintCommand.Execute(null);
+
+            request.Should().Be((ResourceType.Utp, "source_plc"));
+            marker.TemplateResRef.Should().Be("source_plc",
+                "Edit Copy creates a blueprint and must not retarget the placed instance");
+            editor.SceneStatus.Should().Contain("source_plc001");
+
+            mutationLock.Set(true);
+            editor.EditCopySelectedBlueprintCommand.CanExecute(null).Should().BeFalse();
         }
 
         [Test]

--- a/SWLOR.Toolset.Tests/AreaContentsTests.cs
+++ b/SWLOR.Toolset.Tests/AreaContentsTests.cs
@@ -110,19 +110,26 @@ namespace SWLOR.Toolset.Tests
         [Test]
         public void ViewportEditCopyRoutesTheSelectedBlueprintWithoutChangingTheInstance()
         {
+            const string sourceResRef = "source_plc";
+            File.WriteAllBytes(
+                Path.Combine(_moduleRoot, "utp", sourceResRef + ".utp.json"),
+                BlueprintTemplateFactory.CreateFileContent(
+                    ResourceType.Utp,
+                    sourceResRef,
+                    "Source Placeable"));
             (ResourceType Type, string ResRef)? request = null;
             var mutationLock = new ModuleMutationLock();
             var editor = CreateEditor(
                 editCopyBlueprint: (type, resRef) =>
                 {
                     request = (type, resRef);
-                    return "source_plc001";
+                    return sourceResRef + "001";
                 },
                 mutationLock: mutationLock);
             var marker = new InstanceMarker
             {
                 Kind = InstanceMarkerKind.Placeable,
-                TemplateResRef = "source_plc",
+                TemplateResRef = sourceResRef,
                 Tag = "placed_instance",
                 Position = Vector3.Zero,
                 Orientation = Vector2.UnitX
@@ -132,12 +139,28 @@ namespace SWLOR.Toolset.Tests
             editor.EditCopySelectedBlueprintCommand.CanExecute(null).Should().BeTrue();
             editor.EditCopySelectedBlueprintCommand.Execute(null);
 
-            request.Should().Be((ResourceType.Utp, "source_plc"));
-            marker.TemplateResRef.Should().Be("source_plc",
+            request.Should().Be((ResourceType.Utp, sourceResRef));
+            marker.TemplateResRef.Should().Be(sourceResRef,
                 "Edit Copy creates a blueprint and must not retarget the placed instance");
-            editor.SceneStatus.Should().Contain("source_plc001");
+            editor.SceneStatus.Should().Contain(sourceResRef + "001");
 
             mutationLock.Set(true);
+            editor.EditCopySelectedBlueprintCommand.CanExecute(null).Should().BeFalse();
+        }
+
+        [Test]
+        public void ViewportEditCopyIsDisabledWhenTheSourceBlueprintCannotResolve()
+        {
+            var editor = CreateEditor(editCopyBlueprint: (_, _) => "never_created");
+            editor.SelectSceneInstance(new InstanceMarker
+            {
+                Kind = InstanceMarkerKind.Placeable,
+                TemplateResRef = "missing_source",
+                Tag = "broken_instance",
+                Position = Vector3.Zero,
+                Orientation = Vector2.UnitX
+            });
+
             editor.EditCopySelectedBlueprintCommand.CanExecute(null).Should().BeFalse();
         }
 

--- a/SWLOR.Toolset.Tests/BlueprintCopyFactoryTests.cs
+++ b/SWLOR.Toolset.Tests/BlueprintCopyFactoryTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using NUnit.Framework;
 using SWLOR.Toolset.Domain.Documents;
 using SWLOR.Toolset.Domain.Editing;
+using SWLOR.Toolset.Domain.GameData.Resources;
 using SWLOR.Toolset.Domain.Gff;
 using SWLOR.Toolset.Domain.Workspace;
 
@@ -58,6 +59,38 @@ namespace SWLOR.Toolset.Tests
                     "crate",
                     new[] { "crate001", "CRATE002", "crate003" })
                 .Should().Be("crate004");
+        }
+
+        [Test]
+        public void WorkspaceCopyNumberSkipsModuleAndIndexedBlueprints()
+        {
+            var root = Path.Combine(
+                Path.GetTempPath(),
+                "swlor-copy-collision-" + Guid.NewGuid().ToString("N"));
+            var moduleRoot = Path.Combine(root, "Module");
+            var indexedRoot = Path.Combine(root, "Indexed");
+            foreach (var folder in new[] { "are", "utc", "utp" })
+                Directory.CreateDirectory(Path.Combine(moduleRoot, folder));
+            Directory.CreateDirectory(indexedRoot);
+            File.WriteAllBytes(
+                Path.Combine(moduleRoot, "utp", "crate001.utp.json"),
+                BlueprintTemplateFactory.CreateFileContent(ResourceType.Utp, "crate001", "Module Copy"));
+            File.WriteAllBytes(Path.Combine(indexedRoot, "crate002.utp"), Array.Empty<byte>());
+
+            try
+            {
+                var resources = new ResourceIndex(
+                    baseLayer: null,
+                    hakLayersInOrder: new[] { new ResourceIndex.HakLayer("fixture", indexedRoot) });
+                var workspace = new ModuleWorkspace(moduleRoot, resources);
+
+                BlueprintCopyFactory.NextResRef(workspace, ResourceType.Utp, "crate")
+                    .Should().Be("crate003");
+            }
+            finally
+            {
+                Directory.Delete(root, recursive: true);
+            }
         }
 
         [Test]

--- a/SWLOR.Toolset.Tests/BlueprintCopyFactoryTests.cs
+++ b/SWLOR.Toolset.Tests/BlueprintCopyFactoryTests.cs
@@ -1,0 +1,77 @@
+using FluentAssertions;
+using NUnit.Framework;
+using SWLOR.Toolset.Domain.Documents;
+using SWLOR.Toolset.Domain.Editing;
+using SWLOR.Toolset.Domain.Gff;
+using SWLOR.Toolset.Domain.Workspace;
+
+namespace SWLOR.Toolset.Tests
+{
+    public sealed class BlueprintCopyFactoryTests
+    {
+        [TestCase(ResourceType.Utc)]
+        [TestCase(ResourceType.Uti)]
+        [TestCase(ResourceType.Utp)]
+        [TestCase(ResourceType.Utd)]
+        [TestCase(ResourceType.Utm)]
+        [TestCase(ResourceType.Utt)]
+        [TestCase(ResourceType.Uts)]
+        [TestCase(ResourceType.Utw)]
+        public void CopyChangesOnlyTheBlueprintIdentity(ResourceType type)
+        {
+            const string sourceResRef = "source_probe";
+            const string copyResRef = "source_probe001";
+            var source = JsonGffDocument.Parse(
+                BlueprintTemplateFactory.CreateFileContent(type, sourceResRef, "Source Probe"));
+            using (EditScope.EnterConstruction())
+            {
+                source.Root.SetString("Tag", GffFieldType.CExoString, "authored_tag");
+                source.Root.SetString("COPY_SENTINEL", GffFieldType.CExoString, "preserve me");
+            }
+
+            var sourceBefore = source.ToBytes();
+            var copy = JsonGffDocument.Parse(
+                BlueprintCopyFactory.CreateFileContent(type, source, copyResRef));
+
+            source.ToBytes().Should().Equal(sourceBefore, "Edit Copy must not mutate its source document");
+            copy.Root.GetStringOrNull(BlueprintCopyFactory.IdentityFieldName(type))
+                .Should().Be(copyResRef);
+            copy.Root.GetStringOrNull("Tag").Should().Be("authored_tag");
+            copy.Root.GetStringOrNull("COPY_SENTINEL").Should().Be("preserve me");
+        }
+
+        [TestCase("crate", "crate001")]
+        [TestCase("crate001", "crate002")]
+        [TestCase("crate099", "crate100")]
+        [TestCase("crate12", "crate12001")]
+        [TestCase("abcdefghijklmnop", "abcdefghijklm001")]
+        [TestCase("UPPER_CASE", "upper_case001")]
+        public void NextResRefMatchesAuroraNumbering(string source, string expected)
+        {
+            BlueprintCopyFactory.NextResRef(source, Array.Empty<string>()).Should().Be(expected);
+        }
+
+        [Test]
+        public void NextResRefSkipsExistingCopiesCaseInsensitively()
+        {
+            BlueprintCopyFactory.NextResRef(
+                    "crate",
+                    new[] { "crate001", "CRATE002", "crate003" })
+                .Should().Be("crate004");
+        }
+
+        [Test]
+        public void CopyRejectsNonBlueprintTypes()
+        {
+            var source = JsonGffDocument.Parse(
+                BlueprintTemplateFactory.CreateFileContent(ResourceType.Utp, "probe", "Probe"));
+
+            var copy = () => BlueprintCopyFactory.CreateFileContent(
+                ResourceType.Area,
+                source,
+                "probe001");
+
+            copy.Should().Throw<ArgumentOutOfRangeException>();
+        }
+    }
+}

--- a/SWLOR.Toolset.Tests/MerchantEditorTests.cs
+++ b/SWLOR.Toolset.Tests/MerchantEditorTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using NUnit.Framework;
+using SWLOR.NWN.Formats.Common;
 using SWLOR.Toolset.Domain.Documents;
 using SWLOR.Toolset.Domain.Editing;
 using SWLOR.Toolset.Domain.Editors.Behaviors;
@@ -34,7 +35,8 @@ namespace SWLOR.Toolset.Tests
             editor.DetailRows.Select(row => row.Definition.Name).Should().Equal(
                 "LocName", "Tag", "ResRef", "ID");
             editor.DetailRows.Single(row => row.Definition.Name == "Tag").MaxLength.Should().Be(32);
-            editor.DetailRows.Single(row => row.Definition.Name == "ResRef").MaxLength.Should().Be(16);
+            editor.DetailRows.Single(row => row.Definition.Name == "ResRef").MaxLength
+                .Should().Be(NwnResRef.MaxLength);
             editor.InventoryCategories.Select(category => category.Name).Should().Equal(
                 "Armor",
                 "Weapons",

--- a/SWLOR.Toolset.Tests/PaletteEditCopyTests.cs
+++ b/SWLOR.Toolset.Tests/PaletteEditCopyTests.cs
@@ -1,0 +1,125 @@
+using FluentAssertions;
+using NUnit.Framework;
+using SWLOR.Toolset.Domain.Documents;
+using SWLOR.Toolset.Domain.Gff;
+using SWLOR.Toolset.Domain.Workspace;
+using SWLOR.Toolset.Services;
+using SWLOR.Toolset.Shell.Panels;
+using SWLOR.Toolset.Workspace;
+
+namespace SWLOR.Toolset.Tests
+{
+    public sealed class PaletteEditCopyTests
+    {
+        private string _testRoot = string.Empty;
+        private string _moduleRoot = string.Empty;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _testRoot = Path.Combine(
+                Path.GetTempPath(),
+                "swlor-palette-edit-copy-" + Guid.NewGuid().ToString("N"));
+            _moduleRoot = Path.Combine(_testRoot, "Module");
+            foreach (var folder in new[] { "are", "utc", "utp" })
+                Directory.CreateDirectory(Path.Combine(_moduleRoot, folder));
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (Directory.Exists(_testRoot))
+                Directory.Delete(_testRoot, recursive: true);
+        }
+
+        [Test]
+        public void EditCopyCreatesFilesRevealsAndFilesAnIndependentBlueprint()
+        {
+            const string sourceResRef = "test_crate";
+            const string copyResRef = "test_crate001";
+            var sourcePath = Path.Combine(_moduleRoot, "utp", sourceResRef + ".utp.json");
+            File.WriteAllBytes(
+                sourcePath,
+                BlueprintTemplateFactory.CreateFileContent(
+                    ResourceType.Utp,
+                    sourceResRef,
+                    "Test Crate"));
+
+            var log = new OutputLogService();
+            var workspace = new WorkspaceContext(root => new ModuleWorkspace(root), log);
+            workspace.Open(_moduleRoot);
+            var categories = new CategoryService(workspace, log);
+            var furniture = categories.Section(ResourceType.Utp)!.AddFolder("Furniture");
+            var containers = furniture.AddChild("Containers");
+            containers.AddMember(sourceResRef);
+            categories.SaveChanges().Saved.Should().BeTrue();
+
+            var mutationLock = new ModuleMutationLock();
+            var previousAmbient = ModuleMutationLock.ModuleWrites;
+            ModuleMutationLock.ModuleWrites = mutationLock;
+            try
+            {
+                var palette = new PaletteViewModel(
+                    workspace,
+                    categories,
+                    log,
+                    mutationLock: mutationLock)
+                {
+                    SelectedType = ResourceType.Utp
+                };
+                palette.Refresh();
+                palette.SelectedRow = palette.Rows.Single(row => row.Name == "Furniture");
+                var tile = new PaletteTileViewModel(
+                    sourceResRef,
+                    "Test Crate",
+                    categoryPath: null,
+                    PaletteSource.Custom);
+
+                palette.EditCopyCommand.Execute(tile);
+
+                var copyPath = Path.Combine(_moduleRoot, "utp", copyResRef + ".utp.json");
+                File.Exists(copyPath).Should().BeTrue();
+                File.Exists(sourcePath).Should().BeTrue();
+                var copy = JsonGffDocument.Load(copyPath);
+                copy.Root.GetStringOrNull("TemplateResRef").Should().Be(copyResRef);
+                copy.Root.GetStringOrNull("Tag").Should().Be(sourceResRef,
+                    "Edit Copy preserves authored fields other than blueprint identity");
+                categories.Section(ResourceType.Utp)!
+                    .Find("Furniture", "Containers")!
+                    .Members.Should().Contain(copyResRef);
+                palette.Source.Should().Be(PaletteSource.Custom);
+                palette.SelectedTile?.ResRef.Should().Be(copyResRef);
+                palette.StatusMessage.Should().Contain($"Copied Test Crate as {copyResRef}");
+            }
+            finally
+            {
+                ModuleMutationLock.ModuleWrites = previousAmbient;
+            }
+        }
+
+        [Test]
+        public void EditCopyAvailabilityIncludesStandardButFollowsTheModuleLock()
+        {
+            var log = new OutputLogService();
+            var workspace = new WorkspaceContext(root => new ModuleWorkspace(root), log);
+            workspace.Open(_moduleRoot);
+            var mutationLock = new ModuleMutationLock();
+            var palette = new PaletteViewModel(
+                workspace,
+                new CategoryService(workspace, log),
+                log,
+                mutationLock: mutationLock)
+            {
+                Source = PaletteSource.Standard
+            };
+
+            palette.CanWrite.Should().BeFalse("Standard blueprints cannot be edited in place");
+            palette.CanEditCopy.Should().BeTrue("Edit Copy writes a new Custom blueprint");
+            palette.HasBlueprintActions.Should().BeTrue();
+
+            mutationLock.Set(true);
+
+            palette.CanEditCopy.Should().BeFalse();
+        }
+    }
+}

--- a/SWLOR.Toolset.Tests/PaletteEditCopyTests.cs
+++ b/SWLOR.Toolset.Tests/PaletteEditCopyTests.cs
@@ -1,8 +1,10 @@
+using System.Reflection;
 using FluentAssertions;
 using NUnit.Framework;
 using SWLOR.Toolset.Domain.Documents;
 using SWLOR.Toolset.Domain.Gff;
 using SWLOR.Toolset.Domain.Workspace;
+using SWLOR.Toolset.Editors;
 using SWLOR.Toolset.Services;
 using SWLOR.Toolset.Shell.Panels;
 using SWLOR.Toolset.Workspace;
@@ -120,6 +122,49 @@ namespace SWLOR.Toolset.Tests
             mutationLock.Set(true);
 
             palette.CanEditCopy.Should().BeFalse();
+        }
+
+        [Test]
+        public void ViewportCopyOfAnUnfiledBlueprintRefreshesTheOpenPalette()
+        {
+            const string sourceResRef = "loose_crate";
+            const string copyResRef = "loose_crate001";
+            File.WriteAllBytes(
+                Path.Combine(_moduleRoot, "utp", sourceResRef + ".utp.json"),
+                BlueprintTemplateFactory.CreateFileContent(
+                    ResourceType.Utp,
+                    sourceResRef,
+                    "Loose Crate"));
+
+            var log = new OutputLogService();
+            var workspace = new WorkspaceContext(root => new ModuleWorkspace(root), log);
+            workspace.Open(_moduleRoot);
+            var categories = new CategoryService(workspace, log);
+            var palette = new PaletteViewModel(workspace, categories, log)
+            {
+                SelectedType = ResourceType.Utp
+            };
+            palette.Refresh();
+            palette.SelectedRow = palette.Rows.Single(row => row.IsUnsorted);
+            palette.Tiles.Should().Contain(tile => tile.ResRef == sourceResRef);
+            palette.Tiles.Should().NotContain(tile => tile.ResRef == copyResRef);
+
+            var editors = new EditorService(
+                workspace,
+                new LookupOptionProvider(workspace),
+                log,
+                factory: null!,
+                prompts: null!,
+                categories: categories);
+            var editCopy = typeof(EditorService).GetMethod(
+                "TryEditCopyAndOpenBlueprint",
+                BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+            editCopy.Invoke(editors, new object[] { ResourceType.Utp, sourceResRef })
+                .Should().Be(copyResRef);
+
+            palette.Tiles.Should().Contain(tile => tile.ResRef == copyResRef,
+                "the viewport copy must appear under Unsorted without an unrelated palette refresh");
         }
     }
 }

--- a/SWLOR.Toolset.Tests/TriggerBehaviorTests.cs
+++ b/SWLOR.Toolset.Tests/TriggerBehaviorTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using FluentAssertions;
 using NUnit.Framework;
+using SWLOR.NWN.Formats.Common;
 using SWLOR.Toolset.Domain.Documents;
 using SWLOR.Toolset.Domain.Editors.Behaviors;
 using SWLOR.Toolset.Domain.Editors.Triggers;
@@ -402,9 +403,7 @@ namespace SWLOR.Toolset.Tests
             var resRef = TriggerEditorLayout.Basic.Single(row => row.Name == "TemplateResRef");
             var tag = TriggerEditorLayout.Basic.Single(row => row.Name == "Tag");
 
-            // 16 is the engine's own limit - the GFF ResRef field is a fixed 16 bytes.
-            resRef.MaxLength.Should().Be(16);
-            resRef.MaxLength.Should().Be(TriggerEditorLayout.MaxResRefLength);
+            resRef.MaxLength.Should().Be(NwnResRef.MaxLength);
             resRef.Label.Should().Be("ResRef");
             resRef.IsReadOnly.Should().BeFalse(
                 "rename-on-save keeps the internal identity, file name, and placements together");

--- a/SWLOR.Toolset/Archives/ErfArchiveViewModel.cs
+++ b/SWLOR.Toolset/Archives/ErfArchiveViewModel.cs
@@ -2,6 +2,7 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using SWLOR.NWN.Formats.Common;
 using SWLOR.Toolset.Services;
 using SWLOR.Toolset.Settings;
 
@@ -305,7 +306,7 @@ namespace SWLOR.Toolset.Archives
         private static string SuggestedRename(string resRef)
         {
             const string suffix = "_imp";
-            var prefixLength = Math.Max(1, 16 - suffix.Length);
+            var prefixLength = Math.Max(1, NwnResRef.MaxLength - suffix.Length);
             return resRef[..Math.Min(resRef.Length, prefixLength)] + suffix;
         }
 
@@ -922,14 +923,11 @@ namespace SWLOR.Toolset.Archives
                     continue;
 
                 var value = row.RenameResRef;
-                if (string.IsNullOrWhiteSpace(value) || value.Length > 16 ||
-                    value.Any(character => character is not (>= 'a' and <= 'z'
-                        or >= 'A' and <= 'Z'
-                        or >= '0' and <= '9'
-                        or '_')))
+                if (!NwnResRef.IsValid(value))
                 {
                     StatusText =
-                        $"'{row.FileName}' needs a new 1-16 character resref using letters, digits, or underscores.";
+                        $"'{row.FileName}' needs a new 1-{NwnResRef.MaxLength} character resref " +
+                        "using letters, digits, or underscores.";
                     return false;
                 }
             }

--- a/SWLOR.Toolset/Editors/AreaEditorViewModel.cs
+++ b/SWLOR.Toolset/Editors/AreaEditorViewModel.cs
@@ -80,6 +80,12 @@ namespace SWLOR.Toolset.Editors
         /// <summary>Opens a blueprint in its own editor tab - the selection bar's one action.</summary>
         private readonly Action<ResourceType, string>? _openBlueprint;
 
+        /// <summary>Creates and opens an independent custom copy of a selected instance's blueprint.</summary>
+        private readonly Func<ResourceType, string, string?>? _editCopyBlueprint;
+
+        /// <summary>The shared pack/build/validation lock governing module writes.</summary>
+        private readonly ModuleMutationLock? _mutationLock;
+
         /// <summary>
         /// Which session each still-undoable edit went to, oldest first.
         /// </summary>
@@ -238,6 +244,7 @@ namespace SWLOR.Toolset.Editors
                 OnPropertyChanged(nameof(SelectionCoordinates));
                 OnPropertyChanged(nameof(IDocumentStatusSource.StatusDetail));
                 EditSelectedBlueprintCommand.NotifyCanExecuteChanged();
+                EditCopySelectedBlueprintCommand.NotifyCanExecuteChanged();
                 OpenSelectedInstancePropertiesCommand.NotifyCanExecuteChanged();
             }
         }
@@ -390,6 +397,35 @@ namespace SWLOR.Toolset.Editors
             !string.IsNullOrWhiteSpace(instance.TemplateResRef) &&
             MapKindToSectionType(instance.Kind) is { } type &&
             File.Exists(_workspace.GetResourcePath(type, instance.TemplateResRef));
+
+        /// <summary>
+        /// Creates a new Custom blueprint from the selected instance's source and opens the new copy.
+        /// The placed instance remains linked to its original blueprint.
+        /// </summary>
+        [RelayCommand(CanExecute = nameof(CanEditCopySelectedBlueprint))]
+        private void EditCopySelectedBlueprint()
+        {
+            if (SelectedSceneInstance is not { } instance ||
+                string.IsNullOrWhiteSpace(instance.TemplateResRef) ||
+                MapKindToSectionType(instance.Kind) is not { } type ||
+                _editCopyBlueprint == null)
+                return;
+
+            var copyResRef = _editCopyBlueprint(type, instance.TemplateResRef);
+            SceneStatus = copyResRef == null
+                ? $"Could not copy {SelectionName} - see Output."
+                : $"Created and opened blueprint copy {copyResRef}.";
+        }
+
+        private bool CanEditCopySelectedBlueprint() =>
+            _editCopyBlueprint != null &&
+            _mutationLock?.IsLocked != true &&
+            SelectedSceneInstance is { } instance &&
+            !string.IsNullOrWhiteSpace(instance.TemplateResRef) &&
+            MapKindToSectionType(instance.Kind) != null;
+
+        private void OnMutationLockChanged() =>
+            EditCopySelectedBlueprintCommand.NotifyCanExecuteChanged();
 
         /// <summary>
         /// Maps a 3D-view instance's kind to the blueprint type of the section that lists it, or
@@ -1503,7 +1539,9 @@ namespace SWLOR.Toolset.Editors
             Func<string, IReadOnlyList<BehaviorChoice>>? resolveSoundChoices = null,
             IReadOnlyList<string>? audioResources = null,
             Services.SoundPreviewService? soundPreview = null,
-            AreaEditorDocumentLoad? loadedDocuments = null)
+            AreaEditorDocumentLoad? loadedDocuments = null,
+            Func<ResourceType, string, string?>? editCopyBlueprint = null,
+            ModuleMutationLock? mutationLock = null)
         {
             _scriptSlotHost = scriptSlotHost;
             _resolveBlueprintModel = resolveBlueprintModel;
@@ -1511,6 +1549,10 @@ namespace SWLOR.Toolset.Editors
             _waypointAppearances = waypointAppearances;
             _resolveBlueprintName = resolveBlueprintName;
             _openBlueprint = openBlueprint;
+            _editCopyBlueprint = editCopyBlueprint;
+            _mutationLock = mutationLock;
+            if (_mutationLock != null)
+                _mutationLock.Changed += OnMutationLockChanged;
             _log = log;
             _workspace = workspace;
             _areResRef = areResRef;
@@ -2635,6 +2677,8 @@ namespace SWLOR.Toolset.Editors
                 return base.OnClose();
 
             _disposed = true;
+            if (_mutationLock != null)
+                _mutationLock.Changed -= OnMutationLockChanged;
             foreach (var section in Sections)
                 section.Dispose();
             _areSession.Dispose();

--- a/SWLOR.Toolset/Editors/AreaEditorViewModel.cs
+++ b/SWLOR.Toolset/Editors/AreaEditorViewModel.cs
@@ -422,7 +422,22 @@ namespace SWLOR.Toolset.Editors
             _mutationLock?.IsLocked != true &&
             SelectedSceneInstance is { } instance &&
             !string.IsNullOrWhiteSpace(instance.TemplateResRef) &&
-            MapKindToSectionType(instance.Kind) != null;
+            MapKindToSectionType(instance.Kind) is { } type &&
+            CanResolveBlueprint(type, instance.TemplateResRef);
+
+        private bool CanResolveBlueprint(ResourceType type, string resRef)
+        {
+            if (File.Exists(_workspace.GetResourcePath(type, resRef)))
+                return true;
+
+            if (ResourceIndex == null)
+                return false;
+
+            var identity = new ResourceIdentity(
+                resRef,
+                ResourceIdentity.TypeFromExtension(type.Extension()));
+            return ResourceIndex.TryLookup(identity, out _);
+        }
 
         private void OnMutationLockChanged() =>
             EditCopySelectedBlueprintCommand.NotifyCanExecuteChanged();

--- a/SWLOR.Toolset/Editors/BlueprintEditorViewModel.cs
+++ b/SWLOR.Toolset/Editors/BlueprintEditorViewModel.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.Input;
 using Dock.Model.Mvvm.Controls;
+using SWLOR.NWN.Formats.Common;
 using SWLOR.Toolset.Domain.Documents;
 using SWLOR.Toolset.Domain.Editing;
 using SWLOR.Toolset.Domain.Editors;
@@ -405,10 +406,11 @@ namespace SWLOR.Toolset.Editors
                 var targetResRef =
                     _session.Document.Root.GetStringOrNull("TemplateResRef")?.Trim().ToLowerInvariant()
                     ?? string.Empty;
-                if (!IsValidResRef(targetResRef))
+                if (!NwnResRef.IsCanonical(targetResRef))
                 {
                     _log.AppendLine(
-                        $"Cannot save {_resRef}: ResRef '{targetResRef}' must be 1-16 characters " +
+                        $"Cannot save {_resRef}: ResRef '{targetResRef}' must be " +
+                        $"1-{NwnResRef.MaxLength} characters " +
                         "of a-z, 0-9, or underscore.");
                     return false;
                 }
@@ -607,9 +609,5 @@ namespace SWLOR.Toolset.Editors
             Title = IsDirty ? $"{_resRef} *" : _resRef;
         }
 
-        private static bool IsValidResRef(string value) =>
-            value.Length is >= 1 and <= 16 &&
-            value.All(character =>
-                character is >= 'a' and <= 'z' or >= '0' and <= '9' or '_');
     }
 }

--- a/SWLOR.Toolset/Editors/Creatures/CreatureEquipmentSet.cs
+++ b/SWLOR.Toolset/Editors/Creatures/CreatureEquipmentSet.cs
@@ -1,3 +1,4 @@
+using SWLOR.NWN.Formats.Common;
 using SWLOR.Toolset.Domain.Documents;
 using SWLOR.Toolset.Domain.Editing;
 using SWLOR.Toolset.Domain.Editors.Creatures;
@@ -140,7 +141,7 @@ namespace SWLOR.Toolset.Editors.Creatures
 
         private string UniqueResRef(string creatureResRef, string suffix)
         {
-            var prefixLength = Math.Max(1, 16 - suffix.Length);
+            var prefixLength = Math.Max(1, NwnResRef.MaxLength - suffix.Length);
             var stem = new string(creatureResRef
                     .ToLowerInvariant()
                     .Where(character => char.IsAsciiLetterOrDigit(character) || character == '_')
@@ -150,13 +151,13 @@ namespace SWLOR.Toolset.Editors.Creatures
             if (stem.Length == 0)
                 stem = "creature"[..Math.Min(8, prefixLength)];
 
-            var candidate = (stem + suffix)[..Math.Min(16, stem.Length + suffix.Length)];
+            var candidate = (stem + suffix)[..Math.Min(NwnResRef.MaxLength, stem.Length + suffix.Length)];
             for (var counter = 2;
                  File.Exists(Path.Combine(_itemDirectory, candidate + ".uti.json")) || _documents.ContainsKey(candidate);
                  counter++)
             {
                 var number = counter.ToString(System.Globalization.CultureInfo.InvariantCulture);
-                var allowedStem = Math.Max(1, 16 - suffix.Length - number.Length);
+                var allowedStem = Math.Max(1, NwnResRef.MaxLength - suffix.Length - number.Length);
                 candidate = stem[..Math.Min(stem.Length, allowedStem)] + suffix + number;
             }
 

--- a/SWLOR.Toolset/Editors/Creatures/CreatureSoundSetPreviewResolver.cs
+++ b/SWLOR.Toolset/Editors/Creatures/CreatureSoundSetPreviewResolver.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using SWLOR.NWN.Formats.Common;
 using SWLOR.Toolset.Domain.GameData.Resources;
 using SWLOR.Toolset.Domain.GameData.TwoDa;
 
@@ -75,7 +76,7 @@ namespace SWLOR.Toolset.Editors.Creatures
                 if (index < 0 || index >= offsets.Length || offsets[index] > data.Length - 20L)
                     continue;
                 stream.Position = offsets[index];
-                var resRef = Encoding.ASCII.GetString(reader.ReadBytes(16)).TrimEnd('\0');
+                var resRef = Encoding.ASCII.GetString(reader.ReadBytes(NwnResRef.MaxLength)).TrimEnd('\0');
                 if (!string.IsNullOrWhiteSpace(resRef) && resRef != "****")
                     return resRef;
             }

--- a/SWLOR.Toolset/Editors/EditorService.cs
+++ b/SWLOR.Toolset/Editors/EditorService.cs
@@ -1003,8 +1003,9 @@ namespace SWLOR.Toolset.Editors
                     ? workspace.LoadBlueprint(type, sourceResRef)
                     : workspace.LoadIndexedBlueprint(type, sourceResRef);
                 var copyResRef = BlueprintCopyFactory.NextResRef(
-                    sourceResRef,
-                    workspace.EnumerateResRefs(type));
+                    workspace,
+                    type,
+                    sourceResRef);
                 var copyPath = workspace.GetResourcePath(type, copyResRef);
                 var content = BlueprintCopyFactory.CreateFileContent(type, source.Document, copyResRef);
 
@@ -1012,6 +1013,7 @@ namespace SWLOR.Toolset.Editors
                 SaveService.WriteNewAtomic(copyPath, content);
                 _workspaceContext.RefreshCatalogEntry(type, copyResRef);
 
+                var categoryNotificationRaised = false;
                 if (_categories != null)
                 {
                     var sourceSection = isCustomSource
@@ -1027,6 +1029,7 @@ namespace SWLOR.Toolset.Editors
                         var targetFolder = EnsureBlueprintCopyFolder(customSection, categoryPath);
                         targetFolder.AddMember(copyResRef);
                         var save = _categories.SaveChanges();
+                        categoryNotificationRaised = save.Saved;
                         if (!save.Saved)
                         {
                             _log.AppendLine(
@@ -1034,6 +1037,12 @@ namespace SWLOR.Toolset.Editors
                                 $"but could not file it under '{categoryPath[^1]}': {save.Problem}");
                         }
                     }
+
+                    // A successful category save raises Changed itself. An unfiled copy, or a failed
+                    // category save restored to Unsorted, still needs that notification so an open
+                    // palette re-enumerates the newly created module resource immediately.
+                    if (!categoryNotificationRaised)
+                        _categories.NotifyChanged();
                 }
 
                 _log.AppendLine(

--- a/SWLOR.Toolset/Editors/EditorService.cs
+++ b/SWLOR.Toolset/Editors/EditorService.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using SWLOR.Toolset.Domain.Editors;
 using SWLOR.Toolset.Domain.Editors.Behaviors;
 using SWLOR.Toolset.Domain.Editors.Schemas;
+using SWLOR.Toolset.Domain.Categories;
 using SWLOR.Toolset.Domain.Documents;
 using SWLOR.Toolset.Domain.Gff;
 using SWLOR.Toolset.Domain.GameData.GameCode;
@@ -982,6 +983,88 @@ namespace SWLOR.Toolset.Editors
             {
                 _log.AppendLine($"Failed to open editor for {resRef}: {ex.Message}");
             }
+        }
+
+        /// <summary>
+        /// Aurora-style Edit Copy for an area instance: create a new module blueprint from its source,
+        /// retain the source category when possible, and open the independent copy.
+        /// </summary>
+        private string? TryEditCopyAndOpenBlueprint(ResourceType type, string sourceResRef)
+        {
+            var workspace = _workspaceContext.Workspace;
+            if (workspace == null || !ModuleWorkspace.BlueprintTypes.Contains(type))
+                return null;
+
+            try
+            {
+                var sourcePath = workspace.GetResourcePath(type, sourceResRef);
+                var isCustomSource = File.Exists(sourcePath);
+                var source = isCustomSource
+                    ? workspace.LoadBlueprint(type, sourceResRef)
+                    : workspace.LoadIndexedBlueprint(type, sourceResRef);
+                var copyResRef = BlueprintCopyFactory.NextResRef(
+                    sourceResRef,
+                    workspace.EnumerateResRefs(type));
+                var copyPath = workspace.GetResourcePath(type, copyResRef);
+                var content = BlueprintCopyFactory.CreateFileContent(type, source.Document, copyResRef);
+
+                Directory.CreateDirectory(Path.GetDirectoryName(copyPath)!);
+                SaveService.WriteNewAtomic(copyPath, content);
+                _workspaceContext.RefreshCatalogEntry(type, copyResRef);
+
+                if (_categories != null)
+                {
+                    var sourceSection = isCustomSource
+                        ? _categories.Section(type)
+                        : _categories.StandardSection(type);
+                    var sourceFolder = sourceSection?.FoldersContaining(sourceResRef).FirstOrDefault();
+                    var categoryPath = sourceFolder == null || sourceSection == null
+                        ? Array.Empty<string>()
+                        : sourceSection.PathTo(sourceFolder).ToArray();
+
+                    if (categoryPath.Length > 0 && _categories.Section(type) is { } customSection)
+                    {
+                        var targetFolder = EnsureBlueprintCopyFolder(customSection, categoryPath);
+                        targetFolder.AddMember(copyResRef);
+                        var save = _categories.SaveChanges();
+                        if (!save.Saved)
+                        {
+                            _log.AppendLine(
+                                $"Copied {type.Extension()} blueprint '{sourceResRef}' to '{copyResRef}', " +
+                                $"but could not file it under '{categoryPath[^1]}': {save.Problem}");
+                        }
+                    }
+                }
+
+                _log.AppendLine(
+                    $"Copied {type.Extension()} blueprint '{sourceResRef}' to '{copyResRef}' ({copyPath}).");
+                TryOpenEditor(type, copyResRef);
+                return copyResRef;
+            }
+            catch (Exception ex)
+            {
+                _log.AppendLine(
+                    $"Edit Copy failed for {type.Extension()} blueprint '{sourceResRef}': {ex.Message}");
+                return null;
+            }
+        }
+
+        private static CategoryFolder EnsureBlueprintCopyFolder(
+            CategorySection section,
+            IReadOnlyList<string> path)
+        {
+            var current = section.Folders.FirstOrDefault(folder =>
+                              string.Equals(folder.Name, path[0], StringComparison.OrdinalIgnoreCase))
+                          ?? section.AddFolder(path[0]);
+            for (var index = 1; index < path.Count; index++)
+            {
+                var segment = path[index];
+                current = current.Children.FirstOrDefault(child =>
+                              string.Equals(child.Name, segment, StringComparison.OrdinalIgnoreCase))
+                          ?? current.AddChild(segment);
+            }
+
+            return current;
         }
 
         private Sources.ObjectSourceSectionViewModel CreateObjectSource(
@@ -3339,7 +3422,9 @@ namespace SWLOR.Toolset.Editors
                     ResolveSoundChoices,
                     SoundResources(),
                     SoundPreviews(),
-                    loadedDocuments);
+                    loadedDocuments,
+                    TryEditCopyAndOpenBlueprint,
+                    _mutationLock);
                 editor.Closed += _ => _openAreaEditors.Remove(resRef);
                 editor.TilesetChanged += () => _factory.NotifyActiveAreaChanged();
                 editor.CloseRequested += _ => _factory.CloseDocument(editor);

--- a/SWLOR.Toolset/Editors/Items/ItemDocumentViewModel.cs
+++ b/SWLOR.Toolset/Editors/Items/ItemDocumentViewModel.cs
@@ -1,5 +1,4 @@
 using SWLOR.Toolset.Domain.Editors.Items;
-using System.Text.RegularExpressions;
 using CommunityToolkit.Mvvm.Input;
 using Dock.Model.Mvvm.Controls;
 using SWLOR.NWN.Formats.Common;
@@ -27,8 +26,6 @@ namespace SWLOR.Toolset.Editors.Items
     /// </remarks>
     public partial class ItemDocumentViewModel : Document, IEditorDocument
     {
-        private static readonly Regex ResRefShape = new("^[a-z0-9_]{1,16}$", RegexOptions.Compiled);
-
         private readonly DocumentSession _session;
         private readonly OutputLogService _log;
         private readonly IEditorPromptService _prompts;
@@ -176,10 +173,11 @@ namespace SWLOR.Toolset.Editors.Items
                 }
 
                 var targetResRef = Editor.TemplateResRef.Trim().ToLowerInvariant();
-                if (!ResRefShape.IsMatch(targetResRef))
+                if (!NwnResRef.IsCanonical(targetResRef))
                 {
                     _log.AppendLine(
-                        $"Cannot save {_resRef}: ResRef '{Editor.TemplateResRef}' must be 1-16 " +
+                        $"Cannot save {_resRef}: ResRef '{Editor.TemplateResRef}' must be " +
+                        $"1-{NwnResRef.MaxLength} " +
                         "characters of a-z, 0-9, or underscore.");
                     return false;
                 }

--- a/SWLOR.Toolset/Editors/Views/AreaEditorView.axaml
+++ b/SWLOR.Toolset/Editors/Views/AreaEditorView.axaml
@@ -62,6 +62,9 @@
                 <MenuItem Header="Edit blueprint..."
                           Command="{Binding EditSelectedBlueprintCommand}"
                           ToolTip.Tip="Open the blueprint this was placed from" />
+                <MenuItem Header="Edit Copy..."
+                          Command="{Binding EditCopySelectedBlueprintCommand}"
+                          ToolTip.Tip="Create and edit a new Custom blueprint from this object's source" />
               </ContextMenu>
             </Border.ContextMenu>
           </Border>

--- a/SWLOR.Toolset/Services/BlueprintResRef.cs
+++ b/SWLOR.Toolset/Services/BlueprintResRef.cs
@@ -1,3 +1,4 @@
+using SWLOR.NWN.Formats.Common;
 using SWLOR.Toolset.Domain.Editing;
 using SWLOR.Toolset.Domain.Documents;
 using SWLOR.Toolset.Domain.Gff;
@@ -14,12 +15,11 @@ namespace SWLOR.Toolset.Services
         {
             var raw = session.Document.Root.GetStringOrNull(fieldName) ?? string.Empty;
             normalized = raw.Trim().ToLowerInvariant();
-            if (normalized.Length is < 1 or > 16 ||
-                normalized.Any(character =>
-                    character is not (>= 'a' and <= 'z' or >= '0' and <= '9' or '_')))
+            if (!NwnResRef.IsCanonical(normalized))
             {
                 problem =
-                    $"ResRef '{raw}' must be 1-16 characters of a-z, 0-9, or underscore.";
+                    $"ResRef '{raw}' must be 1-{NwnResRef.MaxLength} characters " +
+                    "of a-z, 0-9, or underscore.";
                 return false;
             }
 

--- a/SWLOR.Toolset/Services/BlueprintSaveCoordinator.cs
+++ b/SWLOR.Toolset/Services/BlueprintSaveCoordinator.cs
@@ -1,3 +1,4 @@
+using SWLOR.NWN.Formats.Common;
 using SWLOR.Toolset.Domain.Documents;
 using SWLOR.Toolset.Domain.Editing;
 using SWLOR.Toolset.Domain.Gff;
@@ -84,10 +85,11 @@ namespace SWLOR.Toolset.Services
                     0, Array.Empty<string>());
             }
 
-            if (!IsValidResRef(targetResRef))
+            if (!NwnResRef.IsCanonical(targetResRef))
             {
                 _log.AppendLine(
-                    $"Cannot rename {currentResRef}: ResRef '{targetResRef}' must be 1-16 " +
+                    $"Cannot rename {currentResRef}: ResRef '{targetResRef}' must be " +
+                    $"1-{NwnResRef.MaxLength} " +
                     "characters of a-z, 0-9, or underscore.");
                 return failed;
             }
@@ -552,11 +554,6 @@ namespace SWLOR.Toolset.Services
                    ?? throw new InvalidOperationException(
                        $"Could not determine the module root for '{resourcePath}'.");
         }
-
-        private static bool IsValidResRef(string value) =>
-            value.Length is >= 1 and <= 16 &&
-            value.All(character =>
-                character is >= 'a' and <= 'z' or >= '0' and <= '9' or '_');
 
         private static bool HasMultipleCaseVariants(string path)
         {

--- a/SWLOR.Toolset/Services/ErfArchiveService.cs
+++ b/SWLOR.Toolset/Services/ErfArchiveService.cs
@@ -133,16 +133,16 @@ namespace SWLOR.Toolset.Services
         };
 
         private static readonly Regex IncludePattern = new(
-            @"^\s*#\s*include\s+""(?<resref>[A-Za-z0-9_]{1,16})""",
+            $@"^\s*#\s*include\s+""(?<resref>[A-Za-z0-9_]{{1,{NwnResRef.MaxLength}}})""",
             RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.Multiline);
         private static readonly Regex CreateItemPattern = new(
-            @"\bCreateItemOnObject\s*\(\s*""(?<resref>[A-Za-z0-9_]{1,16})""",
+            $@"\bCreateItemOnObject\s*\(\s*""(?<resref>[A-Za-z0-9_]{{1,{NwnResRef.MaxLength}}})""",
             RegexOptions.Compiled | RegexOptions.CultureInvariant);
         private static readonly Regex CreateObjectPattern = new(
-            @"\bCreateObject\s*\(\s*OBJECT_TYPE_(?<type>CREATURE|ITEM|PLACEABLE|STORE|WAYPOINT|DOOR|TRIGGER|SOUND)\s*,\s*""(?<resref>[A-Za-z0-9_]{1,16})""",
+            $@"\bCreateObject\s*\(\s*OBJECT_TYPE_(?<type>CREATURE|ITEM|PLACEABLE|STORE|WAYPOINT|DOOR|TRIGGER|SOUND)\s*,\s*""(?<resref>[A-Za-z0-9_]{{1,{NwnResRef.MaxLength}}})""",
             RegexOptions.Compiled | RegexOptions.CultureInvariant);
         private static readonly Regex ExecuteScriptPattern = new(
-            @"\bExecuteScript\s*\(\s*""(?<resref>[A-Za-z0-9_]{1,16})""",
+            $@"\bExecuteScript\s*\(\s*""(?<resref>[A-Za-z0-9_]{{1,{NwnResRef.MaxLength}}})""",
             RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
         private readonly WorkspaceContext _workspaceContext;
@@ -1279,7 +1279,8 @@ namespace SWLOR.Toolset.Services
                 if (!IsValidResRef(renamed))
                 {
                     throw new InvalidOperationException(
-                        $"The new resref for '{asset.FileName}' must be 1-16 ASCII letters, digits, or underscores.");
+                        $"The new resref for '{asset.FileName}' must be 1-{NwnResRef.MaxLength} " +
+                        "ASCII letters, digits, or underscores.");
                 }
 
                 renameMap.Add(ArchiveKey(asset.Extension, asset.ResRef), renamed);
@@ -2297,16 +2298,7 @@ namespace SWLOR.Toolset.Services
         private static bool IsSupportedExtension(string extension) =>
             GffExtensions.Contains(extension) || PlainExtensions.Contains(extension);
 
-        private static bool IsValidResRef(string? value)
-        {
-            if (string.IsNullOrEmpty(value) || value.Length > 16)
-                return false;
-
-            return value.All(character => character is >= 'a' and <= 'z'
-                or >= 'A' and <= 'Z'
-                or >= '0' and <= '9'
-                or '_');
-        }
+        private static bool IsValidResRef(string? value) => NwnResRef.IsValid(value);
 
         private static string DisplayType(string extension)
         {

--- a/SWLOR.Toolset/Shell/Panels/PaletteViewModel.cs
+++ b/SWLOR.Toolset/Shell/Panels/PaletteViewModel.cs
@@ -1093,7 +1093,8 @@ namespace SWLOR.Toolset.Shell.Panels
             var kind = SelectedType.SingularDisplayName();
             var name = await _prompts.PromptForTextAsync(
                 $"New {kind}",
-                "The ResRef is derived from this name: lowercase, no spaces, 16 characters at most - " +
+                $"The ResRef is derived from this name: lowercase, no spaces, " +
+                $"{NwnResRef.MaxLength} characters at most - " +
                 "NWN's own limit.",
                 string.Empty,
                 "Create").ConfigureAwait(true);
@@ -1177,7 +1178,7 @@ namespace SWLOR.Toolset.Shell.Panels
                 else if (character is ' ' or '_' or '-' && builder.Length > 0 && builder[^1] != '_')
                     builder.Append('_');
 
-                if (builder.Length == 16)
+                if (builder.Length == NwnResRef.MaxLength)
                     break;
             }
 

--- a/SWLOR.Toolset/Shell/Panels/PaletteViewModel.cs
+++ b/SWLOR.Toolset/Shell/Panels/PaletteViewModel.cs
@@ -214,9 +214,11 @@ namespace SWLOR.Toolset.Shell.Panels
             OnPropertyChanged(nameof(IsCustomSource));
             OnPropertyChanged(nameof(IsStandardSource));
             OnPropertyChanged(nameof(CanWrite));
+            OnPropertyChanged(nameof(CanEditCopy));
             OnPropertyChanged(nameof(CanCreateBlueprint));
             OnPropertyChanged(nameof(ReadOnlyNotice));
             OnPropertyChanged(nameof(HasReadOnlyNotice));
+            OnPropertyChanged(nameof(HasBlueprintActions));
 
             if (_settings != null && !_restoring)
                 _settings.PaletteShowsStandard = IsStandardSource;
@@ -254,8 +256,23 @@ namespace SWLOR.Toolset.Shell.Panels
         /// </remarks>
         public bool CanWrite => IsCustomSource && IsBlueprintMode && _mutationLock?.IsLocked != true;
 
+        /// <summary>
+        /// Edit Copy writes a new module blueprint but never changes its source, so it is available on
+        /// both Custom and Standard palette entries whenever ordinary module writes are available.
+        /// </summary>
+        public bool CanEditCopy => IsBlueprintMode && _mutationLock?.IsLocked != true;
+
+        /// <summary>Whether a blueprint tile has anything useful to expose through its ellipsis.</summary>
+        public bool HasBlueprintActions => CanWrite || CanEditCopy || HasReadOnlyNotice;
+
         /// <summary>Re-reads <see cref="CanWrite"/>, for when the module-wide lock has flipped.</summary>
-        public void NotifyWriteAvailabilityChanged() => OnPropertyChanged(nameof(CanWrite));
+        public void NotifyWriteAvailabilityChanged()
+        {
+            OnPropertyChanged(nameof(CanWrite));
+            OnPropertyChanged(nameof(CanEditCopy));
+            OnPropertyChanged(nameof(CanCreateBlueprint));
+            OnPropertyChanged(nameof(HasBlueprintActions));
+        }
 
         /// <summary>
         /// Creation is narrower than editing: types whose editor cannot finish a usable resource
@@ -560,9 +577,11 @@ namespace SWLOR.Toolset.Shell.Panels
             OnPropertyChanged(nameof(ShowsSourceSwitch));
             OnPropertyChanged(nameof(ShowsTilePaintSwitch));
             OnPropertyChanged(nameof(CanWrite));
+            OnPropertyChanged(nameof(CanEditCopy));
             OnPropertyChanged(nameof(CanCreateBlueprint));
             OnPropertyChanged(nameof(ReadOnlyNotice));
             OnPropertyChanged(nameof(HasReadOnlyNotice));
+            OnPropertyChanged(nameof(HasBlueprintActions));
             SelectedRow = null;
             SelectedTile = null;
             Refresh();
@@ -717,6 +736,165 @@ namespace SWLOR.Toolset.Shell.Panels
                 return;
 
             _editorService?.Invoke().TryOpenEditor(SelectedType, tile.ResRef);
+        }
+
+        /// <summary>
+        /// Creates an independent custom blueprint from the selected blueprint and opens that copy for
+        /// editing. The source and all instances placed from it remain untouched.
+        /// </summary>
+        [RelayCommand]
+        private void EditCopy(PaletteTileViewModel? tile)
+        {
+            if (tile == null || tile.IsTile || !CanEditCopy)
+                return;
+
+            var workspace = _workspaceContext.Workspace;
+            if (workspace == null)
+                return;
+
+            var sourceSection = tile.Source == PaletteSource.Standard
+                ? _categories.StandardSection(SelectedType)
+                : _categories.Section(SelectedType);
+            var sourceFolder = SourceFolderForCopy(tile, sourceSection);
+            var sourcePath = sourceFolder == null || sourceSection == null
+                ? Array.Empty<string>()
+                : sourceSection.PathTo(sourceFolder).ToArray();
+
+            string copyResRef;
+            string copyPath;
+            try
+            {
+                copyResRef = BlueprintCopyFactory.NextResRef(
+                    tile.ResRef,
+                    workspace.EnumerateResRefs(SelectedType));
+                copyPath = workspace.GetResourcePath(SelectedType, copyResRef);
+
+                var source = tile.Source == PaletteSource.Standard
+                    ? workspace.LoadIndexedBlueprint(SelectedType, tile.ResRef)
+                    : workspace.LoadBlueprint(SelectedType, tile.ResRef);
+                var content = BlueprintCopyFactory.CreateFileContent(
+                    SelectedType,
+                    source.Document,
+                    copyResRef);
+
+                Directory.CreateDirectory(Path.GetDirectoryName(copyPath)!);
+                SaveService.WriteNewAtomic(copyPath, content);
+            }
+            catch (Exception ex)
+            {
+                StatusMessage = $"Could not copy {tile.Name}: {ex.Message}";
+                _log.AppendLine(
+                    $"Edit Copy failed for {SelectedType.Extension()} blueprint '{tile.ResRef}': {ex.Message}");
+                return;
+            }
+
+            _workspaceContext.RefreshCatalogEntry(SelectedType, copyResRef);
+
+            string? targetPathKey = null;
+            var filed = true;
+            if (sourcePath.Length > 0 && _categories.Section(SelectedType) is { } customSection)
+            {
+                var targetFolder = EnsureFolderPath(customSection, sourcePath);
+                targetFolder.AddMember(copyResRef);
+                filed = SaveCategories();
+                if (filed)
+                    targetPathKey = customSection.PathKey(targetFolder);
+            }
+
+            // Edit Copy always lands on the Custom side. Reveal the new entry there before opening its
+            // editor, matching Aurora and making the new blueprint immediately available for placement.
+            if (!IsCustomSource)
+                Source = PaletteSource.Custom;
+            else
+                Refresh();
+
+            RevealCustomCopy(copyResRef, filed ? targetPathKey : null);
+
+            if (filed)
+            {
+                StatusMessage = $"Copied {tile.Name} as {copyResRef}.";
+                _log.AppendLine(
+                    $"Copied {SelectedType.Extension()} blueprint '{tile.ResRef}' to '{copyResRef}' ({copyPath}).");
+            }
+            else
+            {
+                var category = sourcePath.Length == 0 ? "its source category" : sourcePath[^1];
+                StatusMessage =
+                    $"Copied {tile.Name} as {copyResRef}, but it could not be filed under '{category}' - " +
+                    $"it is in Unsorted. {StatusMessage}";
+                _log.AppendLine(
+                    $"Copied {SelectedType.Extension()} blueprint '{tile.ResRef}' to '{copyResRef}', " +
+                    $"but could not file the copy under '{category}'.");
+            }
+
+            _editorService?.Invoke().TryOpenEditor(SelectedType, copyResRef);
+        }
+
+        private CategoryFolder? SourceFolderForCopy(
+            PaletteTileViewModel tile,
+            CategorySection? sourceSection)
+        {
+            if (sourceSection == null)
+                return null;
+
+            var containing = sourceSection.FoldersContaining(tile.ResRef).ToList();
+            if (containing.Count == 0)
+                return null;
+
+            // A parent row includes all descendants. Prefer the leaf below the row whose tile menu was
+            // used; search has no category context, so its stable first filing is the best answer.
+            if (!IsSearching && SelectedRow?.Folder is { } selectedFolder)
+            {
+                var selectedPath = sourceSection.PathTo(selectedFolder);
+                var beneathSelection = containing.FirstOrDefault(folder =>
+                {
+                    var candidatePath = sourceSection.PathTo(folder);
+                    return candidatePath.Count >= selectedPath.Count &&
+                           candidatePath.Take(selectedPath.Count)
+                               .SequenceEqual(selectedPath, StringComparer.OrdinalIgnoreCase);
+                });
+
+                if (beneathSelection != null)
+                    return beneathSelection;
+            }
+
+            return containing[0];
+        }
+
+        /// <summary>Finds or creates the Custom category corresponding to a source category path.</summary>
+        private static CategoryFolder EnsureFolderPath(
+            CategorySection section,
+            IReadOnlyList<string> path)
+        {
+            var current = section.Folders.FirstOrDefault(folder =>
+                              string.Equals(folder.Name, path[0], StringComparison.OrdinalIgnoreCase))
+                          ?? section.AddFolder(path[0]);
+
+            for (var index = 1; index < path.Count; index++)
+            {
+                var segment = path[index];
+                current = current.Children.FirstOrDefault(child =>
+                              string.Equals(child.Name, segment, StringComparison.OrdinalIgnoreCase))
+                          ?? current.AddChild(segment);
+            }
+
+            return current;
+        }
+
+        private void RevealCustomCopy(string copyResRef, string? targetPathKey)
+        {
+            var section = _categories.Section(SelectedType);
+            var targetFolder = targetPathKey == null ? null : section?.FindByPathKey(targetPathKey);
+            var row = targetFolder == null
+                ? _allRows.FirstOrDefault(candidate => candidate.IsUnsorted)
+                : _allRows.FirstOrDefault(candidate => ReferenceEquals(candidate.Folder, targetFolder));
+
+            if (targetFolder != null)
+                ExpandTo(targetFolder);
+
+            SelectedRow = row;
+            SelectedTile = Tiles.FirstOrDefault(tile =>
+                string.Equals(tile.ResRef, copyResRef, StringComparison.OrdinalIgnoreCase));
         }
 
         // ----- context-menu actions -----

--- a/SWLOR.Toolset/Shell/Panels/PaletteViewModel.cs
+++ b/SWLOR.Toolset/Shell/Panels/PaletteViewModel.cs
@@ -765,8 +765,9 @@ namespace SWLOR.Toolset.Shell.Panels
             try
             {
                 copyResRef = BlueprintCopyFactory.NextResRef(
-                    tile.ResRef,
-                    workspace.EnumerateResRefs(SelectedType));
+                    workspace,
+                    SelectedType,
+                    tile.ResRef);
                 copyPath = workspace.GetResourcePath(SelectedType, copyResRef);
 
                 var source = tile.Source == PaletteSource.Standard

--- a/SWLOR.Toolset/Shell/Views/PaletteView.axaml
+++ b/SWLOR.Toolset/Shell/Views/PaletteView.axaml
@@ -264,6 +264,10 @@
                           Command="{Binding $parent[ListBox].((panels:PaletteViewModel)DataContext).EditCommand}"
                           CommandParameter="{Binding}"
                           IsVisible="{Binding $parent[ListBox].((panels:PaletteViewModel)DataContext).CanWrite}" />
+                <MenuItem Header="Edit Copy..."
+                          Command="{Binding $parent[ListBox].((panels:PaletteViewModel)DataContext).EditCopyCommand}"
+                          CommandParameter="{Binding}"
+                          IsVisible="{Binding $parent[ListBox].((panels:PaletteViewModel)DataContext).CanEditCopy}" />
                 <MenuItem Header="Delete blueprint..."
                           Command="{Binding $parent[ListBox].((panels:PaletteViewModel)DataContext).DeleteTileCommand}"
                           CommandParameter="{Binding}"
@@ -292,7 +296,7 @@
                 <Button Classes="link" Content="&#x22EF;" FontSize="15" Padding="7,1"
                         HorizontalAlignment="Right" VerticalAlignment="Top" Margin="0,1,1,0"
                         Click="OnTileMenuButtonClick"
-                        IsVisible="{Binding $parent[ListBox].((panels:PaletteViewModel)DataContext).CanWrite}"
+                        IsVisible="{Binding $parent[ListBox].((panels:PaletteViewModel)DataContext).HasBlueprintActions}"
                         ToolTip.Tip="Actions for this blueprint" />
               </Panel>
 


### PR DESCRIPTION
## Summary
- add Aurora-style **Edit Copy** beside Edit in blueprint palette and placed-object context menus
- support all eight blueprint resource types, including Standard-to-Custom copies
- preserve authored fields and category placement while assigning collision-safe numbered ResRefs across module and Standard/HAK layers
- leave existing placed instances linked to their original blueprint and honor the module mutation lock
- refresh open palettes after viewport-created Unsorted copies and disable the action for unresolved sources

## Validation
- `dotnet build SWLOR.Toolset.Tests/SWLOR.Toolset.Tests.csproj -p:RunPostBuildEvent=Never --artifacts-path .codex-build/artifacts`
- 104 relevant Toolset tests passed; 1 unrelated palette fixture skipped
- Codex follow-up review found no major issues on commit `510a7f0003`

A broad substring-based palette run also selected resource-dependent `TilePaletteCorpusTests`; seven existing corpus checks fail in this worktree because its resource index lacks the expected `shp02`/`tmi` and complete `sw_t_*` tileset corpus.