### PR TITLE
Add cross-system achievement expansion

### DIFF
--- a/SWLOR.Game.Server.Tests/Service/AchievementExpansionTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/AchievementExpansionTests.cs
@@ -1,0 +1,146 @@
+using System.Reflection;
+using FluentAssertions;
+using NUnit.Framework;
+using SWLOR.Game.Server.Entity;
+using SWLOR.Game.Server.Enumeration;
+using SWLOR.Game.Server.Service.AchievementService;
+using SWLOR.Game.Server.Service.DroidService;
+using SWLOR.Game.Server.Service.FishingService;
+using SWLOR.Game.Server.Service.SkillService;
+using SWLOR.Game.Server.Service.SpaceService;
+using SWLOR.Game.Server.Service.TaxiService;
+using Player = SWLOR.Game.Server.Entity.Player;
+
+namespace SWLOR.Game.Server.Tests.Service;
+
+public sealed class AchievementExpansionTests
+{
+    [Test]
+    public void NewAchievements_AreActiveAndUseConsecutiveStableIds()
+    {
+        var achievements = Enum.GetValues<AchievementType>()
+            .Where(type => (int)type is >= 181 and <= 210)
+            .ToArray();
+
+        achievements.Select(type => (int)type).Should().Equal(Enumerable.Range(181, 30));
+        achievements.Should().HaveCount(30);
+
+        foreach (var achievement in achievements)
+        {
+            var detail = typeof(AchievementType)
+                .GetMember(achievement.ToString())
+                .Single()
+                .GetCustomAttribute<AchievementAttribute>();
+
+            detail.Should().NotBeNull();
+            detail!.IsActive.Should().BeTrue();
+            detail.Name.Should().NotBeNullOrWhiteSpace();
+            detail.Description.Should().NotBeNullOrWhiteSpace();
+        }
+    }
+
+    [TestCase(FishingLocationType.ViscaraLake, PlanetType.Viscara)]
+    [TestCase(FishingLocationType.MonCalaDacCitySurface, PlanetType.MonCala)]
+    [TestCase(FishingLocationType.HutlarQionTundra, PlanetType.Hutlar)]
+    [TestCase(FishingLocationType.TatooineBabySarlaccCave, PlanetType.Tatooine)]
+    [TestCase(FishingLocationType.DathomirGrottos, PlanetType.Dathomir)]
+    [TestCase(FishingLocationType.DantooineLake, PlanetType.Dantooine)]
+    [TestCase(FishingLocationType.Invalid, PlanetType.Invalid)]
+    public void FishingLocations_MapToTheirPlanets(FishingLocationType location, PlanetType expected)
+    {
+        AchievementTracking.GetFishingPlanet(location).Should().Be(expected);
+    }
+
+    [Test]
+    public void FullyOperational_RequiresEveryDroidPartAndAnActiveInstruction()
+    {
+        var droid = new ConstructedDroid
+        {
+            SerializedCPU = "cpu",
+            SerializedHead = "head",
+            SerializedBody = "body",
+            SerializedArms = "arms",
+            SerializedLegs = "legs",
+            ActivePerks = { new DroidPerk() }
+        };
+
+        AchievementTracking.IsFullyOperational(droid).Should().BeTrue();
+        droid.SerializedArms = string.Empty;
+        AchievementTracking.IsFullyOperational(droid).Should().BeFalse();
+    }
+
+    [Test]
+    public void CompleteModuleSet_RequiresAllThreePowerCategories()
+    {
+        var status = new ShipStatus();
+        status.HighPowerModules[1] = new ShipStatus.ShipStatusModule();
+        status.LowPowerModules[1] = new ShipStatus.ShipStatusModule();
+
+        AchievementTracking.HasCompleteModuleSet(status).Should().BeFalse();
+
+        status.ConfigurationModules[1] = new ShipStatus.ShipStatusModule();
+        AchievementTracking.HasCompleteModuleSet(status).Should().BeTrue();
+    }
+
+    [TestCase(100, 10, true)]
+    [TestCase(100, 11, false)]
+    [TestCase(0, 0, false)]
+    public void LowHull_UsesTenPercentInclusive(int maximum, int current, bool expected)
+    {
+        AchievementTracking.IsLowHull(new ShipStatus { MaxHull = maximum, Hull = current })
+            .Should().Be(expected);
+    }
+
+    [TestCase(30, 30, 24, true)]
+    [TestCase(30, 29, 23, false)]
+    [TestCase(30, 30, 30, false)]
+    [TestCase(30, 40, 30, false)]
+    public void GuardAchievement_RequiresGuardToChangeALethalHitIntoSurvival(
+        int hitPoints,
+        int incomingDamage,
+        int adjustedDamage,
+        bool expected)
+    {
+        AchievementTracking.GuardPreventedLethalHit(hitPoints, incomingDamage, adjustedDamage)
+            .Should().Be(expected);
+    }
+
+    [Test]
+    public void LocalKnowledge_RequiresEveryTaxiDestination()
+    {
+        var player = new Player();
+        player.TaxiDestinations[1] = Enum.GetValues<TaxiDestinationType>()
+            .Where(type => type != TaxiDestinationType.Invalid)
+            .ToList();
+
+        AchievementTracking.HasAllTaxiDestinations(player).Should().BeTrue();
+        player.TaxiDestinations[1].Remove(TaxiDestinationType.DantooineMedical);
+        AchievementTracking.HasAllTaxiDestinations(player).Should().BeFalse();
+    }
+
+    [Test]
+    public void GuildBreadth_RequiresRankOneInEveryActiveGuild()
+    {
+        var player = new Player();
+        foreach (var guild in Enum.GetValues<GuildType>().Where(type => type != GuildType.Invalid))
+            player.Guilds[guild] = new PlayerGuild { Rank = 1 };
+
+        AchievementTracking.HasGuildBreadth(player).Should().BeTrue();
+        player.Guilds[GuildType.AgricultureGuild].Rank = 0;
+        AchievementTracking.HasGuildBreadth(player).Should().BeFalse();
+    }
+
+    [Test]
+    public void Polyglot_RequiresThreeNonBasicLanguagesAtRankTwenty()
+    {
+        var player = new Player();
+        player.Skills[SkillType.Basic] = new PlayerSkill { Rank = 20 };
+        player.Skills[SkillType.Bothese] = new PlayerSkill { Rank = 20 };
+        player.Skills[SkillType.Cheunh] = new PlayerSkill { Rank = 20 };
+        player.Skills[SkillType.Dosh] = new PlayerSkill { Rank = 19 };
+
+        AchievementTracking.HasThreeMasteredLanguages(player).Should().BeFalse();
+        player.Skills[SkillType.Dosh].Rank = 20;
+        AchievementTracking.HasThreeMasteredLanguages(player).Should().BeTrue();
+    }
+}

--- a/SWLOR.Game.Server.Tests/Service/AchievementTrackingTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/AchievementTrackingTests.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using FluentAssertions;
 using NUnit.Framework;
 using SWLOR.Game.Server.Entity;
@@ -13,32 +12,8 @@ using Player = SWLOR.Game.Server.Entity.Player;
 
 namespace SWLOR.Game.Server.Tests.Service;
 
-public sealed class AchievementExpansionTests
+public sealed class AchievementTrackingTests
 {
-    [Test]
-    public void NewAchievements_AreActiveAndUseConsecutiveStableIds()
-    {
-        var achievements = Enum.GetValues<AchievementType>()
-            .Where(type => (int)type is >= 181 and <= 210)
-            .ToArray();
-
-        achievements.Select(type => (int)type).Should().Equal(Enumerable.Range(181, 30));
-        achievements.Should().HaveCount(30);
-
-        foreach (var achievement in achievements)
-        {
-            var detail = typeof(AchievementType)
-                .GetMember(achievement.ToString())
-                .Single()
-                .GetCustomAttribute<AchievementAttribute>();
-
-            detail.Should().NotBeNull();
-            detail!.IsActive.Should().BeTrue();
-            detail.Name.Should().NotBeNullOrWhiteSpace();
-            detail.Description.Should().NotBeNullOrWhiteSpace();
-        }
-    }
-
     [TestCase(FishingLocationType.ViscaraLake, PlanetType.Viscara)]
     [TestCase(FishingLocationType.MonCalaDacCitySurface, PlanetType.MonCala)]
     [TestCase(FishingLocationType.HutlarQionTundra, PlanetType.Hutlar)]

--- a/SWLOR.Game.Server.Tests/Service/AchievementTrackingTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/AchievementTrackingTests.cs
@@ -14,6 +14,22 @@ namespace SWLOR.Game.Server.Tests.Service;
 
 public sealed class AchievementTrackingTests
 {
+    [Test]
+    public void PublicPropertyVisits_RequireAVisitorFromAnotherAccount()
+    {
+        new Player().PendingPublicPropertyVisitorAccountIds.Should().BeEmpty();
+
+        AchievementTracking.HasDifferentAccountVisitor(
+                new[] { "owner-account", "owner-account" },
+                "owner-account")
+            .Should().BeFalse();
+
+        AchievementTracking.HasDifferentAccountVisitor(
+                new[] { "owner-account", "visitor-account" },
+                "owner-account")
+            .Should().BeTrue();
+    }
+
     [TestCase(FishingLocationType.ViscaraLake, PlanetType.Viscara)]
     [TestCase(FishingLocationType.MonCalaDacCitySurface, PlanetType.MonCala)]
     [TestCase(FishingLocationType.HutlarQionTundra, PlanetType.Hutlar)]

--- a/SWLOR.Game.Server.Tests/Service/AchievementTypeTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/AchievementTypeTests.cs
@@ -1,0 +1,33 @@
+using System.Reflection;
+using FluentAssertions;
+using NUnit.Framework;
+using SWLOR.Game.Server.Service.AchievementService;
+
+namespace SWLOR.Game.Server.Tests.Service;
+
+public sealed class AchievementTypeTests
+{
+    [Test]
+    public void AchievementDefinitions_181Through210_AreActiveAndUseConsecutiveStableIds()
+    {
+        var achievements = Enum.GetValues<AchievementType>()
+            .Where(type => (int)type is >= 181 and <= 210)
+            .ToArray();
+
+        achievements.Select(type => (int)type).Should().Equal(Enumerable.Range(181, 30));
+        achievements.Should().HaveCount(30);
+
+        foreach (var achievement in achievements)
+        {
+            var detail = typeof(AchievementType)
+                .GetMember(achievement.ToString())
+                .Single()
+                .GetCustomAttribute<AchievementAttribute>();
+
+            detail.Should().NotBeNull();
+            detail!.IsActive.Should().BeTrue();
+            detail.Name.Should().NotBeNullOrWhiteSpace();
+            detail.Description.Should().NotBeNullOrWhiteSpace();
+        }
+    }
+}

--- a/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
@@ -619,8 +619,8 @@ public class CombatDamageTests
         var combatSource = File.ReadAllText(Path.Combine(root.FullName, "SWLOR.Game.Server", "Service", "Combat.cs"));
         var damageRollSource = File.ReadAllText(Path.Combine(root.FullName, "SWLOR.Game.Server", "Native", "GetDamageRoll.cs"));
 
-        combatSource.Should().Contain("bool isLandedAttack)");
         var guard = ExtractMethod(combatSource, "public static int ApplyGuardedHitModifiers(");
+        guard.Should().Contain("out GuardedHitOutcome guardedHitOutcome");
         guard.Should().Contain("!isLandedAttack");
         guard.Should().Contain("!GetIsObjectValid(attacker)");
         guard.Should().Contain("defender == attacker");
@@ -630,6 +630,10 @@ public class CombatDamageTests
         guard.IndexOf("!isLandedAttack", StringComparison.Ordinal).Should().BeLessThan(
             guard.IndexOf("var guardChance", StringComparison.Ordinal),
             "discarded swings must never enter the Guard roll");
+        guard.Should().NotContain("Achievement.GiveAchievement");
+        var evaluateGuardOutcome = ExtractMethod(combatSource, "public static void EvaluateGuardedHitOutcome(");
+        evaluateGuardOutcome.Should().Contain("guardedHitOutcome.DamageWithoutGuard");
+        evaluateGuardOutcome.Should().Contain("AchievementType.BehindMe");
         var hostileSource = ExtractMethod(combatSource, "internal static bool IsHostileAttackSource(");
         hostileSource.Should().Contain("GetIsPC(attacker)");
         hostileSource.Should().Contain("GetIsDM(attacker)");
@@ -641,7 +645,19 @@ public class CombatDamageTests
         damageRollSource.Should().Contain("private static bool IsLandedAttackOnDamageableTarget(");
         damageRollSource.Should().Contain("targetObject.m_bPlotObject == 1");
         damageRollSource.Should().Contain("ResolveAttackRoll.IsSuccessfulAttackResult(attackData.m_nAttackResult)");
-        damageRollSource.Should().Contain("isLandedAttack);");
+        damageRollSource.Should().Contain("out var guardedHitOutcome");
+        damageRollSource.Should().Contain("guardedHitOutcome: guardedHitOutcome");
+        var guardedHitIndex = damageRollSource.IndexOf(
+            "damage = Combat.ApplyGuardedHitModifiers(",
+            StringComparison.Ordinal);
+        var damageTakenIndex = damageRollSource.IndexOf(
+            "damage = Combat.ApplyDamageTakenModifiers(",
+            StringComparison.Ordinal);
+        var guardOutcomeIndex = damageRollSource.IndexOf(
+            "Combat.EvaluateGuardedHitOutcome(target.m_idSelf, guardedHitOutcome, damage);",
+            StringComparison.Ordinal);
+        damageTakenIndex.Should().BeGreaterThan(guardedHitIndex);
+        guardOutcomeIndex.Should().BeGreaterThan(damageTakenIndex);
     }
 
     [Test]

--- a/SWLOR.Game.Server/Entity/Account.cs
+++ b/SWLOR.Game.Server/Entity/Account.cs
@@ -35,10 +35,18 @@ namespace SWLOR.Game.Server.Entity
 
     public class AchievementProgress
     {
+        public AchievementProgress()
+        {
+            SlicingSourcesCompleted = new HashSet<int>();
+            FishingPlanetsCaught = new HashSet<int>();
+        }
+
         public ulong EnemiesKilled { get; set; }
         public ulong PerksLearned { get; set; }
         public ulong SkillsLearned { get; set; }
         public ulong QuestsCompleted { get; set; }
         public ulong ItemsCrafted { get; set; }
+        public HashSet<int> SlicingSourcesCompleted { get; set; }
+        public HashSet<int> FishingPlanetsCaught { get; set; }
     }
 }

--- a/SWLOR.Game.Server/Entity/Player.cs
+++ b/SWLOR.Game.Server/Entity/Player.cs
@@ -81,6 +81,7 @@ namespace SWLOR.Game.Server.Entity
             CraftedRecipes = new Dictionary<RecipeType, DateTime>();
             LearnedTechniques = new Dictionary<FeatType, DateTime>();
             PendingAchievements = new HashSet<int>();
+            PendingPublicPropertyVisitorAccountIds = new HashSet<string>();
             EquippedTechniques = new List<FeatType>();
             CharacterType = CharacterType.Invalid;
             KeyItems = new Dictionary<KeyItemType, DateTime>();
@@ -197,6 +198,7 @@ namespace SWLOR.Game.Server.Entity
         public Dictionary<RecipeType, DateTime> CraftedRecipes { get; set; }
         public Dictionary<FeatType, DateTime> LearnedTechniques { get; set; }
         public HashSet<int> PendingAchievements { get; set; }
+        public HashSet<string> PendingPublicPropertyVisitorAccountIds { get; set; }
         public List<FeatType> EquippedTechniques { get; set; }
         public Dictionary<KeyItemType, DateTime> KeyItems{ get; set; }
         public Dictionary<GuildType, PlayerGuild> Guilds { get; set; }

--- a/SWLOR.Game.Server/Entity/Player.cs
+++ b/SWLOR.Game.Server/Entity/Player.cs
@@ -63,6 +63,7 @@ namespace SWLOR.Game.Server.Entity
             Resistances = Resistance.CreateDefaultResistanceValues();
 
             ActiveShipId = Guid.Empty.ToString();
+            AccountId = string.Empty;
             UnknownDisplayName = string.Empty;
             IsUsingDualPistolMode = false;
             EmoteStyle = EmoteStyle.Regular;
@@ -79,6 +80,7 @@ namespace SWLOR.Game.Server.Entity
             UnlockedRecipes = new Dictionary<RecipeType, DateTime>();
             CraftedRecipes = new Dictionary<RecipeType, DateTime>();
             LearnedTechniques = new Dictionary<FeatType, DateTime>();
+            PendingAchievements = new HashSet<int>();
             EquippedTechniques = new List<FeatType>();
             CharacterType = CharacterType.Invalid;
             KeyItems = new Dictionary<KeyItemType, DateTime>();
@@ -106,6 +108,7 @@ namespace SWLOR.Game.Server.Entity
         public int Version { get; set; }
         [Indexed]
         public string Name { get; set; }
+        public string AccountId { get; set; }
         public int MaxHP { get; set; }
         public int MaxFP { get; set; }
         public int MaxStamina { get; set; }
@@ -193,6 +196,7 @@ namespace SWLOR.Game.Server.Entity
         public Dictionary<RecipeType, DateTime> UnlockedRecipes { get; set; }
         public Dictionary<RecipeType, DateTime> CraftedRecipes { get; set; }
         public Dictionary<FeatType, DateTime> LearnedTechniques { get; set; }
+        public HashSet<int> PendingAchievements { get; set; }
         public List<FeatType> EquippedTechniques { get; set; }
         public Dictionary<KeyItemType, DateTime> KeyItems{ get; set; }
         public Dictionary<GuildType, PlayerGuild> Guilds { get; set; }

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Beastmaster/TameAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Beastmaster/TameAbilityDefinition.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using SWLOR.Game.Server.Entity;
 using SWLOR.Game.Server.Service;
 using SWLOR.Game.Server.Service.AbilityService;
+using SWLOR.Game.Server.Service.AchievementService;
 using SWLOR.Game.Server.Service.BeastMasteryService;
 using SWLOR.Game.Server.Service.CombatService;
 using SWLOR.Game.Server.Service.DBService;
@@ -140,6 +141,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Beastmaster
 
                     dbPlayer.ActiveBeastId = dbBeast.Id;
                     DB.Set(dbPlayer);
+                    Achievement.GiveAchievement(activator, AchievementType.ANewBond);
 
                     SendMessageToPC(activator, ColorToken.Green($"Successfully tamed {GetName(target)}!"));
                     DestroyObject(target);

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/FirstAid/ResuscitationAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/FirstAid/ResuscitationAbilityDefinition.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using SWLOR.Game.Server.Feature.AbilityDefinition;
 using SWLOR.Game.Server.Feature.StatusEffectDefinition;
 using SWLOR.Game.Server.Service;
+using SWLOR.Game.Server.Service.AchievementService;
 using SWLOR.Game.Server.Service.AbilityService;
 using SWLOR.Game.Server.Service.CombatService;
 using SWLOR.Game.Server.Service.PerkService;
@@ -76,6 +77,8 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.FirstAid
                 return;
 
             ApplyEffectToObject(DurationType.Instant, EffectResurrection(), target);
+            if (activator != target && GetIsPC(target) && !GetIsDM(target))
+                Achievement.GiveAchievement(activator, AchievementType.NotOnMyWatch);
             FirstAidTreatmentAdjustments.ApplyTraumaMedicRiders(activator, target);
             DelayCommand(0.1f, () => Ability.ReapplyAuraEffectsForCreature(target));
             ApplyEffectToObject(DurationType.Instant, EffectVisualEffect(VisualEffect.Vfx_Imp_Raise_Dead), target);
@@ -88,6 +91,8 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.FirstAid
                 return;
 
             ApplyEffectToObject(DurationType.Instant, EffectResurrection(), target);
+            if (activator != target && GetIsPC(target) && !GetIsDM(target))
+                Achievement.GiveAchievement(activator, AchievementType.NotOnMyWatch);
             FirstAidTreatmentAdjustments.ApplyTraumaMedicRiders(activator, target);
             // Resurrection is not settled until after the current engine command finishes.
             // Healing in the same tick is silently discarded because the target is still dead.

--- a/SWLOR.Game.Server/Feature/AchievementProgression.cs
+++ b/SWLOR.Game.Server/Feature/AchievementProgression.cs
@@ -162,6 +162,10 @@ namespace SWLOR.Game.Server.Feature
             {
                 Achievement.GiveAchievement(player, AchievementType.GainSkills6);
             }
+
+            var dbPlayer = DB.Get<Player>(GetObjectUUID(player));
+            if (AchievementTracking.HasThreeMasteredLanguages(dbPlayer))
+                Achievement.GiveAchievement(player, AchievementType.Polyglot);
         }
 
         /// <summary>
@@ -221,6 +225,9 @@ namespace SWLOR.Game.Server.Feature
             {
                 Achievement.GiveAchievement(player, AchievementType.CompleteQuests10);
             }
+
+            if (AchievementTracking.HasEligiblePartyMember(player))
+                Achievement.GiveAchievement(player, AchievementType.StrongerTogether);
         }
 
         /// <summary>

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/CraftViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/CraftViewModel.cs
@@ -5,6 +5,7 @@ using SWLOR.Game.Server.Entity;
 using SWLOR.Game.Server.Feature.GuiDefinition.Payload;
 using SWLOR.Game.Server.Feature.GuiDefinition.RefreshEvent;
 using SWLOR.Game.Server.Service;
+using SWLOR.Game.Server.Service.AchievementService;
 using SWLOR.Game.Server.Service.CombatService;
 using SWLOR.Game.Server.Service.CraftService;
 using SWLOR.Game.Server.Service.GuiService;
@@ -1438,6 +1439,9 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
                 dbPlayer.CraftedRecipes[_recipe] = DateTime.UtcNow;
                 DB.Set(dbPlayer);
             }
+
+            if (AchievementTracking.HasCraftedAllDisciplines(dbPlayer))
+                Achievement.GiveAchievement(Player, AchievementType.RenaissanceCrafter);
 
             // Give XP plus a percent bonus based on the quality achieved.
             var xp = CalculateXP(

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/MarketBuyViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/MarketBuyViewModel.cs
@@ -3,6 +3,7 @@ using SWLOR.Game.Server.Core;
 using SWLOR.Game.Server.Entity;
 using SWLOR.Game.Server.Feature.GuiDefinition.Payload;
 using SWLOR.Game.Server.Service;
+using SWLOR.Game.Server.Service.AchievementService;
 using SWLOR.Game.Server.Service.DBService;
 using SWLOR.Game.Server.Service.GuiService;
 using SWLOR.Game.Server.Service.GuiService.Component;
@@ -332,6 +333,12 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
                 var proceeds = (int)(price - (price * market.TaxRate));
                 dbSeller.MarketTill += proceeds;
                 DB.Set(dbSeller);
+
+                if (!string.IsNullOrWhiteSpace(dbItem.SellerCDKey))
+                {
+                    Achievement.GiveAchievement(Player, AchievementType.CreditsWillDoFine);
+                    Achievement.GiveAchievementByAccountId(dbItem.SellerCDKey, AchievementType.AFairDeal);
+                }
             });
         };
 

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/ResearchViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/ResearchViewModel.cs
@@ -4,6 +4,7 @@ using SWLOR.Game.Server.Core.Bioware;
 using SWLOR.Game.Server.Entity;
 using SWLOR.Game.Server.Feature.GuiDefinition.Payload;
 using SWLOR.Game.Server.Service;
+using SWLOR.Game.Server.Service.AchievementService;
 using SWLOR.Game.Server.Service.CombatService;
 using SWLOR.Game.Server.Service.CraftService;
 using SWLOR.Game.Server.Service.DBService;
@@ -543,6 +544,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             Gui.TogglePlayerWindow(Player, GuiWindowType.Research);
 
             DB.Delete<ResearchJob>(dbJob.Id);
+            Achievement.GiveAchievement(Player, AchievementType.FirstPrinciples);
         };
     }
 }

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/ShipManagementViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/ShipManagementViewModel.cs
@@ -4,6 +4,7 @@ using SWLOR.Game.Server.Entity;
 using SWLOR.Game.Server.Enumeration;
 using SWLOR.Game.Server.Feature.GuiDefinition.Payload;
 using SWLOR.Game.Server.Service;
+using SWLOR.Game.Server.Service.AchievementService;
 using SWLOR.Game.Server.Service.DBService;
 using SWLOR.Game.Server.Service.GuiService;
 using SWLOR.Game.Server.Service.PropertyService;
@@ -1382,6 +1383,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
                     }
                 };
                 DB.Set(ship);
+                Achievement.GiveAchievement(Player, AchievementType.ClearForDeparture);
 
                 // Update the UI with the new ship details.
                 ShipCountRegistered = $"Ships: {dbPlayerShips.Count + 1} / {Space.MaxRegisteredShips}";
@@ -1574,6 +1576,8 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
                     moduleDetails.ModuleEquippedAction?.Invoke(dbShip.Status, moduleBonus);
 
                     DB.Set(dbShip);
+                    if (AchievementTracking.HasCompleteModuleSet(dbShip.Status))
+                        Achievement.GiveAchievement(Player, AchievementType.AllSystemsGreen);
 
                     DestroyObject(item);
                     LoadShip();
@@ -1645,6 +1649,8 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
                     moduleDetails.ModuleEquippedAction?.Invoke(dbShip.Status, moduleBonus);
 
                     DB.Set(dbShip);
+                    if (AchievementTracking.HasCompleteModuleSet(dbShip.Status))
+                        Achievement.GiveAchievement(Player, AchievementType.AllSystemsGreen);
 
                     DestroyObject(item);
                     LoadShip();
@@ -1715,6 +1721,8 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
                         moduleDetails.ModuleEquippedAction?.Invoke(dbShip.Status, moduleBonus);
 
                         DB.Set(dbShip);
+                        if (AchievementTracking.HasCompleteModuleSet(dbShip.Status))
+                            Achievement.GiveAchievement(Player, AchievementType.AllSystemsGreen);
 
                         DestroyObject(item);
                         LoadShip();

--- a/SWLOR.Game.Server/Feature/ItemDefinition/BeastEggItemDefinition.cs
+++ b/SWLOR.Game.Server/Feature/ItemDefinition/BeastEggItemDefinition.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using SWLOR.Game.Server.Entity;
 using SWLOR.Game.Server.Service;
+using SWLOR.Game.Server.Service.AchievementService;
 using SWLOR.Game.Server.Service.BeastMasteryService;
 using SWLOR.Game.Server.Service.CombatService;
 using SWLOR.Game.Server.Service.DBService;
@@ -160,6 +161,7 @@ namespace SWLOR.Game.Server.Feature.ItemDefinition
 
                     dbPlayer.ActiveBeastId = dbBeast.Id;
                     DB.Set(dbPlayer);
+                    Achievement.GiveAchievement(user, AchievementType.ANewBond);
 
                     DestroyObject(item);
                 });

--- a/SWLOR.Game.Server/Feature/PlayerInitialization.cs
+++ b/SWLOR.Game.Server/Feature/PlayerInitialization.cs
@@ -3,6 +3,7 @@ using SWLOR.Game.Server.Core;
 using SWLOR.Game.Server.Entity;
 using SWLOR.Game.Server.Enumeration;
 using SWLOR.Game.Server.Service;
+using SWLOR.Game.Server.Service.AchievementService;
 using SWLOR.Game.Server.Service.CurrencyService;
 using SWLOR.Game.Server.Service.LogService;
 using SWLOR.Game.Server.Service.SkillService;
@@ -27,6 +28,12 @@ namespace SWLOR.Game.Server.Feature
 
             var playerId = GetObjectUUID(player);
             var dbPlayer = DB.Get<Player>(playerId) ?? new Player(playerId);
+            var accountId = GetPCPublicCDKey(player);
+            if (dbPlayer.AccountId != accountId)
+            {
+                dbPlayer.AccountId = accountId;
+                DB.Set(dbPlayer);
+            }
 
             // Already been initialized. Don't do it again.
             if (dbPlayer.Version >= 1 || dbPlayer.Version == -1) // Note: -1 signifies legacy characters. The Migration service handles upgrading legacy characters.
@@ -35,6 +42,8 @@ namespace SWLOR.Game.Server.Feature
                     PlayerName.RefreshNameOverridesForPlayer(player);
 
                 InitializeSavingThrows(player);
+                Achievement.FlushPendingAchievements(player);
+                AchievementTracking.EvaluatePersistedAchievements(player);
                 ExecuteScript(ScriptName.OnCharacterInitAfter, OBJECT_SELF);
                 return;
             }
@@ -61,6 +70,8 @@ namespace SWLOR.Game.Server.Feature
             if (PlayerDescriptor.EnsureUnknownDisplayName(player))
                 PlayerName.RefreshNameOverridesForPlayer(player);
 
+            Achievement.FlushPendingAchievements(player);
+            AchievementTracking.EvaluatePersistedAchievements(player);
             ExecuteScript(ScriptName.OnCharacterInitAfter, OBJECT_SELF);
         }
 

--- a/SWLOR.Game.Server/Feature/PlayerInitialization.cs
+++ b/SWLOR.Game.Server/Feature/PlayerInitialization.cs
@@ -42,6 +42,7 @@ namespace SWLOR.Game.Server.Feature
                     PlayerName.RefreshNameOverridesForPlayer(player);
 
                 InitializeSavingThrows(player);
+                AchievementTracking.ResolvePendingPublicPropertyVisits(player);
                 Achievement.FlushPendingAchievements(player);
                 AchievementTracking.EvaluatePersistedAchievements(player);
                 ExecuteScript(ScriptName.OnCharacterInitAfter, OBJECT_SELF);
@@ -70,6 +71,7 @@ namespace SWLOR.Game.Server.Feature
             if (PlayerDescriptor.EnsureUnknownDisplayName(player))
                 PlayerName.RefreshNameOverridesForPlayer(player);
 
+            AchievementTracking.ResolvePendingPublicPropertyVisits(player);
             Achievement.FlushPendingAchievements(player);
             AchievementTracking.EvaluatePersistedAchievements(player);
             ExecuteScript(ScriptName.OnCharacterInitAfter, OBJECT_SELF);

--- a/SWLOR.Game.Server/Feature/StatusEffectDefinition/GuardedStatusEffect.cs
+++ b/SWLOR.Game.Server/Feature/StatusEffectDefinition/GuardedStatusEffect.cs
@@ -256,6 +256,16 @@ namespace SWLOR.Game.Server.Feature.StatusEffectDefinition
             return OBJECT_INVALID;
         }
 
+        public static uint GetActiveGuardSource(uint target)
+        {
+            if (!SourceByGuardedTarget.TryGetValue(target, out var source))
+                return OBJECT_INVALID;
+
+            return IsActiveGuardedBySource(target, source)
+                ? source
+                : OBJECT_INVALID;
+        }
+
         public static void RefreshGuardBenefitsFromSource(uint source)
         {
             if (!GuardedTargetsBySource.TryGetValue(source, out var targets))

--- a/SWLOR.Game.Server/Native/GetDamageRoll.cs
+++ b/SWLOR.Game.Server/Native/GetDamageRoll.cs
@@ -590,7 +590,8 @@ namespace SWLOR.Game.Server.Native
                 attacker.m_idSelf,
                 damage,
                 damageType,
-                isLandedAttack);
+                isLandedAttack,
+                out var guardedHitOutcome);
             if (isLandedAttack && damage > 0 && attackType == (uint)AttackType.Melee)
             {
                 Combat.ApplyMeleeDamageTakenEffects(target.m_idSelf, attacker.m_idSelf);
@@ -602,7 +603,9 @@ namespace SWLOR.Game.Server.Native
                 attacker.m_idSelf,
                 damageType,
                 preTargetStatusStageDamage: damageBeforeTargetStatusStage,
-                isLandedAttack: isLandedAttack);
+                isLandedAttack: isLandedAttack,
+                guardedHitOutcome: guardedHitOutcome);
+            Combat.EvaluateGuardedHitOutcome(target.m_idSelf, guardedHitOutcome, damage);
             if (isLandedAttack)
             {
                 Combat.ApplyNextAttackGuardedHitEnmityBonus(

--- a/SWLOR.Game.Server/Service/Achievement.cs
+++ b/SWLOR.Game.Server/Service/Achievement.cs
@@ -49,21 +49,83 @@ namespace SWLOR.Game.Server.Service
             if (!GetIsPC(player) || GetIsDM(player)) return;
 
             var cdKey = GetPCPublicCDKey(player);
-            var account = DB.Get<Account>(cdKey) ?? new Account(cdKey);
-            if (account.Achievements.ContainsKey(achievementType)) return;
+            if (!GiveAchievementByAccountId(cdKey, achievementType)) return;
 
             var playerId = GetObjectUUID(player);
             var dbPlayer = DB.Get<Player>(playerId);
-            var now = DateTime.UtcNow;
-            account.Achievements[achievementType] = now;
-            DB.Set(account);
 
             // Player turned off achievement notifications. Nothing left to do here.
-            if (!dbPlayer.Settings.DisplayAchievementNotification) return;
+            if (dbPlayer?.Settings?.DisplayAchievementNotification == true &&
+                _activeAchievements.TryGetValue(achievementType, out var achievement))
+            {
+                DisplayAchievementNotificationWindow(player, achievement.Name);
+                PlayerPlugin.PlaySound(player, "gui_prompt", OBJECT_INVALID);
+            }
 
-            var achievement = _activeAchievements[achievementType];
-            DisplayAchievementNotificationWindow(player, achievement.Name);
-            PlayerPlugin.PlaySound(player, "gui_prompt", OBJECT_INVALID);
+            AchievementTracking.OnAchievementGranted(player, achievementType);
+        }
+
+        /// <summary>
+        /// Gives an achievement directly to an account. This supports achievements earned while
+        /// their recipient is offline, such as completed market sales.
+        /// </summary>
+        /// <returns>true when the achievement was newly granted.</returns>
+        public static bool GiveAchievementByAccountId(string accountId, AchievementType achievementType)
+        {
+            if (string.IsNullOrWhiteSpace(accountId) || achievementType == AchievementType.Invalid)
+                return false;
+
+            var detail = achievementType.GetAttribute<AchievementType, AchievementAttribute>();
+            if (!detail.IsActive)
+                return false;
+
+            var account = DB.Get<Account>(accountId) ?? new Account(accountId);
+            account.Achievements ??= new Dictionary<AchievementType, DateTime>();
+            if (account.Achievements.ContainsKey(achievementType))
+                return false;
+
+            account.Achievements[achievementType] = DateTime.UtcNow;
+            DB.Set(account);
+            return true;
+        }
+
+        /// <summary>
+        /// Queues an achievement on a persisted character when only its player ID is known.
+        /// The achievement is moved to the owner's account the next time that character enters.
+        /// </summary>
+        public static void QueueAchievementForPlayerId(string playerId, AchievementType achievementType)
+        {
+            if (string.IsNullOrWhiteSpace(playerId) || achievementType == AchievementType.Invalid)
+                return;
+
+            var dbPlayer = DB.Get<Player>(playerId);
+            if (dbPlayer == null)
+                return;
+
+            dbPlayer.PendingAchievements ??= new HashSet<int>();
+            if (dbPlayer.PendingAchievements.Add((int)achievementType))
+                DB.Set(dbPlayer);
+        }
+
+        public static void FlushPendingAchievements(uint player)
+        {
+            if (!GetIsPC(player) || GetIsDM(player))
+                return;
+
+            var playerId = GetObjectUUID(player);
+            var dbPlayer = DB.Get<Player>(playerId);
+            if (dbPlayer?.PendingAchievements == null || dbPlayer.PendingAchievements.Count == 0)
+                return;
+
+            var pending = dbPlayer.PendingAchievements.ToList();
+            dbPlayer.PendingAchievements.Clear();
+            DB.Set(dbPlayer);
+
+            foreach (var achievementId in pending)
+            {
+                if (Enum.IsDefined(typeof(AchievementType), achievementId))
+                    GiveAchievement(player, (AchievementType)achievementId);
+            }
         }
 
         /// <summary>

--- a/SWLOR.Game.Server/Service/AchievementService/AchievementTracking.cs
+++ b/SWLOR.Game.Server/Service/AchievementService/AchievementTracking.cs
@@ -224,14 +224,61 @@ namespace SWLOR.Game.Server.Service.AchievementService
             }
 
             var owner = DB.Get<Player>(ownerPlayerId);
-            if (owner == null ||
-                string.IsNullOrWhiteSpace(owner.AccountId) ||
-                owner.AccountId == GetPCPublicCDKey(visitor))
+            if (owner == null)
             {
                 return;
             }
 
+            var visitorAccountId = GetPCPublicCDKey(visitor);
+            if (string.IsNullOrWhiteSpace(visitorAccountId))
+                return;
+
+            if (string.IsNullOrWhiteSpace(owner.AccountId))
+            {
+                owner.PendingPublicPropertyVisitorAccountIds ??= new HashSet<string>();
+                if (owner.PendingPublicPropertyVisitorAccountIds.Add(visitorAccountId))
+                    DB.Set(owner);
+                return;
+            }
+
+            if (owner.AccountId == visitorAccountId)
+                return;
+
             Achievement.QueueAchievementForPlayerId(ownerPlayerId, AchievementType.OpenDoorPolicy);
+        }
+
+        public static void ResolvePendingPublicPropertyVisits(uint owner)
+        {
+            if (!GetIsPC(owner) || GetIsDM(owner))
+                return;
+
+            var dbPlayer = DB.Get<Player>(GetObjectUUID(owner));
+            if (dbPlayer?.PendingPublicPropertyVisitorAccountIds == null ||
+                dbPlayer.PendingPublicPropertyVisitorAccountIds.Count == 0)
+            {
+                return;
+            }
+
+            var ownerAccountId = GetPCPublicCDKey(owner);
+            var shouldAward = HasDifferentAccountVisitor(
+                dbPlayer.PendingPublicPropertyVisitorAccountIds,
+                ownerAccountId);
+
+            dbPlayer.PendingPublicPropertyVisitorAccountIds.Clear();
+            DB.Set(dbPlayer);
+
+            if (shouldAward)
+                Achievement.GiveAchievement(owner, AchievementType.OpenDoorPolicy);
+        }
+
+        public static bool HasDifferentAccountVisitor(
+            IEnumerable<string> visitorAccountIds,
+            string ownerAccountId)
+        {
+            return !string.IsNullOrWhiteSpace(ownerAccountId) &&
+                   visitorAccountIds?.Any(visitorAccountId =>
+                       !string.IsNullOrWhiteSpace(visitorAccountId) &&
+                       visitorAccountId != ownerAccountId) == true;
         }
 
         public static bool HasCraftedAllDisciplines(Player dbPlayer)

--- a/SWLOR.Game.Server/Service/AchievementService/AchievementTracking.cs
+++ b/SWLOR.Game.Server/Service/AchievementService/AchievementTracking.cs
@@ -1,0 +1,322 @@
+using System.Collections.Generic;
+using System.Linq;
+using SWLOR.Game.Server.Core;
+using SWLOR.Game.Server.Entity;
+using SWLOR.Game.Server.Enumeration;
+using SWLOR.Game.Server.Extension;
+using SWLOR.Game.Server.Service.CraftService;
+using SWLOR.Game.Server.Service.DroidService;
+using SWLOR.Game.Server.Service.DBService;
+using SWLOR.Game.Server.Service.FishingService;
+using SWLOR.Game.Server.Service.SkillService;
+using SWLOR.Game.Server.Service.SlicingService;
+using SWLOR.Game.Server.Service.SpaceService;
+using SWLOR.Game.Server.Service.TaxiService;
+using Player = SWLOR.Game.Server.Entity.Player;
+
+namespace SWLOR.Game.Server.Service.AchievementService
+{
+    public static class AchievementTracking
+    {
+        private const int MaximumFactionStanding = 5000;
+
+        private static readonly AchievementType[] OrbitAchievements =
+        {
+            AchievementType.ExploreHutlarOrbit,
+            AchievementType.ExploreMonCalaOrbit,
+            AchievementType.ExploreTatooineOrbit,
+            AchievementType.ExploreViscaraOrbit,
+            AchievementType.ExploreKorribanOrbit,
+            AchievementType.ExploreDathomirOrbit,
+            AchievementType.ExploreDantooineOrbit,
+            AchievementType.ExploreNarShaddaaOrbit,
+        };
+
+        private static readonly GuildType[] ActiveGuilds = Enum
+            .GetValues(typeof(GuildType))
+            .Cast<GuildType>()
+            .Where(type => type.GetAttribute<GuildType, GuildAttribute>().IsActive)
+            .ToArray();
+
+        private static readonly SkillType[] ActiveNonBasicLanguages = Enum
+            .GetValues(typeof(SkillType))
+            .Cast<SkillType>()
+            .Where(type => type != SkillType.Basic)
+            .Where(type =>
+            {
+                var detail = type.GetAttribute<SkillType, SkillAttribute>();
+                return detail.IsActive && detail.Category == SkillCategoryType.Languages;
+            })
+            .ToArray();
+
+        public static void EvaluatePersistedAchievements(uint player)
+        {
+            if (!GetIsPC(player) || GetIsDM(player))
+                return;
+
+            var playerId = GetObjectUUID(player);
+            var dbPlayer = DB.Get<Player>(playerId);
+            if (dbPlayer == null)
+                return;
+
+            var account = DB.Get<Account>(GetPCPublicCDKey(player)) ?? new Account(GetPCPublicCDKey(player));
+            account.Achievements ??= new Dictionary<AchievementType, DateTime>();
+            bool Needs(AchievementType type) => !account.Achievements.ContainsKey(type);
+
+            if (Needs(AchievementType.ANewBond) && HasOwnedBeast(playerId))
+                Achievement.GiveAchievement(player, AchievementType.ANewBond);
+            if (Needs(AchievementType.ApexCompanion) && HasApexBeast(playerId))
+                Achievement.GiveAchievement(player, AchievementType.ApexCompanion);
+            if (Needs(AchievementType.LearnedBehavior) && (dbPlayer.LearnedTechniques?.Count ?? 0) >= 10)
+                Achievement.GiveAchievement(player, AchievementType.LearnedBehavior);
+            if (Needs(AchievementType.FieldResearcher) && CountIncubationFieldNotes(dbPlayer) >= 10)
+                Achievement.GiveAchievement(player, AchievementType.FieldResearcher);
+            if (Needs(AchievementType.RenaissanceCrafter) && HasCraftedAllDisciplines(dbPlayer))
+                Achievement.GiveAchievement(player, AchievementType.RenaissanceCrafter);
+            if (Needs(AchievementType.LocalKnowledge) && HasAllTaxiDestinations(dbPlayer))
+                Achievement.GiveAchievement(player, AchievementType.LocalKnowledge);
+            if (Needs(AchievementType.TheGuildedAge) && HasGuildBreadth(dbPlayer))
+                Achievement.GiveAchievement(player, AchievementType.TheGuildedAge);
+            if (Needs(AchievementType.AKnownQuantity) &&
+                dbPlayer.Factions?.Values.Any(x => x.Standing >= MaximumFactionStanding) == true)
+                Achievement.GiveAchievement(player, AchievementType.AKnownQuantity);
+            if (Needs(AchievementType.Polyglot) && HasThreeMasteredLanguages(dbPlayer))
+                Achievement.GiveAchievement(player, AchievementType.Polyglot);
+
+            if (Needs(AchievementType.ClearForDeparture) || Needs(AchievementType.AllSystemsGreen))
+            {
+                var ships = GetOwnedShips(playerId);
+                if (Needs(AchievementType.ClearForDeparture) && ships.Count > 0)
+                    Achievement.GiveAchievement(player, AchievementType.ClearForDeparture);
+                if (Needs(AchievementType.AllSystemsGreen) && ships.Any(x => HasCompleteModuleSet(x.Status)))
+                    Achievement.GiveAchievement(player, AchievementType.AllSystemsGreen);
+            }
+
+            if (Needs(AchievementType.TheGrandTour))
+                CheckGrandTour(player);
+        }
+
+        public static void OnAchievementGranted(uint player, AchievementType achievementType)
+        {
+            if (OrbitAchievements.Contains(achievementType))
+                CheckGrandTour(player);
+        }
+
+        public static void CheckGrandTour(uint player)
+        {
+            if (!GetIsPC(player) || GetIsDM(player))
+                return;
+
+            var account = DB.Get<Account>(GetPCPublicCDKey(player));
+            if (account?.Achievements != null && OrbitAchievements.All(account.Achievements.ContainsKey))
+                Achievement.GiveAchievement(player, AchievementType.TheGrandTour);
+        }
+
+        public static void RecordSlicingSuccess(uint player, SlicingSourceType source, bool usedTool)
+        {
+            if (!GetIsPC(player) || GetIsDM(player))
+                return;
+
+            var account = GetOrCreateAccount(player);
+            EnsureProgressCollections(account);
+            var changed = account.AchievementProgress.SlicingSourcesCompleted.Add((int)source);
+            if (changed)
+                DB.Set(account);
+
+            if (!usedTool)
+                Achievement.GiveAchievement(player, AchievementType.CleanSlice);
+
+            if (account.AchievementProgress.SlicingSourcesCompleted.Contains((int)SlicingSourceType.Lockbox) &&
+                account.AchievementProgress.SlicingSourcesCompleted.Contains((int)SlicingSourceType.Terminal))
+            {
+                Achievement.GiveAchievement(player, AchievementType.TwoKindsOfTrouble);
+            }
+        }
+
+        public static void RecordFishCaught(
+            uint player,
+            int fishLevel,
+            int agricultureRank,
+            FishingLocationType location)
+        {
+            if (!GetIsPC(player) || GetIsDM(player))
+                return;
+
+            if (fishLevel >= 52)
+                Achievement.GiveAchievement(player, AchievementType.NoSuchThingAsLuck);
+            if (fishLevel >= agricultureRank + 5)
+                Achievement.GiveAchievement(player, AchievementType.AgainstTheCurrent);
+
+            var planet = GetFishingPlanet(location);
+            if (planet == PlanetType.Invalid)
+                return;
+
+            var account = GetOrCreateAccount(player);
+            EnsureProgressCollections(account);
+            if (account.AchievementProgress.FishingPlanetsCaught.Add((int)planet))
+                DB.Set(account);
+
+            if (account.AchievementProgress.FishingPlanetsCaught.Count >= 5)
+                Achievement.GiveAchievement(player, AchievementType.GalacticAngler);
+        }
+
+        public static PlanetType GetFishingPlanet(FishingLocationType location)
+        {
+            var value = (int)location;
+            if (value is >= 1 and <= 9) return PlanetType.Viscara;
+            if (value is >= 10 and <= 15) return PlanetType.MonCala;
+            if (value is >= 16 and <= 19) return PlanetType.Hutlar;
+            if (value is >= 20 and <= 21) return PlanetType.Tatooine;
+            if (value is >= 22 and <= 26) return PlanetType.Dathomir;
+            if (value is >= 27 and <= 31) return PlanetType.Dantooine;
+            return PlanetType.Invalid;
+        }
+
+        public static bool IsFullyOperational(ConstructedDroid droid)
+        {
+            return droid != null &&
+                   !string.IsNullOrWhiteSpace(droid.SerializedCPU) &&
+                   !string.IsNullOrWhiteSpace(droid.SerializedHead) &&
+                   !string.IsNullOrWhiteSpace(droid.SerializedBody) &&
+                   !string.IsNullOrWhiteSpace(droid.SerializedArms) &&
+                   !string.IsNullOrWhiteSpace(droid.SerializedLegs) &&
+                   (droid.ActivePerks?.Count ?? 0) > 0;
+        }
+
+        public static bool HasCompleteModuleSet(ShipStatus status)
+        {
+            return status != null &&
+                   (status.HighPowerModules?.Count ?? 0) > 0 &&
+                   (status.LowPowerModules?.Count ?? 0) > 0 &&
+                   (status.ConfigurationModules?.Count ?? 0) > 0;
+        }
+
+        public static bool IsLowHull(ShipStatus status)
+        {
+            return status != null && status.MaxHull > 0 && status.Hull > 0 && status.Hull * 10 <= status.MaxHull;
+        }
+
+        public static bool GuardPreventedLethalHit(int currentHitPoints, int incomingDamage, int adjustedDamage)
+        {
+            return currentHitPoints > 0 &&
+                   incomingDamage >= currentHitPoints &&
+                   adjustedDamage < currentHitPoints;
+        }
+
+        public static bool HasEligiblePartyMember(uint player)
+        {
+            return Party.GetAllPartyMembers(player).Any(member =>
+                member != player &&
+                GetIsObjectValid(member) &&
+                GetIsPC(member) &&
+                !GetIsDM(member) &&
+                GetArea(member) == GetArea(player));
+        }
+
+        public static void RecordPublicPropertyVisit(uint visitor, string ownerPlayerId)
+        {
+            if (!GetIsPC(visitor) ||
+                GetIsDM(visitor) ||
+                string.IsNullOrWhiteSpace(ownerPlayerId) ||
+                ownerPlayerId == GetObjectUUID(visitor))
+            {
+                return;
+            }
+
+            var owner = DB.Get<Player>(ownerPlayerId);
+            if (owner == null ||
+                string.IsNullOrWhiteSpace(owner.AccountId) ||
+                owner.AccountId == GetPCPublicCDKey(visitor))
+            {
+                return;
+            }
+
+            Achievement.QueueAchievementForPlayerId(ownerPlayerId, AchievementType.OpenDoorPolicy);
+        }
+
+        public static bool HasCraftedAllDisciplines(Player dbPlayer)
+        {
+            if (dbPlayer?.CraftedRecipes == null)
+                return false;
+
+            var disciplines = new HashSet<SkillType>();
+            foreach (var recipeType in dbPlayer.CraftedRecipes.Keys)
+            {
+                if (!Craft.RecipeExists(recipeType))
+                    continue;
+
+                var skill = Craft.GetRecipe(recipeType).Skill;
+                if (skill is SkillType.Smithery or SkillType.Engineering or SkillType.Fabrication or SkillType.Agriculture)
+                    disciplines.Add(skill);
+            }
+
+            return disciplines.Count == 4;
+        }
+
+        public static bool HasAllTaxiDestinations(Player dbPlayer)
+        {
+            var unlocked = dbPlayer?.TaxiDestinations?.Values
+                .SelectMany(x => x)
+                .ToHashSet() ?? new HashSet<TaxiDestinationType>();
+            return Enum.GetValues(typeof(TaxiDestinationType))
+                .Cast<TaxiDestinationType>()
+                .Where(x => x != TaxiDestinationType.Invalid)
+                .All(unlocked.Contains);
+        }
+
+        public static bool HasGuildBreadth(Player dbPlayer)
+        {
+            return dbPlayer?.Guilds != null &&
+                   ActiveGuilds.All(guild => dbPlayer.Guilds.TryGetValue(guild, out var progress) && progress.Rank >= 1);
+        }
+
+        public static bool HasThreeMasteredLanguages(Player dbPlayer)
+        {
+            return dbPlayer?.Skills != null && ActiveNonBasicLanguages.Count(language =>
+                dbPlayer.Skills.TryGetValue(language, out var skill) && skill.Rank >= 20) >= 3;
+        }
+
+        private static int CountIncubationFieldNotes(Player dbPlayer)
+        {
+            return dbPlayer.KeyItems?.Keys.Count(keyItem =>
+                IncubationFieldNote.TryGetNoteForKeyItem(keyItem, out _)) ?? 0;
+        }
+
+        private static bool HasOwnedBeast(string playerId)
+        {
+            var query = new DBQuery<Beast>().AddFieldSearch(nameof(Beast.OwnerPlayerId), playerId, false);
+            return DB.SearchCount(query) > 0;
+        }
+
+        private static bool HasApexBeast(string playerId)
+        {
+            var query = new DBQuery<Beast>().AddFieldSearch(nameof(Beast.OwnerPlayerId), playerId, false);
+            var count = (int)DB.SearchCount(query);
+            return count > 0 && DB.Search(query.AddPaging(count, 0)).Any(beast => beast.Level >= 50);
+        }
+
+        private static List<PlayerShip> GetOwnedShips(string playerId)
+        {
+            var query = new DBQuery<PlayerShip>().AddFieldSearch(nameof(PlayerShip.OwnerPlayerId), playerId, false);
+            var count = (int)DB.SearchCount(query);
+            return count <= 0
+                ? new List<PlayerShip>()
+                : DB.Search(query.AddPaging(count, 0)).ToList();
+        }
+
+        private static Account GetOrCreateAccount(uint player)
+        {
+            var accountId = GetPCPublicCDKey(player);
+            var account = DB.Get<Account>(accountId) ?? new Account(accountId);
+            EnsureProgressCollections(account);
+            return account;
+        }
+
+        private static void EnsureProgressCollections(Account account)
+        {
+            account.AchievementProgress ??= new AchievementProgress();
+            account.AchievementProgress.SlicingSourcesCompleted ??= new HashSet<int>();
+            account.AchievementProgress.FishingPlanetsCaught ??= new HashSet<int>();
+        }
+    }
+}

--- a/SWLOR.Game.Server/Service/AchievementService/AchievementType.cs
+++ b/SWLOR.Game.Server/Service/AchievementService/AchievementType.cs
@@ -468,6 +468,67 @@ namespace SWLOR.Game.Server.Service.AchievementService
         UntouchableInstinct = 179,
         [Achievement("Force-Bonded Beast", "Completed the Force-Bonded Beast capstone quest line.", true)]
         ForceBondedBeast = 180,
+
+        [Achievement("A New Bond", "Register any beast in your stable.", true)]
+        ANewBond = 181,
+        [Achievement("Survival of the Strangest", "Produce a mutated beast through incubation.", true)]
+        SurvivalOfTheStrangest = 182,
+        [Achievement("Apex Companion", "Raise a beast to level 50.", true)]
+        ApexCompanion = 183,
+        [Achievement("Fully Operational", "Deploy a droid with a CPU, head, body, arms, legs, and an active AI instruction.", true)]
+        FullyOperational = 184,
+        [Achievement("Learned Behavior", "Learn 10 distinct Mimicry techniques.", true)]
+        LearnedBehavior = 185,
+        [Achievement("Field Researcher", "Collect 10 incubation field notes.", true)]
+        FieldResearcher = 186,
+        [Achievement("Ghost in the Machine", "Complete an infiltration undetected and without entering combat.", true)]
+        GhostInTheMachine = 187,
+        [Achievement("Trap Whisperer", "Disarm a concealed tier 5 trap.", true)]
+        TrapWhisperer = 188,
+        [Achievement("Clean Slice", "Solve a slicing board without using a slicing tool.", true)]
+        CleanSlice = 189,
+        [Achievement("Two Kinds of Trouble", "Successfully slice both a lockbox and a terminal.", true)]
+        TwoKindsOfTrouble = 190,
+        [Achievement("No Such Thing as Luck", "Catch a hidden level 52 fish.", true)]
+        NoSuchThingAsLuck = 191,
+        [Achievement("Against the Current", "Catch a fish at least 5 levels above your Agriculture rank.", true)]
+        AgainstTheCurrent = 192,
+        [Achievement("Galactic Angler", "Catch fish on 5 different planets.", true)]
+        GalacticAngler = 193,
+        [Achievement("First Principles", "Complete and claim a research job.", true)]
+        FirstPrinciples = 194,
+        [Achievement("Renaissance Crafter", "Craft a recipe in Smithery, Engineering, Fabrication, and Agriculture.", true)]
+        RenaissanceCrafter = 195,
+        [Achievement("Clear for Departure", "Register your first starship.", true)]
+        ClearForDeparture = 196,
+        [Achievement("Never Tell Me the Odds", "Destroy hostile NPC spacecraft while your own ship is at 10% hull or less.", true)]
+        NeverTellMeTheOdds = 197,
+        [Achievement("All Systems Green", "Equip a high-power, low-power, and configuration module on the same ship.", true)]
+        AllSystemsGreen = 198,
+        [Achievement("The Grand Tour", "Explore the orbits of Hutlar, Mon Cala, Tatooine, Viscara, Korriban, Dathomir, Dantooine, and Nar Shaddaa.", true)]
+        TheGrandTour = 199,
+        [Achievement("Local Knowledge", "Unlock all 14 taxi destinations.", true)]
+        LocalKnowledge = 200,
+        [Achievement("The Guilded Age", "Reach rank 1 in all five active guilds.", true)]
+        TheGuildedAge = 201,
+        [Achievement("A Known Quantity", "Reach maximum standing with any faction.", true)]
+        AKnownQuantity = 202,
+        [Achievement("Credits Will Do Fine", "Buy a market listing from another account.", true)]
+        CreditsWillDoFine = 203,
+        [Achievement("Polyglot", "Reach rank 20 in three non-Basic languages on one character.", true)]
+        Polyglot = 204,
+        [Achievement("A Fair Deal", "Have another account buy one of your market listings.", true)]
+        AFairDeal = 205,
+        [Achievement("Contractual Obligation", "Complete a quest contract authored by another player.", true)]
+        ContractualObligation = 206,
+        [Achievement("Open Door Policy", "Have another player enter one of your publicly accessible properties.", true)]
+        OpenDoorPolicy = 207,
+        [Achievement("Stronger Together", "Complete a non-contract quest while grouped with another eligible player.", true)]
+        StrongerTogether = 208,
+        [Achievement("Not on My Watch", "Resuscitate another player.", true)]
+        NotOnMyWatch = 209,
+        [Achievement("Behind Me!", "Prevent an otherwise lethal hit against another player with Guard.", true)]
+        BehindMe = 210,
 	}
 
     public class AchievementAttribute: Attribute

--- a/SWLOR.Game.Server/Service/BeastMastery.cs
+++ b/SWLOR.Game.Server/Service/BeastMastery.cs
@@ -217,6 +217,8 @@ namespace SWLOR.Game.Server.Service
             }
 
             DB.Set(dbBeast);
+            if (dbBeast.Level >= MaxLevel)
+                Achievement.GiveAchievement(player, AchievementService.AchievementType.ApexCompanion);
             ApplyStats(beast);
 
             Gui.PublishRefreshEvent(player, new BeastGainXPRefreshEvent());
@@ -801,6 +803,7 @@ namespace SWLOR.Game.Server.Service
             if (mutation != BeastType.Invalid)
             {
                 IncubationFieldNote.GrantDiscoveredNote(player, mutation);
+                Achievement.GiveAchievement(player, AchievementService.AchievementType.SurvivalOfTheStrangest);
             }
 
             var egg = CreateBeastEgg(beastType, player);

--- a/SWLOR.Game.Server/Service/Combat.cs
+++ b/SWLOR.Game.Server/Service/Combat.cs
@@ -8,6 +8,7 @@ using SWLOR.Game.Server.Extension;
 using SWLOR.Game.Server.Feature.AbilityDefinition;
 using SWLOR.Game.Server.Feature.StatusEffectDefinition;
 using SWLOR.Game.Server.Service.ActivityService;
+using SWLOR.Game.Server.Service.AchievementService;
 using SWLOR.Game.Server.Service.AbilityService;
 using SWLOR.Game.Server.Service.CombatService;
 using SWLOR.Game.Server.Service.LogService;
@@ -3241,6 +3242,18 @@ namespace SWLOR.Game.Server.Service
             var reductionPercent = GetGuardDamageReductionPercent(defender);
             var preventedDamage = Math.Min(damage, GameMath.PercentOf(damage, reductionPercent));
             var adjustedDamage = Math.Max(0, damage - preventedDamage);
+
+            var guardSource = GuardedStatusEffect.GetActiveGuardSource(defender);
+            if (GetIsObjectValid(guardSource) &&
+                guardSource != defender &&
+                GetIsPC(guardSource) &&
+                !GetIsDM(guardSource) &&
+                GetIsPC(defender) &&
+                !GetIsDM(defender) &&
+                AchievementTracking.GuardPreventedLethalHit(GetCurrentHitPoints(defender), damage, adjustedDamage))
+            {
+                Achievement.GiveAchievement(guardSource, AchievementType.BehindMe);
+            }
 
             TrackGuardedHit(defender);
             StatusEffect.OnGuardedHit(defender, attacker, preventedDamage);

--- a/SWLOR.Game.Server/Service/Combat.cs
+++ b/SWLOR.Game.Server/Service/Combat.cs
@@ -26,6 +26,19 @@ namespace SWLOR.Game.Server.Service
 {
     public static class Combat
     {
+        public sealed class GuardedHitOutcome
+        {
+            public GuardedHitOutcome(uint source, int damageWithoutGuard)
+            {
+                Source = source;
+                DamageWithoutGuard = damageWithoutGuard;
+            }
+
+            public uint Source { get; }
+            public int DamageWithoutGuard { get; internal set; }
+            public int TemporaryHitPointsGranted { get; internal set; }
+        }
+
         private const float DamageStatDeltaMultiplier = 0.35f;
         public const int BaseGuardDamageReductionPercent = 20;
         public const int MaximumGuardDamageReductionPercent = 40;
@@ -559,16 +572,92 @@ namespace SWLOR.Game.Server.Service
             CombatDamageType damageType = CombatDamageType.Physical,
             CombatDamageDeliveryType deliveryType = CombatDamageDeliveryType.Direct,
             int? preTargetStatusStageDamage = null,
-            bool isLandedAttack = true)
+            bool isLandedAttack = true,
+            GuardedHitOutcome guardedHitOutcome = null)
+        {
+            if (damage <= 0 && (guardedHitOutcome == null || guardedHitOutcome.DamageWithoutGuard <= 0))
+                return damage;
+
+            if (HasDamageImmunity(defender, damageType))
+            {
+                if (guardedHitOutcome != null)
+                    guardedHitOutcome.DamageWithoutGuard = 0;
+                return 0;
+            }
+
+            damage = ApplyDamageTakenValueModifiers(defender, damage, preTargetStatusStageDamage);
+            if (guardedHitOutcome != null)
+            {
+                guardedHitOutcome.DamageWithoutGuard = ApplyDamageTakenValueModifiers(
+                    defender,
+                    guardedHitOutcome.DamageWithoutGuard,
+                    preTargetStatusStageDamage);
+            }
+
+            // The math above is pure; everything below consumes one-shot effects or deals real
+            // damage to third parties. A swing the engine later discards must not burn a redirect
+            // or fatal-prevention charge, transfer damage to a protector, or grant temporary HP.
+            if (!isLandedAttack)
+                return damage;
+
+            damage = ApplyDamageTakenRedirectToStatusSource(
+                defender,
+                attacker,
+                damage,
+                damageType,
+                guardedHitOutcome);
+            if (deliveryType != CombatDamageDeliveryType.Transferred)
+            {
+                damage = ApplyDamageTakenShareToStatusSource(
+                    defender,
+                    attacker,
+                    damage,
+                    damageType,
+                    guardedHitOutcome);
+            }
+
+            if (damage <= 0 && (guardedHitOutcome == null || guardedHitOutcome.DamageWithoutGuard <= 0))
+                return 0;
+
+            var fatalDamageWouldBePreventedWithoutGuard = guardedHitOutcome != null &&
+                                                          CanPreventFatalDamageAndGrantTemporaryHP(
+                                                              defender,
+                                                              guardedHitOutcome.DamageWithoutGuard);
+            if (TryPreventFatalDamageAndGrantTemporaryHP(defender, damage, restoreToOneHP: false))
+            {
+                if (guardedHitOutcome != null)
+                    guardedHitOutcome.DamageWithoutGuard = 0;
+                return 0;
+            }
+
+            if (fatalDamageWouldBePreventedWithoutGuard)
+                guardedHitOutcome.DamageWithoutGuard = 0;
+
+            if (guardedHitOutcome != null && guardedHitOutcome.DamageWithoutGuard > 0)
+            {
+                var counterfactualTemporaryHP = GetLowHPTemporaryHPBeforeFatalDamage(
+                    defender,
+                    guardedHitOutcome.DamageWithoutGuard);
+                guardedHitOutcome.DamageWithoutGuard = Math.Max(
+                    0,
+                    guardedHitOutcome.DamageWithoutGuard - counterfactualTemporaryHP);
+            }
+
+            var temporaryHitPointsGranted = ApplyLowHPTemporaryHPBeforeFatalDamage(defender, damage);
+            if (guardedHitOutcome != null)
+                guardedHitOutcome.TemporaryHitPointsGranted = temporaryHitPointsGranted;
+            return damage;
+        }
+
+        private static int ApplyDamageTakenValueModifiers(
+            uint defender,
+            int damage,
+            int? preTargetStatusStageDamage)
         {
             if (damage <= 0)
                 return damage;
 
-            if (HasDamageImmunity(defender, damageType))
-                return 0;
-
             var percentAdjustment = Stat.GetStatAdjustment(defender, StatType.DamageTakenPercentAdjustment);
-
             if (percentAdjustment != 0)
                 damage = ApplyPercentDamageAdjustment(damage, percentAdjustment);
 
@@ -582,35 +671,17 @@ namespace SWLOR.Game.Server.Service
                     damage = minimumCombinedDamage;
             }
 
-            damage = Math.Max(1, damage);
-
-            // The math above is pure; everything below consumes one-shot effects or deals real
-            // damage to third parties. A swing the engine later discards must not burn a redirect
-            // or fatal-prevention charge, transfer damage to a protector, or grant temporary HP.
-            if (!isLandedAttack)
-                return damage;
-
-            damage = ApplyDamageTakenRedirectToStatusSource(defender, attacker, damage, damageType);
-            if (deliveryType != CombatDamageDeliveryType.Transferred)
-                damage = ApplyDamageTakenShareToStatusSource(defender, attacker, damage, damageType);
-
-            if (damage <= 0)
-                return 0;
-
-            if (TryPreventFatalDamageAndGrantTemporaryHP(defender, damage, restoreToOneHP: false))
-                return 0;
-
-            ApplyLowHPTemporaryHPBeforeFatalDamage(defender, damage);
-            return damage;
+            return Math.Max(1, damage);
         }
 
         private static int ApplyDamageTakenRedirectToStatusSource(
             uint defender,
             uint attacker,
             int damage,
-            CombatDamageType damageType)
+            CombatDamageType damageType,
+            GuardedHitOutcome guardedHitOutcome)
         {
-            if (damage <= 0)
+            if (damage <= 0 && (guardedHitOutcome == null || guardedHitOutcome.DamageWithoutGuard <= 0))
                 return damage;
 
             var redirectPercent = Stat.GetStatAdjustment(defender, StatType.DamageTakenRedirectToStatusSourcePercent);
@@ -621,6 +692,19 @@ namespace SWLOR.Game.Server.Service
                 defender,
                 StatType.DamageTakenRedirectToStatusSourcePercent);
             if (!GetIsObjectValid(redirectTarget) || GetIsDead(redirectTarget) || redirectTarget == defender)
+                return damage;
+
+            if (guardedHitOutcome != null && guardedHitOutcome.DamageWithoutGuard > 0)
+            {
+                var redirectedDamageWithoutGuard = Math.Min(
+                    guardedHitOutcome.DamageWithoutGuard,
+                    GameMath.PercentOf(
+                        guardedHitOutcome.DamageWithoutGuard,
+                        Math.Min(100, redirectPercent)));
+                guardedHitOutcome.DamageWithoutGuard -= redirectedDamageWithoutGuard;
+            }
+
+            if (damage <= 0)
                 return damage;
 
             var redirectedDamage = Math.Min(
@@ -666,9 +750,10 @@ namespace SWLOR.Game.Server.Service
             uint defender,
             uint attacker,
             int damage,
-            CombatDamageType damageType)
+            CombatDamageType damageType,
+            GuardedHitOutcome guardedHitOutcome)
         {
-            if (damage <= 0)
+            if (damage <= 0 && (guardedHitOutcome == null || guardedHitOutcome.DamageWithoutGuard <= 0))
                 return damage;
 
             var sharePercent = Stat.GetStatAdjustment(defender, StatType.DamageTakenShareToStatusSourcePercent);
@@ -685,6 +770,19 @@ namespace SWLOR.Game.Server.Service
             {
                 return damage;
             }
+
+            if (guardedHitOutcome != null && guardedHitOutcome.DamageWithoutGuard > 0)
+            {
+                var sharedDamageWithoutGuard = Math.Min(
+                    guardedHitOutcome.DamageWithoutGuard,
+                    GameMath.PercentOf(
+                        guardedHitOutcome.DamageWithoutGuard,
+                        Math.Min(100, sharePercent)));
+                guardedHitOutcome.DamageWithoutGuard -= sharedDamageWithoutGuard;
+            }
+
+            if (damage <= 0)
+                return damage;
 
             var sharedDamage = Math.Min(
                 damage,
@@ -839,6 +937,24 @@ namespace SWLOR.Game.Server.Service
             ApplyEffectToObject(DurationType.Instant, EffectVisualEffect(VisualEffect.Vfx_Imp_Ac_Bonus), defender);
 
             return true;
+        }
+
+        private static bool CanPreventFatalDamageAndGrantTemporaryHP(uint defender, int damage)
+        {
+            if (!GetIsObjectValid(defender) || damage <= 0)
+                return false;
+
+            var temporaryHPPercent = Stat.GetStatAdjustment(defender, StatType.FatalDamageTemporaryHPPercent);
+            var duration = Stat.GetStatAdjustment(defender, StatType.FatalDamageTemporaryHPDurationSeconds);
+            var currentHP = GetCurrentHitPoints(defender);
+            if (temporaryHPPercent <= 0 || duration <= 0 || currentHP <= 0 || damage < currentHP)
+                return false;
+
+            var cooldown = Stat.GetStatAdjustment(defender, StatType.FatalDamageTemporaryHPCooldownSeconds);
+            return CanUseStatTrigger(
+                defender,
+                StatType.FatalDamageTemporaryHPPercent,
+                TimeSpan.FromSeconds(cooldown));
         }
 
         public static int ApplyTargetStatusAttackModifiers(uint attacker, uint defender, int attack, SkillType skillType)
@@ -2701,33 +2817,52 @@ namespace SWLOR.Game.Server.Service
             TemporaryHitPointEffects.ApplyFlat(defender, "LOW_HP_SHIELD", temporaryHP, duration);
         }
 
-        private static void ApplyLowHPTemporaryHPBeforeFatalDamage(uint defender, int damage)
+        private static int ApplyLowHPTemporaryHPBeforeFatalDamage(uint defender, int damage)
+        {
+            var temporaryHP = GetLowHPTemporaryHPBeforeFatalDamage(defender, damage);
+            if (temporaryHP <= 0)
+                return 0;
+
+            var cooldown = Stat.GetStatAdjustment(defender, StatType.LowHPTemporaryHPCooldownSeconds);
+            if (!TryUseStatTrigger(defender, StatType.LowHPTemporaryHPPercent, cooldown))
+                return 0;
+
+            var duration = Stat.GetStatAdjustment(defender, StatType.LowHPTemporaryHPDurationSeconds);
+            TemporaryHitPointEffects.ApplyFlat(defender, "LOW_HP_SHIELD", temporaryHP, duration);
+            return temporaryHP;
+        }
+
+        private static int GetLowHPTemporaryHPBeforeFatalDamage(uint defender, int damage)
         {
             if (!GetIsObjectValid(defender) || GetIsDead(defender) || damage <= 0)
-                return;
+                return 0;
 
             var threshold = Stat.GetStatAdjustment(defender, StatType.LowHPTemporaryHPThresholdPercent);
             var temporaryHPPercent = Stat.GetStatAdjustment(defender, StatType.LowHPTemporaryHPPercent);
             var duration = Stat.GetStatAdjustment(defender, StatType.LowHPTemporaryHPDurationSeconds);
             var cooldown = Stat.GetStatAdjustment(defender, StatType.LowHPTemporaryHPCooldownSeconds);
             if (threshold <= 0 || temporaryHPPercent <= 0 || duration <= 0)
-                return;
+                return 0;
 
             var maxHP = GetMaxHitPoints(defender);
             var currentHP = GetCurrentHitPoints(defender);
             if (maxHP <= 0 || currentHP <= 0)
-                return;
+                return 0;
 
             var thresholdHP = maxHP * (threshold / 100f);
             var projectedHP = currentHP - damage;
             if (currentHP < thresholdHP || projectedHP >= thresholdHP || projectedHP > 0)
-                return;
+                return 0;
 
-            if (!TryUseStatTrigger(defender, StatType.LowHPTemporaryHPPercent, cooldown))
-                return;
+            if (!CanUseStatTrigger(
+                    defender,
+                    StatType.LowHPTemporaryHPPercent,
+                    TimeSpan.FromSeconds(cooldown)))
+            {
+                return 0;
+            }
 
-            var temporaryHP = GameMath.PercentOf(maxHP, temporaryHPPercent);
-            TemporaryHitPointEffects.ApplyFlat(defender, "LOW_HP_SHIELD", temporaryHP, duration);
+            return GameMath.PercentOf(maxHP, temporaryHPPercent);
         }
 
         private static void ApplyLowHPNoSaveTemporaryHPEffect(uint defender, int damage)
@@ -3224,8 +3359,10 @@ namespace SWLOR.Game.Server.Service
             uint attacker,
             int damage,
             CombatDamageType damageType,
-            bool isLandedAttack)
+            bool isLandedAttack,
+            out GuardedHitOutcome guardedHitOutcome)
         {
+            guardedHitOutcome = null;
             if (!isLandedAttack ||
                 !GetIsObjectValid(defender) ||
                 !GetIsObjectValid(attacker) ||
@@ -3249,10 +3386,9 @@ namespace SWLOR.Game.Server.Service
                 GetIsPC(guardSource) &&
                 !GetIsDM(guardSource) &&
                 GetIsPC(defender) &&
-                !GetIsDM(defender) &&
-                AchievementTracking.GuardPreventedLethalHit(GetCurrentHitPoints(defender), damage, adjustedDamage))
+                !GetIsDM(defender))
             {
-                Achievement.GiveAchievement(guardSource, AchievementType.BehindMe);
+                guardedHitOutcome = new GuardedHitOutcome(guardSource, damage);
             }
 
             TrackGuardedHit(defender);
@@ -3263,6 +3399,34 @@ namespace SWLOR.Game.Server.Service
             SendGuardedHitFeedback(defender, attacker, preventedDamage);
 
             return adjustedDamage;
+        }
+
+        public static void EvaluateGuardedHitOutcome(
+            uint defender,
+            GuardedHitOutcome guardedHitOutcome,
+            int finalDamage)
+        {
+            if (guardedHitOutcome == null ||
+                !GetIsObjectValid(defender) ||
+                !GetIsPC(defender) ||
+                GetIsDM(defender) ||
+                !GetIsObjectValid(guardedHitOutcome.Source) ||
+                !GetIsPC(guardedHitOutcome.Source) ||
+                GetIsDM(guardedHitOutcome.Source))
+            {
+                return;
+            }
+
+            var finalDamageToHitPoints = Math.Max(
+                0,
+                finalDamage - guardedHitOutcome.TemporaryHitPointsGranted);
+            if (AchievementTracking.GuardPreventedLethalHit(
+                    GetCurrentHitPoints(defender),
+                    guardedHitOutcome.DamageWithoutGuard,
+                    finalDamageToHitPoints))
+            {
+                Achievement.GiveAchievement(guardedHitOutcome.Source, AchievementType.BehindMe);
+            }
         }
 
         internal static bool IsHostileAttackSource(uint defender, uint attacker)
@@ -4663,16 +4827,21 @@ namespace SWLOR.Game.Server.Service
 
         internal static bool TryUseStatTrigger(uint creature, StatType statType, TimeSpan cooldown)
         {
+            if (!CanUseStatTrigger(creature, statType, cooldown))
+                return false;
+
+            if (cooldown > TimeSpan.Zero)
+                _statTriggerCooldowns[(creature, statType)] = DateTime.UtcNow.Add(cooldown);
+            return true;
+        }
+
+        private static bool CanUseStatTrigger(uint creature, StatType statType, TimeSpan cooldown)
+        {
             if (cooldown <= TimeSpan.Zero)
                 return true;
 
-            var key = (creature, statType);
-            var now = DateTime.UtcNow;
-            if (_statTriggerCooldowns.TryGetValue(key, out var nextAvailable) && nextAvailable > now)
-                return false;
-
-            _statTriggerCooldowns[key] = now.Add(cooldown);
-            return true;
+            return !_statTriggerCooldowns.TryGetValue((creature, statType), out var nextAvailable) ||
+                   nextAvailable <= DateTime.UtcNow;
         }
 
         private static void RemoveStatTriggerCooldowns(uint creature)

--- a/SWLOR.Game.Server/Service/Droid.cs
+++ b/SWLOR.Game.Server/Service/Droid.cs
@@ -677,6 +677,8 @@ namespace SWLOR.Game.Server.Service
 
             // Inventory / Equipment
             var constructedDroid = LoadConstructedDroid(controller);
+            if (AchievementService.AchievementTracking.IsFullyOperational(constructedDroid))
+                Achievement.GiveAchievement(player, AchievementService.AchievementType.FullyOperational);
 
             foreach (var (slot, serialized) in constructedDroid.EquippedItems)
             {

--- a/SWLOR.Game.Server/Service/EspionageInfiltration.cs
+++ b/SWLOR.Game.Server/Service/EspionageInfiltration.cs
@@ -136,6 +136,7 @@ namespace SWLOR.Game.Server.Service
                 return;
             }
 
+            Achievement.GiveAchievement(player, AchievementService.AchievementType.GhostInTheMachine);
             GrantXp(player, npc, wasDetected: false);
         }
 

--- a/SWLOR.Game.Server/Service/Faction.cs
+++ b/SWLOR.Game.Server/Service/Faction.cs
@@ -111,6 +111,8 @@ namespace SWLOR.Game.Server.Service
             }
 
             DB.Set(dbPlayer);
+            if (dbPlayer.Factions[faction].Standing >= MaximumFaction)
+                Achievement.GiveAchievement(player, AchievementService.AchievementType.AKnownQuantity);
         }
 
         /// <summary>

--- a/SWLOR.Game.Server/Service/Fishing.cs
+++ b/SWLOR.Game.Server/Service/Fishing.cs
@@ -6,6 +6,7 @@ using SWLOR.Game.Server.Core.Bioware;
 using SWLOR.Game.Server.Entity;
 using SWLOR.Game.Server.Extension;
 using SWLOR.Game.Server.Service.ActivityService;
+using SWLOR.Game.Server.Service.AchievementService;
 using SWLOR.Game.Server.Service.FishingService;
 using SWLOR.Game.Server.Service.SkillService;
 using SWLOR.NWN.API.NWNX;
@@ -424,6 +425,7 @@ namespace SWLOR.Game.Server.Service
                 CreateItemOnObject(fish.Resref, player);
 
                 SendMessageToPC(player, $"You landed a {fish.Name}!");
+                AchievementTracking.RecordFishCaught(player, fish.Level, skill, locationId);
             }
 
             SendMessageToPC(player, $"Bait Remaining: {remainingBait}x {baitName}");

--- a/SWLOR.Game.Server/Service/Guild.cs
+++ b/SWLOR.Game.Server/Service/Guild.cs
@@ -119,6 +119,8 @@ namespace SWLOR.Game.Server.Service
 
             dbPlayer.Guilds[guild] = dbGuild;
             DB.Set(dbPlayer);
+            if (AchievementService.AchievementTracking.HasGuildBreadth(dbPlayer))
+                Achievement.GiveAchievement(player, AchievementService.AchievementType.TheGuildedAge);
         }
 
         /// <summary>

--- a/SWLOR.Game.Server/Service/KeyItem.cs
+++ b/SWLOR.Game.Server/Service/KeyItem.cs
@@ -161,6 +161,12 @@ namespace SWLOR.Game.Server.Service
             dbPlayer.KeyItems[keyItem] = DateTime.UtcNow;
             DB.Set(dbPlayer);
 
+            if (IncubationFieldNote.TryGetNoteForKeyItem(keyItem, out _) &&
+                dbPlayer.KeyItems.Keys.Count(x => IncubationFieldNote.TryGetNoteForKeyItem(x, out _)) >= 10)
+            {
+                Achievement.GiveAchievement(player, AchievementService.AchievementType.FieldResearcher);
+            }
+
             var keyItemDetail = _allKeyItems[keyItem];
             SendMessageToPC(player, $"You acquire the '{keyItemDetail.Name}' key item.");
             Gui.PublishRefreshEvent(player, new KeyItemReceivedRefreshEvent(keyItem));

--- a/SWLOR.Game.Server/Service/Mimicry.cs
+++ b/SWLOR.Game.Server/Service/Mimicry.cs
@@ -418,6 +418,8 @@ namespace SWLOR.Game.Server.Service
             // Persist the learned techniques before GiveSkillXP runs - it performs its own
             // DB.Get/DB.Set of this player, so saving our stale copy afterward would clobber the XP.
             DB.Set(dbPlayer);
+            if (dbPlayer.LearnedTechniques.Count >= 10)
+                Achievement.GiveAchievement(player, AchievementService.AchievementType.LearnedBehavior);
 
             foreach (var detail in learnedDetails)
             {

--- a/SWLOR.Game.Server/Service/Property.cs
+++ b/SWLOR.Game.Server/Service/Property.cs
@@ -2880,6 +2880,9 @@ namespace SWLOR.Game.Server.Service
             var position = new Vector3(entrance.X, entrance.Y, entrance.Z);
             var location = Location(instance.Area, position, entrance.W);
 
+            if (property.IsPubliclyAccessible)
+                AchievementService.AchievementTracking.RecordPublicPropertyVisit(player, property.OwnerPlayerId);
+
             StoreOriginalLocation(player);
             AssignCommand(player, () =>
             {
@@ -3292,6 +3295,9 @@ namespace SWLOR.Game.Server.Service
                 var entrance = GetEntrancePosition(interior.Layout);
                 var position = Vector3(entrance.X, entrance.Y, entrance.Z);
                 var location = Location(instance.Area, position, entrance.W);
+
+                if (interior.IsPubliclyAccessible)
+                    AchievementService.AchievementTracking.RecordPublicPropertyVisit(player, interior.OwnerPlayerId);
 
                 StoreOriginalLocation(player);
                 AssignCommand(player, () => ActionJumpToLocation(location));

--- a/SWLOR.Game.Server/Service/QuestContractService/QuestContractReward.cs
+++ b/SWLOR.Game.Server/Service/QuestContractService/QuestContractReward.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using SWLOR.Game.Server.Entity;
 using SWLOR.Game.Server.Feature.GuiDefinition.RefreshEvent;
+using SWLOR.Game.Server.Service.AchievementService;
 using SWLOR.Game.Server.Service.LogService;
 using SWLOR.Game.Server.Service.QuestService;
 using SWLOR.NWN.API.NWNX;
@@ -63,6 +64,11 @@ namespace SWLOR.Game.Server.Service.QuestContractService
             }
 
             DB.Set(contract);
+            if (!string.IsNullOrWhiteSpace(contract.AuthorCDKey) &&
+                contract.AuthorCDKey != GetPCPublicCDKey(player))
+            {
+                Achievement.GiveAchievement(player, AchievementType.ContractualObligation);
+            }
 
             // Refresh the completing player's contract board (if open) so the fulfilled contract
             // disappears from the Browse list immediately.

--- a/SWLOR.Game.Server/Service/SlicingService/SlicingSession.cs
+++ b/SWLOR.Game.Server/Service/SlicingService/SlicingSession.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using SWLOR.Game.Server.Core;
 using SWLOR.Game.Server.Entity;
+using SWLOR.Game.Server.Service.AchievementService;
 using SWLOR.Game.Server.Service.DBService;
 using SWLOR.Game.Server.Service.GuiService;
 using SWLOR.Game.Server.Service.ItemService;
@@ -592,6 +593,7 @@ namespace SWLOR.Game.Server.Service.SlicingService
             Log.Write(LogGroup.Crafting,
                 $"Player '{GetName(session.Player)}' ({playerId}) completed {session.Source} slicing board {session.Board.BoardId} and received {reward.Quantity}x '{reward.Resref}'.");
             SendMessageToPC(session.Player, $"You recover {reward.Quantity}x {Cache.GetItemNameByResref(reward.Resref)}.");
+            AchievementTracking.RecordSlicingSuccess(session.Player, session.Source, session.HasUsedTool);
 
             Release(session);
             if (session.Source == SlicingSourceType.Lockbox)

--- a/SWLOR.Game.Server/Service/Space.cs
+++ b/SWLOR.Game.Server/Service/Space.cs
@@ -5,6 +5,7 @@ using SWLOR.Game.Server.Core.Bioware;
 using SWLOR.Game.Server.Core.NWNX.Enum;
 using SWLOR.Game.Server.Entity;
 using SWLOR.Game.Server.Enumeration;
+using SWLOR.Game.Server.Service.AchievementService;
 using SWLOR.Game.Server.Service.DBService;
 using SWLOR.Game.Server.Service.GuiService;
 using SWLOR.Game.Server.Service.LogService;
@@ -1690,6 +1691,14 @@ namespace SWLOR.Game.Server.Service
             // Apply death if shield and hull have reached zero.
             if (targetShipStatus.Shield <= 0 && targetShipStatus.Hull <= 0)
             {
+                if (GetIsPC(attacker) &&
+                    !GetIsPC(target) &&
+                    (GetIsReactionTypeHostile(target, attacker) || GetIsEnemy(target, attacker)) &&
+                    AchievementTracking.IsLowHull(GetShipStatus(attacker)))
+                {
+                    Achievement.GiveAchievement(attacker, AchievementType.NeverTellMeTheOdds);
+                }
+
                 // Lexicon Note regarding GetFirstObjectInShape/GetNextObjectInShape
                 // Do not apply EffectDamage without a DelayCommand (do DelayCommand(0.0, Apply...) at minimum).
                 // If you do fire it the OnDamaged or OnDeath OnPlayerDeath script may fire, causing this loop to reset

--- a/SWLOR.Game.Server/Service/Taxi.cs
+++ b/SWLOR.Game.Server/Service/Taxi.cs
@@ -62,6 +62,8 @@ namespace SWLOR.Game.Server.Service
             SendMessageToPC(player, $"'{detail.Name}' registered into taxi destinations!");
 
             DB.Set(dbPlayer);
+            if (AchievementService.AchievementTracking.HasAllTaxiDestinations(dbPlayer))
+                Achievement.GiveAchievement(player, AchievementService.AchievementType.LocalKnowledge);
         }
 
         /// <summary>

--- a/SWLOR.Game.Server/Service/Traps.cs
+++ b/SWLOR.Game.Server/Service/Traps.cs
@@ -384,6 +384,8 @@ namespace SWLOR.Game.Server.Service
             {
                 Deactivate(record);
                 GrantDisarmXP(user, record.Tier);
+                if (record.Tier >= 5)
+                    Achievement.GiveAchievement(user, AchievementService.AchievementType.TrapWhisperer);
                 SendMessageToPC(user, "You disarm the trap.");
                 return;
             }


### PR DESCRIPTION
## Summary

- add 30 account-wide achievements spanning beasts, droids, espionage, slicing, fishing, crafting, space, travel, factions, markets, properties, quests, and cooperative combat
- add shared achievement tracking with persisted cross-character progress, login-time retroactive evaluation, offline account grants, and queued character-owner delivery
- wire each achievement to its authoritative gameplay completion point, including deferred cross-account validation for legacy public-property owners
- evaluate Guard lethality only after the complete damage-taken pipeline, including redirects, sharing, and fatal-save effects
- add focused rule coverage for stable IDs, fishing planets, droid completeness, ship modules, low-hull kills, Guard lethality prevention, taxi breadth, guild breadth, and languages

## Test plan

- `dotnet build SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj --no-restore -p:RunPostBuildEvent=Never -p:UseSharedCompilation=false`
- `dotnet test SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj --no-build --filter "FullyQualifiedName~AchievementTrackingTests|FullyQualifiedName~GuardedHitModifiers_OnlyRunForPhysicalDamageFromDamageRoll"` (21 passed)
- `dotnet test SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj --no-build --filter "FullyQualifiedName~AchievementTrackingTests|FullyQualifiedName~CombatDamageTests"` (73 passed; 3 known missing-`SWLOR_Haks` failures)
- full suite baseline: 1,775 passed, 108 failed, 1 skipped; failures are unrelated missing `SWLOR_Haks` submodule assets, existing Force Burst coverage gaps, and NWN engine-initialization-dependent tests
