### PR TITLE
Add beast egg spawn command

### DIFF
--- a/SWLOR.Game.Server.Tests/Feature/DMChatCommandTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/DMChatCommandTests.cs
@@ -24,6 +24,48 @@ public class DMChatCommandTests
     }
 
     [Test]
+    public void SpawnBeastEgg_AllowsStaffAndTestUsersToCreateTypedEggs()
+    {
+        var commands = new DMChatCommand().BuildChatCommands();
+
+        commands.Should().ContainKey("spawnegg");
+
+        var command = commands["spawnegg"];
+        command.Authorization.Should().Be(AuthorizationLevel.DM | AuthorizationLevel.Admin);
+        command.AvailableToAllOnTestEnvironment.Should().BeTrue();
+        command.RequiresTarget.Should().BeFalse();
+        command.Description.Should().Contain("/spawnegg help");
+        command.ValidateArguments.Should().NotBeNull();
+        command.DoAction.Should().NotBeNull();
+        command.ValidateArguments(0, "help").Should().BeEmpty();
+    }
+
+    [Test]
+    public void SpawnBeastEgg_HelpListsConfiguredTypesAndEggsReceiveTheDNATypeProperty()
+    {
+        var root = FindRepositoryRoot();
+        var dmChatCommandSource = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "SWLOR.Game.Server",
+            "Feature",
+            "ChatCommandDefinition",
+            "DMChatCommand.cs"));
+        var beastMasterySource = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "SWLOR.Game.Server",
+            "Service",
+            "BeastMastery.cs"));
+
+        dmChatCommandSource.Should().Contain("BeastMastery.GetAllBeastTypes()")
+            .And.Contain("Usage: /spawnegg <beast type>")
+            .And.Contain("[NWNEventHandler(ScriptName.OnModuleCacheAfter)]")
+            .And.Contain("_spawnBeastEggHelpMessages = messages.ToArray()")
+            .And.Contain("foreach (var message in _spawnBeastEggHelpMessages)")
+            .And.Contain("BeastMastery.CreateBeastEgg(beastType, user)");
+        beastMasterySource.Should().Contain("ItemPropertyCustom(ItemPropertyType.DNAType, (int)beastType)");
+    }
+
+    [Test]
     public void LocationTargeting_IsOptInForChatCommands()
     {
         var root = FindRepositoryRoot();

--- a/SWLOR.Game.Server/Feature/ChatCommandDefinition/DMChatCommand.cs
+++ b/SWLOR.Game.Server/Feature/ChatCommandDefinition/DMChatCommand.cs
@@ -5,6 +5,7 @@ using SWLOR.Game.Server.Entity;
 using SWLOR.Game.Server.Enumeration;
 using SWLOR.Game.Server.Feature.GuiDefinition.RefreshEvent;
 using SWLOR.Game.Server.Service;
+using SWLOR.Game.Server.Service.BeastMasteryService;
 using SWLOR.Game.Server.Service.GuiService;
 using SWLOR.Game.Server.Service.ChatCommandService;
 using SWLOR.Game.Server.Service.FactionService;
@@ -13,6 +14,7 @@ using SWLOR.Game.Server.Service.QuestService;
 using SWLOR.Game.Server.Service.LogService;
 using Faction = SWLOR.Game.Server.Service.Faction;
 using ChatChannel = SWLOR.Game.Server.Core.NWNX.Enum.ChatChannel;
+using SWLOR.NWN.API.Engine;
 using SWLOR.NWN.API.NWNX;
 using SWLOR.NWN.API.NWScript;
 using SWLOR.NWN.API.NWScript.Enum;
@@ -24,6 +26,9 @@ namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
     {
         private readonly ChatCommandBuilder _builder = new ChatCommandBuilder();
         private static readonly ApplicationSettings _appSettings = ApplicationSettings.Get();
+        private static string[] _spawnBeastEggHelpMessages = Array.Empty<string>();
+
+        private const int SpawnEggTypesPerHelpMessage = 20;
 
         public Dictionary<string, ChatCommandDetail> BuildChatCommands()
         {
@@ -40,6 +45,7 @@ namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
             SetLocalVariable();
             SetPortrait();
             SpawnItem();
+            SpawnBeastEgg();
             GiveRPXP();
             ResetPerkCooldown();
             PlayVFX();
@@ -64,6 +70,26 @@ namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
             UnlockCapstoneQuests();
 
             return _builder.Build();
+        }
+
+        [NWNEventHandler(ScriptName.OnModuleCacheAfter)]
+        public static void CacheSpawnBeastEggHelp()
+        {
+            var beastTypes = BeastMastery.GetAllBeastTypes()
+                .OrderBy(type => type.ToString())
+                .ToArray();
+            var messages = new List<string>
+            {
+                "Usage: /spawnegg <beast type>",
+                "Available beast types:"
+            };
+
+            for (var index = 0; index < beastTypes.Length; index += SpawnEggTypesPerHelpMessage)
+            {
+                messages.Add(string.Join(", ", beastTypes.Skip(index).Take(SpawnEggTypesPerHelpMessage)));
+            }
+
+            _spawnBeastEggHelpMessages = messages.ToArray();
         }
 
         private void UnlockCapstoneQuests()
@@ -637,6 +663,50 @@ namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
                     }
 
                     SetIdentified(item, true);
+                });
+        }
+
+        private void SpawnBeastEgg()
+        {
+            _builder.Create("spawnegg")
+                .Description("Spawns a beast egg by beast type. Use /spawnegg help to list available types.")
+                .Permissions(AuthorizationLevel.DM, AuthorizationLevel.Admin)
+                .AvailableToAllOnTestEnvironment()
+                .Validate((user, args) =>
+                {
+                    if (args.Length <= 0)
+                    {
+                        return ColorToken.Red("Please specify a beast type. Use /spawnegg help to list available types.");
+                    }
+
+                    if (args[0].Equals("help", StringComparison.OrdinalIgnoreCase))
+                        return string.Empty;
+
+                    if (!Enum.TryParse(args[0], true, out BeastType beastType) ||
+                        !BeastMastery.GetAllBeastTypes().Contains(beastType))
+                    {
+                        return ColorToken.Red($"Unknown beast type '{args[0]}'. Use /spawnegg help to list available types.");
+                    }
+
+                    return string.Empty;
+                })
+                .Action((user, target, location, args) =>
+                {
+                    if (args[0].Equals("help", StringComparison.OrdinalIgnoreCase))
+                    {
+                        foreach (var message in _spawnBeastEggHelpMessages)
+                        {
+                            SendMessageToPC(user, message);
+                        }
+
+                        return;
+                    }
+
+                    Enum.TryParse(args[0], true, out BeastType beastType);
+                    var egg = BeastMastery.CreateBeastEgg(beastType, user);
+                    var beastDetail = BeastMastery.GetBeastDetail(beastType);
+
+                    SendMessageToPC(user, $"Spawned '{GetName(egg)}' for beast type {beastType} ({beastDetail.Name}).");
                 });
         }
 

--- a/SWLOR.Game.Server/Service/BeastMastery.cs
+++ b/SWLOR.Game.Server/Service/BeastMastery.cs
@@ -793,8 +793,6 @@ namespace SWLOR.Game.Server.Service
 
         public static void CreateBeastEgg(IncubationJob job, uint player)
         {
-            var egg = CreateItemOnObject(BeastEggResref, player);
-
             var mutation = DetermineMutation(job.BeastDNAType, job);
             var beastType = mutation == BeastType.Invalid ? job.BeastDNAType : mutation;
 
@@ -805,10 +803,9 @@ namespace SWLOR.Game.Server.Service
                 IncubationFieldNote.GrantDiscoveredNote(player, mutation);
             }
 
+            var egg = CreateBeastEgg(beastType, player);
             var itemProperties = new List<ItemProperty>
             {
-                ItemPropertyCustom(ItemPropertyType.DNAType, (int)beastType),
-
                 ItemPropertyCustom(ItemPropertyType.Incubation, (int)IncubationStatType.AttackPurity, job.AttackPurity),
                 ItemPropertyCustom(ItemPropertyType.Incubation, (int)IncubationStatType.AccuracyPurity, job.AccuracyPurity),
                 ItemPropertyCustom(ItemPropertyType.Incubation, (int)IncubationStatType.EvasionPurity, job.EvasionPurity),
@@ -838,13 +835,22 @@ namespace SWLOR.Game.Server.Service
                 BiowareXP2.IPSafeAddItemProperty(egg, ip, 0f, AddItemPropertyPolicy.ReplaceExisting, false, false);
             }
 
-            var beastDetail = GetBeastDetail(beastType);
-            SetName(egg, $"Beast Egg: {beastDetail.Name}");
-
             var addGoldPiece = CalculateEggVendorBonus(job);
             ItemPlugin.SetAddGoldPieceValue(egg, addGoldPiece);
 
             DB.Delete<IncubationJob>(job.Id);
+        }
+
+        public static uint CreateBeastEgg(BeastType beastType, uint player)
+        {
+            var egg = CreateItemOnObject(BeastEggResref, player);
+            var dnaType = ItemPropertyCustom(ItemPropertyType.DNAType, (int)beastType);
+            BiowareXP2.IPSafeAddItemProperty(egg, dnaType, 0f, AddItemPropertyPolicy.ReplaceExisting, false, false);
+
+            var beastDetail = GetBeastDetail(beastType);
+            SetName(egg, $"Beast Egg: {beastDetail.Name}");
+
+            return egg;
         }
 
         private static int CalculateEggVendorBonus(IncubationJob job)


### PR DESCRIPTION
## Summary
- add `/spawnegg <beast type>` for DMs/Admins and all users on test servers
- add `/spawnegg help` with startup-cached output from configured beast definitions
- share typed beast egg creation between the command and normal incubation

## Verification
- `dotnet build SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj --no-restore -p:RunPostBuildEvent=Never`
- `dotnet test SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj --no-build --filter "FullyQualifiedName~DMChatCommandTests|FullyQualifiedName~BeastmasterCombatUpgradeTests"` (12 passed)