### PR TITLE
Improve toolset area editor workflows and performance

### DIFF
--- a/SWLOR.Toolset.Domain/Documents/GicDocument.cs
+++ b/SWLOR.Toolset.Domain/Documents/GicDocument.cs
@@ -59,6 +59,28 @@ namespace SWLOR.Toolset.Domain.Documents
             AlignCount(list, type, expectedCount);
         }
 
+        /// <summary>
+        /// Inserts a deep copy of an object's paired comment, or a blank row when the source area had
+        /// no aligned comment entry.
+        /// </summary>
+        public void InsertCopiedComment(
+            string listFieldName,
+            ResourceType type,
+            int index,
+            int expectedCount,
+            JsonGffStruct? source)
+        {
+            var list = GetOrCreateList(listFieldName);
+            while (list.Elements!.Count < index)
+                list.InsertElement(list.Elements.Count, CreateBlankComment(type));
+
+            var entry = source != null
+                ? InstanceFieldMap.Duplicate(source)
+                : CreateBlankComment(type);
+            list.InsertElement(index, entry);
+            AlignCount(list, type, expectedCount);
+        }
+
         /// <summary>Duplicates the comment row paired with a duplicated GIT instance.</summary>
         public void DuplicateComment(
             string listFieldName,

--- a/SWLOR.Toolset.Domain/Render/AreaScene.cs
+++ b/SWLOR.Toolset.Domain/Render/AreaScene.cs
@@ -411,6 +411,43 @@ namespace SWLOR.Toolset.Domain.Render
             var instances = Instances.ToArray();
             instances[index] = replacement;
 
+            return WithInstances(instances);
+        }
+
+        /// <summary>
+        /// This scene with one newly placed instance added, leaving every area-wide render input shared.
+        /// </summary>
+        /// <remarks>
+        /// Full scene assembly groups markers by kind. Insert into that same ordering so the cheap
+        /// placement path produces the same list shape as <see cref="AreaSceneBuilder.Build"/>, while
+        /// preserving the tile list by reference so the renderer does not rebuild its tile batches.
+        /// </remarks>
+        public AreaScene WithInstanceAdded(InstanceMarker instance)
+        {
+            ArgumentNullException.ThrowIfNull(instance);
+
+            var insertAt = Instances.Count;
+            for (var i = 0; i < Instances.Count; i++)
+            {
+                if (Instances[i].Kind > instance.Kind)
+                {
+                    insertAt = i;
+                    break;
+                }
+            }
+
+            var instances = new InstanceMarker[Instances.Count + 1];
+            for (var i = 0; i < insertAt; i++)
+                instances[i] = Instances[i];
+            instances[insertAt] = instance;
+            for (var i = insertAt; i < Instances.Count; i++)
+                instances[i + 1] = Instances[i];
+
+            return WithInstances(instances);
+        }
+
+        private AreaScene WithInstances(IReadOnlyList<InstanceMarker> instances)
+        {
             return new AreaScene
             {
                 Tileset = Tileset,
@@ -420,6 +457,7 @@ namespace SWLOR.Toolset.Domain.Render
                 Instances = instances,
                 Diagnostics = Diagnostics,
                 DoorAnchors = DoorAnchors,
+                IsInteriorTileset = IsInteriorTileset,
                 Lighting = Lighting
             };
         }

--- a/SWLOR.Toolset.Domain/Render/AreaSceneBuilder.cs
+++ b/SWLOR.Toolset.Domain/Render/AreaSceneBuilder.cs
@@ -252,6 +252,60 @@ namespace SWLOR.Toolset.Domain.Render
             return markers;
         }
 
+        /// <summary>
+        /// Builds the render marker for one newly placed GIT instance through the same resolution path
+        /// used by a complete scene build.
+        /// </summary>
+        /// <remarks>
+        /// Object placement does not change the tile grid or any other instance. Exposing the single
+        /// marker operation lets an editor publish that one addition immediately instead of serializing
+        /// and parsing both area documents and rebuilding every tile and existing marker.
+        /// </remarks>
+        public static InstanceMarker BuildInstanceMarker(
+            ResourceType type,
+            JsonGffStruct instance,
+            TileModelCache modelCache,
+            PlaceableAppearanceService? placeableAppearances = null,
+            DoorTypeService? doorTypes = null,
+            WaypointAppearanceService? waypointAppearances = null,
+            Func<JsonGffStruct, RenderModel?>? resolveCreatureModel = null,
+            IReadOnlyList<TilePlacement>? tiles = null)
+        {
+            ArgumentNullException.ThrowIfNull(instance);
+            ArgumentNullException.ThrowIfNull(modelCache);
+
+            return type switch
+            {
+                ResourceType.Utc => BuildMarker(
+                    instance, InstanceMarkerKind.Creature, type,
+                    resolveModel: resolveCreatureModel,
+                    modelCorrection: CreatureModelFacing.ForwardCorrection),
+                ResourceType.Utd => BuildMarker(
+                    instance, InstanceMarkerKind.Door, type,
+                    resolveModel: placed => ResolveDoorModel(placed, doorTypes, modelCache),
+                    isDoorTransition: placed => IsDoorTransition(placed, doorTypes)),
+                ResourceType.Uti => BuildMarker(instance, InstanceMarkerKind.Item, type),
+                ResourceType.Utp => BuildMarker(
+                    instance, InstanceMarkerKind.Placeable, type,
+                    resolveModel: placed => ResolvePlaceableModel(placed, placeableAppearances, modelCache)),
+                ResourceType.Uts => BuildMarker(instance, InstanceMarkerKind.Sound, type),
+                ResourceType.Utm => BuildMarker(
+                    instance, InstanceMarkerKind.Store, type,
+                    resolveModel: _ => modelCache.GetOrBuild(WaypointMarkerModel.MerchantModelResRef),
+                    modelCorrection: WaypointMarkerModel.ForwardCorrection),
+                ResourceType.Utt => BuildMarker(
+                    instance, InstanceMarkerKind.Trigger, type,
+                    includeGeometry: true,
+                    tiles: tiles),
+                ResourceType.Utw => BuildMarker(
+                    instance, InstanceMarkerKind.Waypoint, type,
+                    resolveModel: placed => ResolveWaypointModel(placed, waypointAppearances, modelCache),
+                    modelCorrection: WaypointMarkerModel.ForwardCorrection),
+                _ => throw new ArgumentOutOfRangeException(
+                    nameof(type), type, "This resource type is not an area instance.")
+            };
+        }
+
         private static void AddMarkers(
             List<InstanceMarker> markers,
             IReadOnlyList<JsonGffStruct> instances,
@@ -264,50 +318,63 @@ namespace SWLOR.Toolset.Domain.Render
             Func<JsonGffStruct, bool>? isDoorTransition = null)
         {
             foreach (var instance in instances)
+                markers.Add(BuildMarker(
+                    instance, kind, type, includeGeometry, resolveModel, modelCorrection, tiles,
+                    isDoorTransition));
+        }
+
+        private static InstanceMarker BuildMarker(
+            JsonGffStruct instance,
+            InstanceMarkerKind kind,
+            ResourceType type,
+            bool includeGeometry = false,
+            Func<JsonGffStruct, RenderModel?>? resolveModel = null,
+            Matrix4x4? modelCorrection = null,
+            IReadOnlyList<TilePlacement>? tiles = null,
+            Func<JsonGffStruct, bool>? isDoorTransition = null)
+        {
+            var (x, y, z) = InstanceFieldMap.GetPosition(type, instance);
+            var (xo, yo) = InstanceFieldMap.GetOrientation(type, instance);
+            var templateResRef = InstanceFieldMap.GetTemplateResRef(type, instance);
+            var tag = InstanceFieldMap.GetTag(instance);
+            var position = new Vector3(x, y, z);
+            var geometry = includeGeometry ? ReadGeometry(instance) : null;
+
+            // Trigger Geometry is stored as offsets from X/Y/ZPosition. The stored PointZ is
+            // whatever height each vertex happened to be clicked at and the corpus mixes floor
+            // heights inside one flat polygon, so each vertex is draped onto the walkmesh under
+            // it - the same thing Aurora does - keeping the stored Z only when no floor covers
+            // that point (off-grid vertices, tiles with no resolvable .wok).
+            if (geometry != null)
             {
-                var (x, y, z) = InstanceFieldMap.GetPosition(type, instance);
-                var (xo, yo) = InstanceFieldMap.GetOrientation(type, instance);
-                var templateResRef = InstanceFieldMap.GetTemplateResRef(type, instance);
-                var tag = InstanceFieldMap.GetTag(instance);
-                var position = new Vector3(x, y, z);
-                var geometry = includeGeometry ? ReadGeometry(instance) : null;
-
-                // Trigger Geometry is stored as offsets from X/Y/ZPosition. The stored PointZ is
-                // whatever height each vertex happened to be clicked at and the corpus mixes floor
-                // heights inside one flat polygon, so each vertex is draped onto the walkmesh under
-                // it - the same thing Aurora does - keeping the stored Z only when no floor covers
-                // that point (off-grid vertices, tiles with no resolvable .wok).
-                if (geometry != null)
+                geometry = geometry.Select(point =>
                 {
-                    geometry = geometry.Select(point =>
-                    {
-                        var world = point + position;
-                        if (tiles != null && AreaWalkmesh.GroundHeightAt(tiles, world.X, world.Y) is { } floor)
-                            world = new Vector3(world.X, world.Y, floor);
-                        return world;
-                    }).ToArray();
-                }
-
-                markers.Add(new InstanceMarker
-                {
-                    Kind = kind,
-                    TemplateResRef = templateResRef,
-                    Tag = tag,
-                    Position = position,
-                    Orientation = new Vector2(xo, yo),
-                    // A model-space correction composes before the instance's own EE visual
-                    // transform, which is itself instance-local - see WaypointMarkerModel.
-                    VisualTransform = modelCorrection is { } correction
-                        ? correction * InstanceFieldMap.GetVisualTransform(instance)
-                        : InstanceFieldMap.GetVisualTransform(instance),
-                    Geometry = geometry,
-                    Model = resolveModel?.Invoke(instance),
-                    IsDoorTransition = isDoorTransition?.Invoke(instance) ?? false,
-                    SoundMinDistance = kind == InstanceMarkerKind.Sound ? instance.GetSingleOrNull("MinDistance") : null,
-                    SoundMaxDistance = kind == InstanceMarkerKind.Sound ? instance.GetSingleOrNull("MaxDistance") : null,
-                    IsPositionalSound = kind == InstanceMarkerKind.Sound && (instance.GetIntOrNull("Positional") ?? 0) != 0
-                });
+                    var world = point + position;
+                    if (tiles != null && AreaWalkmesh.GroundHeightAt(tiles, world.X, world.Y) is { } floor)
+                        world = new Vector3(world.X, world.Y, floor);
+                    return world;
+                }).ToArray();
             }
+
+            return new InstanceMarker
+            {
+                Kind = kind,
+                TemplateResRef = templateResRef,
+                Tag = tag,
+                Position = position,
+                Orientation = new Vector2(xo, yo),
+                // A model-space correction composes before the instance's own EE visual
+                // transform, which is itself instance-local - see WaypointMarkerModel.
+                VisualTransform = modelCorrection is { } correction
+                    ? correction * InstanceFieldMap.GetVisualTransform(instance)
+                    : InstanceFieldMap.GetVisualTransform(instance),
+                Geometry = geometry,
+                Model = resolveModel?.Invoke(instance),
+                IsDoorTransition = isDoorTransition?.Invoke(instance) ?? false,
+                SoundMinDistance = kind == InstanceMarkerKind.Sound ? instance.GetSingleOrNull("MinDistance") : null,
+                SoundMaxDistance = kind == InstanceMarkerKind.Sound ? instance.GetSingleOrNull("MaxDistance") : null,
+                IsPositionalSound = kind == InstanceMarkerKind.Sound && (instance.GetIntOrNull("Positional") ?? 0) != 0
+            };
         }
 
         /// <summary>Placeable instances carry their appearance directly: Appearance → placeables.2da ModelName.</summary>

--- a/SWLOR.Toolset.Domain/Workspace/BlueprintCatalog.cs
+++ b/SWLOR.Toolset.Domain/Workspace/BlueprintCatalog.cs
@@ -205,9 +205,17 @@ namespace SWLOR.Toolset.Domain.Workspace
         /// current catalog snapshot immediately. A concurrent initial build also merges the
         /// refreshed entry before publishing its final snapshot, so the update cannot be lost.
         /// </summary>
-        public CatalogEntry? RefreshEntry(ResourceType type, string resRef)
+        public CatalogEntry? RefreshEntry(ResourceType type, string resRef) =>
+            RefreshEntry(type, resRef, out _);
+
+        /// <summary>
+        /// Re-reads one resource and reports whether its indexed metadata or membership changed.
+        /// Content-only edits return the existing entry without invalidating the ordered snapshot.
+        /// </summary>
+        public CatalogEntry? RefreshEntry(ResourceType type, string resRef, out bool changed)
         {
             var key = IdentityKey(type, resRef);
+            changed = false;
 
             // Recreating a resref that was deleted earlier has to lift its tombstone, or the entry
             // would be published here and then dropped again by a still-running build.
@@ -216,12 +224,16 @@ namespace SWLOR.Toolset.Domain.Workspace
             var entry = BuildEntry(type, resRef);
             if (entry == null)
             {
-                RemoveEntry(type, resRef);
+                changed = RemoveEntry(type, resRef);
                 return null;
             }
 
+            if (_indexedEntries.TryGetValue(key, out var existing) && existing == entry)
+                return existing;
+
             _indexedEntries[key] = entry;
             PublishSnapshot();
+            changed = true;
 
             return entry;
         }
@@ -229,13 +241,18 @@ namespace SWLOR.Toolset.Domain.Workspace
         /// <summary>
         /// Drops a resource that no longer exists, so panels stop listing a file that has been deleted.
         /// </summary>
-        public void RemoveEntry(ResourceType type, string resRef)
+        public bool RemoveEntry(ResourceType type, string resRef)
         {
             var key = IdentityKey(type, resRef);
             _removed[key] = true;
 
             if (_indexedEntries.TryRemove(key, out _))
+            {
                 PublishSnapshot();
+                return true;
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/SWLOR.Toolset.Tests/AreaContentsTests.cs
+++ b/SWLOR.Toolset.Tests/AreaContentsTests.cs
@@ -567,7 +567,7 @@ namespace SWLOR.Toolset.Tests
         }
 
         [Test]
-        public async Task SavingAGitOnlyEditPublishesTheAreaCatalogChange()
+        public async Task SavingAGitOnlyEditDoesNotPublishAnAreaCatalogChange()
         {
             var editor = CreateEditor();
             var section = editor.SectionFor(ResourceType.Utp)!;
@@ -580,10 +580,10 @@ namespace SWLOR.Toolset.Tests
             section.DetailTag = "git_only_catalog_refresh";
 
             (await editor.TrySaveAsync()).Should().BeTrue();
-            notifications.Should().Be(1,
-                "placed-instance tags and script slots are indexed from GIT, not ARE");
+            notifications.Should().Be(0,
+                "the area catalog entry is parsed from ARE metadata, never the paired GIT");
             placementNotifications.Should().Be(1,
-                "a saved GIT changes the module placement index");
+                "a saved GIT changes the module's GIT-derived indexes");
             new GitDocument(JsonGffDocument.Load(
                     Path.Combine(_moduleRoot, "git", $"{AreaResRef}.git.json")))
                 .Placeables[0].GetStringOrNull("Tag")
@@ -612,7 +612,7 @@ namespace SWLOR.Toolset.Tests
         }
 
         [Test]
-        public async Task ReloadingAnExternalGitChangePublishesTheAreaCatalogChange()
+        public async Task ReloadingAnExternalGitChangeDoesNotPublishAnAreaCatalogChange()
         {
             var editor = CreateEditor(new ReloadPrompts());
             var section = editor.SectionFor(ResourceType.Utp)!;
@@ -632,7 +632,8 @@ namespace SWLOR.Toolset.Tests
 
             (await editor.TrySaveAsync()).Should().BeTrue();
 
-            notifications.Should().Be(1);
+            notifications.Should().Be(0,
+                "reloading GIT instance data cannot change catalog metadata read from the ARE");
             placementNotifications.Should().Be(1,
                 "reloading the paired GIT changes the placement snapshot");
             editor.SectionFor(ResourceType.Utp)!.Rows[0].Tag.Should().Be(diskTag);

--- a/SWLOR.Toolset.Tests/AreaPlacementIncrementalTests.cs
+++ b/SWLOR.Toolset.Tests/AreaPlacementIncrementalTests.cs
@@ -1,0 +1,244 @@
+using System.Numerics;
+using Avalonia.Headless.NUnit;
+using FluentAssertions;
+using NUnit.Framework;
+using SWLOR.Toolset.Domain.Documents;
+using SWLOR.Toolset.Domain.GameData.Lookups;
+using SWLOR.Toolset.Domain.GameData.Resources;
+using SWLOR.Toolset.Domain.Gff;
+using SWLOR.Toolset.Domain.Render;
+using SWLOR.Toolset.Domain.Workspace;
+using SWLOR.Toolset.Editors;
+using SWLOR.Toolset.Services;
+using SWLOR.Toolset.Shell.Panels;
+using SWLOR.Toolset.Workspace;
+
+namespace SWLOR.Toolset.Tests
+{
+    /// <summary>Object placement updates one marker instead of rebuilding a complete area scene.</summary>
+    [TestFixture]
+    public sealed class AreaPlacementIncrementalTests
+    {
+        private const string AreaResRef = "prefab_space";
+        private const string PlaceableResRef = "rugpitpcbl";
+        private string _moduleRoot = string.Empty;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _moduleRoot = Path.Combine(
+                Path.GetTempPath(), $"swlor-placement-fast-{Guid.NewGuid():N}");
+            foreach (var folder in CorpusLocator.GffFolders)
+                Directory.CreateDirectory(Path.Combine(_moduleRoot, folder));
+
+            foreach (var folder in new[] { "are", "git", "gic" })
+            {
+                File.Copy(
+                    Path.Combine(CorpusLocator.ModuleDirectory, folder, $"{AreaResRef}.{folder}.json"),
+                    Path.Combine(_moduleRoot, folder, $"{AreaResRef}.{folder}.json"));
+            }
+
+            File.Copy(
+                Path.Combine(CorpusLocator.ModuleDirectory, "utp", $"{PlaceableResRef}.utp.json"),
+                Path.Combine(_moduleRoot, "utp", $"{PlaceableResRef}.utp.json"));
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (Directory.Exists(_moduleRoot))
+                Directory.Delete(_moduleRoot, recursive: true);
+        }
+
+        [AvaloniaTest]
+        public async Task PlacementPublishesOneMarkerWithoutASecondFullSceneBuild()
+        {
+            var editor = await CreateEditorAsync();
+            editor.EnsureSceneBuilt();
+            await WaitUntilAsync(() => editor.AreaScene != null && !editor.IsBuildingScene);
+
+            var before = editor.AreaScene!;
+            var originalInstanceCount = before.Instances.Count;
+            editor.ArmPlacement(
+                ResourceType.Utp,
+                PlaceableResRef,
+                PaletteSource.Custom).Should().BeTrue();
+
+            editor.CommitPlacement(new Vector3(12.5f, 7.25f, 0f));
+
+            var published = editor.AreaScene;
+            published.Should().NotBeSameAs(before, "the placed marker is published synchronously");
+            published!.Tiles.Should().BeSameAs(before.Tiles,
+                "placement must not rebuild or copy the area's tile grid");
+            published.Diagnostics.Should().BeSameAs(before.Diagnostics);
+            published.Instances.Should().HaveCount(originalInstanceCount + 1);
+            editor.SelectedSceneInstance.Should().BeSameAs(published.Instances[^1]);
+            editor.SelectedSceneInstance!.TemplateResRef.Should().Be(PlaceableResRef);
+            editor.SelectedSceneInstance.Position.Should().Be(new Vector3(12.5f, 7.25f, 0f));
+            editor.IsBuildingScene.Should().BeFalse();
+
+            // Run past the ordinary edit debounce. If the placement failed to claim the new scene
+            // revision, that delayed refresh would still replace this cheap scene with a full build.
+            await Task.Delay(350);
+            editor.AreaScene.Should().BeSameAs(published);
+            editor.IsBuildingScene.Should().BeFalse();
+        }
+
+        [AvaloniaTest]
+        public async Task CopyPasteArmsTheCursorAndPreservesTheCompleteInstanceAndComment()
+        {
+            AddAuthoredSourcePlacement();
+            var editor = await CreateEditorAsync(new AreaInstanceClipboard());
+            editor.EnsureSceneBuilt();
+            await WaitUntilAsync(() => editor.AreaScene != null && !editor.IsBuildingScene);
+
+            var source = editor.AreaScene!.Instances.Should().ContainSingle(
+                marker => marker.Kind == InstanceMarkerKind.Placeable).Which;
+            AssertFacingNorth(source.Orientation);
+            editor.SelectSceneInstance(source);
+
+            editor.CopySelectedSceneInstance().Should().BeTrue();
+
+            // Prove Ctrl+C took an independent snapshot rather than remembering the live row.
+            editor.RotateSelectedInstance(source, new Vector2(1f, 0f));
+            editor.PasteCopiedSceneInstance().Should().BeTrue();
+            editor.IsPlacementPending.Should().BeTrue();
+            editor.PlacementGhost.Should().NotBeNull();
+            editor.PlacementGhost!.TemplateResRef.Should().Be(PlaceableResRef);
+            AssertFacingNorth(editor.PlacementGhost.Orientation);
+
+            var destination = new Vector3(18.5f, 21.25f, 0f);
+            editor.CommitPlacement(destination);
+
+            editor.IsPlacementPending.Should().BeFalse();
+            editor.AreaScene!.Instances.Should().HaveCount(2);
+            editor.SelectedSceneInstance.Should().NotBeNull();
+            var pastedMarker = editor.SelectedSceneInstance!;
+            pastedMarker.Position.Should().Be(destination);
+            AssertFacingNorth(pastedMarker.Orientation);
+
+            (await editor.TrySaveAsync()).Should().BeTrue();
+            var savedGit = GitDocument.Load(Path.Combine(
+                _moduleRoot, "git", $"{AreaResRef}.git.json"));
+            savedGit.Placeables.Should().HaveCount(2);
+            var pasted = savedGit.Placeables[1];
+            pasted.GetStringOrNull("COPY_SENTINEL").Should().Be("preserve the full instance");
+            pasted.GetStringOrNull("Tag").Should().Be("copied_source_tag");
+            InstanceFieldMap.GetPosition(ResourceType.Utp, pasted)
+                .Should().Be((destination.X, destination.Y, destination.Z));
+            var pastedFacing = InstanceFieldMap.GetOrientation(ResourceType.Utp, pasted);
+            pastedFacing.XOrientation.Should().BeApproximately(0f, 0.00001f);
+            pastedFacing.YOrientation.Should().BeApproximately(1f, 0.00001f,
+                "paste retains the copied heading unless a doorway supplies one");
+
+            var savedGic = GicDocument.Load(Path.Combine(
+                _moduleRoot, "gic", $"{AreaResRef}.gic.json"));
+            savedGic.Placeables.Should().HaveCount(2);
+            GicDocument.GetComment(savedGic.Placeables[1]).Should().Be("builder note survives copy");
+
+            editor.UndoInstancesCommand.Execute(null);
+            editor.Sections.Single(section => section.BlueprintType == ResourceType.Utp)
+                .Rows.Should().ContainSingle("paste is one undoable edit");
+            (await editor.TrySaveAsync()).Should().BeTrue();
+            GicDocument.Load(Path.Combine(_moduleRoot, "gic", $"{AreaResRef}.gic.json"))
+                .Placeables.Should().ContainSingle("undo removes the paired copied comment too");
+        }
+
+        private void AddAuthoredSourcePlacement()
+        {
+            var gitPath = Path.Combine(_moduleRoot, "git", $"{AreaResRef}.git.json");
+            var git = JsonGffDocument.Load(gitPath);
+            var placeables = git.Root.GetOrNull("Placeable List");
+            if (placeables == null)
+            {
+                placeables = JsonGffField.CreateList();
+                git.Root.Add("Placeable List", placeables);
+            }
+
+            var blueprint = JsonGffDocument.Load(Path.Combine(
+                _moduleRoot, "utp", $"{PlaceableResRef}.utp.json"));
+            var source = InstanceFieldMap.CreateInstance(
+                ResourceType.Utp,
+                blueprint,
+                PlaceableResRef,
+                4f,
+                6f,
+                0f,
+                0f,
+                1f);
+            source.SetString("Tag", GffFieldType.CExoString, "copied_source_tag");
+            source.SetString(
+                "COPY_SENTINEL", GffFieldType.CExoString, "preserve the full instance");
+            placeables.InsertElement(placeables.Elements!.Count, source);
+            File.WriteAllBytes(gitPath, git.ToBytes());
+
+            var gicPath = Path.Combine(_moduleRoot, "gic", $"{AreaResRef}.gic.json");
+            var gicJson = JsonGffDocument.Load(gicPath);
+            var gic = new GicDocument(gicJson);
+            gic.InsertBlankComment(
+                "Placeable List", ResourceType.Utp, 0, expectedCount: 1);
+            GicDocument.SetComment(gic.Placeables[0], "builder note survives copy");
+            File.WriteAllBytes(gicPath, gicJson.ToBytes());
+        }
+
+        private async Task<AreaEditorViewModel> CreateEditorAsync(
+            AreaInstanceClipboard? clipboard = null)
+        {
+            var log = new OutputLogService();
+            var context = new WorkspaceContext(_ => throw new NotSupportedException(), log);
+            var resources = new ResourceIndex(null, Array.Empty<ResourceIndex.HakLayer>());
+            await resources.InitializationTask;
+            return new AreaEditorViewModel(
+                AreaResRef,
+                new ModuleWorkspace(_moduleRoot),
+                new LookupOptionProvider(context),
+                gameCodeIndex: null,
+                log,
+                tilesetCatalog: new TilesetCatalog(resources),
+                tileModelCache: new TileModelCache(resources),
+                resourceIndex: resources,
+                prompts: new StubPrompts(),
+                instanceClipboard: clipboard);
+        }
+
+        private static void AssertFacingNorth(Vector2 orientation)
+        {
+            orientation.X.Should().BeApproximately(0f, 0.00001f);
+            orientation.Y.Should().BeApproximately(1f, 0.00001f);
+        }
+
+        private static async Task WaitUntilAsync(Func<bool> condition)
+        {
+            var deadline = DateTime.UtcNow.AddSeconds(5);
+            while (!condition())
+            {
+                if (DateTime.UtcNow >= deadline)
+                    Assert.Fail("Timed out waiting for the initial area scene build.");
+
+                await Task.Delay(25);
+            }
+        }
+
+        private sealed class StubPrompts : IEditorPromptService
+        {
+            public Task<UnsavedChangesChoice> ConfirmCloseAsync(string name) =>
+                Task.FromResult(UnsavedChangesChoice.Cancel);
+
+            public Task<ExternalChangeChoice> ConfirmExternalChangeAsync(string path) =>
+                Task.FromResult(ExternalChangeChoice.Cancel);
+
+            public Task<string?> PromptForTextAsync(
+                string headline,
+                string message,
+                string initialValue,
+                string confirmLabel) =>
+                Task.FromResult<string?>(null);
+
+            public Task<bool> ConfirmDestructiveAsync(
+                string headline,
+                string message,
+                string confirmLabel) =>
+                Task.FromResult(false);
+        }
+    }
+}

--- a/SWLOR.Toolset.Tests/AreaPlacementIncrementalTests.cs
+++ b/SWLOR.Toolset.Tests/AreaPlacementIncrementalTests.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using Avalonia.Headless.NUnit;
+using Avalonia.Input;
 using FluentAssertions;
 using NUnit.Framework;
 using SWLOR.Toolset.Domain.Documents;
@@ -144,6 +145,25 @@ namespace SWLOR.Toolset.Tests
                 .Placeables.Should().ContainSingle("undo removes the paired copied comment too");
         }
 
+        [AvaloniaTest]
+        public async Task AreaEditorViewRoutesControlCopyAndPasteToPlacement()
+        {
+            AddAuthoredSourcePlacement();
+            var editor = await CreateEditorAsync(new AreaInstanceClipboard());
+            editor.EnsureSceneBuilt();
+            await WaitUntilAsync(() => editor.AreaScene != null && !editor.IsBuildingScene);
+            editor.SelectSceneInstance(editor.AreaScene!.Instances.Should().ContainSingle(
+                marker => marker.Kind == InstanceMarkerKind.Placeable).Which);
+
+            var view = new ShortcutAreaEditorView { DataContext = editor };
+
+            view.SendControlKey(Key.C).Should().BeTrue();
+            view.SendControlKey(Key.V).Should().BeTrue();
+            editor.IsPlacementPending.Should().BeTrue();
+            editor.PlacementGhost.Should().NotBeNull();
+            editor.PlacementGhost!.TemplateResRef.Should().Be(PlaceableResRef);
+        }
+
         private void AddAuthoredSourcePlacement()
         {
             var gitPath = Path.Combine(_moduleRoot, "git", $"{AreaResRef}.git.json");
@@ -239,6 +259,21 @@ namespace SWLOR.Toolset.Tests
                 string message,
                 string confirmLabel) =>
                 Task.FromResult(false);
+        }
+
+        private sealed class ShortcutAreaEditorView : AreaEditorView
+        {
+            public bool SendControlKey(Key key)
+            {
+                var args = new KeyEventArgs
+                {
+                    RoutedEvent = KeyDownEvent,
+                    Key = key,
+                    KeyModifiers = KeyModifiers.Control
+                };
+                OnKeyDown(args);
+                return args.Handled;
+            }
         }
     }
 }

--- a/SWLOR.Toolset.Tests/AreaSceneInstanceUpdateTests.cs
+++ b/SWLOR.Toolset.Tests/AreaSceneInstanceUpdateTests.cs
@@ -49,7 +49,8 @@ namespace SWLOR.Toolset.Tests
                     }
                 },
                 Instances = instances,
-                Diagnostics = new AreaSceneDiagnostics()
+                Diagnostics = new AreaSceneDiagnostics(),
+                IsInteriorTileset = true
             };
 
         /// <summary>
@@ -232,6 +233,45 @@ namespace SWLOR.Toolset.Tests
             updated!.Tiles.Should().BeSameAs(scene.Tiles);
             updated.DoorAnchors.Should().BeSameAs(scene.DoorAnchors);
             updated.Lighting.Should().BeSameAs(scene.Lighting);
+            updated.IsInteriorTileset.Should().BeTrue();
+        }
+
+        [Test]
+        public void AddingAnInstanceLeavesAreaWideSceneInputsAlone()
+        {
+            var existing = Marker(InstanceMarkerKind.Placeable);
+            var added = Marker(InstanceMarkerKind.Waypoint, new Vector3(50, 60, 0));
+            var scene = SceneWith(existing);
+
+            var updated = scene.WithInstanceAdded(added);
+
+            updated.Should().NotBeSameAs(scene);
+            updated.Instances.Should().Equal(existing, added);
+            updated.Tiles.Should().BeSameAs(scene.Tiles);
+            updated.DoorAnchors.Should().BeSameAs(scene.DoorAnchors);
+            updated.Diagnostics.Should().BeSameAs(scene.Diagnostics);
+            updated.Lighting.Should().BeSameAs(scene.Lighting);
+            updated.IsInteriorTileset.Should().BeTrue();
+            scene.Instances.Should().ContainSingle().Which.Should().BeSameAs(
+                existing, "the published scene is immutable");
+        }
+
+        [Test]
+        public void AddingAnInstanceKeepsTheFullBuilderKindOrder()
+        {
+            var creature = Marker(InstanceMarkerKind.Creature);
+            var placeable = Marker(InstanceMarkerKind.Placeable);
+            var waypoint = Marker(InstanceMarkerKind.Waypoint);
+            var door = Marker(InstanceMarkerKind.Door);
+            var scene = SceneWith(creature, placeable, waypoint);
+
+            var updated = scene.WithInstanceAdded(door);
+
+            updated.Instances.Select(instance => instance.Kind).Should().Equal(
+                InstanceMarkerKind.Creature,
+                InstanceMarkerKind.Door,
+                InstanceMarkerKind.Placeable,
+                InstanceMarkerKind.Waypoint);
         }
 
         [Test]

--- a/SWLOR.Toolset.Tests/BlueprintCatalogLookupTests.cs
+++ b/SWLOR.Toolset.Tests/BlueprintCatalogLookupTests.cs
@@ -108,6 +108,23 @@ namespace SWLOR.Toolset.Tests
         }
 
         [Test]
+        public async Task RefreshWithUnchangedMetadataKeepsThePublishedSnapshot()
+        {
+            var catalog = await BuiltCatalogAsync();
+            var published = catalog.Entries;
+
+            var refreshed = catalog.RefreshEntry(
+                ResourceType.Utc,
+                "npc_guard",
+                out var changed);
+
+            refreshed.Should().NotBeNull();
+            changed.Should().BeFalse();
+            catalog.Entries.Should().BeSameAs(published,
+                "content-only saves must not re-sort and republish the full catalog");
+        }
+
+        [Test]
         public async Task RefreshRemovesAResourceThatDisappearedBeforeItCouldBeRead()
         {
             var catalog = await BuiltCatalogAsync();

--- a/SWLOR.Toolset.Tests/ModuleExplorerSearchTests.cs
+++ b/SWLOR.Toolset.Tests/ModuleExplorerSearchTests.cs
@@ -1,6 +1,7 @@
 using Avalonia.Headless.NUnit;
 using FluentAssertions;
 using NUnit.Framework;
+using SWLOR.Toolset.Domain.Categories;
 using SWLOR.Toolset.Domain.Conversations;
 using SWLOR.Toolset.Domain.Documents;
 using SWLOR.Toolset.Domain.Workspace;
@@ -158,6 +159,55 @@ namespace SWLOR.Toolset.Tests
             ContainsResRef(explorer.Rows, "ordinary").Should().BeTrue();
             ContainsResRef(explorer.Rows, "dialog1").Should().BeFalse();
             explorer.Tabs.Single(tab => tab.Type == ResourceType.Dlg).Count.Should().Be(1);
+        }
+
+        [Test]
+        public void AreaSearchHidesCategoriesWithoutMatchesAndRestoresThemWhenCleared()
+        {
+            File.WriteAllText(Path.Combine(_root, "are", "nanostation015.are.json"), "{}");
+            File.WriteAllText(Path.Combine(_root, "are", "tatooine001.are.json"), "{}");
+
+            var log = new OutputLogService();
+            var workspace = new WorkspaceContext(root => new ModuleWorkspace(root), log);
+            workspace.Open(_root);
+            var categories = new CategoryService(workspace, log);
+            var section = categories.Section(ResourceType.Area)!;
+            section.IsSeeded = true;
+            var stations = section.AddFolder("Stations");
+            stations.AddChild("Nanostation").AddMember("nanostation015");
+            stations.AddChild("Other Stations").AddMember("tatooine001");
+            section.AddFolder("Planets").AddMember("tatooine001");
+            section.AddFolder("Empty Category");
+
+            var explorer = new ModuleExplorerViewModel(
+                workspace,
+                new PropertiesViewModel(workspace, log),
+                categories,
+                log);
+            explorer.Initialize();
+
+            var stationsRow = explorer.Rows.Single(row => row.Folder == stations);
+            explorer.ToggleCommand.Execute(stationsRow);
+            explorer.Rows.Should().Contain(row => row.Name == "Other Stations");
+            explorer.Rows.Should().Contain(row => row.Name == "Planets");
+            explorer.Rows.Should().Contain(row => row.Name == "Empty Category");
+            explorer.Rows.Should().Contain(row => row.Name == CategorySection.UnsortedFolderName);
+
+            explorer.Filter = "nanostation015";
+
+            explorer.Rows.Should().Contain(row => row.Name == "Stations");
+            explorer.Rows.Should().Contain(row => row.Name == "Nanostation");
+            explorer.Rows.Should().NotContain(row => row.Name == "Other Stations");
+            explorer.Rows.Should().NotContain(row => row.Name == "Planets");
+            explorer.Rows.Should().NotContain(row => row.Name == "Empty Category");
+            explorer.Rows.Should().NotContain(row => row.Name == CategorySection.UnsortedFolderName);
+
+            explorer.Filter = string.Empty;
+
+            explorer.Rows.Should().Contain(row => row.Name == "Other Stations");
+            explorer.Rows.Should().Contain(row => row.Name == "Planets");
+            explorer.Rows.Should().Contain(row => row.Name == "Empty Category");
+            explorer.Rows.Should().Contain(row => row.Name == CategorySection.UnsortedFolderName);
         }
 
         /// <summary>

--- a/SWLOR.Toolset.Tests/WorkspaceContextCatalogTests.cs
+++ b/SWLOR.Toolset.Tests/WorkspaceContextCatalogTests.cs
@@ -150,7 +150,7 @@ namespace SWLOR.Toolset.Tests
         }
 
         [Test]
-        public void PairedGitInvalidationPublishesTagAndPlacementRefreshNotifications()
+        public void PairedGitInvalidationPublishesEveryGitDerivedRefreshNotification()
         {
             var workspace = new WorkspaceContext(
                 root => new ModuleWorkspace(root),
@@ -158,13 +158,59 @@ namespace SWLOR.Toolset.Tests
             OpenWorkspace(workspace);
             var tagNotifications = 0;
             var placementNotifications = 0;
+            var scriptNotifications = 0;
             workspace.TagIndexInvalidated += () => tagNotifications++;
             workspace.PlacementIndexInvalidated += () => placementNotifications++;
+            workspace.ScriptUsagesInvalidated += () => scriptNotifications++;
 
             workspace.InvalidateGitIndexes();
 
             tagNotifications.Should().Be(1);
             placementNotifications.Should().Be(1);
+            scriptNotifications.Should().Be(1);
+        }
+
+        [Test]
+        public void ContentOnlyCatalogRefreshDoesNotPublishAnOrderedCatalogChange()
+        {
+            var path = Path.Combine(_root, "utc", "existing_creature.utc.json");
+            File.WriteAllText(path, "not valid GFF JSON");
+            var workspace = new WorkspaceContext(
+                root => new ModuleWorkspace(root),
+                new OutputLogService());
+            OpenWorkspace(workspace);
+            workspace.Catalog!.BuildTask.GetAwaiter().GetResult();
+            var contentNotifications = 0;
+            var catalogNotifications = 0;
+            workspace.CatalogEntryRefreshed += (_, _) => contentNotifications++;
+            workspace.CatalogEntriesChanged += (_, _) => catalogNotifications++;
+
+            workspace.RefreshCatalogEntry(ResourceType.Utc, "existing_creature");
+
+            contentNotifications.Should().Be(1,
+                "content-dependent caches still need to hear about a saved blueprint");
+            catalogNotifications.Should().Be(0,
+                "unchanged indexed metadata must not regroup Explorer or requery Search");
+        }
+
+        [Test]
+        public void NewCatalogMembershipPublishesAnOrderedCatalogChange()
+        {
+            var workspace = new WorkspaceContext(
+                root => new ModuleWorkspace(root),
+                new OutputLogService());
+            OpenWorkspace(workspace);
+            workspace.Catalog!.BuildTask.GetAwaiter().GetResult();
+            File.WriteAllText(
+                Path.Combine(_root, "utc", "new_creature.utc.json"),
+                "not valid GFF JSON");
+            var notifications = 0;
+            workspace.CatalogEntriesChanged += (_, _) => notifications++;
+
+            workspace.RefreshCatalogEntry(ResourceType.Utc, "new_creature");
+
+            notifications.Should().Be(1,
+                "adding an entry changes the ordered catalog consumed by Explorer and Search");
         }
 
         [Test]

--- a/SWLOR.Toolset.Tests/WorkspaceContextCatalogTests.cs
+++ b/SWLOR.Toolset.Tests/WorkspaceContextCatalogTests.cs
@@ -1,5 +1,7 @@
 using FluentAssertions;
 using NUnit.Framework;
+using SWLOR.Toolset.Domain.Documents;
+using SWLOR.Toolset.Domain.Gff;
 using SWLOR.Toolset.Domain.Workspace;
 using SWLOR.Toolset.Workspace;
 
@@ -174,12 +176,18 @@ namespace SWLOR.Toolset.Tests
         public void ContentOnlyCatalogRefreshDoesNotPublishAnOrderedCatalogChange()
         {
             var path = Path.Combine(_root, "utc", "existing_creature.utc.json");
-            File.WriteAllText(path, "not valid GFF JSON");
+            var blueprint = new JsonGffDocument("UTC ", new JsonGffStruct());
+            blueprint.Root.SetString("Tag", GffFieldType.CExoString, "same_catalog_tag");
+            blueprint.Root.SetString("Comment", GffFieldType.CExoString, "before refresh");
+            File.WriteAllBytes(path, blueprint.ToBytes());
             var workspace = new WorkspaceContext(
                 root => new ModuleWorkspace(root),
                 new OutputLogService());
             OpenWorkspace(workspace);
             workspace.Catalog!.BuildTask.GetAwaiter().GetResult();
+
+            blueprint.Root.SetString("Comment", GffFieldType.CExoString, "after refresh");
+            File.WriteAllBytes(path, blueprint.ToBytes());
             var contentNotifications = 0;
             var catalogNotifications = 0;
             workspace.CatalogEntryRefreshed += (_, _) => contentNotifications++;

--- a/SWLOR.Toolset/Editors/AreaEditorViewModel.cs
+++ b/SWLOR.Toolset/Editors/AreaEditorViewModel.cs
@@ -86,6 +86,9 @@ namespace SWLOR.Toolset.Editors
         /// <summary>The shared pack/build/validation lock governing module writes.</summary>
         private readonly ModuleMutationLock? _mutationLock;
 
+        /// <summary>Shared by open area tabs so copied placements can cross area boundaries.</summary>
+        private readonly AreaInstanceClipboard _instanceClipboard;
+
         /// <summary>
         /// Which session each still-undoable edit went to, oldest first.
         /// </summary>
@@ -585,9 +588,10 @@ namespace SWLOR.Toolset.Editors
         private InstanceListSectionViewModel? _pendingPlacementSection;
         private string? _pendingPlacementResRef;
         private bool _pendingPlacementUsesIndexedBlueprint;
+        private AreaInstanceClipboardEntry? _pendingPlacementCopy;
 
         /// <summary>True from the moment a palette blueprint is chosen for placement until the next viewport click (or Esc/right-click cancel) resolves it - drives GlAreaControl.IsPlacementActive.</summary>
-        public bool IsPlacementPending => _pendingPlacementResRef != null;
+        public bool IsPlacementPending => _pendingPlacementSection != null;
 
         /// <summary>
         /// 3D-view status line while a placement is pending, or empty otherwise. A door names the
@@ -1178,17 +1182,8 @@ namespace SWLOR.Toolset.Editors
             if (section == null || string.IsNullOrWhiteSpace(resRef))
                 return false;
 
-            // A door is hung in an empty doorway the tile declares, never on open floor and never in a
-            // doorway that already holds one, so an area laid entirely with doorless tiles - or one
-            // whose every doorway is filled - has nowhere to put another. Arming a placement that can
-            // never resolve would leave the builder clicking at a map that refuses every click.
-            if (type == ResourceType.Utd && AreaScene is { } scene && !scene.HasEmptyDoorway())
-            {
-                _log.AppendLine(scene.DoorAnchors.Count == 0
-                    ? $"'{resRef}' cannot be placed: no tile in this area declares a doorway to hang a door in."
-                    : $"'{resRef}' cannot be placed: every doorway in this area already has a door in it.");
+            if (!CanArmObjectPlacement(type, resRef))
                 return false;
-            }
 
             // The other half of the exclusion in ArmTilePlacement: only one thing follows the cursor, so a
             // builder always knows what the next click resolves.
@@ -1197,11 +1192,84 @@ namespace SWLOR.Toolset.Editors
             _pendingPlacementSection = section;
             _pendingPlacementResRef = resRef;
             _pendingPlacementUsesIndexedBlueprint = source == Shell.Panels.PaletteSource.Standard;
+            _pendingPlacementCopy = null;
             PlacementGhost = BuildPlacementGhost(type, resRef, _pendingPlacementUsesIndexedBlueprint);
+            NotifyPlacementChanged();
+            return true;
+        }
+
+        /// <summary>
+        /// Copies the selected placed object as an independent GIT/GIC snapshot.
+        /// </summary>
+        public bool CopySelectedSceneInstance()
+        {
+            if (SelectedSceneInstance is not { } instance ||
+                SectionForKind(instance.Kind) is not { } section)
+            {
+                return false;
+            }
+
+            var index = IndexWithinKind(instance);
+            var copy = index >= 0 ? section.CopyInstanceForPlacement(index, instance) : null;
+            if (copy == null)
+                return false;
+
+            _instanceClipboard.Set(copy);
+            SceneStatus = $"Copied {SelectionName}. Press Ctrl+V to place a copy.";
+            return true;
+        }
+
+        /// <summary>
+        /// Arms the copied object as the placement ghost. The next valid map click commits the clone.
+        /// </summary>
+        public bool PasteCopiedSceneInstance()
+        {
+            if (_instanceClipboard.Content is not { } copy ||
+                !string.Equals(copy.ModuleRoot, _workspace.ModuleRoot, StringComparison.OrdinalIgnoreCase) ||
+                Sections.FirstOrDefault(section => section.BlueprintType == copy.Type) is not { } section)
+            {
+                return false;
+            }
+
+            var resRef = InstanceFieldMap.GetTemplateResRef(copy.Type, copy.Instance);
+            var label = !string.IsNullOrWhiteSpace(resRef)
+                ? resRef
+                : InstanceFieldMap.GetTag(copy.Instance) ?? copy.Type.SingularDisplayName();
+            if (!CanArmObjectPlacement(copy.Type, label))
+                return false;
+
+            CancelTilePlacement();
+            CancelPlacement();
+
+            _pendingPlacementSection = section;
+            _pendingPlacementResRef = label;
+            _pendingPlacementUsesIndexedBlueprint = false;
+            _pendingPlacementCopy = copy;
+            PlacementGhost = copy.Preview;
+            NotifyPlacementChanged();
+            return true;
+        }
+
+        /// <summary>
+        /// A door is hung in an empty doorway the tile declares, never on open floor and never in a
+        /// doorway that already holds one. Other object kinds have no arm-time placement constraint.
+        /// </summary>
+        private bool CanArmObjectPlacement(ResourceType type, string label)
+        {
+            if (type != ResourceType.Utd || AreaScene is not { } scene || scene.HasEmptyDoorway())
+                return true;
+
+            _log.AppendLine(scene.DoorAnchors.Count == 0
+                ? $"'{label}' cannot be placed: no tile in this area declares a doorway to hang a door in."
+                : $"'{label}' cannot be placed: every doorway in this area already has a door in it.");
+            return false;
+        }
+
+        private void NotifyPlacementChanged()
+        {
             OnPropertyChanged(nameof(IsPlacementPending));
             OnPropertyChanged(nameof(PlacementStatus));
             OnPropertyChanged(nameof(HasViewportHud));
-            return true;
         }
 
         private InstanceMarker? _placementGhost;
@@ -1305,7 +1373,8 @@ namespace SWLOR.Toolset.Editors
         /// Called by the view when a viewport click resolves a pending placement
         /// (GlAreaControl.PlacementPointPicked): creates the instance at the clicked ground
         /// position through the pending section's InstanceFieldMap-based Add path (one RunGitEdit
-        /// transaction), then rebuilds the scene and selects the new instance.
+        /// transaction), then appends its one marker to the scene and selects it. A full rebuild is
+        /// retained as a fallback when the scene was already stale.
         /// </summary>
         /// <param name="orientation">
         /// The heading to hang the new instance at, when the viewport chose one - a door takes the
@@ -1316,48 +1385,133 @@ namespace SWLOR.Toolset.Editors
             var section = _pendingPlacementSection;
             var resRef = _pendingPlacementResRef;
             var useIndexedBlueprint = _pendingPlacementUsesIndexedBlueprint;
+            var copiedInstance = _pendingPlacementCopy;
             _pendingPlacementSection = null;
             _pendingPlacementResRef = null;
             _pendingPlacementUsesIndexedBlueprint = false;
+            _pendingPlacementCopy = null;
             PlacementGhost = null;
-            OnPropertyChanged(nameof(IsPlacementPending));
-            OnPropertyChanged(nameof(PlacementStatus));
-            OnPropertyChanged(nameof(HasViewportHud));
+            NotifyPlacementChanged();
 
-            if (section == null || resRef == null)
+            if (section == null || (copiedInstance == null && resRef == null))
                 return;
 
             // Orientation goes in with the add rather than as a follow-up edit, so hanging a door in a
-            // doorway is one undo step and not two.
-            var facing = orientation ?? new Vector2(1f, 0f);
-            if (!section.AddInstanceAt(
-                    resRef,
+            // doorway is one undo step and not two. A copied object retains its authored heading when
+            // no placement rule supplied one.
+            var copiedFacing = copiedInstance != null
+                ? InstanceFieldMap.GetOrientation(section.BlueprintType, copiedInstance.Instance)
+                : (1f, 0f);
+            var facing = orientation ?? new Vector2(copiedFacing.Item1, copiedFacing.Item2);
+            var previousRevision = Volatile.Read(ref _sceneInputRevision);
+            var canUpdateCurrentScene =
+                _sceneBuildRequested &&
+                AreaScene != null &&
+                Volatile.Read(ref _builtSceneInputRevision) == previousRevision;
+            var added = copiedInstance != null
+                ? section.AddCopiedInstanceAt(
+                    copiedInstance,
+                    position.X,
+                    position.Y,
+                    position.Z,
+                    facing.X,
+                    facing.Y)
+                : section.AddInstanceAt(
+                    resRef!,
                     position.X,
                     position.Y,
                     position.Z,
                     facing.X,
                     facing.Y,
-                    useIndexedBlueprint))
+                    useIndexedBlueprint);
+            if (!added)
                 return;
 
             var kind = MapSectionTypeToKind(section.BlueprintType);
             var reselect = kind != null ? (kind.Value, section.Rows.Count - 1) : ((InstanceMarkerKind, int)?)null;
+            if (kind != null && canUpdateCurrentScene &&
+                ApplyPlacementInPlace(section, section.Rows.Count - 1, previousRevision))
+            {
+                return;
+            }
+
             _ = BuildSceneAsync(reselect);
+        }
+
+        /// <summary>
+        /// Publishes one newly placed instance into the current scene without rebuilding the area.
+        /// </summary>
+        /// <remarks>
+        /// Placement changes one GIT list entry. The tiles, walkmeshes, lighting, diagnostics, door
+        /// anchors, and every pre-existing marker are already valid and are carried forward by
+        /// reference. The revision checks make this an optimization only: if any other edit was
+        /// pending, the caller falls back to authoritative full scene assembly.
+        /// </remarks>
+        private bool ApplyPlacementInPlace(
+            InstanceListSectionViewModel section,
+            int index,
+            long previousRevision)
+        {
+            var currentRevision = Volatile.Read(ref _sceneInputRevision);
+            if (currentRevision != previousRevision + 1 ||
+                Volatile.Read(ref _builtSceneInputRevision) != previousRevision ||
+                AreaScene is not { } scene ||
+                _tileModelCache == null ||
+                section.GetInstanceForScene(index) is not { } instance)
+            {
+                return false;
+            }
+
+            InstanceMarker marker;
+            try
+            {
+                marker = AreaSceneBuilder.BuildInstanceMarker(
+                    section.BlueprintType,
+                    instance,
+                    _tileModelCache,
+                    _placeableAppearances,
+                    _doorTypes,
+                    _waypointAppearances,
+                    ResolveCreatureModel,
+                    scene.Tiles);
+            }
+            catch (Exception ex)
+            {
+                _log.AppendLine(
+                    $"Placed {section.BlueprintType.SingularDisplayName().ToLowerInvariant()} marker " +
+                    $"could not be updated in place; rebuilding the scene: {ex.Message}");
+                return false;
+            }
+
+            // A background build or another edit may have won while model resolution ran. Never append
+            // to a scene that is no longer the one these revision checks described.
+            if (!ReferenceEquals(AreaScene, scene) ||
+                Volatile.Read(ref _sceneInputRevision) != currentRevision ||
+                Volatile.Read(ref _builtSceneInputRevision) != previousRevision)
+            {
+                return false;
+            }
+
+            var updated = scene.WithInstanceAdded(marker);
+            Volatile.Write(ref _builtSceneInputRevision, currentRevision);
+            AreaScene = updated;
+            ApplySelection(marker);
+            SceneStatus = string.Empty;
+            return true;
         }
 
         /// <summary>Called by the view when a pending placement is cancelled (Esc or right-click in the viewport, GlAreaControl.PlacementCancelled).</summary>
         public void CancelPlacement()
         {
-            if (_pendingPlacementResRef == null)
+            if (_pendingPlacementSection == null)
                 return;
 
             _pendingPlacementSection = null;
             _pendingPlacementResRef = null;
             _pendingPlacementUsesIndexedBlueprint = false;
+            _pendingPlacementCopy = null;
             PlacementGhost = null;
-            OnPropertyChanged(nameof(IsPlacementPending));
-            OnPropertyChanged(nameof(PlacementStatus));
-            OnPropertyChanged(nameof(HasViewportHud));
+            NotifyPlacementChanged();
         }
 
         /// <summary>
@@ -1556,7 +1710,8 @@ namespace SWLOR.Toolset.Editors
             Services.SoundPreviewService? soundPreview = null,
             AreaEditorDocumentLoad? loadedDocuments = null,
             Func<ResourceType, string, string?>? editCopyBlueprint = null,
-            ModuleMutationLock? mutationLock = null)
+            ModuleMutationLock? mutationLock = null,
+            AreaInstanceClipboard? instanceClipboard = null)
         {
             _scriptSlotHost = scriptSlotHost;
             _resolveBlueprintModel = resolveBlueprintModel;
@@ -1566,6 +1721,7 @@ namespace SWLOR.Toolset.Editors
             _openBlueprint = openBlueprint;
             _editCopyBlueprint = editCopyBlueprint;
             _mutationLock = mutationLock;
+            _instanceClipboard = instanceClipboard ?? new AreaInstanceClipboard();
             if (_mutationLock != null)
                 _mutationLock.Changed += OnMutationLockChanged;
             _log = log;
@@ -1924,9 +2080,9 @@ namespace SWLOR.Toolset.Editors
         /// This is what replaced the Rebuild button. Edits made anywhere - an instance's coordinates
         /// on the Properties tab, a local variable, an area property, undo/redo - all funnel through
         /// <see cref="RunEdit"/>, so hooking the refresh there covers every path instead of asking
-        /// each command to remember. Paths that already rebuild explicitly (placement and the
+        /// each command to remember. Paths that already refresh explicitly (placement and the
         /// gizmos, which also need to reselect what they touched) are not double-served: by the time
-        /// the delay elapses their build has either finished or is in flight for the same revision,
+        /// the delay elapses their incremental update or fallback build has claimed the same revision,
         /// and <see cref="IsSceneCurrent"/> drops the duplicate.
         /// </remarks>
         private void RequestSceneRefresh(bool immediate = false)
@@ -2183,9 +2339,10 @@ namespace SWLOR.Toolset.Editors
                     return false;
             }
 
-            var catalogEntryChanged =
-                _areSession.UndoStack.IsDirty ||
-                _gitSession.UndoStack.IsDirty;
+            // The area's catalog entry is parsed exclusively from ARE metadata. GIT carries placed
+            // instances, so treating a GIT-only save as an area catalog change makes Explorer and
+            // Search rebuild their catalog views for a file they never read.
+            var catalogEntryChanged = _areSession.UndoStack.IsDirty;
             var placementsChanged = _gitSession.UndoStack.IsDirty;
             var instancePairReloaded = false;
             var tilesetBefore = TilesetResRef;
@@ -2257,7 +2414,6 @@ namespace SWLOR.Toolset.Editors
                 if (!string.Equals(tilesetBefore, TilesetResRef, StringComparison.OrdinalIgnoreCase))
                     TilesetChanged?.Invoke();
                 AfterHistoryChange();
-                CatalogEntryChanged?.Invoke();
             }
 
             if (!CommitStagedWrites(staged, arePlan, gitPlan, gicPlan))
@@ -2296,10 +2452,7 @@ namespace SWLOR.Toolset.Editors
                 TilesetChanged?.Invoke();
 
             AfterHistoryChange();
-            if (catalogEntryChanged ||
-                areResult.Reloaded ||
-                gitResult.Reloaded ||
-                instancePairReloaded)
+            if (catalogEntryChanged || areResult.Reloaded)
             {
                 CatalogEntryChanged?.Invoke();
             }
@@ -2666,10 +2819,10 @@ namespace SWLOR.Toolset.Editors
         /// <summary>Raised after an async close prompt approves closing this tab.</summary>
         public event Action<AreaEditorViewModel>? CloseRequested;
 
-        /// <summary>Raised after ARE or GIT data is saved/reloaded so area-backed catalog indexes can refresh.</summary>
+        /// <summary>Raised after ARE data is saved or reloaded so the area's catalog metadata can refresh.</summary>
         public event Action? CatalogEntryChanged;
 
-        /// <summary>Raised after the paired GIT is saved or reloaded so object-source indexes can refresh.</summary>
+        /// <summary>Raised after the paired GIT is saved or reloaded so GIT-derived indexes can refresh.</summary>
         public event Action? PlacementsChanged;
 
         /// <summary>Suppresses a second tab-level prompt after the window-level discard decision.</summary>

--- a/SWLOR.Toolset/Editors/AreaInstanceClipboard.cs
+++ b/SWLOR.Toolset/Editors/AreaInstanceClipboard.cs
@@ -1,0 +1,35 @@
+using SWLOR.Toolset.Domain.Gff;
+using SWLOR.Toolset.Domain.Render;
+using SWLOR.Toolset.Domain.Workspace;
+
+namespace SWLOR.Toolset.Editors
+{
+    /// <summary>
+    /// The toolset-session clipboard for one placed area object.
+    /// </summary>
+    /// <remarks>
+    /// Kept separate from the operating-system text clipboard: the payload is a deep GFF instance,
+    /// its paired GIC comment, and a render preview. One clipboard is shared by every area editor
+    /// opened through <see cref="EditorService"/>, so an object copied in one area may be pasted in
+    /// another area of the same module without exposing a lossy text representation to other
+    /// applications.
+    /// </remarks>
+    public sealed class AreaInstanceClipboard
+    {
+        internal AreaInstanceClipboardEntry? Content { get; private set; }
+
+        internal void Set(AreaInstanceClipboardEntry content)
+        {
+            ArgumentNullException.ThrowIfNull(content);
+            Content = content;
+        }
+    }
+
+    /// <summary>An independent clipboard snapshot. Its GFF values are private deep clones.</summary>
+    internal sealed record AreaInstanceClipboardEntry(
+        string ModuleRoot,
+        ResourceType Type,
+        JsonGffStruct Instance,
+        JsonGffStruct? Comment,
+        InstanceMarker Preview);
+}

--- a/SWLOR.Toolset/Editors/EditorService.cs
+++ b/SWLOR.Toolset/Editors/EditorService.cs
@@ -98,6 +98,7 @@ namespace SWLOR.Toolset.Editors
         private readonly Dictionary<string, BlueprintEditorViewModel> _openEditors = new(StringComparer.OrdinalIgnoreCase);
         private readonly Dictionary<string, AreaEditorViewModel> _openAreaEditors = new(StringComparer.OrdinalIgnoreCase);
         private readonly HashSet<string> _openingAreaEditors = new(StringComparer.OrdinalIgnoreCase);
+        private readonly AreaInstanceClipboard _areaInstanceClipboard = new();
         private readonly Dictionary<string, ObjectPlacement> _pendingAreaReveals =
             new(StringComparer.OrdinalIgnoreCase);
         private readonly List<WeakReference<Sources.ObjectSourceSectionViewModel>> _objectSources = new();
@@ -3433,13 +3434,14 @@ namespace SWLOR.Toolset.Editors
                     SoundPreviews(),
                     loadedDocuments,
                     TryEditCopyAndOpenBlueprint,
-                    _mutationLock);
+                    _mutationLock,
+                    _areaInstanceClipboard);
                 editor.Closed += _ => _openAreaEditors.Remove(resRef);
                 editor.TilesetChanged += () => _factory.NotifyActiveAreaChanged();
                 editor.CloseRequested += _ => _factory.CloseDocument(editor);
                 editor.CatalogEntryChanged += () =>
                     _workspaceContext.RefreshCatalogEntry(ResourceType.Area, resRef);
-                editor.PlacementsChanged += _workspaceContext.InvalidatePlacementIndex;
+                editor.PlacementsChanged += _workspaceContext.InvalidateGitIndexes;
                 _openAreaEditors[resRef] = editor;
                 _factory.OpenDocument(editor);
                 DispatchPendingAreaReveal(editor);

--- a/SWLOR.Toolset/Editors/InstanceListSectionViewModel.cs
+++ b/SWLOR.Toolset/Editors/InstanceListSectionViewModel.cs
@@ -8,6 +8,7 @@ using SWLOR.Toolset.Domain.Editors.Sounds;
 using SWLOR.Toolset.Domain.Editors.Waypoints;
 using SWLOR.Toolset.Domain.GameData.GameCode;
 using SWLOR.Toolset.Domain.Gff;
+using SWLOR.Toolset.Domain.Render;
 using SWLOR.Toolset.Domain.Workspace;
 using SWLOR.Toolset.Editors.Sounds;
 using SWLOR.Toolset.Editors.Waypoints;
@@ -708,6 +709,60 @@ namespace SWLOR.Toolset.Editors
         }
 
         /// <summary>
+        /// Inserts a copied instance at a new map position while preserving every other authored GIT
+        /// field and its paired GIC comment.
+        /// </summary>
+        internal bool AddCopiedInstanceAt(
+            AreaInstanceClipboardEntry copy,
+            float x,
+            float y,
+            float z,
+            float xOrientation,
+            float yOrientation)
+        {
+            if (copy.Type != _blueprintType ||
+                !string.Equals(copy.ModuleRoot, _workspace.ModuleRoot, StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            try
+            {
+                var ok = _runEdit($"Paste {Title} instance", () =>
+                {
+                    var listField = _gitSession.Document.Root.GetOrNull(_listFieldName);
+                    if (listField == null)
+                    {
+                        listField = JsonGffField.CreateList();
+                        _gitSession.Document.Root.Add(_listFieldName, listField);
+                    }
+
+                    var instance = InstanceFieldMap.Duplicate(copy.Instance);
+                    InstanceFieldMap.SetPosition(_blueprintType, instance, x, y, z);
+                    InstanceFieldMap.SetOrientation(
+                        _blueprintType, instance, xOrientation, yOrientation);
+
+                    var insertAt = listField.Elements!.Count;
+                    listField.InsertElement(insertAt, instance);
+                    new GicDocument(_gicSession.Document).InsertCopiedComment(
+                        _listFieldName,
+                        _blueprintType,
+                        insertAt,
+                        listField.Elements.Count,
+                        copy.Comment);
+                });
+
+                if (ok)
+                    RefreshFromDocument();
+
+                return ok;
+            }
+            catch (Exception ex)
+            {
+                _log.AppendLine($"Failed to paste {Title} instance: {ex.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Sets the position of the instance at <paramref name="index"/> through
         /// <see cref="InstanceFieldMap.SetPosition"/> - the exact setter the detail form's X/Y/Z
         /// editors use - as one RunGitEdit transaction. Used by the 3D-view move gizmo
@@ -857,6 +912,36 @@ namespace SWLOR.Toolset.Editors
                 return null;
 
             return listField.Elements[index];
+        }
+
+        /// <summary>
+        /// The authored instance at a row index, for the area editor's single-marker scene update.
+        /// Kept internal so mutable document structures do not escape the editor assembly.
+        /// </summary>
+        internal JsonGffStruct? GetInstanceForScene(int index) => GetElement(index);
+
+        /// <summary>
+        /// Takes an independent clipboard snapshot of one GIT instance and its aligned GIC comment.
+        /// </summary>
+        internal AreaInstanceClipboardEntry? CopyInstanceForPlacement(
+            int index,
+            InstanceMarker preview)
+        {
+            var instance = GetElement(index);
+            if (instance == null)
+                return null;
+
+            var comments = _gicSession.Document.Root.GetOrNull(_listFieldName)?.Elements;
+            var comment = comments != null && index >= 0 && index < comments.Count
+                ? InstanceFieldMap.Duplicate(comments[index])
+                : null;
+
+            return new AreaInstanceClipboardEntry(
+                _workspace.ModuleRoot,
+                _blueprintType,
+                InstanceFieldMap.Duplicate(instance),
+                comment,
+                preview);
         }
 
         private static string PaletteFileName(ResourceType type)

--- a/SWLOR.Toolset/Editors/Views/AreaEditorView.axaml
+++ b/SWLOR.Toolset/Editors/Views/AreaEditorView.axaml
@@ -35,6 +35,7 @@
           <Border Grid.Row="0" x:Name="ViewportInput" Background="Transparent"
                   PointerPressed="OnViewportPointerPressed"
                   PointerMoved="OnViewportPointerMoved"
+                  PointerExited="OnViewportPointerExited"
                   PointerReleased="OnViewportPointerReleased"
                   PointerWheelChanged="OnViewportPointerWheel"
                   ContextRequested="OnViewportContextRequested">

--- a/SWLOR.Toolset/Editors/Views/AreaEditorView.axaml.cs
+++ b/SWLOR.Toolset/Editors/Views/AreaEditorView.axaml.cs
@@ -247,8 +247,9 @@ namespace SWLOR.Toolset.Editors
         }
 
         /// <summary>
-        /// Delete removes whatever the map has selected. Not handled when nothing is selected, so
-        /// the key still reaches a field or grid that wants it.
+        /// Area-object shortcuts that remain after the focused control has had first refusal. Delete
+        /// removes the selection; Ctrl+C snapshots it; Ctrl+V arms that snapshot on the map cursor.
+        /// An inapplicable shortcut is not handled, so it may continue to a field or grid that wants it.
         /// </summary>
         /// <remarks>
         /// On the view rather than the GL control because the control is only hit-testable through
@@ -259,10 +260,22 @@ namespace SWLOR.Toolset.Editors
         {
             base.OnKeyDown(e);
 
-            if (e.Handled || e.Key != Avalonia.Input.Key.Delete || _viewModel == null)
+            if (e.Handled || _viewModel == null)
                 return;
 
-            e.Handled = _viewModel.DeleteSelectedSceneInstance();
+            if (e.KeyModifiers == Avalonia.Input.KeyModifiers.Control)
+            {
+                if (e.Key == Avalonia.Input.Key.C)
+                    e.Handled = _viewModel.CopySelectedSceneInstance();
+                else if (e.Key == Avalonia.Input.Key.V)
+                    e.Handled = _viewModel.PasteCopiedSceneInstance();
+
+                if (e.Handled)
+                    return;
+            }
+
+            if (e.Key == Avalonia.Input.Key.Delete)
+                e.Handled = _viewModel.DeleteSelectedSceneInstance();
         }
 
         /// <summary>

--- a/SWLOR.Toolset/Editors/Views/AreaEditorView.axaml.cs
+++ b/SWLOR.Toolset/Editors/Views/AreaEditorView.axaml.cs
@@ -109,8 +109,8 @@ namespace SWLOR.Toolset.Editors
             AreaView.Scene = _viewModel.AreaScene;
             RestoreViewportStateWhenReady();
             AreaView.SelectedInstance = _viewModel.SelectedSceneInstance;
-            AreaView.IsPlacementActive = _viewModel.IsPlacementPending;
             AreaView.PlacementGhost = _viewModel.PlacementGhost;
+            AreaView.IsPlacementActive = _viewModel.IsPlacementPending;
             AreaView.IsTilePlacementActive = _viewModel.IsTilePlacementPending;
             AreaView.TilePlacementTargetsVertex = _viewModel.TilePlacementTargetsVertex;
             AreaView.TilePlacementTargetsEdge = _viewModel.TilePlacementTargetsEdge;
@@ -397,6 +397,9 @@ namespace SWLOR.Toolset.Editors
 
         private void OnViewportPointerMoved(object? sender, Avalonia.Input.PointerEventArgs e) =>
             AreaView.HandlePointerMoved(e);
+
+        private void OnViewportPointerExited(object? sender, Avalonia.Input.PointerEventArgs e) =>
+            AreaView.HandlePointerExited(e);
 
         private void OnViewportPointerReleased(object? sender, Avalonia.Input.PointerReleasedEventArgs e) =>
             AreaView.HandlePointerReleased(e);

--- a/SWLOR.Toolset/Shell/Panels/ModuleExplorerViewModel.cs
+++ b/SWLOR.Toolset/Shell/Panels/ModuleExplorerViewModel.cs
@@ -132,6 +132,13 @@ namespace SWLOR.Toolset.Shell.Panels
                     QueueDialogueScan();
                 }
 
+                // Dialogs and scripts are intentionally absent from BlueprintCatalog. Their rows
+                // still follow file changes, but no full catalog regroup is needed to do that.
+                if (!WorkspaceContext.IsCatalogIndexedType(type))
+                    Refresh();
+            };
+            _workspaceContext.CatalogEntriesChanged += (_, _) =>
+            {
                 if (_workspaceContext.Catalog is { } catalog)
                     RefreshFromCatalog(catalog);
             };
@@ -1327,6 +1334,13 @@ namespace SWLOR.Toolset.Shell.Panels
 
         private void Publish(ExplorerNodeViewModel node)
         {
+            // Filtered folder counts already include every matching descendant. A zero therefore means
+            // neither this category nor anything beneath it can lead to a search result. Keep the full
+            // tree in _roots so clearing the search restores its expansion state, but do not publish
+            // dead-end categories (including an empty Unsorted bucket) while the builder is searching.
+            if (!string.IsNullOrWhiteSpace(Filter) && node.IsBranch && node.Count == 0)
+                return;
+
             Rows.Add(node);
             if (!node.IsExpanded)
                 return;

--- a/SWLOR.Toolset/Shell/Panels/SearchViewModel.cs
+++ b/SWLOR.Toolset/Shell/Panels/SearchViewModel.cs
@@ -41,7 +41,7 @@ namespace SWLOR.Toolset.Shell.Panels
             _log = log ?? throw new ArgumentNullException(nameof(log));
             Id = "Search";
             Title = "Search";
-            _workspaceContext.CatalogEntryRefreshed += (_, _) => Refresh();
+            _workspaceContext.CatalogEntriesChanged += (_, _) => Refresh();
         }
 
         /// <summary>

--- a/SWLOR.Toolset/Viewport/GlAreaControl.cs
+++ b/SWLOR.Toolset/Viewport/GlAreaControl.cs
@@ -4,6 +4,7 @@ using Avalonia.Input;
 using Avalonia.OpenGL;
 using Avalonia.OpenGL.Controls;
 using Avalonia.Threading;
+using Serilog;
 using Silk.NET.OpenGL;
 using SWLOR.Toolset.Domain.GameData.Resources;
 using SWLOR.Toolset.Domain.Render;
@@ -634,8 +635,22 @@ void main()
                 if (_isPlacementActive == value)
                     return;
 
+                var templateResRef = _placementGhost?.TemplateResRef ?? _placementTemplateResRef;
                 _isPlacementActive = value;
+                if (!value)
+                {
+                    _ghostPosition = null;
+                    _snappedDoorAnchor = null;
+                }
+
+                Log.ForContext<GlAreaControl>().Information(
+                    "Area object placement mode changed to {IsPlacementActive} for {TemplateResRef}",
+                    value,
+                    templateResRef ?? "(none)");
                 RefreshPlacementGhostAtCursor();
+
+                if (!value)
+                    _placementTemplateResRef = null;
             }
         }
 
@@ -646,6 +661,7 @@ void main()
         public event Action? PlacementCancelled;
 
         private InstanceMarker? _placementGhost;
+        private string? _placementTemplateResRef;
 
         /// <summary>
         /// What to draw under the cursor while <see cref="IsPlacementActive"/>: the object about to
@@ -662,6 +678,8 @@ void main()
                     return;
 
                 _placementGhost = value;
+                if (!string.IsNullOrWhiteSpace(value?.TemplateResRef))
+                    _placementTemplateResRef = value.TemplateResRef;
                 _ghostPosition = null;
                 RefreshPlacementGhostAtCursor();
             }
@@ -1358,6 +1376,12 @@ void main()
         public void HandlePointerMoved(PointerEventArgs e)
         {
             var pointerPos = e.GetPosition(this);
+            if (!Bounds.Contains(pointerPos))
+            {
+                InvalidateHoverPointer("pointer moved outside viewport bounds");
+                return;
+            }
+
             _hoverPointerPos = pointerPos;
             _hasHoverPointerPos = true;
 
@@ -1754,13 +1778,10 @@ void main()
 
         private void CancelPlacement()
         {
-            _snappedDoorAnchor = null;
             if (!_isPlacementActive)
                 return;
 
-            _isPlacementActive = false;
-            _ghostPosition = null;
-            RequestNextFrameRendering();
+            IsPlacementActive = false;
             PlacementCancelled?.Invoke();
         }
 
@@ -1840,15 +1861,12 @@ void main()
                 if (NearestDoorAnchor(hit) is not { } anchor)
                     return;
 
-                _isPlacementActive = false;
-                _ghostPosition = null;
-                _snappedDoorAnchor = null;
+                IsPlacementActive = false;
                 PlacementPointPicked?.Invoke(new PlacementPick(anchor.Position, anchor.Orientation));
                 return;
             }
 
-            _isPlacementActive = false;
-            _ghostPosition = null;
+            IsPlacementActive = false;
             PlacementPointPicked?.Invoke(new PlacementPick(hit, null));
         }
 
@@ -2073,6 +2091,25 @@ void main()
             {
                 _previewAnimationStartedTicks = System.Diagnostics.Stopwatch.GetTimestamp();
             }
+        }
+
+        /// <summary>Clears cursor previews when the pointer leaves the map surface.</summary>
+        public void HandlePointerExited(PointerEventArgs e) =>
+            InvalidateHoverPointer("pointer exited viewport");
+
+        private void InvalidateHoverPointer(string reason)
+        {
+            if (!_hasHoverPointerPos)
+                return;
+
+            _hasHoverPointerPos = false;
+            _ghostPosition = null;
+            _snappedDoorAnchor = null;
+            _tileHoverCell = null;
+            _tileHoverEdge = null;
+            Log.ForContext<GlAreaControl>().Information(
+                "Area viewport hover cache invalidated: {Reason}", reason);
+            RequestNextFrameRendering();
         }
 
         private PreviewAnimationSnapshot PreviewAnimation()
@@ -2419,6 +2456,12 @@ void main()
         {
             base.OnPointerMoved(e);
             HandlePointerMoved(e);
+        }
+
+        protected override void OnPointerExited(PointerEventArgs e)
+        {
+            base.OnPointerExited(e);
+            HandlePointerExited(e);
         }
 
         protected override void OnPointerReleased(PointerReleasedEventArgs e)

--- a/SWLOR.Toolset/Viewport/GlAreaControl.cs
+++ b/SWLOR.Toolset/Viewport/GlAreaControl.cs
@@ -562,6 +562,8 @@ void main()
         private Point _pressStartPos;
         private bool _isClickCandidate;
         private InstanceMarker? _selectedInstance;
+        private Point _hoverPointerPos;
+        private bool _hasHoverPointerPos;
 
         // ----- Move/rotate gizmo -----
         private InstanceMarker? _manipulationOriginal;
@@ -627,7 +629,14 @@ void main()
         public bool IsPlacementActive
         {
             get => _isPlacementActive;
-            set => _isPlacementActive = value;
+            set
+            {
+                if (_isPlacementActive == value)
+                    return;
+
+                _isPlacementActive = value;
+                RefreshPlacementGhostAtCursor();
+            }
         }
 
         /// <summary>Raised when placement mode is active and a plain click (not a camera drag) lands in the viewport: the world-space ground point (ray intersected with the Z=0 plane). Clears <see cref="IsPlacementActive"/> before raising.</summary>
@@ -654,7 +663,7 @@ void main()
 
                 _placementGhost = value;
                 _ghostPosition = null;
-                RequestNextFrameRendering();
+                RefreshPlacementGhostAtCursor();
             }
         }
 
@@ -1348,14 +1357,18 @@ void main()
 
         public void HandlePointerMoved(PointerEventArgs e)
         {
+            var pointerPos = e.GetPosition(this);
+            _hoverPointerPos = pointerPos;
+            _hasHoverPointerPos = true;
+
             // The ghost must track the pointer with no button held - the one case the drag-mode
             // guard below rejects - so it is updated first and independently of it.
             if (_isPlacementActive && _placementGhost != null)
-                UpdatePlacementGhost(e.GetPosition(this));
+                UpdatePlacementGhost(pointerPos);
 
             // The cell highlight is a cursor too, and tracks with no button held for the same reason.
             if (_isTilePlacementActive && !_isPlacementActive)
-                UpdateTileHoverCell(e.GetPosition(this));
+                UpdateTileHoverCell(pointerPos);
 
             if (_dragMode == DragMode.None)
                 return;
@@ -1368,7 +1381,7 @@ void main()
                     (e.KeyModifiers & KeyModifiers.Shift) != 0) is { } liveDrag)
                 _dragMode = liveDrag;
 
-            var pos = e.GetPosition(this);
+            var pos = pointerPos;
             var dx = (float)(pos.X - _lastPointerPos.X);
             var dy = (float)(pos.Y - _lastPointerPos.Y);
             _lastPointerPos = pos;
@@ -1774,6 +1787,18 @@ void main()
             // put the preview off where the builder was not looking.
             _snappedDoorAnchor = SnapsToDoorAnchors ? NearestDoorAnchor(hit) : null;
             _ghostPosition = _snappedDoorAnchor?.Position ?? hit;
+
+            RequestNextFrameRendering();
+        }
+
+        /// <summary>
+        /// Reuses the last passive hover position when placement is armed from the keyboard, so the
+        /// ghost appears under a stationary cursor rather than waiting for another mouse move.
+        /// </summary>
+        private void RefreshPlacementGhostAtCursor()
+        {
+            if (_isPlacementActive && _placementGhost != null && _hasHoverPointerPos)
+                UpdatePlacementGhost(_hoverPointerPos);
 
             RequestNextFrameRendering();
         }

--- a/SWLOR.Toolset/Workspace/ModuleFileWatcher.cs
+++ b/SWLOR.Toolset/Workspace/ModuleFileWatcher.cs
@@ -84,8 +84,9 @@ namespace SWLOR.Toolset.Workspace
                     _workspaceContext.InvalidatePaletteChoices(paletteResRef);
 
                 // Resolved scripted resources invalidate through Refresh/Remove below. GIT has no
-                // ResourceType, so its placed-instance script slots need the direct path.
+                // ResourceType, but InvalidateGitIndexes above already covers its script slots.
                 if (affectsScriptUsages &&
+                    !affectsPlacementIndex &&
                     (!resolved || !Domain.Script.ScriptUsageIndex.ScriptedTypes.Contains(type)))
                 {
                     _workspaceContext.InvalidateScriptUsages();

--- a/SWLOR.Toolset/Workspace/WorkspaceContext.cs
+++ b/SWLOR.Toolset/Workspace/WorkspaceContext.cs
@@ -22,7 +22,17 @@ namespace SWLOR.Toolset.Workspace
 
         public event Action? WorkspaceOpened;
         public event Action? CatalogBuildCompleted;
+        /// <summary>
+        /// Raised for every saved, reloaded, created, or removed resource so content-dependent
+        /// caches can invalidate even when its catalog Name/Tag did not change.
+        /// </summary>
         public event Action<ResourceType, string>? CatalogEntryRefreshed;
+        /// <summary>
+        /// Raised only when the ordered catalog's indexed metadata or membership actually changed.
+        /// Explorer and Search subscribe here so an ordinary content-only save does not make them
+        /// regroup and requery the entire catalog.
+        /// </summary>
+        public event Action<ResourceType, string>? CatalogEntriesChanged;
         public event Action? PlacementIndexInvalidated;
         public event Action? ScriptUsagesInvalidated;
         public event Action? TagIndexInvalidated;
@@ -188,9 +198,12 @@ namespace SWLOR.Toolset.Workspace
         {
             InvalidateTagIndexWhenRelevant(type);
             InvalidateScriptUsagesWhenRelevant(type);
-            if (IsCatalogIndexedType(type))
-                Catalog?.RefreshEntry(type, resRef);
+            var catalogChanged = false;
+            if (IsCatalogIndexedType(type) && Catalog is { } catalog)
+                catalog.RefreshEntry(type, resRef, out catalogChanged);
             CatalogEntryRefreshed?.Invoke(type, resRef);
+            if (catalogChanged)
+                CatalogEntriesChanged?.Invoke(type, resRef);
         }
 
         /// <summary>
@@ -206,9 +219,12 @@ namespace SWLOR.Toolset.Workspace
             if (type == ResourceType.Area)
                 InvalidatePlacementIndex();
             InvalidateScriptUsagesWhenRelevant(type);
-            if (IsCatalogIndexedType(type))
-                Catalog?.RemoveEntry(type, resRef);
+            var catalogChanged = false;
+            if (IsCatalogIndexedType(type) && Catalog is { } catalog)
+                catalogChanged = catalog.RemoveEntry(type, resRef);
             CatalogEntryRefreshed?.Invoke(type, resRef);
+            if (catalogChanged)
+                CatalogEntriesChanged?.Invoke(type, resRef);
         }
 
         /// <summary>
@@ -231,6 +247,7 @@ namespace SWLOR.Toolset.Workspace
         {
             InvalidateTagIndex();
             InvalidatePlacementIndex();
+            InvalidateScriptUsages();
         }
 
         /// <summary>
@@ -247,7 +264,7 @@ namespace SWLOR.Toolset.Workspace
 
         /// <summary>
         /// Drops the lazy script-usage snapshot. Paired GIT files are not first-class resource types,
-        /// so the file watcher calls this directly when a placed-instance script slot changes.
+        /// so their grouped invalidation routes here directly when a placed-instance script slot changes.
         /// </summary>
         public void InvalidateScriptUsages() => ScriptUsagesInvalidated?.Invoke();
 


### PR DESCRIPTION
## Summary
- hide empty module categories while filtering so search results are easy to locate
- update newly placed area instances incrementally and add Ctrl+C/Ctrl+V placement from the mouse cursor
- stop GIT-only area saves from rebuilding catalog-backed panels and preserve the correct GIT-derived index invalidations
- add focused regression coverage for search filtering, placement updates, clipboard behavior, and catalog notifications

## Testing
- `dotnet build SWLOR.Toolset.Tests\\SWLOR.Toolset.Tests.csproj -p:RunPostBuildEvent=Never --no-restore -m:1`
- `dotnet test SWLOR.Toolset.Tests\\SWLOR.Toolset.Tests.csproj --no-build --no-restore --filter "FullyQualifiedName~AreaContentsTests|FullyQualifiedName~AreaPlacementIncrementalTests|FullyQualifiedName~AreaSceneInstanceUpdateTests|FullyQualifiedName~WorkspaceContextCatalogTests|FullyQualifiedName~BlueprintCatalogLookupTests|FullyQualifiedName~ModuleFileWatcherTests|FullyQualifiedName~ModuleExplorerSearchTests|FullyQualifiedName~SearchViewModelTests"` (136 passed)