### PR TITLE
Fix conversation text row spacing

### DIFF
--- a/SWLOR.Game.Server.Tests/Service/ConversationArchitectureTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/ConversationArchitectureTests.cs
@@ -226,6 +226,9 @@ public class ConversationArchitectureTests
         textPanelSource.Should().Contain(".SetScrollbars(NuiScrollbars.Y)",
             "the containing dialogue list owns the panel's only scrollbar");
         textPanelSource.Should().NotContain(".SetScrollbars(NuiScrollbars.Auto)");
+        textPanelSource.Should().Contain(".SetPadding(4f)",
+            "compact dialogue rows must retain reduced text padding");
+        textPanelSource.Should().NotContain(".SetPadding(8f)");
         textPanelSource.Should().Contain(".SetHeight(24f)",
             "each text widget should fit one display line rather than wrapping inside a fixed-height row");
         textPanelSource.Should().Contain(".SetRowHeight(28f)",
@@ -277,7 +280,9 @@ public class ConversationArchitectureTests
         ((int)limitMethod!.Invoke(null, new object[] { 650f })!).Should().Be(57);
         ((int)limitMethod.Invoke(null, new object[] { 400f })!).Should().Be(26);
         ((int)limitMethod.Invoke(null, new object[] { 300f })!).Should().Be(13);
-        ((int)limitMethod.Invoke(null, new object[] { 200f })!).Should().Be(4);
+        ((int)limitMethod.Invoke(null, new object[] { 208f })!).Should().Be(2);
+        ((int)limitMethod.Invoke(null, new object[] { 200f })!).Should().Be(1);
+        ((int)limitMethod.Invoke(null, new object[] { 180f })!).Should().Be(1);
 
         var splitMethod = typeof(ConversationViewModel).GetMethod(
             "SplitDialogueText",

--- a/SWLOR.Game.Server.Tests/Service/ConversationArchitectureTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/ConversationArchitectureTests.cs
@@ -222,14 +222,16 @@ public class ConversationArchitectureTests
 
         var textPanelSource = definitionSource[textPanelStart..textPanelEnd];
         textPanelSource.Should().Contain(".SetScrollbars(NuiScrollbars.None)",
-            "dialogue text must wrap without adding a nested scrollbar");
+            "individual dialogue lines must not add a nested scrollbar");
         textPanelSource.Should().Contain(".SetScrollbars(NuiScrollbars.Y)",
             "the containing dialogue list owns the panel's only scrollbar");
         textPanelSource.Should().NotContain(".SetScrollbars(NuiScrollbars.Auto)");
-        textPanelSource.Should().Contain(".SetHeight(48f)",
-            "each text widget should fit a compact wrapped segment rather than reserve the full panel height");
-        textPanelSource.Should().Contain(".SetRowHeight(56f)",
-            "styled dialogue blocks should consume space in proportion to their rendered text");
+        textPanelSource.Should().Contain(".SetHeight(24f)",
+            "each text widget should fit one display line rather than wrapping inside a fixed-height row");
+        textPanelSource.Should().Contain(".SetRowHeight(28f)",
+            "successive dialogue lines should flow without multi-line row spacing");
+        textPanelSource.Should().NotContain(".SetHeight(48f)");
+        textPanelSource.Should().NotContain(".SetRowHeight(56f)");
         textPanelSource.Should().NotContain(".SetHeight(196f)");
         textPanelSource.Should().NotContain(".SetRowHeight(208f)");
 
@@ -272,19 +274,47 @@ public class ConversationArchitectureTests
             System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
         limitMethod.Should().NotBeNull();
 
-        ((int)limitMethod!.Invoke(null, new object[] { 650f })!).Should().Be(80);
-        ((int)limitMethod.Invoke(null, new object[] { 400f })!).Should().Be(46);
-        ((int)limitMethod.Invoke(null, new object[] { 300f })!).Should().Be(24);
+        ((int)limitMethod!.Invoke(null, new object[] { 650f })!).Should().Be(57);
+        ((int)limitMethod.Invoke(null, new object[] { 400f })!).Should().Be(26);
+        ((int)limitMethod.Invoke(null, new object[] { 300f })!).Should().Be(13);
         ((int)limitMethod.Invoke(null, new object[] { 200f })!).Should().Be(4);
 
         var splitMethod = typeof(ConversationViewModel).GetMethod(
             "SplitDialogueText",
             System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
         var source = string.Join(" ", Enumerable.Repeat("responsive", 30));
-        var segments = ((IEnumerable<string>)splitMethod!.Invoke(null, new object[] { source, 46 })!).ToArray();
+        var segmentLimit = (int)limitMethod.Invoke(null, new object[] { 400f })!;
+        var segments = ((IEnumerable<string>)splitMethod!.Invoke(
+            null,
+            new object[] { source, segmentLimit })!).ToArray();
 
-        segments.Should().OnlyContain(segment => segment.Length <= 46);
+        segments.Should().OnlyContain(segment => segment.Length <= segmentLimit);
         string.Join(" ", segments).Should().Be(source);
+    }
+
+    [Test]
+    public void DefaultWidthConversationText_FlowsThroughSingleLineRows()
+    {
+        var limitMethod = typeof(ConversationViewModel).GetMethod(
+            "CalculateDialogueSegmentLimit",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        var splitMethod = typeof(ConversationViewModel).GetMethod(
+            "SplitDialogueText",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        limitMethod.Should().NotBeNull();
+        splitMethod.Should().NotBeNull();
+
+        const string source =
+            "We will be landing onto CZ-220 shortly. Please make sure you have all your belongings before exiting the ship.";
+        var segmentLimit = (int)limitMethod!.Invoke(null, new object[] { 650f })!;
+        var segments = ((IEnumerable<string>)splitMethod!.Invoke(
+            null,
+            new object[] { source, segmentLimit })!).ToArray();
+
+        segments.Should().Equal(
+            "We will be landing onto CZ-220 shortly. Please make sure",
+            "you have all your belongings before exiting the ship.");
+        segments.Should().OnlyContain(segment => segment.Length <= segmentLimit);
     }
 
     [Test]
@@ -322,10 +352,15 @@ public class ConversationArchitectureTests
     [Test]
     public void EveryAuthoredConversationBlock_FitsCompactRows()
     {
-        var method = typeof(ConversationViewModel).GetMethod(
+        var splitMethod = typeof(ConversationViewModel).GetMethod(
             "SplitDialogueText",
             System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
-        method.Should().NotBeNull();
+        var limitMethod = typeof(ConversationViewModel).GetMethod(
+            "CalculateDialogueSegmentLimit",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        splitMethod.Should().NotBeNull();
+        limitMethod.Should().NotBeNull();
+        var defaultSegmentLimit = (int)limitMethod!.Invoke(null, new object[] { 650f })!;
 
         var conversationDirectory = Path.Combine(
             FindRepositoryRoot().FullName,
@@ -341,10 +376,15 @@ public class ConversationArchitectureTests
                 foreach (var block in node.Value["Text"]?.Children<JObject>() ?? [])
                 {
                     var source = block["Text"]?.Value<string>() ?? string.Empty;
-                    var segments = ((IEnumerable<string>)method!.Invoke(null, new object[] { source, 80 })!).ToArray();
+                    var segments = ((IEnumerable<string>)splitMethod!.Invoke(
+                        null,
+                        new object[] { source, defaultSegmentLimit })!).ToArray();
                     if (!string.IsNullOrWhiteSpace(source) && segments.Length == 0)
                         errors.Add($"{Path.GetFileName(path)}:{node.Name} produced no display rows");
-                    if (segments.Any(segment => segment.Length > 80 || segment.Contains('\n') || segment.Contains('\r')))
+                    if (segments.Any(segment =>
+                            segment.Length > defaultSegmentLimit ||
+                            segment.Contains('\n') ||
+                            segment.Contains('\r')))
                         errors.Add($"{Path.GetFileName(path)}:{node.Name} produced an oversized display row");
                 }
             }

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ConversationWindowDefinition.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ConversationWindowDefinition.cs
@@ -56,12 +56,12 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                                             .BindColor(model => model.LineColors)
                                             .SetShowBorder(false)
                                             .SetScrollbars(NuiScrollbars.None)
-                                            .SetPadding(8f)
-                                            .SetHeight(48f);
+                                            .SetPadding(4f)
+                                            .SetHeight(24f);
                                     });
                                 })
                                     .BindRowCount(model => model.LineTexts)
-                                    .SetRowHeight(56f)
+                                    .SetRowHeight(28f)
                                     .SetShowBorders(false)
                                     .SetScrollbars(NuiScrollbars.Y);
                             });

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/ConversationViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/ConversationViewModel.cs
@@ -219,18 +219,16 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
         {
             const float defaultWindowWidth = 650f;
             const float nonDialogueWidth = 190f;
-            const float minimumDialogueWidth = 18f;
             const float estimatedCharacterWidth = 8f;
-            const int minimumSegmentLength = 4;
 
             // NUI lists require a fixed row height and do not expose font measurement. Keep each
             // segment to one estimated display line so the text widget cannot wrap within a row and
             // introduce extra vertical space before the next segment.
             var effectiveWindowWidth = windowWidth > 0f ? windowWidth : defaultWindowWidth;
-            var dialogueWidth = Math.Max(minimumDialogueWidth, effectiveWindowWidth - nonDialogueWidth);
+            var dialogueWidth = Math.Max(estimatedCharacterWidth, effectiveWindowWidth - nonDialogueWidth);
             var charactersPerLine = (int)Math.Floor(dialogueWidth / estimatedCharacterWidth);
 
-            return Math.Max(charactersPerLine, minimumSegmentLength);
+            return Math.Max(charactersPerLine, 1);
         }
 
         private static IEnumerable<string> SplitDialogueText(string text, int segmentCharacterLimit)

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/ConversationViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/ConversationViewModel.cs
@@ -220,22 +220,17 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             const float defaultWindowWidth = 650f;
             const float nonDialogueWidth = 190f;
             const float minimumDialogueWidth = 18f;
-            const float estimatedCharacterWidth = 9f;
-            const int renderedLinesPerRow = 2;
+            const float estimatedCharacterWidth = 8f;
             const int minimumSegmentLength = 4;
-            const int maximumSegmentLength = 80;
 
-            // NUI lists require a fixed row height and do not expose font measurement. Budget two
-            // conservative text lines from the dialogue column's current width so resizing creates
-            // more compact rows instead of clipping wrapped text or forcing the window wider.
+            // NUI lists require a fixed row height and do not expose font measurement. Keep each
+            // segment to one estimated display line so the text widget cannot wrap within a row and
+            // introduce extra vertical space before the next segment.
             var effectiveWindowWidth = windowWidth > 0f ? windowWidth : defaultWindowWidth;
             var dialogueWidth = Math.Max(minimumDialogueWidth, effectiveWindowWidth - nonDialogueWidth);
             var charactersPerLine = (int)Math.Floor(dialogueWidth / estimatedCharacterWidth);
 
-            return Math.Clamp(
-                charactersPerLine * renderedLinesPerRow,
-                minimumSegmentLength,
-                maximumSegmentLength);
+            return Math.Max(charactersPerLine, minimumSegmentLength);
         }
 
         private static IEnumerable<string> SplitDialogueText(string text, int segmentCharacterLimit)


### PR DESCRIPTION
## Summary

- render NPC conversation text as compact single-line list rows so native wrapping cannot create extra vertical gaps between manually segmented text
- calculate each segment from one estimated display line and remove the fixed 80-character ceiling
- add a regression for the CZ-220 shuttle sentence and validate the full authored conversation corpus at the default-width limit

## Testing

- `dotnet build SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj -p:RunPostBuildEvent=Never`
- `dotnet test SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj --no-build --filter "FullyQualifiedName~ConversationArchitectureTests|FullyQualifiedName~IntroShuttleAndMedicalTerminalTests"` (19 passed)

## Notes

NUI does not expose font measurement, so runtime line sizing still uses a conservative character-width estimate. This change eliminates the observed two-line-row spacing defect across the shared NUI renderer; arbitrary runtime-substituted text remains subject to that engine limitation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Conversation text now appears in more compact, single-line rows.
  * Reduced row spacing and padding improve the amount of dialogue visible at once.
  * Dialogue splitting now adapts more accurately to different window widths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->