### PR TITLE
Standardize and harden GUI framework

### DIFF
--- a/.claude/skills/swlor-gui-window-generation/SKILL.md
+++ b/.claude/skills/swlor-gui-window-generation/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: swlor-gui-window-generation
+description: Build a new SWLOR NUI GUI window from a wireframe image or written spec through a GuiWindowType enum entry, IGuiWindowDefinition, GuiViewModelBase view model, debug chat command, and warning-free boot validation. Use when creating, modifying, or repairing NUI windows, tabs, tables, modals, or bindings in this repository.
+---
+
+# SWLOR GUI Window Generation
+
+## Core Rule
+
+Build with the framework's proven components — never hand-roll their equivalents:
+
+- `GuiStandardLayout.AddStandardLayout` for the window root — **even when the
+  wireframe has no tabs** (then: zero `AddTabRow` calls, no `SetTabPanelHeight`, and
+  ONE partial holding the entire body, applied in `Initialize`). NEVER hand-roll the
+  root layout — not even as stacked rows in a root column: deviating from the
+  standard shape freezes the content region at a constant width regardless of window
+  resizing (layout rule R5).
+- `GuiTabGroup` + `GuiToggleGroupSync` for tabs (rule R4).
+- `OnModalClosedRestore` override for any tabbed window that shows modals (rule R6).
+- Copy widget patterns from `SWLOR.Game.Server/Feature/GuiDefinition/DebugNuiGalleryDefinition.cs`
+  (the living example of every widget and binding path) before inventing anything.
+  Every builder call you write must already exist under
+  `SWLOR.Game.Server/Service/GuiService/Component/` — grep before writing.
+
+**Zero `[NUI layout warning]` lines for your window at server boot is a hard gate.**
+The validator only reports confirmed defects; a warning means your layout will fail.
+
+Leave every data access as a `// TODO: data plumbing` stub returning a plausible
+placeholder value — window structure first, data wiring is a separate task.
+
+## Important Files
+
+- `SWLOR.Game.Server/Service/GuiService/GuiWindowType.cs` — window id enum (debug windows: 900 range)
+- `SWLOR.Game.Server/Feature/GuiDefinition/` — window definitions (reflection-registered)
+- `SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/` — view models
+- `SWLOR.Game.Server/Service/GuiService/Component/GuiStandardLayout.cs` — the root-layout helper
+- `SWLOR.Game.Server/Service/GuiService/Component/GuiTabGroup.cs` — tab orchestration helpers
+- `SWLOR.Game.Server/Feature/ChatCommandDefinition/DebuggingChatCommand.cs` — debug open commands
+- `SWLOR.Game.Server/Readmes/GuiWindowAuthoring.md` — full authoring guide (lifecycle, skeleton, binding table)
+- `SWLOR.Game.Server/Readmes/NuiLayoutRules.md` — layout rules R1-R7 and verified-working shapes
+- `SWLOR.Game.Server/Feature/GuiDefinition/DebugNuiGalleryDefinition.cs` — living widget reference (`/nuigallery`)
+
+## Workflow
+
+1. Read the wireframe image (or written spec). Inventory every visual element into a
+   widget list using `references/wireframe-to-widget-mapping.md`: element → builder
+   calls → binding type → ViewModel property. Note for each datum whether it is
+   static text or bound (bound = anything that changes at runtime).
+2. Read `references/layout-rules-digest.md`. Decide the layout split: which regions
+   are tab partials, which are side rails, and the fixed panel width (250-560f).
+   **If the wireframe has no tab strip:** the standard layout is still mandatory —
+   plan ONE partial containing the entire body (stacked sections all live inside that
+   single partial), zero tab rows, and follow the `TEMPLATE(no-tabs)` markers in the
+   asset templates.
+3. Copy `assets/WindowDefinitionTemplate.cs` and `assets/WindowViewModelTemplate.cs`
+   into `SWLOR.Game.Server/Feature/GuiDefinition/` and `.../ViewModel/`. Rename the
+   files and classes for your window. Add the `GuiWindowType` enum entry. Fill every
+   `// TEMPLATE:` marker per the widget inventory; keep every `// TODO: data plumbing`
+   stub returning placeholder values.
+4. Add a debug chat command in `DebuggingChatCommand.cs` following the `NuiGallery()`
+   method (`.Permissions(AuthorizationLevel.Admin)` + `.AvailableToAllOnTestEnvironment()`,
+   action = `Gui.TogglePlayerWindow(user, GuiWindowType.YourWindow)`).
+5. Work through `references/authoring-checklist.md` — mechanical yes/no sweeps for
+   the rules that cause runtime failures (assign-before-watch, margined widgets in
+   fixed rows, modal restore, invented APIs).
+6. Build once with deployment disabled, then run the GUI corpus tests:
+   `dotnet build SWLOR.Game.Server.Tests/SWLOR.Game.Server.Tests.csproj -p:RunPostBuildEvent=Never`
+   followed by `dotnet test SWLOR.Game.Server.Tests/SWLOR.Game.Server.Tests.csproj
+   --no-build --filter "FullyQualifiedName~GuiLayoutValidationTests"`.
+7. Boot the dev server and check the Server log: there must be ZERO
+   `[NUI layout warning]` entries mentioning your window. (The six warnings from `GUI_WINDOW_DebugNuiGallery`
+   are intentional regression canaries — ignore those, and only those.) Optionally
+   pull your window's `[NUI JSON]` lines from `debugserver/app_logs/Server/` to
+   sanity-check the emitted structure.
+8. Open the window in-game via your chat command: every tab renders and switches, the
+   window resizes without client errors, and every modal path leaves the tab content
+   intact.
+
+## References
+
+- `references/wireframe-to-widget-mapping.md` — read at step 1 (element-to-builder table).
+- `references/layout-rules-digest.md` — read at step 2 (rules digest + verified-working list).
+- `references/authoring-checklist.md` — run at step 5 (pre-build sweeps).
+- `assets/WindowDefinitionTemplate.cs`, `assets/WindowViewModelTemplate.cs` — copy at step 3.

--- a/.claude/skills/swlor-gui-window-generation/assets/WindowDefinitionTemplate.cs
+++ b/.claude/skills/swlor-gui-window-generation/assets/WindowDefinitionTemplate.cs
@@ -1,0 +1,128 @@
+// TEMPLATE: copy to SWLOR.Game.Server/Feature/GuiDefinition/<YourWindow>Definition.cs
+// and rename every "TemplateWindow" token. Delete markers as you fill them.
+using SWLOR.Game.Server.Core.Beamdog;
+using SWLOR.Game.Server.Feature.GuiDefinition.ViewModel;
+using SWLOR.Game.Server.Service.GuiService;
+using SWLOR.Game.Server.Service.GuiService.Component;
+
+namespace SWLOR.Game.Server.Feature.GuiDefinition
+{
+    public class TemplateWindowDefinition : IGuiWindowDefinition
+    {
+        private readonly GuiWindowBuilder<TemplateWindowViewModel> _builder = new();
+
+        private const float TabRowHeight = 28f;
+        // TEMPLATE: one tab row is 28f + ~20f margin allowance. 48f for one row,
+        // 112f for three (see DebugNuiGallery).
+        private const float TabPanelHeight = 48f;
+        // TEMPLATE: fixed tab-panel width, 250-560f (rule R5).
+        private const float ContentPanelWidth = 560f;
+        // TEMPLATE: delete if the wireframe has no side rail.
+        private const float SideRailWidth = 240f;
+
+        public GuiConstructedWindow BuildWindow()
+        {
+            var window = _builder.CreateWindow(GuiWindowType.TemplateWindow) // TEMPLATE: your enum entry
+                .SetInitialGeometry(0, 0, 900f, 560f)                        // TEMPLATE: wireframe proportions
+                .SetTitle("Template Window")                                 // TEMPLATE: wireframe title
+                .SetIsResizable(true)
+                .SetIsCollapsible(true)
+                .BindOnClosed(model => model.OnWindowClosed())
+                // TEMPLATE: one DefinePartialView per tab in the wireframe.
+                // TEMPLATE(no-tabs): if the wireframe has NO tab strip, keep exactly
+                // ONE DefinePartialView (e.g. MainContentPartial) whose builder holds
+                // the ENTIRE body - stacked sections all go inside it as rows.
+                .DefinePartialView(TemplateWindowViewModel.FirstTabPartial, AddFirstTab)
+                .DefinePartialView(TemplateWindowViewModel.SecondTabPartial, AddSecondTab);
+
+            // Rule R5: never hand-roll the root layout - not even as stacked rows in
+            // a root column. AddStandardLayout is mandatory with OR without tabs.
+            window.AddStandardLayout(layout =>
+            {
+                // TEMPLATE(no-tabs): delete SetTabPanelHeight and the AddTabRow block
+                // entirely; keep SetContentPartialElement.
+                layout.SetTabPanelHeight(TabPanelHeight);
+                layout.AddTabRow(row =>
+                {
+                    row.SetHeight(TabRowHeight);
+                    row.AddToggles()
+                        .AddOption("First")   // TEMPLATE: tab captions from the wireframe
+                        .AddOption("Second")
+                        .BindSelectedValue(model => model.TabToggleValue)
+                        .SetWidth(232f)       // TEMPLATE: ~116f per option
+                        .SetHeight(TabRowHeight);
+                });
+                layout.SetContentPartialElement(TemplateWindowViewModel.TabContentElement);
+                // TEMPLATE: delete if no side rail; add more for multiple rails.
+                layout.AddSideColumn(AddSideRail, SideRailWidth);
+            });
+
+            return _builder.Build();
+        }
+
+        // Each tab: fixed-width borderless panel (rule R5). Scrolling comes from
+        // the standard layout's content host group.
+        private static void AddFirstTab(GuiGroup<TemplateWindowViewModel> host)
+        {
+            host.AddColumn(col =>
+            {
+                col.AddRow(row =>
+                {
+                    row.AddGroup(panel =>
+                    {
+                        panel.SetShowBorder(false);
+                        panel.SetScrollbars(NuiScrollbars.None);
+                        panel.AddColumn(content =>
+                        {
+                            // TEMPLATE: build this tab's widgets here, one AddRow per
+                            // wireframe row, using references/wireframe-to-widget-mapping.md.
+                            // Rule R2c: no SetHeight on rows containing buttons/inputs.
+                            content.AddRow(r => r.AddLabel()
+                                .BindText(model => model.StatusText)
+                                .SetHeight(20f)
+                                .SetHorizontalAlign(NuiHorizontalAlign.Left));
+                        });
+                    })
+                        .SetWidth(ContentPanelWidth);
+                });
+            });
+        }
+
+        private static void AddSecondTab(GuiGroup<TemplateWindowViewModel> host)
+        {
+            host.AddColumn(col =>
+            {
+                col.AddRow(row =>
+                {
+                    row.AddGroup(panel =>
+                    {
+                        panel.SetShowBorder(false);
+                        panel.SetScrollbars(NuiScrollbars.None);
+                        panel.AddColumn(content =>
+                        {
+                            // TEMPLATE: second tab's widgets.
+                            content.AddRow(r => r.AddLabel()
+                                .SetText("Second tab")
+                                .SetHeight(20f)
+                                .SetHorizontalAlign(NuiHorizontalAlign.Left));
+                        });
+                    })
+                        .SetWidth(ContentPanelWidth);
+                });
+            });
+        }
+
+        // TEMPLATE: delete if no side rail. Side rails live in the window root
+        // (geometry-bound), so they survive tab swaps.
+        private static void AddSideRail(GuiColumn<TemplateWindowViewModel> col)
+        {
+            col.AddRow(row =>
+            {
+                row.AddLabel()
+                    .SetText("Details")   // TEMPLATE: rail content from the wireframe
+                    .SetHeight(24f)
+                    .SetHorizontalAlign(NuiHorizontalAlign.Left);
+            });
+        }
+    }
+}

--- a/.claude/skills/swlor-gui-window-generation/assets/WindowViewModelTemplate.cs
+++ b/.claude/skills/swlor-gui-window-generation/assets/WindowViewModelTemplate.cs
@@ -1,0 +1,86 @@
+// TEMPLATE: copy to SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/<YourWindow>ViewModel.cs
+// and rename every "TemplateWindow" token. Delete markers as you fill them.
+using System;
+using SWLOR.Game.Server.Service.GuiService;
+using SWLOR.Game.Server.Service.GuiService.Component;
+
+namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
+{
+    public class TemplateWindowViewModel : GuiViewModelBase<TemplateWindowViewModel, GuiPayloadBase>
+    {
+        // TEMPLATE(no-tabs): if the wireframe has NO tab strip, delete FirstTabId/
+        // SecondTabId, the Tabs/TabToggles statics, TabToggleValue, and SelectTab.
+        // Keep TabContentElement, rename the single partial const to
+        // MainContentPartial, and in Initialize (after assignments and watches) call:
+        //     ChangePartialView(TabContentElement, MainContentPartial);
+        // If the window shows modals, override OnModalClosedRestore with that same
+        // ChangePartialView call (rule R6).
+        private const int FirstTabId = 0;
+        private const int SecondTabId = 1;
+        public const string TabContentElement = "templatewindow_tab_content"; // TEMPLATE: unique element id
+        public const string FirstTabPartial = "TEMPLATEWINDOW_TAB_FIRST";     // TEMPLATE: unique partial names
+        public const string SecondTabPartial = "TEMPLATEWINDOW_TAB_SECOND";
+
+        // Rule R4: tab registration + toggle sync are static and shared.
+        private static readonly GuiTabGroup<TemplateWindowViewModel, GuiPayloadBase> Tabs =
+            new GuiTabGroup<TemplateWindowViewModel, GuiPayloadBase>()
+                .AddTab(FirstTabId, FirstTabPartial)
+                .AddTab(SecondTabId, SecondTabPartial, m => m.RefreshSecondTab());
+
+        private static readonly GuiToggleGroupSync TabToggles = new(FirstTabId, SecondTabId);
+
+        public int SelectedTabId { get => Get<int>(); set => Set(value); }
+
+        // Rule R4: this widget-bound property only forwards genuine user clicks.
+        public int TabToggleValue
+        {
+            get => Get<int>();
+            set
+            {
+                Set(value);
+                TabToggles.HandleClientChange(value, SelectTab);
+            }
+        }
+
+        // TEMPLATE: one bound property per dynamic value in the widget inventory.
+        // Use GuiBindingList<T> for list/table columns and chart data.
+        public string StatusText { get => Get<string>(); set => Set(value); }
+
+        protected override void Initialize(GuiPayloadBase initialPayload)
+        {
+            // Rule R3: assign EVERY bound property before any WatchOnClient call.
+            StatusText = "Ready.";   // TODO: data plumbing
+            TabToggleValue = 0;
+
+            // TEMPLATE: watch every property the CLIENT can change (inputs,
+            // checkboxes, combos, sliders, toggles, color pickers).
+            WatchOnClient(model => model.TabToggleValue);
+
+            SelectTab(FirstTabId);
+        }
+
+        public override Action OnWindowClosed() => () => { };
+
+        private void SelectTab(int tabId)
+        {
+            SelectedTabId = tabId;
+            TabToggles.SyncTo(tabId, v => TabToggleValue = v);
+            Tabs.Select(this, TabContentElement, tabId);
+        }
+
+        // Rule R6: modal close wipes the nested tab partial; this restores it.
+        // TEMPLATE: delete ONLY if this window never calls ShowModal/ShowInputModal.
+        protected override void OnModalClosedRestore() => Tabs.Select(this, TabContentElement, SelectedTabId);
+
+        private void RefreshSecondTab()
+        {
+            // TODO: data plumbing - load whatever the second tab displays.
+        }
+
+        // TEMPLATE: one handler per clickable element. Handlers RETURN an Action.
+        public Action OnClickDoSomething() => () =>
+        {
+            StatusText = "Clicked."; // TODO: data plumbing
+        };
+    }
+}

--- a/.claude/skills/swlor-gui-window-generation/references/authoring-checklist.md
+++ b/.claude/skills/swlor-gui-window-generation/references/authoring-checklist.md
@@ -1,0 +1,53 @@
+# Pre-Build Authoring Checklist
+
+Run every sweep; each must answer YES before building.
+
+## Structure
+- [ ] `GuiWindowType` enum entry added (900 range for debug windows), no duplicate value.
+- [ ] Definition class implements `IGuiWindowDefinition` and lives in
+      `SWLOR.Game.Server/Feature/GuiDefinition/`.
+- [ ] ViewModel derives `GuiViewModelBase<TDerived, GuiPayloadBase>` and lives in
+      `.../GuiDefinition/ViewModel/`.
+- [ ] The root layout is ONE `window.AddStandardLayout(...)` call — no hand-rolled
+      `window.AddColumn` root (rule R5). This holds even for windows WITHOUT tabs:
+      grep your definition for `AddStandardLayout` — zero matches is an automatic fail.
+- [ ] No-tab windows: exactly one body partial, applied in `Initialize` via
+      `ChangePartialView(TabContentElement, MainContentPartial)` (and re-applied in
+      `OnModalClosedRestore` if the window shows modals).
+- [ ] Every tab partial is a fixed-width borderless `Scrollbars(None)` panel.
+- [ ] Partial names and element ids are `const string`s on the ViewModel, referenced
+      from the definition (never string literals in two places).
+
+## Rules sweeps
+- [ ] R3: every property referenced by any `Bind*` expression is assigned in
+      `Initialize` BEFORE any `WatchOnClient` call.
+- [ ] Watched properties: every value the CLIENT can change (text edits, checkboxes,
+      combos, sliders, toggles, color pickers) has a `WatchOnClient` call.
+- [ ] R2c: no `row.SetHeight(...)` on any row containing a fixed-height button,
+      image button, toggle button, checkbox, textedit, combo, slider, or progress
+      bar unless every such child deliberately calls `SetMargin(0f)` for a compact
+      grid. (Tab rows with `AddToggles` are the other sanctioned exception.)
+- [ ] R4: the toggles-bound tab property only calls `HandleClientChange`; the swap
+      logic lives in a separate `SelectTab` method.
+- [ ] R6: if the window calls `ShowModal` or `ShowInputModal` anywhere AND has tabs,
+      `OnModalClosedRestore` is overridden.
+- [ ] R1: every non-last `AddTable` column passes a width > 0.
+- [ ] Lists: every cell of one list binds a `GuiBindingList` property, all kept the
+      same length; `BindRowCount` is called; per-row click handlers use
+      `NuiGetEventArrayIndex()`.
+- [ ] Combo option lists (`GuiBindingList<GuiComboEntry>`) are only ever replaced
+      wholesale, never mutated in place.
+
+## API honesty
+- [ ] Every `Bind*` expression is a BARE property reference (`m => m.Prop`) — no
+      string interpolation, concatenation, arithmetic, or method calls inside the
+      lambda (those compile but throw at boot). Computed display text lives in its
+      own string property updated by the ViewModel.
+- [ ] Every `Add*/Set*/Bind*` call used exists in
+      `SWLOR.Game.Server/Service/GuiService/Component/` — verified by grep, not memory.
+- [ ] Event handlers are `public Action Name() => () => { ... };` (they RETURN the action).
+- [ ] All data access points are `// TODO: data plumbing` stubs with placeholder values.
+
+## Open path
+- [ ] Debug chat command added to `DebuggingChatCommand.cs`
+      (Admin + `AvailableToAllOnTestEnvironment`, `Gui.TogglePlayerWindow`).

--- a/.claude/skills/swlor-gui-window-generation/references/layout-rules-digest.md
+++ b/.claude/skills/swlor-gui-window-generation/references/layout-rules-digest.md
@@ -1,0 +1,41 @@
+# Layout Rules Digest
+
+Full text: `SWLOR.Game.Server/Readmes/NuiLayoutRules.md`. The client solves layouts
+with a constraint solver; an unsolvable layout blanks the WHOLE window with a
+context-free error. These rules prevent that. **Zero `[NUI layout warning]` boot
+lines for your window is a hard gate — every warning is a confirmed defect.**
+
+## The rules
+
+- **R1 (throws):** in `AddTable`, every fixed column needs `width > 0`. Only the last
+  column (or `isVariable: true`) may be 0f.
+- **R2c (warns; the window-killer):** never `row.SetHeight(N)` when the row contains a
+  same-height widget with default margins — that is buttons, image buttons, toggle
+  buttons, checkboxes, text edits, combos, sliders, and progress bars (all confirmed
+  in-game). Let such rows derive their height from children. ONLY `AddToggles` /
+  `AddOptions`, or controls explicitly using `SetMargin(0f)` for a compact grid, may
+  share a fixed height with their row.
+- **R3 (throws):** assign every bound property in `Initialize` BEFORE calling
+  `WatchOnClient` on it. The framework throws a descriptive exception if you forget.
+- **R4 (doc):** the property bound to a toggles widget and the property that drives
+  tab swaps must be SEPARATE (`GuiToggleGroupSync` wires them). Client echoes re-run
+  property setters; putting swap logic in the widget-bound setter causes loops.
+- **R5 (doc; helper-enforced):** the window root must be the standard shape — use
+  `window.AddStandardLayout(...)`. Hand-rolled roots freeze the content region at a
+  constant width. Tab partials are fixed-width (250-560f) borderless
+  `Scrollbars(None)` panels; scrolling comes from the standard layout's host group.
+- **R6 (doc; framework hook):** tabbed windows with modals MUST override
+  `protected override void OnModalClosedRestore() => Tabs.Select(this, TabContentElement, SelectedTabId);`
+  or the tab content vanishes when any modal closes.
+- **R7 (doc):** element ids are not validated server-side (typos = client-only error);
+  never nest partials more than 2 deep (window root → partial → one nested slot).
+
+## Verified working — do NOT avoid these (all confirmed in-game)
+
+- Unbounded lists in partials, even with rows after them.
+- Tall stacks of fixed-height groups without scroll wrappers.
+- Fixed list cells with no width; fixed children wider than their fixed parent
+  (width conflicts clip — only cross-axis HEIGHT conflicts in rows kill layouts).
+- Aspect + explicit width AND height on an image; invalid image resrefs (blank);
+  zero or negative widget dimensions; empty bound chart/combo data;
+  length-mismatched list bindings (render, but keep lengths equal anyway).

--- a/.claude/skills/swlor-gui-window-generation/references/wireframe-to-widget-mapping.md
+++ b/.claude/skills/swlor-gui-window-generation/references/wireframe-to-widget-mapping.md
@@ -1,0 +1,53 @@
+# Wireframe Element → Widget Mapping
+
+For each visual element in the wireframe, use this table to pick the builder calls and
+the ViewModel property that backs it. Copyable examples live in
+`SWLOR.Game.Server/Feature/GuiDefinition/DebugNuiGalleryDefinition.cs` — the "Example"
+column names the method to copy from. Every `Add*/Set*/Bind*` call below exists in
+`SWLOR.Game.Server/Service/GuiService/Component/`; do not invent others.
+
+| Wireframe element | Builder calls | VM property type | Gallery example |
+|---|---|---|---|
+| Window title bar | `.SetTitle("...")` (or `.BindTitle`) on `CreateWindow` chain | `string` if bound | `BuildWindow` |
+| Tab strip | `layout.AddTabRow(row => { row.SetHeight(28f); row.AddToggles().AddOption("A").AddOption("B").BindSelectedValue(m => m.TabToggleValue).SetWidth(116f * optionCount).SetHeight(28f); })` inside `AddStandardLayout` | `int` (toggle value) + `int` SelectedTabId | `BuildWindow` |
+| Push button | `row.AddButton().SetText("...").SetHeight(32f).SetWidth(140f).BindOnClicked(m => m.OnClickX())` | `Action OnClickX()` | `AddButtonsTab` |
+| Icon/image button | `row.AddButtonImage().SetImageResref("arrow_up").SetHeight(32f).SetWidth(32f).BindOnClicked(...)` | `Action` | `AddButtonsTab` |
+| Toggle/latch button | `row.AddToggleButton().SetText("...").BindIsToggled(m => m.IsOn).BindOnClicked(...)` | `bool` | `AddButtonsTab` |
+| Checkbox | `row.AddCheckBox().SetText("...").BindIsChecked(m => m.IsChecked).SetHeight(24f).SetWidth(180f)` — watch the property | `bool` (watched) | `AddSelectionTab` |
+| Single-line input | `row.AddTextEdit().SetPlaceholder("...").BindValue(m => m.Text).SetMaxLength(50).SetHeight(32f)` — watch the property | `string` (watched) | `AddTextTab` |
+| Multiline input | same + `.SetIsMultiline(true).SetHasWordWrap(true).SetHeight(80f)` | `string` (watched) | `AddTextTab` |
+| Dropdown (static options) | `row.AddComboBox().AddOption("Label", 0)...BindSelectedIndex(m => m.Selection).SetHeight(32f).SetWidth(250f)` — watch the index | `int` (watched) | `AddSelectionTab` |
+| Dropdown (dynamic options) | same but `.BindOptions(m => m.Options)` | `GuiBindingList<GuiComboEntry>` (replace whole object to change) + `int` | `AddSelectionTab` |
+| Radio group | `row.AddOptions().SetDirection(NuiDirection.Horizontal).AddOption("A")...BindSelectedValue(m => m.Choice).SetHeight(30f).SetWidth(...)` | `int` (watched) | `AddSelectionTab` |
+| Slider | `row.AddSliderInt().BindValue(m => m.Value).SetMinimum(0).SetMaximum(10).SetStepSize(1).SetHeight(32f)` (or `AddSliderFloat`) | `int`/`float` (watched) | `AddSlidersTab` |
+| Progress bar | `row.AddProgressBar().BindValue(m => m.Progress).SetHeight(24f)` — value 0.0-1.0 | `float` | `AddSlidersTab` |
+| Static label | `row.AddLabel().SetText("...").SetHeight(20f).SetHorizontalAlign(NuiHorizontalAlign.Left)` | — | everywhere |
+| Dynamic label | `row.AddLabel().BindText(m => m.LabelText)...` | `string` | `AddButtonsTab` |
+| Wrapping text block | `row.AddText().BindText(m => m.Body).SetShowBorder(true).SetScrollbars(NuiScrollbars.Auto).SetHeight(100f)` | `string` | `AddTextTab` |
+| Image / portrait | `row.AddImage().SetResref("...")` or `.BindResref(m => m.Portrait)` + `.SetAspect(NuiAspect.Fit).SetWidth(...).SetHeight(...)` | `string` if bound | `AddDrawingTab` |
+| List of rows | `row.AddList(template => template.AddCell(cell => cell.AddLabel().BindText(m => m.Names)...))...BindRowCount(m => m.Names).SetRowHeight(28f)` — one `GuiBindingList` per cell, all same length | `GuiBindingList<string/float/...>` | `AddListsTab` |
+| Per-row button in a list | inside a cell: `cell.SetIsVariable(false); cell.AddButton().SetText("...").SetWidth(44f).BindOnClicked(m => m.OnClickRow());` — handler reads `NuiGetEventArrayIndex()` | `Action` | `AddListsTab` |
+| Multi-column table w/ headers | `col.AddTable(t => t.AddColumn("HEADER", 90f, m => m.ColA, ...).AddColumn("LAST", 0f, m => m.ColB).SetRowHeight(24f))` — fixed columns MUST have width > 0 (R1) | `GuiBindingList<string>` per column | `AddListsTab` |
+| Table with button column | `.AddComponentColumn("", 60f, cell => cell.AddButton()...)` + `.BindRowCount(...)` | `Action` + lists | `AddListsTab` |
+| Chart | `row.AddChart().AddSlot(s => s.SetType(NuiChartType.Lines).SetLegend("...").SetColor(r,g,b).AddDataPoint(...)).SetHeight(140f)` or `.BindData(m => m.Data)` | `GuiBindingList<float>` if bound | `AddChartsTab` |
+| Color swatch/picker | `row.AddColorPicker().BindSelectedColor(m => m.Picked).SetHeight(150f).SetWidth(250f)` — watch it | `GuiColor` (watched) | `AddSelectionTab` |
+| Horizontal centering | `row.AddSpacer();` before and after the element | — | `AddGroupsTab` |
+| Bordered panel/frame | `row.AddGroup(g => { g.SetShowBorder(true); g.AddColumn(...); })` | — | `AddGroupsTab` |
+| Confirm dialog | in a handler: `ShowModal("Prompt?", onConfirm, onCancel)` — window MUST override `OnModalClosedRestore` | `Action`s | `AddModalsTab` + VM |
+| Text-entry dialog | `ShowInputModal("Prompt", initial, onConfirm)`; read `ModalInputText` in onConfirm | — | VM `OnClickShowInputModal` |
+| Tooltip | `.SetTooltip("...")` or `.BindTooltip(m => m.Tip)` on any widget | `string` if bound | everywhere |
+| Enabled/disabled state | `.BindIsEnabled(m => m.CanDoX)` + `.SetDisabledTooltip("why")` | `bool` | `AddBindingsTab` |
+| Show/hide | `.BindIsVisible(m => m.ShowX)` | `bool` | `AddBindingsTab` |
+
+Notes:
+- **Every `Bind*` expression must be a BARE property reference: `m => m.Prop`.**
+  String interpolation, concatenation, arithmetic, or method calls inside a bind
+  expression (e.g. `m => $"{m.Count} / {m.Max}"`) COMPILE but throw
+  `ArgumentException: refers to a method, not a property` at boot, killing window
+  template loading. Computed display text gets its own `string` property (e.g.
+  `SetCountText`) that the ViewModel updates whenever its inputs change.
+- "watched" = the client edits the value, so `Initialize` must assign it FIRST and then
+  call `WatchOnClient(m => m.Prop)` (rule R3 — the framework throws if you forget).
+- Widget heights: buttons/inputs 32f, labels 20-24f, checkboxes 24f. Never set a
+  height on a ROW containing these (rule R2c) — only tab rows with Toggles may pair
+  row and widget heights.

--- a/.codex/skills/swlor-gui-window-generation/SKILL.md
+++ b/.codex/skills/swlor-gui-window-generation/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: swlor-gui-window-generation
+description: Build a new SWLOR NUI GUI window from a wireframe image or written spec through a GuiWindowType enum entry, IGuiWindowDefinition, GuiViewModelBase view model, debug chat command, and warning-free boot validation. Use when creating, modifying, or repairing NUI windows, tabs, tables, modals, or bindings in this repository.
+---
+
+# SWLOR GUI Window Generation
+
+## Core Rule
+
+Build with the framework's proven components — never hand-roll their equivalents:
+
+- `GuiStandardLayout.AddStandardLayout` for the window root — **even when the
+  wireframe has no tabs** (then: zero `AddTabRow` calls, no `SetTabPanelHeight`, and
+  ONE partial holding the entire body, applied in `Initialize`). NEVER hand-roll the
+  root layout — not even as stacked rows in a root column: deviating from the
+  standard shape freezes the content region at a constant width regardless of window
+  resizing (layout rule R5).
+- `GuiTabGroup` + `GuiToggleGroupSync` for tabs (rule R4).
+- `OnModalClosedRestore` override for any tabbed window that shows modals (rule R6).
+- Copy widget patterns from `SWLOR.Game.Server/Feature/GuiDefinition/DebugNuiGalleryDefinition.cs`
+  (the living example of every widget and binding path) before inventing anything.
+  Every builder call you write must already exist under
+  `SWLOR.Game.Server/Service/GuiService/Component/` — grep before writing.
+
+**Zero `[NUI layout warning]` lines for your window at server boot is a hard gate.**
+The validator only reports confirmed defects; a warning means your layout will fail.
+
+Leave every data access as a `// TODO: data plumbing` stub returning a plausible
+placeholder value — window structure first, data wiring is a separate task.
+
+## Important Files
+
+- `SWLOR.Game.Server/Service/GuiService/GuiWindowType.cs` — window id enum (debug windows: 900 range)
+- `SWLOR.Game.Server/Feature/GuiDefinition/` — window definitions (reflection-registered)
+- `SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/` — view models
+- `SWLOR.Game.Server/Service/GuiService/Component/GuiStandardLayout.cs` — the root-layout helper
+- `SWLOR.Game.Server/Service/GuiService/Component/GuiTabGroup.cs` — tab orchestration helpers
+- `SWLOR.Game.Server/Feature/ChatCommandDefinition/DebuggingChatCommand.cs` — debug open commands
+- `SWLOR.Game.Server/Readmes/GuiWindowAuthoring.md` — full authoring guide (lifecycle, skeleton, binding table)
+- `SWLOR.Game.Server/Readmes/NuiLayoutRules.md` — layout rules R1-R7 and verified-working shapes
+- `SWLOR.Game.Server/Feature/GuiDefinition/DebugNuiGalleryDefinition.cs` — living widget reference (`/nuigallery`)
+
+## Workflow
+
+1. Read the wireframe image (or written spec). Inventory every visual element into a
+   widget list using `references/wireframe-to-widget-mapping.md`: element → builder
+   calls → binding type → ViewModel property. Note for each datum whether it is
+   static text or bound (bound = anything that changes at runtime).
+2. Read `references/layout-rules-digest.md`. Decide the layout split: which regions
+   are tab partials, which are side rails, and the fixed panel width (250-560f).
+   **If the wireframe has no tab strip:** the standard layout is still mandatory —
+   plan ONE partial containing the entire body (stacked sections all live inside that
+   single partial), zero tab rows, and follow the `TEMPLATE(no-tabs)` markers in the
+   asset templates.
+3. Copy `assets/WindowDefinitionTemplate.cs` and `assets/WindowViewModelTemplate.cs`
+   into `SWLOR.Game.Server/Feature/GuiDefinition/` and `.../ViewModel/`. Rename the
+   files and classes for your window. Add the `GuiWindowType` enum entry. Fill every
+   `// TEMPLATE:` marker per the widget inventory; keep every `// TODO: data plumbing`
+   stub returning placeholder values.
+4. Add a debug chat command in `DebuggingChatCommand.cs` following the `NuiGallery()`
+   method (`.Permissions(AuthorizationLevel.Admin)` + `.AvailableToAllOnTestEnvironment()`,
+   action = `Gui.TogglePlayerWindow(user, GuiWindowType.YourWindow)`).
+5. Work through `references/authoring-checklist.md` — mechanical yes/no sweeps for
+   the rules that cause runtime failures (assign-before-watch, margined widgets in
+   fixed rows, modal restore, invented APIs).
+6. Build once with deployment disabled, then run the GUI corpus tests:
+   `dotnet build SWLOR.Game.Server.Tests/SWLOR.Game.Server.Tests.csproj -p:RunPostBuildEvent=Never`
+   followed by `dotnet test SWLOR.Game.Server.Tests/SWLOR.Game.Server.Tests.csproj
+   --no-build --filter "FullyQualifiedName~GuiLayoutValidationTests"`.
+7. Boot the dev server and check the Server log: there must be ZERO
+   `[NUI layout warning]` entries mentioning your window. (The six warnings from `GUI_WINDOW_DebugNuiGallery`
+   are intentional regression canaries — ignore those, and only those.) Optionally
+   pull your window's `[NUI JSON]` lines from `debugserver/app_logs/Server/` to
+   sanity-check the emitted structure.
+8. Open the window in-game via your chat command: every tab renders and switches, the
+   window resizes without client errors, and every modal path leaves the tab content
+   intact.
+
+## References
+
+- `references/wireframe-to-widget-mapping.md` — read at step 1 (element-to-builder table).
+- `references/layout-rules-digest.md` — read at step 2 (rules digest + verified-working list).
+- `references/authoring-checklist.md` — run at step 5 (pre-build sweeps).
+- `assets/WindowDefinitionTemplate.cs`, `assets/WindowViewModelTemplate.cs` — copy at step 3.

--- a/.codex/skills/swlor-gui-window-generation/agents/openai.yaml
+++ b/.codex/skills/swlor-gui-window-generation/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SWLOR GUI Window Generation"
+  short_description: "Build warning-free SWLOR NUI windows"
+  default_prompt: "Use $swlor-gui-window-generation to build a consistent, warning-free SWLOR NUI window from this wireframe or specification."

--- a/.codex/skills/swlor-gui-window-generation/assets/WindowDefinitionTemplate.cs
+++ b/.codex/skills/swlor-gui-window-generation/assets/WindowDefinitionTemplate.cs
@@ -1,0 +1,128 @@
+// TEMPLATE: copy to SWLOR.Game.Server/Feature/GuiDefinition/<YourWindow>Definition.cs
+// and rename every "TemplateWindow" token. Delete markers as you fill them.
+using SWLOR.Game.Server.Core.Beamdog;
+using SWLOR.Game.Server.Feature.GuiDefinition.ViewModel;
+using SWLOR.Game.Server.Service.GuiService;
+using SWLOR.Game.Server.Service.GuiService.Component;
+
+namespace SWLOR.Game.Server.Feature.GuiDefinition
+{
+    public class TemplateWindowDefinition : IGuiWindowDefinition
+    {
+        private readonly GuiWindowBuilder<TemplateWindowViewModel> _builder = new();
+
+        private const float TabRowHeight = 28f;
+        // TEMPLATE: one tab row is 28f + ~20f margin allowance. 48f for one row,
+        // 112f for three (see DebugNuiGallery).
+        private const float TabPanelHeight = 48f;
+        // TEMPLATE: fixed tab-panel width, 250-560f (rule R5).
+        private const float ContentPanelWidth = 560f;
+        // TEMPLATE: delete if the wireframe has no side rail.
+        private const float SideRailWidth = 240f;
+
+        public GuiConstructedWindow BuildWindow()
+        {
+            var window = _builder.CreateWindow(GuiWindowType.TemplateWindow) // TEMPLATE: your enum entry
+                .SetInitialGeometry(0, 0, 900f, 560f)                        // TEMPLATE: wireframe proportions
+                .SetTitle("Template Window")                                 // TEMPLATE: wireframe title
+                .SetIsResizable(true)
+                .SetIsCollapsible(true)
+                .BindOnClosed(model => model.OnWindowClosed())
+                // TEMPLATE: one DefinePartialView per tab in the wireframe.
+                // TEMPLATE(no-tabs): if the wireframe has NO tab strip, keep exactly
+                // ONE DefinePartialView (e.g. MainContentPartial) whose builder holds
+                // the ENTIRE body - stacked sections all go inside it as rows.
+                .DefinePartialView(TemplateWindowViewModel.FirstTabPartial, AddFirstTab)
+                .DefinePartialView(TemplateWindowViewModel.SecondTabPartial, AddSecondTab);
+
+            // Rule R5: never hand-roll the root layout - not even as stacked rows in
+            // a root column. AddStandardLayout is mandatory with OR without tabs.
+            window.AddStandardLayout(layout =>
+            {
+                // TEMPLATE(no-tabs): delete SetTabPanelHeight and the AddTabRow block
+                // entirely; keep SetContentPartialElement.
+                layout.SetTabPanelHeight(TabPanelHeight);
+                layout.AddTabRow(row =>
+                {
+                    row.SetHeight(TabRowHeight);
+                    row.AddToggles()
+                        .AddOption("First")   // TEMPLATE: tab captions from the wireframe
+                        .AddOption("Second")
+                        .BindSelectedValue(model => model.TabToggleValue)
+                        .SetWidth(232f)       // TEMPLATE: ~116f per option
+                        .SetHeight(TabRowHeight);
+                });
+                layout.SetContentPartialElement(TemplateWindowViewModel.TabContentElement);
+                // TEMPLATE: delete if no side rail; add more for multiple rails.
+                layout.AddSideColumn(AddSideRail, SideRailWidth);
+            });
+
+            return _builder.Build();
+        }
+
+        // Each tab: fixed-width borderless panel (rule R5). Scrolling comes from
+        // the standard layout's content host group.
+        private static void AddFirstTab(GuiGroup<TemplateWindowViewModel> host)
+        {
+            host.AddColumn(col =>
+            {
+                col.AddRow(row =>
+                {
+                    row.AddGroup(panel =>
+                    {
+                        panel.SetShowBorder(false);
+                        panel.SetScrollbars(NuiScrollbars.None);
+                        panel.AddColumn(content =>
+                        {
+                            // TEMPLATE: build this tab's widgets here, one AddRow per
+                            // wireframe row, using references/wireframe-to-widget-mapping.md.
+                            // Rule R2c: no SetHeight on rows containing buttons/inputs.
+                            content.AddRow(r => r.AddLabel()
+                                .BindText(model => model.StatusText)
+                                .SetHeight(20f)
+                                .SetHorizontalAlign(NuiHorizontalAlign.Left));
+                        });
+                    })
+                        .SetWidth(ContentPanelWidth);
+                });
+            });
+        }
+
+        private static void AddSecondTab(GuiGroup<TemplateWindowViewModel> host)
+        {
+            host.AddColumn(col =>
+            {
+                col.AddRow(row =>
+                {
+                    row.AddGroup(panel =>
+                    {
+                        panel.SetShowBorder(false);
+                        panel.SetScrollbars(NuiScrollbars.None);
+                        panel.AddColumn(content =>
+                        {
+                            // TEMPLATE: second tab's widgets.
+                            content.AddRow(r => r.AddLabel()
+                                .SetText("Second tab")
+                                .SetHeight(20f)
+                                .SetHorizontalAlign(NuiHorizontalAlign.Left));
+                        });
+                    })
+                        .SetWidth(ContentPanelWidth);
+                });
+            });
+        }
+
+        // TEMPLATE: delete if no side rail. Side rails live in the window root
+        // (geometry-bound), so they survive tab swaps.
+        private static void AddSideRail(GuiColumn<TemplateWindowViewModel> col)
+        {
+            col.AddRow(row =>
+            {
+                row.AddLabel()
+                    .SetText("Details")   // TEMPLATE: rail content from the wireframe
+                    .SetHeight(24f)
+                    .SetHorizontalAlign(NuiHorizontalAlign.Left);
+            });
+        }
+    }
+}

--- a/.codex/skills/swlor-gui-window-generation/assets/WindowViewModelTemplate.cs
+++ b/.codex/skills/swlor-gui-window-generation/assets/WindowViewModelTemplate.cs
@@ -1,0 +1,86 @@
+// TEMPLATE: copy to SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/<YourWindow>ViewModel.cs
+// and rename every "TemplateWindow" token. Delete markers as you fill them.
+using System;
+using SWLOR.Game.Server.Service.GuiService;
+using SWLOR.Game.Server.Service.GuiService.Component;
+
+namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
+{
+    public class TemplateWindowViewModel : GuiViewModelBase<TemplateWindowViewModel, GuiPayloadBase>
+    {
+        // TEMPLATE(no-tabs): if the wireframe has NO tab strip, delete FirstTabId/
+        // SecondTabId, the Tabs/TabToggles statics, TabToggleValue, and SelectTab.
+        // Keep TabContentElement, rename the single partial const to
+        // MainContentPartial, and in Initialize (after assignments and watches) call:
+        //     ChangePartialView(TabContentElement, MainContentPartial);
+        // If the window shows modals, override OnModalClosedRestore with that same
+        // ChangePartialView call (rule R6).
+        private const int FirstTabId = 0;
+        private const int SecondTabId = 1;
+        public const string TabContentElement = "templatewindow_tab_content"; // TEMPLATE: unique element id
+        public const string FirstTabPartial = "TEMPLATEWINDOW_TAB_FIRST";     // TEMPLATE: unique partial names
+        public const string SecondTabPartial = "TEMPLATEWINDOW_TAB_SECOND";
+
+        // Rule R4: tab registration + toggle sync are static and shared.
+        private static readonly GuiTabGroup<TemplateWindowViewModel, GuiPayloadBase> Tabs =
+            new GuiTabGroup<TemplateWindowViewModel, GuiPayloadBase>()
+                .AddTab(FirstTabId, FirstTabPartial)
+                .AddTab(SecondTabId, SecondTabPartial, m => m.RefreshSecondTab());
+
+        private static readonly GuiToggleGroupSync TabToggles = new(FirstTabId, SecondTabId);
+
+        public int SelectedTabId { get => Get<int>(); set => Set(value); }
+
+        // Rule R4: this widget-bound property only forwards genuine user clicks.
+        public int TabToggleValue
+        {
+            get => Get<int>();
+            set
+            {
+                Set(value);
+                TabToggles.HandleClientChange(value, SelectTab);
+            }
+        }
+
+        // TEMPLATE: one bound property per dynamic value in the widget inventory.
+        // Use GuiBindingList<T> for list/table columns and chart data.
+        public string StatusText { get => Get<string>(); set => Set(value); }
+
+        protected override void Initialize(GuiPayloadBase initialPayload)
+        {
+            // Rule R3: assign EVERY bound property before any WatchOnClient call.
+            StatusText = "Ready.";   // TODO: data plumbing
+            TabToggleValue = 0;
+
+            // TEMPLATE: watch every property the CLIENT can change (inputs,
+            // checkboxes, combos, sliders, toggles, color pickers).
+            WatchOnClient(model => model.TabToggleValue);
+
+            SelectTab(FirstTabId);
+        }
+
+        public override Action OnWindowClosed() => () => { };
+
+        private void SelectTab(int tabId)
+        {
+            SelectedTabId = tabId;
+            TabToggles.SyncTo(tabId, v => TabToggleValue = v);
+            Tabs.Select(this, TabContentElement, tabId);
+        }
+
+        // Rule R6: modal close wipes the nested tab partial; this restores it.
+        // TEMPLATE: delete ONLY if this window never calls ShowModal/ShowInputModal.
+        protected override void OnModalClosedRestore() => Tabs.Select(this, TabContentElement, SelectedTabId);
+
+        private void RefreshSecondTab()
+        {
+            // TODO: data plumbing - load whatever the second tab displays.
+        }
+
+        // TEMPLATE: one handler per clickable element. Handlers RETURN an Action.
+        public Action OnClickDoSomething() => () =>
+        {
+            StatusText = "Clicked."; // TODO: data plumbing
+        };
+    }
+}

--- a/.codex/skills/swlor-gui-window-generation/references/authoring-checklist.md
+++ b/.codex/skills/swlor-gui-window-generation/references/authoring-checklist.md
@@ -1,0 +1,53 @@
+# Pre-Build Authoring Checklist
+
+Run every sweep; each must answer YES before building.
+
+## Structure
+- [ ] `GuiWindowType` enum entry added (900 range for debug windows), no duplicate value.
+- [ ] Definition class implements `IGuiWindowDefinition` and lives in
+      `SWLOR.Game.Server/Feature/GuiDefinition/`.
+- [ ] ViewModel derives `GuiViewModelBase<TDerived, GuiPayloadBase>` and lives in
+      `.../GuiDefinition/ViewModel/`.
+- [ ] The root layout is ONE `window.AddStandardLayout(...)` call — no hand-rolled
+      `window.AddColumn` root (rule R5). This holds even for windows WITHOUT tabs:
+      grep your definition for `AddStandardLayout` — zero matches is an automatic fail.
+- [ ] No-tab windows: exactly one body partial, applied in `Initialize` via
+      `ChangePartialView(TabContentElement, MainContentPartial)` (and re-applied in
+      `OnModalClosedRestore` if the window shows modals).
+- [ ] Every tab partial is a fixed-width borderless `Scrollbars(None)` panel.
+- [ ] Partial names and element ids are `const string`s on the ViewModel, referenced
+      from the definition (never string literals in two places).
+
+## Rules sweeps
+- [ ] R3: every property referenced by any `Bind*` expression is assigned in
+      `Initialize` BEFORE any `WatchOnClient` call.
+- [ ] Watched properties: every value the CLIENT can change (text edits, checkboxes,
+      combos, sliders, toggles, color pickers) has a `WatchOnClient` call.
+- [ ] R2c: no `row.SetHeight(...)` on any row containing a fixed-height button,
+      image button, toggle button, checkbox, textedit, combo, slider, or progress
+      bar unless every such child deliberately calls `SetMargin(0f)` for a compact
+      grid. (Tab rows with `AddToggles` are the other sanctioned exception.)
+- [ ] R4: the toggles-bound tab property only calls `HandleClientChange`; the swap
+      logic lives in a separate `SelectTab` method.
+- [ ] R6: if the window calls `ShowModal` or `ShowInputModal` anywhere AND has tabs,
+      `OnModalClosedRestore` is overridden.
+- [ ] R1: every non-last `AddTable` column passes a width > 0.
+- [ ] Lists: every cell of one list binds a `GuiBindingList` property, all kept the
+      same length; `BindRowCount` is called; per-row click handlers use
+      `NuiGetEventArrayIndex()`.
+- [ ] Combo option lists (`GuiBindingList<GuiComboEntry>`) are only ever replaced
+      wholesale, never mutated in place.
+
+## API honesty
+- [ ] Every `Bind*` expression is a BARE property reference (`m => m.Prop`) — no
+      string interpolation, concatenation, arithmetic, or method calls inside the
+      lambda (those compile but throw at boot). Computed display text lives in its
+      own string property updated by the ViewModel.
+- [ ] Every `Add*/Set*/Bind*` call used exists in
+      `SWLOR.Game.Server/Service/GuiService/Component/` — verified by grep, not memory.
+- [ ] Event handlers are `public Action Name() => () => { ... };` (they RETURN the action).
+- [ ] All data access points are `// TODO: data plumbing` stubs with placeholder values.
+
+## Open path
+- [ ] Debug chat command added to `DebuggingChatCommand.cs`
+      (Admin + `AvailableToAllOnTestEnvironment`, `Gui.TogglePlayerWindow`).

--- a/.codex/skills/swlor-gui-window-generation/references/layout-rules-digest.md
+++ b/.codex/skills/swlor-gui-window-generation/references/layout-rules-digest.md
@@ -1,0 +1,41 @@
+# Layout Rules Digest
+
+Full text: `SWLOR.Game.Server/Readmes/NuiLayoutRules.md`. The client solves layouts
+with a constraint solver; an unsolvable layout blanks the WHOLE window with a
+context-free error. These rules prevent that. **Zero `[NUI layout warning]` boot
+lines for your window is a hard gate — every warning is a confirmed defect.**
+
+## The rules
+
+- **R1 (throws):** in `AddTable`, every fixed column needs `width > 0`. Only the last
+  column (or `isVariable: true`) may be 0f.
+- **R2c (warns; the window-killer):** never `row.SetHeight(N)` when the row contains a
+  same-height widget with default margins — that is buttons, image buttons, toggle
+  buttons, checkboxes, text edits, combos, sliders, and progress bars (all confirmed
+  in-game). Let such rows derive their height from children. ONLY `AddToggles` /
+  `AddOptions`, or controls explicitly using `SetMargin(0f)` for a compact grid, may
+  share a fixed height with their row.
+- **R3 (throws):** assign every bound property in `Initialize` BEFORE calling
+  `WatchOnClient` on it. The framework throws a descriptive exception if you forget.
+- **R4 (doc):** the property bound to a toggles widget and the property that drives
+  tab swaps must be SEPARATE (`GuiToggleGroupSync` wires them). Client echoes re-run
+  property setters; putting swap logic in the widget-bound setter causes loops.
+- **R5 (doc; helper-enforced):** the window root must be the standard shape — use
+  `window.AddStandardLayout(...)`. Hand-rolled roots freeze the content region at a
+  constant width. Tab partials are fixed-width (250-560f) borderless
+  `Scrollbars(None)` panels; scrolling comes from the standard layout's host group.
+- **R6 (doc; framework hook):** tabbed windows with modals MUST override
+  `protected override void OnModalClosedRestore() => Tabs.Select(this, TabContentElement, SelectedTabId);`
+  or the tab content vanishes when any modal closes.
+- **R7 (doc):** element ids are not validated server-side (typos = client-only error);
+  never nest partials more than 2 deep (window root → partial → one nested slot).
+
+## Verified working — do NOT avoid these (all confirmed in-game)
+
+- Unbounded lists in partials, even with rows after them.
+- Tall stacks of fixed-height groups without scroll wrappers.
+- Fixed list cells with no width; fixed children wider than their fixed parent
+  (width conflicts clip — only cross-axis HEIGHT conflicts in rows kill layouts).
+- Aspect + explicit width AND height on an image; invalid image resrefs (blank);
+  zero or negative widget dimensions; empty bound chart/combo data;
+  length-mismatched list bindings (render, but keep lengths equal anyway).

--- a/.codex/skills/swlor-gui-window-generation/references/wireframe-to-widget-mapping.md
+++ b/.codex/skills/swlor-gui-window-generation/references/wireframe-to-widget-mapping.md
@@ -1,0 +1,53 @@
+# Wireframe Element → Widget Mapping
+
+For each visual element in the wireframe, use this table to pick the builder calls and
+the ViewModel property that backs it. Copyable examples live in
+`SWLOR.Game.Server/Feature/GuiDefinition/DebugNuiGalleryDefinition.cs` — the "Example"
+column names the method to copy from. Every `Add*/Set*/Bind*` call below exists in
+`SWLOR.Game.Server/Service/GuiService/Component/`; do not invent others.
+
+| Wireframe element | Builder calls | VM property type | Gallery example |
+|---|---|---|---|
+| Window title bar | `.SetTitle("...")` (or `.BindTitle`) on `CreateWindow` chain | `string` if bound | `BuildWindow` |
+| Tab strip | `layout.AddTabRow(row => { row.SetHeight(28f); row.AddToggles().AddOption("A").AddOption("B").BindSelectedValue(m => m.TabToggleValue).SetWidth(116f * optionCount).SetHeight(28f); })` inside `AddStandardLayout` | `int` (toggle value) + `int` SelectedTabId | `BuildWindow` |
+| Push button | `row.AddButton().SetText("...").SetHeight(32f).SetWidth(140f).BindOnClicked(m => m.OnClickX())` | `Action OnClickX()` | `AddButtonsTab` |
+| Icon/image button | `row.AddButtonImage().SetImageResref("arrow_up").SetHeight(32f).SetWidth(32f).BindOnClicked(...)` | `Action` | `AddButtonsTab` |
+| Toggle/latch button | `row.AddToggleButton().SetText("...").BindIsToggled(m => m.IsOn).BindOnClicked(...)` | `bool` | `AddButtonsTab` |
+| Checkbox | `row.AddCheckBox().SetText("...").BindIsChecked(m => m.IsChecked).SetHeight(24f).SetWidth(180f)` — watch the property | `bool` (watched) | `AddSelectionTab` |
+| Single-line input | `row.AddTextEdit().SetPlaceholder("...").BindValue(m => m.Text).SetMaxLength(50).SetHeight(32f)` — watch the property | `string` (watched) | `AddTextTab` |
+| Multiline input | same + `.SetIsMultiline(true).SetHasWordWrap(true).SetHeight(80f)` | `string` (watched) | `AddTextTab` |
+| Dropdown (static options) | `row.AddComboBox().AddOption("Label", 0)...BindSelectedIndex(m => m.Selection).SetHeight(32f).SetWidth(250f)` — watch the index | `int` (watched) | `AddSelectionTab` |
+| Dropdown (dynamic options) | same but `.BindOptions(m => m.Options)` | `GuiBindingList<GuiComboEntry>` (replace whole object to change) + `int` | `AddSelectionTab` |
+| Radio group | `row.AddOptions().SetDirection(NuiDirection.Horizontal).AddOption("A")...BindSelectedValue(m => m.Choice).SetHeight(30f).SetWidth(...)` | `int` (watched) | `AddSelectionTab` |
+| Slider | `row.AddSliderInt().BindValue(m => m.Value).SetMinimum(0).SetMaximum(10).SetStepSize(1).SetHeight(32f)` (or `AddSliderFloat`) | `int`/`float` (watched) | `AddSlidersTab` |
+| Progress bar | `row.AddProgressBar().BindValue(m => m.Progress).SetHeight(24f)` — value 0.0-1.0 | `float` | `AddSlidersTab` |
+| Static label | `row.AddLabel().SetText("...").SetHeight(20f).SetHorizontalAlign(NuiHorizontalAlign.Left)` | — | everywhere |
+| Dynamic label | `row.AddLabel().BindText(m => m.LabelText)...` | `string` | `AddButtonsTab` |
+| Wrapping text block | `row.AddText().BindText(m => m.Body).SetShowBorder(true).SetScrollbars(NuiScrollbars.Auto).SetHeight(100f)` | `string` | `AddTextTab` |
+| Image / portrait | `row.AddImage().SetResref("...")` or `.BindResref(m => m.Portrait)` + `.SetAspect(NuiAspect.Fit).SetWidth(...).SetHeight(...)` | `string` if bound | `AddDrawingTab` |
+| List of rows | `row.AddList(template => template.AddCell(cell => cell.AddLabel().BindText(m => m.Names)...))...BindRowCount(m => m.Names).SetRowHeight(28f)` — one `GuiBindingList` per cell, all same length | `GuiBindingList<string/float/...>` | `AddListsTab` |
+| Per-row button in a list | inside a cell: `cell.SetIsVariable(false); cell.AddButton().SetText("...").SetWidth(44f).BindOnClicked(m => m.OnClickRow());` — handler reads `NuiGetEventArrayIndex()` | `Action` | `AddListsTab` |
+| Multi-column table w/ headers | `col.AddTable(t => t.AddColumn("HEADER", 90f, m => m.ColA, ...).AddColumn("LAST", 0f, m => m.ColB).SetRowHeight(24f))` — fixed columns MUST have width > 0 (R1) | `GuiBindingList<string>` per column | `AddListsTab` |
+| Table with button column | `.AddComponentColumn("", 60f, cell => cell.AddButton()...)` + `.BindRowCount(...)` | `Action` + lists | `AddListsTab` |
+| Chart | `row.AddChart().AddSlot(s => s.SetType(NuiChartType.Lines).SetLegend("...").SetColor(r,g,b).AddDataPoint(...)).SetHeight(140f)` or `.BindData(m => m.Data)` | `GuiBindingList<float>` if bound | `AddChartsTab` |
+| Color swatch/picker | `row.AddColorPicker().BindSelectedColor(m => m.Picked).SetHeight(150f).SetWidth(250f)` — watch it | `GuiColor` (watched) | `AddSelectionTab` |
+| Horizontal centering | `row.AddSpacer();` before and after the element | — | `AddGroupsTab` |
+| Bordered panel/frame | `row.AddGroup(g => { g.SetShowBorder(true); g.AddColumn(...); })` | — | `AddGroupsTab` |
+| Confirm dialog | in a handler: `ShowModal("Prompt?", onConfirm, onCancel)` — window MUST override `OnModalClosedRestore` | `Action`s | `AddModalsTab` + VM |
+| Text-entry dialog | `ShowInputModal("Prompt", initial, onConfirm)`; read `ModalInputText` in onConfirm | — | VM `OnClickShowInputModal` |
+| Tooltip | `.SetTooltip("...")` or `.BindTooltip(m => m.Tip)` on any widget | `string` if bound | everywhere |
+| Enabled/disabled state | `.BindIsEnabled(m => m.CanDoX)` + `.SetDisabledTooltip("why")` | `bool` | `AddBindingsTab` |
+| Show/hide | `.BindIsVisible(m => m.ShowX)` | `bool` | `AddBindingsTab` |
+
+Notes:
+- **Every `Bind*` expression must be a BARE property reference: `m => m.Prop`.**
+  String interpolation, concatenation, arithmetic, or method calls inside a bind
+  expression (e.g. `m => $"{m.Count} / {m.Max}"`) COMPILE but throw
+  `ArgumentException: refers to a method, not a property` at boot, killing window
+  template loading. Computed display text gets its own `string` property (e.g.
+  `SetCountText`) that the ViewModel updates whenever its inputs change.
+- "watched" = the client edits the value, so `Initialize` must assign it FIRST and then
+  call `WatchOnClient(m => m.Prop)` (rule R3 — the framework throws if you forget).
+- Widget heights: buttons/inputs 32f, labels 20-24f, checkboxes 24f. Never set a
+  height on a ROW containing these (rule R2c) — only tab rows with Toggles may pair
+  row and widget heights.

--- a/SWLOR.Game.Server.Tests/Service/GuiLayoutValidationTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/GuiLayoutValidationTests.cs
@@ -1,0 +1,379 @@
+using FluentAssertions;
+using NUnit.Framework;
+using SWLOR.Game.Server.Feature.GuiDefinition.ViewModel;
+using SWLOR.Game.Server.Service.GuiService;
+using SWLOR.Game.Server.Service.GuiService.Component;
+
+namespace SWLOR.Game.Server.Tests.Service;
+
+/// <summary>
+/// Covers the boot-time NUI layout safety checks: the GuiTableBuilder fixed-zero-width
+/// column guard, confirmed row-height failures, and verified layouts that must remain
+/// warning-free. All checks run before Json serialization, so no NWN engine is required.
+/// See SWLOR.Game.Server/Readmes/NuiLayoutRules.md for the rules under test.
+/// </summary>
+public class GuiLayoutValidationTests
+{
+    [Test]
+    public void GuiTable_FixedColumnWithoutWidth_ThrowsAtBuildTime()
+    {
+        var col = new GuiColumn<DebugNuiGalleryViewModel>();
+
+        var act = () => col.AddTable<DebugNuiGalleryViewModel>(t => t
+            // Width 0 and not the last column and no isVariable => resolves to fixed zero-width.
+            .AddColumn("BROKEN", 0f, model => model.ListNames)
+            .AddColumn("TRAILING", 100f, model => model.ListDescriptions));
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*BROKEN*fixed width*");
+    }
+
+    [Test]
+    public void GuiTable_VariableColumnWithoutWidth_Builds()
+    {
+        var col = new GuiColumn<DebugNuiGalleryViewModel>();
+
+        var act = () => col.AddTable<DebugNuiGalleryViewModel>(t => t
+            .AddColumn("FLEX", 0f, model => model.ListNames, isVariable: true)
+            .AddColumn("FIXED", 100f, model => model.ListDescriptions, isVariable: false));
+
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public void GuiTableSource_RefreshesAndRemovesEveryColumnTogether()
+    {
+        var model = new DebugNuiGalleryViewModel();
+        var rows = new List<TestRow>
+        {
+            new("Alpha", "First"),
+            new("Beta", "Second")
+        };
+        var source = new GuiTableSource<DebugNuiGalleryViewModel, TestRow>()
+            .Column((viewModel, values) => viewModel.ListNames = values, row => row.Name, viewModel => viewModel.ListNames)
+            .Column((viewModel, values) => viewModel.ListDescriptions = values, row => row.Description, viewModel => viewModel.ListDescriptions);
+
+        source.Refresh(model, rows);
+        source.RemoveRowAt(model, rows, 0);
+
+        rows.Should().ContainSingle().Which.Name.Should().Be("Beta");
+        model.ListNames.Should().Equal("Beta");
+        model.ListDescriptions.Should().Equal("Second");
+    }
+
+    [Test]
+    public void GuiTableSource_MissingRemoveGetter_DoesNotPartiallyMutateRows()
+    {
+        var model = new DebugNuiGalleryViewModel();
+        var rows = new List<TestRow> { new("Alpha", "First") };
+        var source = new GuiTableSource<DebugNuiGalleryViewModel, TestRow>()
+            .Column((viewModel, values) => viewModel.ListNames = values, row => row.Name);
+        source.Refresh(model, rows);
+
+        var act = () => source.RemoveRowAt(model, rows, 0);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*no getter registered*");
+        rows.Should().ContainSingle();
+        model.ListNames.Should().Equal("Alpha");
+    }
+
+    [Test]
+    public void GuiTableSource_MismatchedBoundList_DoesNotPartiallyMutateRows()
+    {
+        var model = new DebugNuiGalleryViewModel();
+        var rows = new List<TestRow> { new("Alpha", "First") };
+        var source = new GuiTableSource<DebugNuiGalleryViewModel, TestRow>()
+            .Column((viewModel, values) => viewModel.ListNames = values, row => row.Name, viewModel => viewModel.ListNames)
+            .Column((viewModel, values) => viewModel.ListDescriptions = values, row => row.Description, viewModel => viewModel.ListDescriptions);
+        source.Refresh(model, rows);
+        model.ListDescriptions.RemoveAt(0);
+
+        var act = () => source.RemoveRowAt(model, rows, 0);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*does not contain row 0*");
+        rows.Should().ContainSingle();
+        model.ListNames.Should().Equal("Alpha");
+    }
+
+    [Test]
+    public void GuiToggleGroupSync_ResetsGuardWhenSetterThrows()
+    {
+        var sync = new GuiToggleGroupSync(10, 20);
+        var selectedTab = -1;
+
+        var act = () => sync.SyncTo(10, _ => throw new InvalidOperationException("setter failed"));
+        act.Should().Throw<InvalidOperationException>();
+
+        sync.HandleClientChange(1, tabId => selectedTab = tabId);
+        selectedTab.Should().Be(20);
+    }
+
+    [Test]
+    public void GuiStandardLayout_RequiresContentPartialElement()
+    {
+        var window = new GuiWindow<DebugNuiGalleryViewModel>();
+
+        var act = () => window.AddStandardLayout(_ => { });
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*SetContentPartialElement*");
+    }
+
+    [Test]
+    public void Validator_UnboundedListWithTrailingRow_InNamedPartial_IsAllowed()
+    {
+        var partial = BuildPartialWithListThenRow(boundedListRow: false);
+
+        var findings = GuiLayoutValidator.Validate("test_window", Partials("TEST_PARTIAL", partial));
+
+        findings.Should().BeEmpty();
+    }
+
+    [Test]
+    public void Validator_UnboundedListWithTrailingRow_InMainPartial_IsNotFlagged()
+    {
+        var partial = BuildPartialWithListThenRow(boundedListRow: false);
+
+        var findings = GuiLayoutValidator.Validate("test_window", Partials("%%WINDOW_MAIN%%", partial));
+
+        findings.Should().BeEmpty();
+    }
+
+    [Test]
+    public void Validator_HeightBoundedListWithTrailingRow_IsNotFlagged()
+    {
+        var partial = BuildPartialWithListThenRow(boundedListRow: true);
+
+        var findings = GuiLayoutValidator.Validate("test_window", Partials("TEST_PARTIAL", partial));
+
+        findings.Should().BeEmpty();
+    }
+
+    [Test]
+    public void Validator_ListInsideScrollableGroup_WithTrailingRow_IsNotFlagged()
+    {
+        var partial = CreatePartialWrapper();
+        partial.AddColumn(col =>
+        {
+            col.AddRow(row =>
+            {
+                row.AddGroup(group =>
+                {
+                    group.SetShowBorder(false);
+                    group.SetScrollbars(SWLOR.Game.Server.Core.Beamdog.NuiScrollbars.Auto);
+                    group.AddColumn(inner =>
+                    {
+                        inner.AddRow(innerRow =>
+                        {
+                            innerRow.AddList(template =>
+                            {
+                                template.AddCell(cell => cell.AddLabel().BindText(model => model.ListNames));
+                            })
+                                .BindRowCount(model => model.ListNames);
+                        });
+                    });
+                });
+            });
+
+            col.AddRow(row =>
+            {
+                row.AddButton().SetText(">").SetWidth(32f).SetHeight(32f);
+            });
+        });
+
+        var findings = GuiLayoutValidator.Validate("test_window", Partials("TEST_PARTIAL", partial));
+
+        findings.Should().BeEmpty();
+    }
+
+    [Test]
+    public void Validator_FixedRowWithEqualHeightButton_IsFlagged()
+    {
+        // The confirmed failure shape: a row with an explicit height whose
+        // buttons are the same height leaves no room for default widget margins.
+        var partial = CreatePartialWrapper();
+        partial.AddColumn(col =>
+        {
+            col.AddRow(row =>
+            {
+                row.SetHeight(32f);
+                row.AddButton().SetText("Refresh").SetHeight(32f).SetWidth(90f);
+            });
+        });
+
+        var findings = GuiLayoutValidator.Validate("test_window", Partials("TEST_PARTIAL", partial));
+
+        findings.Should().ContainSingle(f => f.Contains("default margins"));
+    }
+
+    [Test]
+    public void Validator_FixedRowWithEqualHeightMarginlessButton_IsAllowed()
+    {
+        var partial = CreatePartialWrapper();
+        partial.AddColumn(col =>
+        {
+            col.AddRow(row =>
+            {
+                row.SetHeight(32f);
+                row.AddButton()
+                    .SetText("Tile")
+                    .SetHeight(32f)
+                    .SetWidth(32f)
+                    .SetMargin(0f);
+            });
+        });
+
+        var findings = GuiLayoutValidator.Validate("test_window", Partials("TEST_PARTIAL", partial));
+
+        findings.Should().BeEmpty();
+    }
+
+    [Test]
+    public void Validator_TerminalList_IsNotFlagged()
+    {
+        // The CharacterSheet tab shape: an action row (deriving its height from its
+        // children) first, list as the last row.
+        var partial = CreatePartialWrapper();
+        partial.AddColumn(col =>
+        {
+            col.AddRow(row =>
+            {
+                row.AddButton().SetText("Refresh").SetHeight(32f).SetWidth(90f);
+            });
+
+            col.AddRow(row =>
+            {
+                row.AddList(template =>
+                {
+                    template.AddCell(cell => cell.AddLabel().BindText(model => model.ListNames));
+                })
+                    .BindRowCount(model => model.ListNames);
+            });
+        });
+
+        var findings = GuiLayoutValidator.Validate("test_window", Partials("TEST_PARTIAL", partial));
+
+        findings.Should().BeEmpty();
+    }
+
+    [Test]
+    public void Validator_FixedTemplateCellWithoutWidth_IsAllowed()
+    {
+        var partial = CreatePartialWrapper();
+        partial.AddColumn(col =>
+        {
+            col.AddRow(row =>
+            {
+                row.AddList(template =>
+                {
+                    template.AddCell(cell =>
+                    {
+                        cell.SetIsVariable(false);
+                        cell.AddLabel().BindText(model => model.ListNames);
+                    });
+                })
+                    .BindRowCount(model => model.ListNames);
+            });
+        });
+
+        var findings = GuiLayoutValidator.Validate("test_window", Partials("TEST_PARTIAL", partial));
+
+        findings.Should().BeEmpty();
+    }
+
+    [Test]
+    public void AllGuiWindowDefinitions_BuildWithoutUnexpectedLayoutFindings()
+    {
+        using var validationBuild = GuiLayoutValidator.BeginValidationOnlyBuild();
+        var allowedGalleryCanaries = new[]
+        {
+            "GALLERY_HAZARD_BUTTON_ROW",
+            "GALLERY_PROBE_ROW_CHECKBOX",
+            "GALLERY_PROBE_ROW_TEXTEDIT",
+            "GALLERY_PROBE_ROW_COMBO",
+            "GALLERY_PROBE_ROW_SLIDER",
+            "GALLERY_PROBE_ROW_PROGRESS"
+        };
+        var failures = new List<string>();
+        var definitionTypes = typeof(IGuiWindowDefinition).Assembly
+            .GetTypes()
+            .Where(type => typeof(IGuiWindowDefinition).IsAssignableFrom(type) &&
+                           !type.IsInterface &&
+                           !type.IsAbstract)
+            .OrderBy(type => type.FullName);
+
+        foreach (var definitionType in definitionTypes)
+        {
+            GuiConstructedWindow window;
+            try
+            {
+                var definition = (IGuiWindowDefinition)Activator.CreateInstance(definitionType)!;
+                window = definition.BuildWindow();
+            }
+            catch (Exception ex)
+            {
+                failures.Add($"{definitionType.Name} failed to build: {ex.GetType().Name}: {ex.Message}");
+                continue;
+            }
+
+            foreach (var finding in window.LayoutFindings)
+            {
+                var isAllowedGalleryCanary = window.Type == GuiWindowType.DebugNuiGallery &&
+                                             allowedGalleryCanaries.Any(finding.Contains);
+                if (!isAllowedGalleryCanary)
+                    failures.Add(finding);
+            }
+        }
+
+        failures.Should().BeEmpty("every production GUI definition must conform to the shared layout rules");
+    }
+
+    /// <summary>
+    /// Creates a partial wrapper group the way DefinePartialView does: no border,
+    /// no scrollbars. A default GuiGroup is Scrollbars.Auto, which the validator
+    /// legitimately treats as bounding its content.
+    /// </summary>
+    private static GuiGroup<DebugNuiGalleryViewModel> CreatePartialWrapper()
+    {
+        var partial = new GuiGroup<DebugNuiGalleryViewModel>();
+        partial.SetShowBorder(false);
+        partial.SetScrollbars(SWLOR.Game.Server.Core.Beamdog.NuiScrollbars.None);
+        return partial;
+    }
+
+    private static GuiGroup<DebugNuiGalleryViewModel> BuildPartialWithListThenRow(bool boundedListRow)
+    {
+        var partial = CreatePartialWrapper();
+        partial.AddColumn(col =>
+        {
+            col.AddRow(row =>
+            {
+                if (boundedListRow)
+                    row.SetHeight(500f);
+
+                row.AddList(template =>
+                {
+                    template.AddCell(cell => cell.AddLabel().BindText(model => model.ListNames));
+                })
+                    .BindRowCount(model => model.ListNames);
+            });
+
+            // Trailing pagination-style row after the list (height derived from children).
+            col.AddRow(row =>
+            {
+                row.AddButton().SetText(">").SetWidth(32f).SetHeight(32f);
+            });
+        });
+
+        return partial;
+    }
+
+    private static Dictionary<string, IGuiWidget> Partials(string name, IGuiWidget partial)
+    {
+        return new Dictionary<string, IGuiWidget>
+        {
+            [name] = partial
+        };
+    }
+
+    private sealed record TestRow(string Name, string Description);
+}

--- a/SWLOR.Game.Server/Feature/ChatCommandDefinition/DebuggingChatCommand.cs
+++ b/SWLOR.Game.Server/Feature/ChatCommandDefinition/DebuggingChatCommand.cs
@@ -16,6 +16,7 @@ namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
         {
             //MoveDoor();
             EnmityDebugger();
+            NuiGallery();
             GetObjectId();
             ResetBeast();
 
@@ -84,6 +85,18 @@ namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
                 .Action((user, target, location, args) =>
                 {
                     Gui.TogglePlayerWindow(user, GuiWindowType.DebugEnmity);
+                });
+        }
+
+        private void NuiGallery()
+        {
+            _builder.Create("nuigallery")
+                .Description("Opens the NUI control gallery debug window")
+                .Permissions(AuthorizationLevel.Admin)
+                .AvailableToAllOnTestEnvironment()
+                .Action((user, target, location, args) =>
+                {
+                    Gui.TogglePlayerWindow(user, GuiWindowType.DebugNuiGallery);
                 });
         }
 

--- a/SWLOR.Game.Server/Feature/GuiDefinition/CharacterSheetDefinition.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/CharacterSheetDefinition.cs
@@ -25,7 +25,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
 
         public GuiConstructedWindow BuildWindow()
         {
-            _builder.CreateWindow(GuiWindowType.CharacterSheet)
+            var window = _builder.CreateWindow(GuiWindowType.CharacterSheet)
                 .SetInitialGeometry(0, 0, 800f, 460f)
                 .SetTitle("Character Sheet")
                 .SetIsResizable(true)
@@ -33,21 +33,39 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                 .DefinePartialView(CharacterSheetViewModel.AttributesTabPartial, AddAttributesTab)
                 .DefinePartialView(CharacterSheetViewModel.StatsTabPartial, AddStatsTab)
                 .DefinePartialView(CharacterSheetViewModel.ResistancesTabPartial, AddResistancesTab)
-                .DefinePartialView(CharacterSheetViewModel.CraftingTabPartial, AddCraftingTab)
-                .AddColumn(root =>
+                .DefinePartialView(CharacterSheetViewModel.CraftingTabPartial, AddCraftingTab);
+
+            window.AddStandardLayout(layout =>
+            {
+                layout.AddLeadingColumn(AddIdentityRail, RailWidth);
+                layout.SetTabPanelHeight(TabPanelHeight);
+                layout.AddTabRow(tabRow =>
                 {
-                    root.AddRow(mainRow =>
-                    {
-                        mainRow.AddColumn(AddIdentityRail)
-                            .SetWidth(RailWidth);
-
-                        mainRow.AddColumn(AddTabbedDetailArea);
-
-                        mainRow.AddColumn(AddActionsRail)
-                            .SetWidth(ActionsWidth)
-                            .BindIsVisible(model => model.IsPlayerMode);
-                    });
+                    tabRow.SetHeight(TabRowHeight);
+                    tabRow.AddToggles()
+                        .AddOption("Attributes")
+                        .AddOption("Stats")
+                        .BindSelectedValue(model => model.TopTabId)
+                        .SetWidth(TabPairWidth)
+                        .SetHeight(TabRowHeight);
                 });
+                layout.AddTabRow(tabRow =>
+                {
+                    tabRow.SetHeight(TabRowHeight);
+                    tabRow.AddToggles()
+                        .AddOption("Resistances")
+                        .AddOption("Crafting")
+                        .BindSelectedValue(model => model.BottomTabId)
+                        .SetWidth(TabPairWidth)
+                        .SetHeight(TabRowHeight);
+                });
+                layout.SetContentPartialElement(CharacterSheetViewModel.TabContentPartialElement);
+                layout.AddSideColumn(col =>
+                {
+                    AddActionsRail(col);
+                    col.BindIsVisible(model => model.IsPlayerMode);
+                }, ActionsWidth);
+            });
 
             return _builder.Build();
         }
@@ -123,59 +141,6 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
             });
         }
 
-        private static void AddTabbedDetailArea(GuiColumn<CharacterSheetViewModel> col)
-        {
-            col.AddRow(row =>
-            {
-                row.AddGroup(group =>
-                {
-                    group.SetShowBorder(false);
-                    group.SetScrollbars(NuiScrollbars.Auto);
-                    group.AddColumn(tabColumn =>
-                    {
-                        tabColumn.AddRow(tabRow =>
-                        {
-                            tabRow.SetHeight(TabRowHeight);
-                            tabRow.AddToggles()
-                                .AddOption("Attributes")
-                                .AddOption("Stats")
-                                .BindSelectedValue(model => model.TopTabId)
-                                .SetWidth(TabPairWidth)
-                                .SetHeight(TabRowHeight);
-                        });
-
-                        tabColumn.AddRow(tabRow =>
-                        {
-                            tabRow.SetHeight(TabRowHeight);
-                            tabRow.AddToggles()
-                                .AddOption("Resistances")
-                                .AddOption("Crafting")
-                                .BindSelectedValue(model => model.BottomTabId)
-                                .SetWidth(TabPairWidth)
-                                .SetHeight(TabRowHeight);
-                        });
-                    });
-                })
-                    .SetHeight(TabPanelHeight);
-            });
-
-            col.AddRow(row =>
-            {
-                row.AddGroup(group =>
-                {
-                    group.SetShowBorder(false);
-                    group.SetScrollbars(NuiScrollbars.Auto);
-                    group.AddColumn(contentCol =>
-                    {
-                        contentCol.AddRow(contentRow =>
-                        {
-                            contentRow.AddPartialView(CharacterSheetViewModel.TabContentPartialElement);
-                        });
-                    });
-                });
-            });
-        }
-
         private static void AddAttributesTab(GuiGroup<CharacterSheetViewModel> group)
         {
             group.SetShowBorder(false);
@@ -236,39 +201,10 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                         table.SetScrollbars(NuiScrollbars.None);
                         table.AddColumn(tableCol =>
                         {
-                            tableCol.AddRow(row =>
-                            {
-                                AddTableHeader(row, "STAT", 190f, "Character stat.");
-                                AddTableHeader(row, "VALUE", 0f, "Current value.");
-                            });
-
-                            tableCol.AddRow(row =>
-                            {
-                                row.AddList(template =>
-                                {
-                                    template.AddCell(cell =>
-                                    {
-                                        cell.SetIsVariable(false);
-                                        cell.SetWidth(190f);
-                                        cell.AddLabel()
-                                            .BindText(model => model.StatNames)
-                                            .BindTooltip(model => model.StatTooltips)
-                                            .SetHorizontalAlign(NuiHorizontalAlign.Left);
-                                    });
-
-                                    template.AddCell(cell =>
-                                    {
-                                        cell.AddLabel()
-                                            .BindText(model => model.StatValues)
-                                            .BindTooltip(model => model.StatTooltips)
-                                            .SetHorizontalAlign(NuiHorizontalAlign.Left);
-                                    });
-                                })
-                                    .BindRowCount(model => model.StatNames)
-                                    .SetRowHeight(24f)
-                                    .SetShowBorders(false)
-                                    .SetScrollbars(NuiScrollbars.Y);
-                            });
+                            tableCol.AddTable<CharacterSheetViewModel>(t => t
+                                .AddColumn("STAT", 190f, model => model.StatNames, model => model.StatTooltips, "Character stat.")
+                                .AddColumn("VALUE", 0f, model => model.StatValues, model => model.StatTooltips, "Current value.")
+                                .SetRowHeight(24f));
                         });
                     })
                         .SetWidth(StatsPanelWidth);
@@ -289,57 +225,12 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                         table.SetScrollbars(NuiScrollbars.None);
                         table.AddColumn(tableCol =>
                         {
-                            tableCol.AddRow(row =>
-                            {
-                                AddTableHeader(row, "TYPE", 90f, "Resistance family.");
-                                AddTableHeader(row, "SCORE", 55f, "Higher reduces impact.");
-                                AddTableHeader(row, "DAMAGE", 90f, "Damage received.");
-                                AddTableHeader(row, "STATUS", 0f, "Status duration.");
-                            });
-
-                            tableCol.AddRow(row =>
-                            {
-                                row.AddList(template =>
-                                {
-                                    template.AddCell(cell =>
-                                    {
-                                        cell.SetIsVariable(false);
-                                        cell.SetWidth(90f);
-                                        cell.AddLabel()
-                                            .BindText(model => model.ResistanceNames)
-                                            .SetHorizontalAlign(NuiHorizontalAlign.Left);
-                                    });
-
-                                    template.AddCell(cell =>
-                                    {
-                                        cell.SetIsVariable(false);
-                                        cell.SetWidth(55f);
-                                        cell.AddLabel()
-                                            .BindText(model => model.ResistanceScores)
-                                            .SetHorizontalAlign(NuiHorizontalAlign.Left);
-                                    });
-
-                                    template.AddCell(cell =>
-                                    {
-                                        cell.SetIsVariable(false);
-                                        cell.SetWidth(90f);
-                                        cell.AddLabel()
-                                            .BindText(model => model.ResistanceDamageTaken)
-                                            .SetHorizontalAlign(NuiHorizontalAlign.Left);
-                                    });
-
-                                    template.AddCell(cell =>
-                                    {
-                                        cell.AddLabel()
-                                            .BindText(model => model.ResistanceStatusDurations)
-                                            .SetHorizontalAlign(NuiHorizontalAlign.Left);
-                                    });
-                                })
-                                    .BindRowCount(model => model.ResistanceNames)
-                                    .SetRowHeight(24f)
-                                    .SetShowBorders(false)
-                                    .SetScrollbars(NuiScrollbars.Y);
-                            });
+                            tableCol.AddTable<CharacterSheetViewModel>(t => t
+                                .AddColumn("TYPE", 90f, "Resistance family.", model => model.ResistanceNames)
+                                .AddColumn("SCORE", 55f, "Higher reduces impact.", model => model.ResistanceScores)
+                                .AddColumn("DAMAGE", 90f, "Damage received.", model => model.ResistanceDamageTaken)
+                                .AddColumn("STATUS", 0f, "Status duration.", model => model.ResistanceStatusDurations)
+                                .SetRowHeight(24f));
                         });
                     })
                         .SetWidth(ResistancePanelWidth);
@@ -360,48 +251,11 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                         table.SetScrollbars(NuiScrollbars.None);
                         table.AddColumn(tableCol =>
                         {
-                            tableCol.AddRow(row =>
-                            {
-                                AddTableHeader(row, "CRAFT", 135f, "Crafting skill.");
-                                AddTableHeader(row, "CONTROL", 82f, "Craft quality and auto-craft chance.");
-                                AddTableHeader(row, "CRAFTSMANSHIP", 0f, "Craft progress and auto-craft chance.");
-                            });
-
-                            tableCol.AddRow(row =>
-                            {
-                                row.AddList(template =>
-                                {
-                                    template.AddCell(cell =>
-                                    {
-                                        cell.SetIsVariable(false);
-                                        cell.SetWidth(135f);
-                                        cell.AddLabel()
-                                            .BindText(model => model.CraftNames)
-                                            .SetHorizontalAlign(NuiHorizontalAlign.Left);
-                                    });
-
-                                    template.AddCell(cell =>
-                                    {
-                                        cell.SetIsVariable(false);
-                                        cell.SetWidth(82f);
-                                        cell.AddLabel()
-                                            .BindText(model => model.CraftControls)
-                                            .SetHorizontalAlign(NuiHorizontalAlign.Left);
-                                    });
-
-                                    template.AddCell(cell =>
-                                    {
-                                        cell.AddLabel()
-                                            .BindText(model => model.CraftCraftsmanship)
-                                            .SetHorizontalAlign(NuiHorizontalAlign.Left);
-                                    });
-                                })
-                                    .BindRowCount(model => model.CraftNames)
-                                    .SetRowHeight(28f)
-                                    .SetShowBorders(false)
-                                    .SetScrollbars(NuiScrollbars.Y);
-                            });
-
+                            tableCol.AddTable<CharacterSheetViewModel>(t => t
+                                .AddColumn("CRAFT", 135f, "Crafting skill.", model => model.CraftNames)
+                                .AddColumn("CONTROL", 82f, "Craft quality and auto-craft chance.", model => model.CraftControls)
+                                .AddColumn("CRAFTSMANSHIP", 0f, "Craft progress and auto-craft chance.", model => model.CraftCraftsmanship)
+                                .SetRowHeight(28f));
                         });
                     })
                         .SetWidth(CraftingPanelWidth);
@@ -472,28 +326,6 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
 
                 row.AddSpacer();
             });
-        }
-
-        private static void AddTableHeader(
-            GuiRow<CharacterSheetViewModel> row,
-            string text,
-            float width,
-            string tooltip = null)
-        {
-            var label = row.AddLabel()
-                .SetText(text)
-                .SetHeight(22f)
-                .SetHorizontalAlign(NuiHorizontalAlign.Left);
-
-            if (width > 0f)
-            {
-                label.SetWidth(width);
-            }
-
-            if (!string.IsNullOrWhiteSpace(tooltip))
-            {
-                label.SetTooltip(tooltip);
-            }
         }
 
         private static void AddAttributeRow(

--- a/SWLOR.Game.Server/Feature/GuiDefinition/DebugNuiGalleryDefinition.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/DebugNuiGalleryDefinition.cs
@@ -1,0 +1,1576 @@
+using SWLOR.Game.Server.Core.Beamdog;
+using SWLOR.Game.Server.Enumeration;
+using SWLOR.Game.Server.Feature.GuiDefinition.ViewModel;
+using SWLOR.Game.Server.Service.GuiService;
+using SWLOR.Game.Server.Service.GuiService.Component;
+
+namespace SWLOR.Game.Server.Feature.GuiDefinition
+{
+    // Debug window rendering every NUI control wrapper and the interesting
+    // combinations between them, so wrapper or layout-validator regressions are
+    // visible in one place. Opened with /nuigallery (admin; everyone on test).
+    //
+    // The GALLERY_HAZARD_* / GALLERY_PROBE_* partials fall into two categories
+    // (all outcomes verified in-game 2026-07):
+    // - CONFIRMED failures: H1 + P1-P4/P6 (fixed-height row containing a same-height
+    //   margined widget - button, checkbox, textedit, combo, slider, progress - blanks
+    //   the window, rule R2c); H6 (watch on a never-Set property - descriptive R3
+    //   exception); P13a (partial applied to a nonexistent element id - client-side
+    //   error, no server validation exists).
+    // - VERIFIED-WORKING exhibits: W1-W4, P5 (options is margin-free), P7-P12, and
+    //   P13b (3-deep nesting renders but the innermost content is dropped by parent
+    //   re-applies - do not nest partials more than 2 deep).
+    // They are only defined off production. Expected boot warnings on dev/test:
+    // EXACTLY SIX [NUI layout warning] lines, all from this window - the R2c
+    // regression canaries: GALLERY_HAZARD_BUTTON_ROW, GALLERY_PROBE_ROW_CHECKBOX,
+    // GALLERY_PROBE_ROW_TEXTEDIT, GALLERY_PROBE_ROW_COMBO, GALLERY_PROBE_ROW_SLIDER,
+    // GALLERY_PROBE_ROW_PROGRESS. Any other warning, anywhere, is a real defect.
+    public class DebugNuiGalleryDefinition : IGuiWindowDefinition
+    {
+        private readonly GuiWindowBuilder<DebugNuiGalleryViewModel> _builder = new();
+
+        private const float TabRowHeight = 28f;
+        private const float ButtonHeight = 32f;
+        private const float LabelHeight = 20f;
+        private const float ContentPanelWidth = 560f;
+
+        // Three 28px tabbar rows + margins, same proportions as CharacterSheet's
+        // two-row tab panel (76f for two rows).
+        private const float TabPanelHeight = 112f;
+
+        private static bool HazardsAreAvailable
+        {
+            get
+            {
+                var environment = ApplicationSettings.Get().ServerEnvironment;
+                return environment == ServerEnvironmentType.Development ||
+                       environment == ServerEnvironmentType.Test;
+            }
+        }
+
+        public GuiConstructedWindow BuildWindow()
+        {
+            var window = _builder.CreateWindow(GuiWindowType.DebugNuiGallery)
+                .SetInitialGeometry(0, 0, 900f, 560f)
+                .SetTitle("NUI Control Gallery")
+                .SetIsResizable(true)
+                .SetIsCollapsible(true)
+                .BindOnOpened(model => model.OnWindowOpened())
+                .BindOnClosed(model => model.OnWindowClosed())
+                .DefinePartialView(DebugNuiGalleryViewModel.ButtonsTabPartial, AddButtonsTab)
+                .DefinePartialView(DebugNuiGalleryViewModel.TextTabPartial, AddTextTab)
+                .DefinePartialView(DebugNuiGalleryViewModel.SelectionTabPartial, AddSelectionTab)
+                .DefinePartialView(DebugNuiGalleryViewModel.SlidersTabPartial, AddSlidersTab)
+                .DefinePartialView(DebugNuiGalleryViewModel.ListsTabPartial, AddListsTab)
+                .DefinePartialView(DebugNuiGalleryViewModel.GroupsTabPartial, AddGroupsTab)
+                .DefinePartialView(DebugNuiGalleryViewModel.DrawingTabPartial, AddDrawingTab)
+                .DefinePartialView(DebugNuiGalleryViewModel.ChartsTabPartial, AddChartsTab)
+                .DefinePartialView(DebugNuiGalleryViewModel.BindingsTabPartial, AddBindingsTab)
+                .DefinePartialView(DebugNuiGalleryViewModel.ModalsTabPartial, AddModalsTab)
+                .DefinePartialView(DebugNuiGalleryViewModel.HazardsTabPartial, AddHazardsTab);
+
+            if (HazardsAreAvailable)
+            {
+                DefineHazardPartials(window);
+            }
+
+            // Root layout uses GuiStandardLayout - the only root shape proven
+            // to track window geometry (see Readmes/NuiLayoutRules.md R5).
+            window.AddStandardLayout(layout =>
+            {
+                layout.SetTabPanelHeight(TabPanelHeight);
+
+                // Tabbar rows are the one legal fixed-height-row pairing: the
+                // toggles widget has no default margin (layout rule R2c exception).
+                layout.AddTabRow(row =>
+                {
+                    row.SetHeight(TabRowHeight);
+                    row.AddToggles()
+                        .AddOption("Buttons")
+                        .AddOption("Text & Input")
+                        .AddOption("Selection")
+                        .AddOption("Sliders")
+                        .BindSelectedValue(model => model.RowATabValue)
+                        .SetWidth(464f)
+                        .SetHeight(TabRowHeight);
+                });
+
+                layout.AddTabRow(row =>
+                {
+                    row.SetHeight(TabRowHeight);
+                    row.AddToggles()
+                        .AddOption("Lists & Tables")
+                        .AddOption("Groups & Layout")
+                        .AddOption("Images & Drawing")
+                        .AddOption("Charts")
+                        .BindSelectedValue(model => model.RowBTabValue)
+                        .SetWidth(464f)
+                        .SetHeight(TabRowHeight);
+                });
+
+                layout.AddTabRow(row =>
+                {
+                    row.SetHeight(TabRowHeight);
+                    row.AddToggles()
+                        .AddOption("Bindings")
+                        .AddOption("Modals & Events")
+                        .AddOption("Hazards")
+                        .BindSelectedValue(model => model.RowCTabValue)
+                        .SetWidth(348f)
+                        .SetHeight(TabRowHeight);
+                });
+
+                layout.SetContentPartialElement(DebugNuiGalleryViewModel.TabContentElement);
+
+                // The event log lives in the window root (geometry-bound), so
+                // it is always layout-safe and survives tab partial swaps.
+                // Variable-width rail (no fixedWidth): under in-game verification.
+                // If the content region ever freezes at a constant width again,
+                // revert to a fixed width (280f) and record that side rails must
+                // be fixed-width in NuiLayoutRules R5.
+                layout.AddSideColumn(logCol =>
+                {
+                    logCol.AddRow(headerRow =>
+                    {
+                        headerRow.AddLabel()
+                            .SetText("Event Log")
+                            .SetHeight(24f)
+                            .SetHorizontalAlign(NuiHorizontalAlign.Left);
+                        headerRow.AddButton()
+                            .SetText("Clear")
+                            .SetHeight(24f)
+                            .SetWidth(60f)
+                            .BindOnClicked(model => model.OnClickClearLog());
+                    });
+
+                    logCol.AddRow(listRow =>
+                    {
+                        listRow.AddList(template =>
+                        {
+                            template.AddCell(cell =>
+                            {
+                                cell.AddLabel()
+                                    .BindText(model => model.EventLog)
+                                    .BindTooltip(model => model.EventLog)
+                                    .SetHorizontalAlign(NuiHorizontalAlign.Left);
+                            });
+                        })
+                            .BindRowCount(model => model.EventLog)
+                            .SetRowHeight(20f);
+                    });
+                });
+            });
+
+            return _builder.Build();
+        }
+
+        // Standard tab shell: a fixed-width borderless panel, the same shape
+        // CharacterSheet's tab partials use. Vertical/horizontal scrolling is
+        // provided by the auto-scroll group hosting the partial in the window
+        // root, which keeps every tab compressible (layout rule R2b).
+        private static void AddTabShell(
+            GuiGroup<DebugNuiGalleryViewModel> host,
+            Action<GuiColumn<DebugNuiGalleryViewModel>> content)
+        {
+            host.AddColumn(col =>
+            {
+                col.AddRow(row =>
+                {
+                    row.AddGroup(panel =>
+                    {
+                        panel.SetShowBorder(false);
+                        panel.SetScrollbars(NuiScrollbars.None);
+                        panel.AddColumn(content);
+                    })
+                        .SetWidth(ContentPanelWidth);
+                });
+            });
+        }
+
+        private static void AddSectionLabel(GuiColumn<DebugNuiGalleryViewModel> col, string text)
+        {
+            col.AddRow(row =>
+            {
+                row.AddLabel()
+                    .SetText(text)
+                    .SetHeight(LabelHeight)
+                    .SetHorizontalAlign(NuiHorizontalAlign.Left)
+                    .SetColor(GuiColor.Cyan);
+            });
+        }
+
+        private static void AddButtonsTab(GuiGroup<DebugNuiGalleryViewModel> host)
+        {
+            AddTabShell(host, col =>
+            {
+                AddSectionLabel(col, "Plain button + click counter (no row height set - contrast with hazard H1)");
+                col.AddRow(row =>
+                {
+                    row.AddButton()
+                        .SetText("Click me")
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(140f)
+                        .BindOnClicked(model => model.OnClickSimpleButton());
+                    row.AddLabel()
+                        .BindText(model => model.ClickCountText)
+                        .SetHorizontalAlign(NuiHorizontalAlign.Left);
+                });
+
+                AddSectionLabel(col, "Image button");
+                col.AddRow(row =>
+                {
+                    row.AddButtonImage()
+                        .SetImageResref("arrow_up")
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(ButtonHeight)
+                        .SetTooltip("Image button (arrow_up)")
+                        .BindOnClicked(model => model.OnClickImageButton());
+                    row.AddSpacer();
+                });
+
+                AddSectionLabel(col, "Bound-text button (its label is rewritten server-side on click)");
+                col.AddRow(row =>
+                {
+                    row.AddButton()
+                        .BindText(model => model.DynamicButtonText)
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(300f)
+                        .BindOnClicked(model => model.OnClickBoundTextButton());
+                    row.AddSpacer();
+                });
+
+                AddSectionLabel(col, "Toggle button with bound toggled state");
+                col.AddRow(row =>
+                {
+                    row.AddToggleButton()
+                        .SetText("Toggle me")
+                        .BindIsToggled(model => model.SampleToggle)
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(140f)
+                        .BindOnClicked(model => model.OnClickSampleToggle());
+                    row.AddLabel()
+                        .BindText(model => model.SampleToggleText)
+                        .SetHorizontalAlign(NuiHorizontalAlign.Left);
+                });
+
+                AddSectionLabel(col, "Disabled + encouraged + fully-bound specimen (driven from Bindings tab)");
+                col.AddRow(row =>
+                {
+                    row.AddButton()
+                        .SetText("Disabled")
+                        .SetIsEnabled(false)
+                        .SetDisabledTooltip("Disabled tooltip shows on hover")
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(120f);
+                    row.AddButton()
+                        .SetText("Encouraged")
+                        .SetIsEncouraged(true)
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(120f)
+                        .BindOnClicked(model => model.OnClickImageButton());
+                    row.AddButton()
+                        .SetText("Specimen")
+                        .BindIsEnabled(model => model.IsSampleEnabled)
+                        .BindColor(model => model.SampleColor)
+                        .BindTooltip(model => model.SampleTooltip)
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(120f)
+                        .BindOnClicked(model => model.OnClickImageButton());
+                });
+
+                AddSectionLabel(col, "Label with mouse down/up events");
+                col.AddRow(row =>
+                {
+                    row.AddLabel()
+                        .SetText("[ Press and release the mouse on this label ]")
+                        .SetHeight(24f)
+                        .SetHorizontalAlign(NuiHorizontalAlign.Left)
+                        .BindOnMouseDown(model => model.OnMouseDownLabel())
+                        .BindOnMouseUp(model => model.OnMouseUpLabel());
+                });
+            });
+        }
+
+        private static void AddTextTab(GuiGroup<DebugNuiGalleryViewModel> host)
+        {
+            AddTabShell(host, col =>
+            {
+                AddSectionLabel(col, "Label alignment grid (horizontal x vertical)");
+                col.AddRow(row =>
+                {
+                    row.AddLabel().SetText("Left/Top").SetHeight(24f).SetWidth(140f)
+                        .SetHorizontalAlign(NuiHorizontalAlign.Left).SetVerticalAlign(NuiVerticalAlign.Top);
+                    row.AddLabel().SetText("Center/Top").SetHeight(24f).SetWidth(140f)
+                        .SetHorizontalAlign(NuiHorizontalAlign.Center).SetVerticalAlign(NuiVerticalAlign.Top);
+                    row.AddLabel().SetText("Right/Top").SetHeight(24f).SetWidth(140f)
+                        .SetHorizontalAlign(NuiHorizontalAlign.Right).SetVerticalAlign(NuiVerticalAlign.Top);
+                });
+                col.AddRow(row =>
+                {
+                    row.AddLabel().SetText("Left/Middle").SetHeight(24f).SetWidth(140f)
+                        .SetHorizontalAlign(NuiHorizontalAlign.Left).SetVerticalAlign(NuiVerticalAlign.Middle);
+                    row.AddLabel().SetText("Center/Middle").SetHeight(24f).SetWidth(140f)
+                        .SetHorizontalAlign(NuiHorizontalAlign.Center).SetVerticalAlign(NuiVerticalAlign.Middle);
+                    row.AddLabel().SetText("Right/Middle").SetHeight(24f).SetWidth(140f)
+                        .SetHorizontalAlign(NuiHorizontalAlign.Right).SetVerticalAlign(NuiVerticalAlign.Middle);
+                });
+                col.AddRow(row =>
+                {
+                    row.AddLabel().SetText("Left/Bottom").SetHeight(24f).SetWidth(140f)
+                        .SetHorizontalAlign(NuiHorizontalAlign.Left).SetVerticalAlign(NuiVerticalAlign.Bottom);
+                    row.AddLabel().SetText("Center/Bottom").SetHeight(24f).SetWidth(140f)
+                        .SetHorizontalAlign(NuiHorizontalAlign.Center).SetVerticalAlign(NuiVerticalAlign.Bottom);
+                    row.AddLabel().SetText("Right/Bottom").SetHeight(24f).SetWidth(140f)
+                        .SetHorizontalAlign(NuiHorizontalAlign.Right).SetVerticalAlign(NuiVerticalAlign.Bottom);
+                });
+
+                AddSectionLabel(col, "Text block with border and scrollbars, bound to a long string");
+                col.AddRow(row =>
+                {
+                    row.AddText()
+                        .BindText(model => model.LongText)
+                        .SetShowBorder(true)
+                        .SetScrollbars(NuiScrollbars.Auto)
+                        .SetHeight(100f);
+                });
+
+                AddSectionLabel(col, "Single-line text edit (watched) and its live server-side mirror");
+                col.AddRow(row =>
+                {
+                    row.AddTextEdit()
+                        .SetPlaceholder("Type here - each client sync is logged")
+                        .BindValue(model => model.TextEditValue)
+                        .SetMaxLength(50)
+                        .SetHeight(ButtonHeight);
+                });
+                col.AddRow(row =>
+                {
+                    row.AddLabel()
+                        .BindText(model => model.MirrorLabelText)
+                        .SetHeight(LabelHeight)
+                        .SetHorizontalAlign(NuiHorizontalAlign.Left);
+                });
+
+                AddSectionLabel(col, "Multiline word-wrap text edit at a fixed height");
+                col.AddRow(row =>
+                {
+                    row.AddTextEdit()
+                        .SetPlaceholder("Multiline")
+                        .BindValue(model => model.MultilineValue)
+                        .SetMaxLength(500)
+                        .SetIsMultiline(true)
+                        .SetHasWordWrap(true)
+                        .SetHeight(80f);
+                });
+            });
+        }
+
+        private static void AddSelectionTab(GuiGroup<DebugNuiGalleryViewModel> host)
+        {
+            AddTabShell(host, col =>
+            {
+                AddSectionLabel(col, "Watched checkbox with server-side mirror");
+                col.AddRow(row =>
+                {
+                    row.AddCheckBox()
+                        .SetText("Watched checkbox")
+                        .BindIsChecked(model => model.IsChecked)
+                        .SetHeight(24f)
+                        .SetWidth(180f);
+                    row.AddLabel()
+                        .BindText(model => model.CheckboxMirrorText)
+                        .SetHorizontalAlign(NuiHorizontalAlign.Left);
+                });
+
+                AddSectionLabel(col, "Combo box with static options (watched index)");
+                col.AddRow(row =>
+                {
+                    row.AddComboBox()
+                        .AddOption("Static option 1", 0)
+                        .AddOption("Static option 2", 1)
+                        .AddOption("Static option 3", 2)
+                        .AddOption("Static option 4", 3)
+                        .BindSelectedIndex(model => model.StaticComboSelection)
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(250f);
+                    row.AddSpacer();
+                });
+
+                AddSectionLabel(col, "Combo box with bound options, replaced wholesale while open");
+                col.AddRow(row =>
+                {
+                    row.AddComboBox()
+                        .BindOptions(model => model.DynamicComboOptions)
+                        .BindSelectedIndex(model => model.DynamicComboSelection)
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(250f);
+                    row.AddButton()
+                        .SetText("Replace Options")
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(140f)
+                        .BindOnClicked(model => model.OnClickReplaceComboOptions());
+                });
+
+                AddSectionLabel(col, "Radio options - horizontal and vertical (both watched)");
+                col.AddRow(row =>
+                {
+                    row.AddOptions()
+                        .SetDirection(NuiDirection.Horizontal)
+                        .AddOption("One")
+                        .AddOption("Two")
+                        .AddOption("Three")
+                        .BindSelectedValue(model => model.OptionsHorizontalValue)
+                        .SetHeight(30f)
+                        .SetWidth(300f);
+                    row.AddSpacer();
+                });
+                col.AddRow(row =>
+                {
+                    row.AddOptions()
+                        .SetDirection(NuiDirection.Vertical)
+                        .AddOption("Alpha")
+                        .AddOption("Beta")
+                        .AddOption("Gamma")
+                        .BindSelectedValue(model => model.OptionsVerticalValue)
+                        .SetHeight(90f)
+                        .SetWidth(200f);
+                    row.AddSpacer();
+                });
+
+                AddSectionLabel(col, "Color picker (watched) driving the label's bound color");
+                col.AddRow(row =>
+                {
+                    row.AddColorPicker()
+                        .BindSelectedColor(model => model.PickedColor)
+                        .SetHeight(150f)
+                        .SetWidth(250f);
+                    row.AddLabel()
+                        .SetText("Colored by the picker")
+                        .BindColor(model => model.PickedColor)
+                        .SetHorizontalAlign(NuiHorizontalAlign.Left);
+                });
+            });
+        }
+
+        private static void AddSlidersTab(GuiGroup<DebugNuiGalleryViewModel> host)
+        {
+            AddTabShell(host, col =>
+            {
+                AddSectionLabel(col, "Int slider (watched) - its value drives the progress bar below");
+                col.AddRow(row =>
+                {
+                    row.AddSliderInt()
+                        .BindValue(model => model.SliderIntValue)
+                        .SetMinimum(0)
+                        .SetMaximum(10)
+                        .SetStepSize(1)
+                        .SetHeight(ButtonHeight);
+                });
+
+                AddSectionLabel(col, "Progress bar (bound) with server-side mutation buttons");
+                col.AddRow(row =>
+                {
+                    row.AddProgressBar()
+                        .BindValue(model => model.ProgressValue)
+                        .SetHeight(24f);
+                });
+                col.AddRow(row =>
+                {
+                    row.AddButton()
+                        .SetText("+10%")
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(100f)
+                        .BindOnClicked(model => model.OnClickProgressAdd());
+                    row.AddButton()
+                        .SetText("Reset")
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(100f)
+                        .BindOnClicked(model => model.OnClickProgressReset());
+                    row.AddSpacer();
+                });
+
+                AddSectionLabel(col, "Float slider with a bound maximum changed at runtime");
+                col.AddRow(row =>
+                {
+                    row.AddSliderFloat()
+                        .BindValue(model => model.SliderFloatValue)
+                        .SetMinimum(0f)
+                        .BindMaximum(model => model.SliderFloatMax)
+                        .SetStepSize(0.05f)
+                        .SetHeight(ButtonHeight);
+                });
+                col.AddRow(row =>
+                {
+                    row.AddButton()
+                        .SetText("Change Maximum")
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(160f)
+                        .BindOnClicked(model => model.OnClickRaiseSliderMax());
+                    row.AddSpacer();
+                });
+            });
+        }
+
+        private static void AddListsTab(GuiGroup<DebugNuiGalleryViewModel> host)
+        {
+            AddTabShell(host, col =>
+            {
+                AddSectionLabel(col, "Mixed-cell list: fixed label / element-sized button / variable label / progress / image");
+                col.AddRow(row =>
+                {
+                    row.AddList(template =>
+                    {
+                        template.AddCell(cell =>
+                        {
+                            cell.SetIsVariable(false);
+                            cell.SetWidth(90f);
+                            cell.AddLabel()
+                                .BindText(model => model.ListNames)
+                                .SetHorizontalAlign(NuiHorizontalAlign.Left);
+                        });
+                        template.AddCell(cell =>
+                        {
+                            // Element-sized fixed cell: no cell width, the inner
+                            // button's width sizes it (validator-exempt shape).
+                            cell.SetIsVariable(false);
+                            cell.AddButton()
+                                .SetText("Log")
+                                .SetWidth(44f)
+                                .BindOnClicked(model => model.OnClickListRowButton());
+                        });
+                        template.AddCell(cell =>
+                        {
+                            cell.AddLabel()
+                                .BindText(model => model.ListDescriptions)
+                                .SetHorizontalAlign(NuiHorizontalAlign.Left);
+                        });
+                        template.AddCell(cell =>
+                        {
+                            cell.SetIsVariable(false);
+                            cell.SetWidth(80f);
+                            cell.AddProgressBar()
+                                .BindValue(model => model.ListProgress);
+                        });
+                        template.AddCell(cell =>
+                        {
+                            cell.SetIsVariable(false);
+                            cell.SetWidth(40f);
+                            cell.AddImage()
+                                .BindResref(model => model.ListResrefs)
+                                .SetAspect(NuiAspect.Fit);
+                        });
+                    })
+                        .BindRowCount(model => model.ListNames)
+                        .SetRowHeight(28f)
+                        .SetHeight(150f);
+                });
+                col.AddRow(row =>
+                {
+                    row.AddButton()
+                        .SetText("Add Row")
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(110f)
+                        .BindOnClicked(model => model.OnClickListAddRow());
+                    row.AddButton()
+                        .SetText("Remove Row")
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(110f)
+                        .BindOnClicked(model => model.OnClickListRemoveRow());
+                    row.AddButton()
+                        .SetText("Replace Lists")
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(110f)
+                        .BindOnClicked(model => model.OnClickListReplace());
+                    row.AddSpacer();
+                });
+
+                AddSectionLabel(col, "Table: fixed(90) / fixed(120) / variable-last columns, with tooltips");
+                col.AddTable(table => table
+                    .AddColumn("FIXED 90", 90f, model => model.TableColA, model => model.TableTooltips, "Fixed-width column (90)")
+                    .AddColumn("FIXED 120", 120f, model => model.TableColB, null, "Fixed-width column (120)")
+                    .AddColumn("VARIABLE", 0f, model => model.TableColC, null, "Last column defaults to variable")
+                    .SetRowHeight(24f));
+
+                AddSectionLabel(col, "Headerless table with a component (button) column and explicit row count");
+                col.AddTable(table => table
+                    .SetShowHeader(false)
+                    .AddComponentColumn("", 60f, cell =>
+                    {
+                        cell.AddButton()
+                            .SetText("Ping")
+                            .SetHeight(22f)
+                            .BindOnClicked(model => model.OnClickTable2RowButton());
+                    })
+                    .AddColumn("NAME", 0f, model => model.Table2Names)
+                    .BindRowCount(model => model.Table2Names)
+                    .SetRowHeight(28f));
+            });
+        }
+
+        private static void AddGroupsTab(GuiGroup<DebugNuiGalleryViewModel> host)
+        {
+            AddTabShell(host, col =>
+            {
+                AddSectionLabel(col, "Groups nested three deep: border / auto-scroll / borderless");
+                col.AddRow(row =>
+                {
+                    row.AddGroup(outer =>
+                    {
+                        outer.SetShowBorder(true);
+                        outer.SetScrollbars(NuiScrollbars.None);
+                        outer.AddColumn(outerCol =>
+                        {
+                            outerCol.AddRow(r => r.AddLabel().SetText("Outer group (border, no scroll)").SetHeight(LabelHeight).SetHorizontalAlign(NuiHorizontalAlign.Left));
+                            outerCol.AddRow(r =>
+                            {
+                                r.AddGroup(middle =>
+                                {
+                                    middle.SetShowBorder(true);
+                                    middle.SetScrollbars(NuiScrollbars.Auto);
+                                    middle.AddColumn(middleCol =>
+                                    {
+                                        middleCol.AddRow(r2 => r2.AddLabel().SetText("Middle group (auto scroll)").SetHeight(LabelHeight).SetHorizontalAlign(NuiHorizontalAlign.Left));
+                                        middleCol.AddRow(r2 =>
+                                        {
+                                            r2.AddGroup(inner =>
+                                            {
+                                                inner.SetShowBorder(false);
+                                                inner.SetScrollbars(NuiScrollbars.None);
+                                                inner.AddColumn(innerCol =>
+                                                {
+                                                    innerCol.AddRow(r3 => r3.AddLabel().SetText("Inner borderless group").SetHeight(LabelHeight).SetHorizontalAlign(NuiHorizontalAlign.Left));
+                                                });
+                                            });
+                                        });
+                                    });
+                                });
+                            });
+                        });
+                    })
+                        .SetHeight(140f);
+                });
+
+                AddSectionLabel(col, "Spacers centering content within a row");
+                col.AddRow(row =>
+                {
+                    row.AddSpacer();
+                    row.AddLabel()
+                        .SetText("[ Centered by spacers ]")
+                        .SetHeight(LabelHeight)
+                        .SetWidth(180f);
+                    row.AddSpacer();
+                });
+
+                AddSectionLabel(col, "Spacer pushing content to the bottom of a fixed-height group");
+                col.AddRow(row =>
+                {
+                    row.AddGroup(group =>
+                    {
+                        group.SetScrollbars(NuiScrollbars.None);
+                        group.AddColumn(groupCol =>
+                        {
+                            groupCol.AddRow(r => r.AddLabel().SetText("Top of group").SetHeight(LabelHeight).SetHorizontalAlign(NuiHorizontalAlign.Left));
+                            groupCol.AddRow(r => r.AddSpacer());
+                            groupCol.AddRow(r => r.AddLabel().SetText("Pushed to bottom by a spacer").SetHeight(LabelHeight).SetHorizontalAlign(NuiHorizontalAlign.Left));
+                        });
+                    })
+                        .SetHeight(90f);
+                });
+
+                AddSectionLabel(col, "Sibling sizing: fixed width vs aspect ratio vs variable");
+                col.AddRow(row =>
+                {
+                    row.SetHeight(50f);
+                    row.AddGroup(group =>
+                    {
+                        group.AddColumn(c => c.AddRow(r => r.AddLabel().SetText("W=100")));
+                    })
+                        .SetWidth(100f);
+                    row.AddGroup(group =>
+                    {
+                        group.AddColumn(c => c.AddRow(r => r.AddLabel().SetText("Aspect 2:1")));
+                    })
+                        .SetAspectRatio(2f);
+                    row.AddGroup(group =>
+                    {
+                        group.AddColumn(c => c.AddRow(r => r.AddLabel().SetText("Variable width")));
+                    });
+                });
+
+                AddSectionLabel(col, "Identical labels: margin 0 vs default margin vs padding 10");
+                col.AddRow(row =>
+                {
+                    row.AddLabel().SetText("Margin 0").SetHeight(24f).SetMargin(0f).SetHorizontalAlign(NuiHorizontalAlign.Left);
+                });
+                col.AddRow(row =>
+                {
+                    row.AddLabel().SetText("Default margin").SetHeight(24f).SetHorizontalAlign(NuiHorizontalAlign.Left);
+                });
+                col.AddRow(row =>
+                {
+                    row.AddLabel().SetText("Padding 10").SetHeight(24f).SetPadding(10f).SetHorizontalAlign(NuiHorizontalAlign.Left);
+                });
+
+                AddSectionLabel(col, "Fixed-width group with exactly-fitting fixed children (legal - contrast with hazard H5)");
+                col.AddRow(row =>
+                {
+                    row.AddGroup(group =>
+                    {
+                        group.AddColumn(c => c.AddRow(r =>
+                        {
+                            r.AddLabel().SetText("Fixed 90").SetWidth(90f).SetHeight(24f);
+                            r.AddLabel().SetText("Fixed 90").SetWidth(90f).SetHeight(24f);
+                        }));
+                    })
+                        .SetWidth(220f)
+                        .SetHeight(50f);
+                    row.AddSpacer();
+                });
+
+                AddSectionLabel(col, "Twenty rows inside an unsized-content scrollable group (the R2b-correct shape)");
+                col.AddRow(row =>
+                {
+                    row.AddGroup(group =>
+                    {
+                        group.SetScrollbars(NuiScrollbars.Auto);
+                        group.AddColumn(groupCol =>
+                        {
+                            for (var line = 1; line <= 20; line++)
+                            {
+                                var text = $"Scrollable line {line} of 20";
+                                groupCol.AddRow(r => r.AddLabel().SetText(text).SetHeight(24f).SetHorizontalAlign(NuiHorizontalAlign.Left));
+                            }
+                        });
+                    })
+                        .SetHeight(150f);
+                });
+            });
+        }
+
+        private static void AddDrawingTab(GuiGroup<DebugNuiGalleryViewModel> host)
+        {
+            AddTabShell(host, col =>
+            {
+                AddSectionLabel(col, "Same image in four aspect modes (hover for the mode name)");
+                col.AddRow(row =>
+                {
+                    row.AddImage().SetResref("arrow_up").SetAspect(NuiAspect.Fit).SetTooltip("NuiAspect.Fit").SetWidth(48f).SetHeight(48f);
+                    row.AddImage().SetResref("arrow_up").SetAspect(NuiAspect.Fill).SetTooltip("NuiAspect.Fill").SetWidth(48f).SetHeight(48f);
+                    row.AddImage().SetResref("arrow_up").SetAspect(NuiAspect.Exact).SetTooltip("NuiAspect.Exact").SetWidth(48f).SetHeight(48f);
+                    row.AddImage().SetResref("arrow_up").SetAspect(NuiAspect.ExactScaled).SetTooltip("NuiAspect.ExactScaled").SetWidth(48f).SetHeight(48f);
+                    row.AddImage().SetResref("arrow_up").SetAspect(NuiAspect.Exact).SetRegion(new GuiRectangle(0f, 0f, 16f, 16f)).SetTooltip("SetRegion(0,0,16,16)").SetWidth(48f).SetHeight(48f);
+                    row.AddSpacer();
+                });
+
+                AddSectionLabel(col, "Image with a bound resref, cycled server-side");
+                col.AddRow(row =>
+                {
+                    row.AddImage()
+                        .BindResref(model => model.CycledImageResref)
+                        .SetAspect(NuiAspect.Fit)
+                        .SetWidth(48f)
+                        .SetHeight(48f);
+                    row.AddButton()
+                        .SetText("Cycle Image")
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(120f)
+                        .BindOnClicked(model => model.OnClickCycleImage());
+                    row.AddSpacer();
+                });
+
+                AddSectionLabel(col, "Static draw list over a label: circle, arc, curve, polyline, text, image item");
+                col.AddRow(row =>
+                {
+                    row.AddLabel()
+                        .SetText(".")
+                        .SetHeight(100f)
+                        .AddDrawList(drawList => drawList
+                            .SetIsConstrainedToTargetBounds(true)
+                            .AddCircle(circle => circle
+                                .SetColor(0, 255, 255)
+                                .SetIsFilled(false)
+                                .SetLineThickness(2f)
+                                .SetBounds(10f, 10f, 40f, 40f))
+                            .AddArc(arc => arc
+                                .SetColor(255, 0, 0)
+                                .SetLineThickness(2f)
+                                .SetCenter(90f, 30f)
+                                .SetRadius(20f)
+                                .SetAMinimum(0f)
+                                .SetAMaximum(3.14f))
+                            .AddCurve(curve => curve
+                                .SetColor(0, 255, 0)
+                                .SetLineThickness(2f)
+                                .SetA(120f, 10f)
+                                .SetB(200f, 50f)
+                                .SetCtrl0(140f, 60f)
+                                .SetCtrl1(180f, 0f))
+                            .AddPolyLine(polyLine => polyLine
+                                .SetColor(255, 255, 255)
+                                .SetIsFilled(false)
+                                .SetLineThickness(2f)
+                                .AddPoint(220f, 10f)
+                                .AddPoint(260f, 50f)
+                                .AddPoint(300f, 10f))
+                            .AddText(text => text
+                                .SetColor(255, 255, 255)
+                                .SetBounds(10f, 60f, 220f, 30f)
+                                .SetText("draw list text item"))
+                            .AddImage(image => image
+                                .SetResref("arrow_up")
+                                .SetPosition(250f, 60f, 32f, 32f)
+                                .SetAspect(NuiAspect.Exact)
+                                .SetDrawTextureRegion(0, 0, 16, 16)));
+                });
+
+                AddSectionLabel(col, "Bound draw geometry over an image - Animate steps bounds and color");
+                col.AddRow(row =>
+                {
+                    row.AddImage()
+                        .SetResref("arrow_up")
+                        .SetAspect(NuiAspect.Exact)
+                        .SetWidth(100f)
+                        .SetHeight(100f)
+                        .AddDrawList(drawList => drawList
+                            .SetIsConstrainedToTargetBounds(true)
+                            .AddCircle(circle => circle
+                                .BindColor(model => model.DrawColor)
+                                .SetIsFilled(true)
+                                .SetLineThickness(1f)
+                                .BindBounds(model => model.DrawCircleBounds)));
+                    row.AddButton()
+                        .SetText("Animate")
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(120f)
+                        .BindOnClicked(model => model.OnClickAnimateDraw());
+                    row.AddSpacer();
+                });
+
+                AddSectionLabel(col, "Constrained vs unconstrained draw lists (circle drawn past the widget edge)");
+                col.AddRow(row =>
+                {
+                    row.AddLabel()
+                        .SetText("Constrained")
+                        .SetWidth(100f)
+                        .SetHeight(60f)
+                        .AddDrawList(drawList => drawList
+                            .SetIsConstrainedToTargetBounds(true)
+                            .AddCircle(circle => circle
+                                .SetColor(0, 255, 255)
+                                .SetIsFilled(true)
+                                .SetLineThickness(1f)
+                                .SetBounds(70f, 20f, 60f, 60f)));
+                    row.AddLabel()
+                        .SetText("Unconstrained")
+                        .SetWidth(100f)
+                        .SetHeight(60f)
+                        .AddDrawList(drawList => drawList
+                            .SetIsConstrainedToTargetBounds(false)
+                            .AddCircle(circle => circle
+                                .SetColor(255, 0, 0)
+                                .SetIsFilled(true)
+                                .SetLineThickness(1f)
+                                .SetBounds(70f, 20f, 60f, 60f)));
+                    row.AddSpacer();
+                });
+            });
+        }
+
+        private static void AddChartsTab(GuiGroup<DebugNuiGalleryViewModel> host)
+        {
+            AddTabShell(host, col =>
+            {
+                AddSectionLabel(col, "Chart with a static line slot and an explicit height");
+                col.AddRow(row =>
+                {
+                    row.AddChart()
+                        .AddSlot(slot => slot
+                            .SetType(NuiChartType.Lines)
+                            .SetLegend("Static line")
+                            .SetColor(0, 138, 250)
+                            .AddDataPoint(1f)
+                            .AddDataPoint(4f)
+                            .AddDataPoint(2f)
+                            .AddDataPoint(6f)
+                            .AddDataPoint(3f))
+                        .SetHeight(140f);
+                });
+
+                AddSectionLabel(col, "Two slots in one chart: bound bar data + static line overlay");
+                col.AddRow(row =>
+                {
+                    row.AddChart()
+                        .AddSlot(slot => slot
+                            .SetType(NuiChartType.Columns)
+                            .BindLegend(model => model.ChartLegend)
+                            .BindColor(model => model.ChartColor)
+                            .BindData(model => model.ChartData))
+                        .AddSlot(slot => slot
+                            .SetType(NuiChartType.Lines)
+                            .SetLegend("Static overlay")
+                            .SetColor(169, 169, 169)
+                            .AddDataPoint(5f)
+                            .AddDataPoint(2f)
+                            .AddDataPoint(4f)
+                            .AddDataPoint(1f)
+                            .AddDataPoint(3f))
+                        .SetHeight(140f);
+                });
+                col.AddRow(row =>
+                {
+                    row.AddButton()
+                        .SetText("Randomize Data")
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(140f)
+                        .BindOnClicked(model => model.OnClickRandomizeChart());
+                    row.AddSpacer();
+                });
+
+                AddSectionLabel(col, "Unsized chart in a scroll region (documents fill-the-span behavior; may collapse)");
+                col.AddRow(row =>
+                {
+                    row.AddChart()
+                        .AddSlot(slot => slot
+                            .SetType(NuiChartType.Lines)
+                            .SetLegend("Unsized chart")
+                            .SetColor(0, 139, 0)
+                            .AddDataPoint(2f)
+                            .AddDataPoint(5f)
+                            .AddDataPoint(1f));
+                });
+            });
+        }
+
+        private static void AddBindingsTab(GuiGroup<DebugNuiGalleryViewModel> host)
+        {
+            AddTabShell(host, col =>
+            {
+                AddSectionLabel(col, "Specimen widgets driven by bound IsVisible / IsEnabled / color / tooltip");
+                col.AddRow(row =>
+                {
+                    row.AddLabel()
+                        .SetText("[ Visibility + color + tooltip specimen ]")
+                        .BindIsVisible(model => model.IsSampleVisible)
+                        .BindColor(model => model.SampleColor)
+                        .BindTooltip(model => model.SampleTooltip)
+                        .SetHeight(24f)
+                        .SetHorizontalAlign(NuiHorizontalAlign.Left);
+                });
+                col.AddRow(row =>
+                {
+                    row.AddButton()
+                        .SetText("Enable-bound button")
+                        .BindIsEnabled(model => model.IsSampleEnabled)
+                        .SetDisabledTooltip("Currently disabled via bound IsEnabled")
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(180f)
+                        .BindOnClicked(model => model.OnClickImageButton());
+                    row.AddSpacer();
+                });
+                col.AddRow(row =>
+                {
+                    row.AddButton().SetText("Toggle Visible").SetHeight(ButtonHeight).SetWidth(120f)
+                        .BindOnClicked(model => model.OnClickToggleVisible());
+                    row.AddButton().SetText("Toggle Enabled").SetHeight(ButtonHeight).SetWidth(120f)
+                        .BindOnClicked(model => model.OnClickToggleEnabled());
+                    row.AddButton().SetText("Cycle Color").SetHeight(ButtonHeight).SetWidth(120f)
+                        .BindOnClicked(model => model.OnClickCycleColor());
+                    row.AddButton().SetText("Cycle Tooltip").SetHeight(ButtonHeight).SetWidth(120f)
+                        .BindOnClicked(model => model.OnClickCycleTooltip());
+                });
+
+                AddSectionLabel(col, "Watched text edit (assigned before watch per rule R3), plus watch re-issue");
+                col.AddRow(row =>
+                {
+                    row.AddTextEdit()
+                        .SetPlaceholder("Watched value")
+                        .BindValue(model => model.WatchDemoValue)
+                        .SetMaxLength(40)
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(250f);
+                    row.AddButton()
+                        .SetText("Re-issue Watch")
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(140f)
+                        .BindOnClicked(model => model.OnClickRewatch());
+                });
+
+                AddSectionLabel(col, "Window geometry (drag/resize, then log the server-side value)");
+                col.AddRow(row =>
+                {
+                    row.AddButton()
+                        .SetText("Log Geometry")
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(140f)
+                        .BindOnClicked(model => model.OnClickLogGeometry());
+                    row.AddSpacer();
+                });
+
+                AddSectionLabel(col, "Bind flood: 20 pushes to one property inside a single event");
+                col.AddRow(row =>
+                {
+                    row.AddLabel()
+                        .BindText(model => model.FloodCounterText)
+                        .SetHeight(LabelHeight)
+                        .SetHorizontalAlign(NuiHorizontalAlign.Left);
+                });
+                col.AddRow(row =>
+                {
+                    row.AddButton()
+                        .SetText("Flood 20 Updates")
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(160f)
+                        .BindOnClicked(model => model.OnClickBindFlood());
+                    row.AddSpacer();
+                });
+            });
+        }
+
+        private static void AddModalsTab(GuiGroup<DebugNuiGalleryViewModel> host)
+        {
+            AddTabShell(host, col =>
+            {
+                AddSectionLabel(col, "Stock modal partials (confirm/cancel results are logged)");
+                col.AddRow(row =>
+                {
+                    row.AddButton()
+                        .SetText("Show Confirm Modal")
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(180f)
+                        .BindOnClicked(model => model.OnClickShowModal());
+                    row.AddButton()
+                        .SetText("Show Input Modal")
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(180f)
+                        .BindOnClicked(model => model.OnClickShowInputModal());
+                });
+
+                AddSectionLabel(col, "Partial-swap robustness");
+                col.AddRow(row =>
+                {
+                    row.AddButton()
+                        .SetText("Re-apply Current Tab")
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(180f)
+                        .BindOnClicked(model => model.OnClickReapplyTab());
+                    row.AddSpacer();
+                });
+
+                AddSectionLabel(col, "Window open/close events are logged; close and reopen with /nuigallery to verify");
+            });
+        }
+
+        private static void AddHazardsTab(GuiGroup<DebugNuiGalleryViewModel> host)
+        {
+            // Uses the standard fixed-width shell; the hazard constructs exercise
+            // their constraints inside the slot itself. The slot is the terminal
+            // row so the safe state stays legal.
+            AddTabShell(host, col =>
+            {
+                if (!HazardsAreAvailable)
+                {
+                    col.AddRow(row =>
+                    {
+                        row.AddLabel()
+                            .SetText("Hazard partials are disabled on this environment.")
+                            .SetHeight(24f);
+                    });
+                    return;
+                }
+
+                col.AddRow(row =>
+                {
+                    row.AddLabel()
+                        .SetText("Confirmed-failure buttons will blank the window or throw; verified-working buttons render their exhibit.")
+                        .SetHeight(LabelHeight)
+                        .SetHorizontalAlign(NuiHorizontalAlign.Left)
+                        .SetColor(GuiColor.Red);
+                });
+                col.AddRow(row =>
+                {
+                    row.AddLabel()
+                        .SetText("If the window blanks out: switch tabs, or close and reopen with /nuigallery.")
+                        .SetHeight(LabelHeight)
+                        .SetHorizontalAlign(NuiHorizontalAlign.Left);
+                });
+
+                AddSectionLabel(col, "Confirmed failures (verified in-game 2026-07)");
+                col.AddRow(row =>
+                {
+                    row.AddButton()
+                        .SetText("H1: Button-Height Row")
+                        .SetTooltip("row.SetHeight(32) + button.SetHeight(32): unsolvable, blanks the window (R2c)")
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(200f)
+                        .BindOnClicked(model => model.OnClickHazardButtonRow());
+                    row.AddButton()
+                        .SetText("H6: Watch Unset Prop")
+                        .SetTooltip("WatchOnClient on a never-Set property: descriptive InvalidOperationException (R3); window unaffected and reopenable.")
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(200f)
+                        .BindOnClicked(model => model.OnClickHazardWatchUnset());
+                    row.AddSpacer();
+                });
+                col.AddRow(row =>
+                {
+                    row.AddButton()
+                        .SetText("P1: Row+Checkbox (FAILS)")
+                        .SetTooltip("row.SetHeight(32)+checkbox.SetHeight(32). CONFIRMED: checkbox has default margins - blanks the window (R2c).")
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(200f)
+                        .BindOnClicked(model => model.OnClickProbeRowCheckbox());
+                    row.AddButton()
+                        .SetText("P2: Row+TextEdit (FAILS)")
+                        .SetTooltip("row.SetHeight(32)+textedit.SetHeight(32). CONFIRMED: textedit has default margins - blanks the window (R2c).")
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(200f)
+                        .BindOnClicked(model => model.OnClickProbeRowTextEdit());
+                    row.AddSpacer();
+                });
+                col.AddRow(row =>
+                {
+                    row.AddButton()
+                        .SetText("P3: Row+Combo (FAILS)")
+                        .SetTooltip("row.SetHeight(32)+combo.SetHeight(32). CONFIRMED: combo has default margins - blanks the window (R2c).")
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(200f)
+                        .BindOnClicked(model => model.OnClickProbeRowCombo());
+                    row.AddButton()
+                        .SetText("P4: Row+SliderInt (FAILS)")
+                        .SetTooltip("row.SetHeight(32)+slider.SetHeight(32). CONFIRMED: slider has default margins - blanks the window (R2c).")
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(200f)
+                        .BindOnClicked(model => model.OnClickProbeRowSlider());
+                    row.AddSpacer();
+                });
+                col.AddRow(row =>
+                {
+                    row.AddButton()
+                        .SetText("P6: Row+Progress (FAILS)")
+                        .SetTooltip("row.SetHeight(32)+progress.SetHeight(32). CONFIRMED: progress has default margins - blanks the window (R2c).")
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(200f)
+                        .BindOnClicked(model => model.OnClickProbeRowProgress());
+                    row.AddButton()
+                        .SetText("P13a: Bad Element Id")
+                        .SetTooltip("ChangePartialView onto a nonexistent element id. CONFIRMED: client-side 'element id not found' error, no server exception; close/reopen recovers. There is no server-side element-id validation.")
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(200f)
+                        .BindOnClicked(model => model.OnClickProbeBadElementId());
+                    row.AddSpacer();
+                });
+
+                AddSectionLabel(col, "Verified working (previously suspected, confirmed OK in-game 2026-07)");
+                col.AddRow(row =>
+                {
+                    row.AddButton()
+                        .SetText("W1: Unbounded List (OK)")
+                        .SetTooltip("Unbounded list followed by another row in a partial. VERIFIED: renders correctly in-game; kept as a regression exhibit.")
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(200f)
+                        .BindOnClicked(model => model.OnClickHazardListNonTerminal());
+                    row.AddButton()
+                        .SetText("W2: Tall Fixed Stack (OK)")
+                        .SetTooltip("12 x 120px fixed-height groups with no scroll wrapper. VERIFIED: renders correctly in-game; kept as a regression exhibit.")
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(200f)
+                        .BindOnClicked(model => model.OnClickHazardTallStack());
+                    row.AddSpacer();
+                });
+                col.AddRow(row =>
+                {
+                    row.AddButton()
+                        .SetText("W3: Zero-Width Cell (OK)")
+                        .SetTooltip("Fixed list cell with no width anywhere. VERIFIED: renders correctly in-game; kept as a regression exhibit.")
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(200f)
+                        .BindOnClicked(model => model.OnClickHazardZeroCell());
+                    row.AddButton()
+                        .SetText("W4: Width Conflict (OK)")
+                        .SetTooltip("Two 150px-wide buttons inside a 200px-wide group. VERIFIED: renders correctly in-game; kept as a regression exhibit.")
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(200f)
+                        .BindOnClicked(model => model.OnClickHazardWidthConflict());
+                    row.AddSpacer();
+                });
+                col.AddRow(row =>
+                {
+                    row.AddButton()
+                        .SetText("P5: Row+Options (OK)")
+                        .SetTooltip("row.SetHeight(32)+options.SetHeight(32). VERIFIED: options is margin-free (like toggles/tabbar) - renders correctly.")
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(200f)
+                        .BindOnClicked(model => model.OnClickProbeRowOptions());
+                    row.AddButton()
+                        .SetText("P7: Narrow Group (OK)")
+                        .SetTooltip("100f-wide fixed group containing a 150f-wide fixed button. VERIFIED: renders correctly.")
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(200f)
+                        .BindOnClicked(model => model.OnClickProbeColWidth());
+                    row.AddSpacer();
+                });
+                col.AddRow(row =>
+                {
+                    row.AddButton()
+                        .SetText("P8: Aspect+Dims (OK)")
+                        .SetTooltip("Image with aspect Exact plus explicit width AND height; second image with invalid resref. VERIFIED: renders correctly.")
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(200f)
+                        .BindOnClicked(model => model.OnClickProbeAspect());
+                    row.AddButton()
+                        .SetText("P9: Zero Dims (OK)")
+                        .SetTooltip("Button with SetWidth(0)/SetHeight(0). VERIFIED: renders correctly.")
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(200f)
+                        .BindOnClicked(model => model.OnClickProbeZeroDim());
+                    row.AddSpacer();
+                });
+                col.AddRow(row =>
+                {
+                    row.AddButton()
+                        .SetText("P10: Negative Dims (OK)")
+                        .SetTooltip("Button with SetWidth(-10)/SetHeight(-10). VERIFIED: renders correctly.")
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(200f)
+                        .BindOnClicked(model => model.OnClickProbeNegDim());
+                    row.AddButton()
+                        .SetText("P11: List Mismatch (OK)")
+                        .SetTooltip("One list's cells bound to 5-row and 2-row lists. VERIFIED: renders without failure. Check Lists & Tables tab; recover via Replace Lists.")
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(200f)
+                        .BindOnClicked(model => model.OnClickProbeListMismatch());
+                    row.AddSpacer();
+                });
+                col.AddRow(row =>
+                {
+                    row.AddButton()
+                        .SetText("P12: Empty Data (OK)")
+                        .SetTooltip("Empty chart data + empty combo options. VERIFIED: renders without failure. Check Charts/Selection tabs; recover via Randomize Data / Replace Options.")
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(200f)
+                        .BindOnClicked(model => model.OnClickProbeEmptyData());
+                    row.AddButton()
+                        .SetText("P13b: Nested x3 (OK*)")
+                        .SetTooltip("Partial inside a partial inside a partial (3 deep). VERIFIED with caveat: renders, but the innermost content is dropped by the parent's re-apply after a moment - do not nest partials more than 2 deep in real windows.")
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(200f)
+                        .BindOnClicked(model => model.OnClickProbeNestedPartial());
+                    row.AddSpacer();
+                });
+
+                col.AddRow(row =>
+                {
+                    row.AddButton()
+                        .SetText("Reset Hazard Slot")
+                        .SetHeight(ButtonHeight)
+                        .SetWidth(200f)
+                        .BindOnClicked(model => model.OnClickHazardReset());
+                    row.AddSpacer();
+                });
+
+                col.AddRow(row =>
+                {
+                    var slot = row.AddPartialView(DebugNuiGalleryViewModel.HazardSlotElement);
+                    slot.AddColumn(slotCol =>
+                    {
+                        slotCol.AddRow(r =>
+                        {
+                            r.AddLabel()
+                                .SetText("No hazard loaded.")
+                                .SetHeight(24f);
+                        });
+                    });
+                });
+            });
+        }
+
+        private static void DefineHazardPartials(GuiWindow<DebugNuiGalleryViewModel> window)
+        {
+            window.DefinePartialView(DebugNuiGalleryViewModel.HazardSafePartial, safe =>
+            {
+                safe.AddColumn(col =>
+                {
+                    col.AddRow(row =>
+                    {
+                        row.AddLabel()
+                            .SetText("Hazard slot reset. No hazard loaded.")
+                            .SetHeight(24f);
+                    });
+                });
+            });
+
+            // H1 - the confirmed R2c failure: a row whose explicit height equals its
+            // button's height cannot satisfy row_height >= child_height + margins.
+            window.DefinePartialView(DebugNuiGalleryViewModel.HazardButtonRowPartial, hazard =>
+            {
+                hazard.AddColumn(col =>
+                {
+                    col.AddRow(row =>
+                    {
+                        row.SetHeight(32f);
+                        row.AddButton()
+                            .SetText("Unsolvable")
+                            .SetHeight(32f);
+                    });
+                });
+            });
+
+            // H2 - unbounded list that is not the terminal content of its column (R2).
+            // Previously suspected to fail, but verified rendering correctly in-game 2026-07.
+            window.DefinePartialView(DebugNuiGalleryViewModel.HazardListNonTerminalPartial, hazard =>
+            {
+                hazard.AddColumn(col =>
+                {
+                    col.AddRow(row =>
+                    {
+                        row.AddList(template =>
+                        {
+                            template.AddCell(cell =>
+                            {
+                                cell.AddLabel()
+                                    .BindText(model => model.ListNames)
+                                    .SetHorizontalAlign(NuiHorizontalAlign.Left);
+                            });
+                        })
+                            .BindRowCount(model => model.ListNames);
+                    });
+                    col.AddRow(row =>
+                    {
+                        row.AddLabel()
+                            .SetText("Row after the unbounded list")
+                            .SetHeight(LabelHeight);
+                    });
+                });
+            });
+
+            // H3 - fixed heights stacking past the host viewport with no scroll wrapper (R2b).
+            // Previously suspected to fail, but verified rendering correctly in-game 2026-07.
+            window.DefinePartialView(DebugNuiGalleryViewModel.HazardTallStackPartial, hazard =>
+            {
+                hazard.AddColumn(col =>
+                {
+                    for (var block = 1; block <= 12; block++)
+                    {
+                        var text = $"Fixed 120px block {block} of 12";
+                        col.AddRow(row =>
+                        {
+                            row.AddGroup(group =>
+                            {
+                                group.SetScrollbars(NuiScrollbars.None);
+                                group.AddColumn(c => c.AddRow(r => r.AddLabel().SetText(text)));
+                            })
+                                .SetHeight(120f);
+                        });
+                    }
+                });
+            });
+
+            // H4 - fixed template cell with no width on the cell or its element.
+            // Previously suspected to fail, but verified rendering correctly in-game 2026-07.
+            window.DefinePartialView(DebugNuiGalleryViewModel.HazardZeroCellPartial, hazard =>
+            {
+                hazard.AddColumn(col =>
+                {
+                    col.AddRow(row =>
+                    {
+                        row.AddList(template =>
+                        {
+                            template.AddCell(cell =>
+                            {
+                                cell.SetIsVariable(false);
+                                cell.AddLabel()
+                                    .BindText(model => model.ListNames);
+                            });
+                        })
+                            .BindRowCount(model => model.ListNames)
+                            .SetHeight(120f);
+                    });
+                });
+            });
+
+            // H5 - fixed child widths that cannot fit inside a fixed parent width.
+            // Previously suspected to fail, but verified rendering correctly in-game 2026-07.
+            window.DefinePartialView(DebugNuiGalleryViewModel.HazardWidthConflictPartial, hazard =>
+            {
+                hazard.AddColumn(col =>
+                {
+                    col.AddRow(row =>
+                    {
+                        row.AddGroup(group =>
+                        {
+                            group.AddColumn(c => c.AddRow(r =>
+                            {
+                                r.AddButton().SetText("150 wide A").SetWidth(150f);
+                                r.AddButton().SetText("150 wide B").SetWidth(150f);
+                            }));
+                        })
+                            .SetWidth(200f)
+                            .SetHeight(60f);
+                    });
+                });
+            });
+
+            // Probes - generalizing R2c margin detection across widget families.
+            // Each probe uses a fixed row (32px) with SetHeight(32f) on its widget.
+            // Outcome unknown per family; a confirmed BLANK promotes that family
+            // into the validator's button-family list.
+            DefineFixedRowProbe(window, DebugNuiGalleryViewModel.ProbeRowCheckboxPartial, 32f, row =>
+            {
+                row.AddCheckBox()
+                    .SetText("Probe")
+                    .BindIsChecked(model => model.IsChecked)
+                    .SetHeight(32f)
+                    .SetWidth(150f);
+            });
+
+            DefineFixedRowProbe(window, DebugNuiGalleryViewModel.ProbeRowTextEditPartial, 32f, row =>
+            {
+                row.AddTextEdit()
+                    .SetPlaceholder("Probe")
+                    .BindValue(model => model.TextEditValue)
+                    .SetMaxLength(50)
+                    .SetHeight(32f);
+            });
+
+            DefineFixedRowProbe(window, DebugNuiGalleryViewModel.ProbeRowComboPartial, 32f, row =>
+            {
+                row.AddComboBox()
+                    .AddOption("Probe A", 0)
+                    .AddOption("Probe B", 1)
+                    .BindSelectedIndex(model => model.StaticComboSelection)
+                    .SetHeight(32f)
+                    .SetWidth(150f);
+            });
+
+            DefineFixedRowProbe(window, DebugNuiGalleryViewModel.ProbeRowSliderPartial, 32f, row =>
+            {
+                row.AddSliderInt()
+                    .BindValue(model => model.SliderIntValue)
+                    .SetMinimum(0)
+                    .SetMaximum(10)
+                    .SetStepSize(1)
+                    .SetHeight(32f);
+            });
+
+            DefineFixedRowProbe(window, DebugNuiGalleryViewModel.ProbeRowOptionsPartial, 32f, row =>
+            {
+                row.AddOptions()
+                    .SetDirection(NuiDirection.Horizontal)
+                    .AddOption("One")
+                    .AddOption("Two")
+                    .BindSelectedValue(model => model.OptionsHorizontalValue)
+                    .SetHeight(32f)
+                    .SetWidth(200f);
+            });
+
+            DefineFixedRowProbe(window, DebugNuiGalleryViewModel.ProbeRowProgressPartial, 32f, row =>
+            {
+                row.AddProgressBar()
+                    .BindValue(model => model.ProgressValue)
+                    .SetHeight(32f);
+            });
+
+            // Structural probes - outcome unknown, verified in-game via the probe buttons.
+            // P7: column-axis width conflict.
+            window.DefinePartialView(DebugNuiGalleryViewModel.ProbeColWidthPartial, hazard =>
+            {
+                hazard.AddColumn(col =>
+                {
+                    col.AddRow(row =>
+                    {
+                        row.AddGroup(group =>
+                        {
+                            group.AddColumn(inner => inner.AddRow(r => r.AddButton().SetText("150 wide").SetWidth(150f).SetHeight(32f)));
+                        })
+                            .SetWidth(100f)
+                            .SetHeight(60f);
+                    });
+                });
+            });
+
+            // P8: aspect + both dimensions on one image, plus an invalid resref image.
+            window.DefinePartialView(DebugNuiGalleryViewModel.ProbeAspectPartial, hazard =>
+            {
+                hazard.AddColumn(col =>
+                {
+                    col.AddRow(row =>
+                    {
+                        row.AddImage()
+                            .SetResref("arrow_up")
+                            .SetAspect(NuiAspect.Exact)
+                            .SetWidth(64f)
+                            .SetHeight(200f)
+                            .SetTooltip("Aspect Exact + width 64 + height 200");
+                    });
+                    col.AddRow(row =>
+                    {
+                        row.AddLabel().SetText("Below: image with invalid resref 'zz_no_such_img'").SetHeight(20f);
+                    });
+                    col.AddRow(row =>
+                    {
+                        row.AddImage()
+                            .SetResref("zz_no_such_img")
+                            .SetAspect(NuiAspect.Fit)
+                            .SetWidth(48f)
+                            .SetHeight(48f);
+                    });
+                });
+            });
+
+            // P9 / P10: zero and negative dimensions.
+            window.DefinePartialView(DebugNuiGalleryViewModel.ProbeZeroDimPartial, hazard =>
+            {
+                hazard.AddColumn(col =>
+                {
+                    col.AddRow(row => row.AddButton().SetText("Zero-dim").SetWidth(0f).SetHeight(0f));
+                });
+            });
+            window.DefinePartialView(DebugNuiGalleryViewModel.ProbeNegDimPartial, hazard =>
+            {
+                hazard.AddColumn(col =>
+                {
+                    col.AddRow(row => row.AddButton().SetText("Neg-dim").SetWidth(-10f).SetHeight(-10f));
+                });
+            });
+
+            // P13b: 3-deep partial nesting host (a partial containing another partial slot).
+            window.DefinePartialView(DebugNuiGalleryViewModel.ProbeNestedHostPartial, hazard =>
+            {
+                hazard.AddColumn(col =>
+                {
+                    col.AddRow(row =>
+                    {
+                        row.AddLabel().SetText("Nested host loaded; inner slot below.").SetHeight(20f);
+                    });
+                    col.AddRow(row =>
+                    {
+                        var slot = row.AddPartialView(DebugNuiGalleryViewModel.ProbeNestedSlotElement);
+                        slot.AddColumn(slotCol =>
+                        {
+                            slotCol.AddRow(r => r.AddLabel().SetText("Inner slot default content.").SetHeight(20f));
+                        });
+                    });
+                });
+            });
+        }
+
+        private static void DefineFixedRowProbe(
+            GuiWindow<DebugNuiGalleryViewModel> window,
+            string partialName,
+            float rowHeight,
+            Action<GuiRow<DebugNuiGalleryViewModel>> addWidget)
+        {
+            window.DefinePartialView(partialName, hazard =>
+            {
+                hazard.AddColumn(col =>
+                {
+                    col.AddRow(row =>
+                    {
+                        row.SetHeight(rowHeight);
+                        addWidget(row);
+                    });
+                });
+            });
+        }
+    }
+}

--- a/SWLOR.Game.Server/Feature/GuiDefinition/MarketBuyDefinition.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/MarketBuyDefinition.cs
@@ -1,6 +1,7 @@
 using SWLOR.Game.Server.Core.Beamdog;
 using SWLOR.Game.Server.Feature.GuiDefinition.ViewModel;
 using SWLOR.Game.Server.Service.GuiService;
+using SWLOR.Game.Server.Service.GuiService.Component;
 
 namespace SWLOR.Game.Server.Feature.GuiDefinition
 {
@@ -77,62 +78,47 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                         {
                             col2.AddRow(row2 =>
                             {
-                                row2.AddList(template =>
+                                row2.AddColumn(col3 =>
                                 {
-
-                                    template.AddCell(cell =>
-                                    {
-                                        cell.SetWidth(40f);
-                                        cell.SetIsVariable(false);
-
-                                        cell.AddGroup(group =>
+                                    col3.AddTable<MarketBuyViewModel>(t => t
+                                        .AddComponentColumn("", 40f, cell =>
                                         {
-                                            group.AddImage()
-                                                .BindResref(model => model.ItemIconResrefs)
-                                                .SetHorizontalAlign(NuiHorizontalAlign.Center)
-                                                .SetVerticalAlign(NuiVerticalAlign.Top)
+                                            cell.AddGroup(group =>
+                                            {
+                                                group.AddImage()
+                                                    .BindResref(model => model.ItemIconResrefs)
+                                                    .SetHorizontalAlign(NuiHorizontalAlign.Center)
+                                                    .SetVerticalAlign(NuiVerticalAlign.Top)
+                                                    .BindTooltip(model => model.ItemNames);
+                                            });
+                                        })
+                                        .AddComponentColumn("", 0f, cell =>
+                                        {
+                                            cell.AddText()
+                                                .BindText(model => model.ItemNames)
                                                 .BindTooltip(model => model.ItemNames);
-                                        });
-                                    })
-                                        .SetPadding(50f);
-
-                                    template.AddCell(cell =>
-                                    {
-                                        cell.AddText()
-                                            .BindText(model => model.ItemNames)
-                                            .BindTooltip(model => model.ItemNames);
-                                    });
-
-                                    template.AddCell(cell =>
-                                    {
-                                        cell.SetIsVariable(false);
-                                        cell.SetWidth(120f);
-
-                                        cell.AddLabel()
-                                            .BindText(model => model.ItemPriceNames);
-                                    });
-
-                                    template.AddCell(cell =>
-                                    {
-                                        cell.SetWidth(40f);
-                                        cell.SetIsVariable(false);
-                                        cell.AddButton()
-                                            .SetText("?")
-                                            .SetWidth(40f)
-                                            .SetHeight(40f)
-                                            .BindOnClicked(model => model.OnClickExamine());
-                                    });
-
-                                    template.AddCell(cell =>
-                                    {
-                                        cell.AddButton()
-                                            .SetText("Buy")
-                                            .BindOnClicked(model => model.OnClickBuy())
-                                            .BindIsEnabled(model => model.ItemBuyEnabled);
-                                    });
-                                })
-                                    .BindRowCount(model => model.ItemNames)
-                                    .SetRowHeight(40f);
+                                        }, isVariable: true)
+                                        .AddColumn("", 120f, model => model.ItemPriceNames)
+                                        .AddComponentColumn("", 40f, cell =>
+                                        {
+                                            cell.AddButton()
+                                                .SetText("?")
+                                                .SetWidth(40f)
+                                                .SetHeight(40f)
+                                                .BindOnClicked(model => model.OnClickExamine());
+                                        })
+                                        .AddComponentColumn("", 0f, cell =>
+                                        {
+                                            cell.AddButton()
+                                                .SetText("Buy")
+                                                .BindOnClicked(model => model.OnClickBuy())
+                                                .BindIsEnabled(model => model.ItemBuyEnabled);
+                                        }, isVariable: true)
+                                        .SetShowHeader(false)
+                                        .SetPadding(50f)
+                                        .SetRowHeight(40f)
+                                        .BindRowCount(model => model.ItemNames));
+                                });
                             });
 
                             col2.AddPagination(

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/CharacterSheetViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/CharacterSheetViewModel.cs
@@ -6,17 +6,20 @@ using SWLOR.Game.Server.Service;
 using SWLOR.Game.Server.Service.CombatService;
 using SWLOR.Game.Server.Service.CraftService;
 using SWLOR.Game.Server.Service.GuiService;
+using SWLOR.Game.Server.Service.GuiService.Component;
 using SWLOR.Game.Server.Service.PerkService;
 using SWLOR.Game.Server.Service.SkillService;
 using SWLOR.Game.Server.Service.StatService;
 using SWLOR.Game.Server.Service.StatusEffectService;
 using SWLOR.NWN.API.NWNX;
 using SWLOR.NWN.API.NWScript.Enum;
+using System.Collections.Generic;
+using System.Linq;
 using Skill = SWLOR.Game.Server.Service.Skill;
 
 namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
 {
-    public class CharacterSheetViewModel: GuiViewModelBase<CharacterSheetViewModel, CharacterSheetPayload>,
+    public class CharacterSheetViewModel : GuiViewModelBase<CharacterSheetViewModel, CharacterSheetPayload>,
         IGuiRefreshable<ChangePortraitRefreshEvent>,
         IGuiRefreshable<DisguiseChangedRefreshEvent>,
         IGuiRefreshable<SkillXPRefreshEvent>,
@@ -45,7 +48,91 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
         public const string CraftingTabPartial = "CHARACTER_SHEET_CRAFTING_TAB";
 
         private uint _target;
-        private bool _isSynchronizingTabRows;
+
+        // Tab registration: id -> partial view -> refresh action. Replaces
+        // GetTabPartialName + the RefreshSelectedTabData switch statement that
+        // used to live inside RestoreSelectedTabPartial.
+        private static readonly GuiTabGroup<CharacterSheetViewModel, CharacterSheetPayload> Tabs =
+            new GuiTabGroup<CharacterSheetViewModel, CharacterSheetPayload>()
+                .AddTab(AttributesTabId, AttributesTabPartial)
+                .AddTab(StatsTabId, StatsTabPartial, m => { if (GetIsObjectValid(m._target)) m.RefreshCharacterStatsList(); })
+                .AddTab(ResistancesTabId, ResistancesTabPartial, m => { if (GetIsObjectValid(m._target)) m.RefreshResistances(); })
+                .AddTab(CraftingTabId, CraftingTabPartial, m => { if (GetIsObjectValid(m._target)) m.RefreshCraftingStats(); });
+
+        // Paired-toggle sync: replaces the hand-written _isSynchronizingTabRows
+        // guard. Each group maps its own local toggle index (0/1) to a shared
+        // tab id.
+        private static readonly GuiToggleGroupSync TopToggles = new(AttributesTabId, StatsTabId);
+        private static readonly GuiToggleGroupSync BottomToggles = new(ResistancesTabId, CraftingTabId);
+
+        // Row DTOs for the three tables below - one list of these per refresh,
+        // instead of hand-synced parallel GuiBindingList<string> instances.
+        private sealed class StatEntry
+        {
+            public string Name { get; }
+            public string Value { get; }
+            public string Tooltip { get; }
+
+            public StatEntry(string name, string value, string tooltip)
+            {
+                Name = name;
+                Value = value;
+                Tooltip = tooltip;
+            }
+        }
+
+        private sealed class ResistanceEntry
+        {
+            public string Name { get; }
+            public string Score { get; }
+            public string DamageTaken { get; }
+            public string StatusDuration { get; }
+
+            public ResistanceEntry(string name, string score, string damageTaken, string statusDuration)
+            {
+                Name = name;
+                Score = score;
+                DamageTaken = damageTaken;
+                StatusDuration = statusDuration;
+            }
+        }
+
+        private sealed class CraftEntry
+        {
+            public string Name { get; }
+            public string Control { get; }
+            public string Craftsmanship { get; }
+
+            public CraftEntry(string name, string control, string craftsmanship)
+            {
+                Name = name;
+                Control = control;
+                Craftsmanship = craftsmanship;
+            }
+        }
+
+        // Column mappings: which bound property receives each column, and how
+        // to pull that column's value out of a row DTO. Replaces the 3
+        // hand-rolled parallel-list-building blocks previously duplicated
+        // across RefreshCharacterStatsList / RefreshResistances / RefreshCraftingStats.
+        private static readonly GuiTableSource<CharacterSheetViewModel, StatEntry> StatsTable =
+            new GuiTableSource<CharacterSheetViewModel, StatEntry>()
+                .Column((m, v) => m.StatNames = v, r => r.Name)
+                .Column((m, v) => m.StatValues = v, r => r.Value)
+                .Column((m, v) => m.StatTooltips = v, r => r.Tooltip);
+
+        private static readonly GuiTableSource<CharacterSheetViewModel, ResistanceEntry> ResistancesTable =
+            new GuiTableSource<CharacterSheetViewModel, ResistanceEntry>()
+                .Column((m, v) => m.ResistanceNames = v, r => r.Name)
+                .Column((m, v) => m.ResistanceScores = v, r => r.Score)
+                .Column((m, v) => m.ResistanceDamageTaken = v, r => r.DamageTaken)
+                .Column((m, v) => m.ResistanceStatusDurations = v, r => r.StatusDuration);
+
+        private static readonly GuiTableSource<CharacterSheetViewModel, CraftEntry> CraftingTable =
+            new GuiTableSource<CharacterSheetViewModel, CraftEntry>()
+                .Column((m, v) => m.CraftNames = v, r => r.Name)
+                .Column((m, v) => m.CraftControls = v, r => r.Control)
+                .Column((m, v) => m.CraftCraftsmanship = v, r => r.Craftsmanship);
 
         public bool IsViewingTarget(uint target)
         {
@@ -58,9 +145,15 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             set
             {
                 Set(value);
-                RefreshTabRowSelection();
 
-                RestoreSelectedTabPartial();
+                // Drive both toggle-pair properties to reflect the new
+                // selection (or -1 if this tab isn't in that pair).
+                TopToggles.SyncTo(value, v => TopTabId = v);
+                BottomToggles.SyncTo(value, v => BottomTabId = v);
+
+                // Runs the tab's refresh action, then swaps the nested
+                // partial via the safe double-reapply path.
+                Tabs.Select(this, TabContentPartialElement, value);
             }
         }
 
@@ -70,11 +163,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             set
             {
                 Set(value);
-
-                if (_isSynchronizingTabRows || value < 0)
-                    return;
-
-                SelectTab(value == 0 ? AttributesTabId : StatsTabId);
+                TopToggles.HandleClientChange(value, tabId => SelectedTabId = tabId);
             }
         }
 
@@ -84,11 +173,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             set
             {
                 Set(value);
-
-                if (_isSynchronizingTabRows || value < 0)
-                    return;
-
-                SelectTab(value == 0 ? ResistancesTabId : CraftingTabId);
+                BottomToggles.HandleClientChange(value, tabId => SelectedTabId = tabId);
             }
         }
 
@@ -536,136 +621,63 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
 
             ShowModal(promptMessage, () =>
             {
-                try
+                if (GetResRef(GetArea(_target)) == "char_migration")
                 {
-                    if (GetResRef(GetArea(_target)) == "char_migration")
+                    FloatingTextStringOnCreature($"Stats cannot be upgraded in this area.", _target, false);
+                    return;
+                }
+
+                playerId = GetObjectUUID(_target);
+                dbPlayer = DB.Get<Player>(playerId);
+                isRacial = dbPlayer.RacialStat == AbilityType.Invalid;
+                var rawScore = CreaturePlugin.GetRawAbilityScore(_target, ability);
+                var purchasedScore = GetPurchasedAttributeScore(dbPlayer, ability);
+
+                if (isRacial)
+                {
+                    if (rawScore >= MaxRacialAttributeScore || purchasedScore > MaxPurchasedAttributeScore)
                     {
-                        FloatingTextStringOnCreature($"Stats cannot be upgraded in this area.", _target, false);
+                        FloatingTextStringOnCreature($"You cannot upgrade this attribute beyond {MaxRacialAttributeScore} with a racial bonus.", _target, false);
                         return;
                     }
 
-                    playerId = GetObjectUUID(_target);
-                    dbPlayer = DB.Get<Player>(playerId);
-                    isRacial = dbPlayer.RacialStat == AbilityType.Invalid;
-                    var rawScore = CreaturePlugin.GetRawAbilityScore(_target, ability);
-                    var purchasedScore = GetPurchasedAttributeScore(dbPlayer, ability);
-
-                    if (isRacial)
+                    dbPlayer.RacialStat = ability;
+                }
+                else
+                {
+                    if (purchasedScore >= MaxPurchasedAttributeScore)
                     {
-                        if (rawScore >= MaxRacialAttributeScore || purchasedScore > MaxPurchasedAttributeScore)
-                        {
-                            FloatingTextStringOnCreature($"You cannot upgrade this attribute beyond {MaxRacialAttributeScore} with a racial bonus.", _target, false);
-                            return;
-                        }
-
-                        dbPlayer.RacialStat = ability;
-                    }
-                    else
-                    {
-                        if (purchasedScore >= MaxPurchasedAttributeScore)
-                        {
-                            FloatingTextStringOnCreature($"You cannot upgrade this attribute beyond {MaxPurchasedAttributeScore} with AP.", _target, false);
-                            return;
-                        }
-
-                        if (rawScore >= MaxRacialAttributeScore)
-                        {
-                            FloatingTextStringOnCreature($"You cannot upgrade this attribute beyond {MaxRacialAttributeScore}.", _target, false);
-                            return;
-                        }
-
-                        if (dbPlayer.UnallocatedAP <= 0)
-                        {
-                            FloatingTextStringOnCreature("You do not have enough AP to purchase this upgrade.", _target, false);
-                            return;
-                        }
-
-                        dbPlayer.UnallocatedAP--;
-                        dbPlayer.UpgradedStats[ability]++;
+                        FloatingTextStringOnCreature($"You cannot upgrade this attribute beyond {MaxPurchasedAttributeScore} with AP.", _target, false);
+                        return;
                     }
 
-                    CreaturePlugin.ModifyRawAbilityScore(_target, ability, 1);
+                    if (rawScore >= MaxRacialAttributeScore)
+                    {
+                        FloatingTextStringOnCreature($"You cannot upgrade this attribute beyond {MaxRacialAttributeScore}.", _target, false);
+                        return;
+                    }
 
-                    DB.Set(dbPlayer);
+                    if (dbPlayer.UnallocatedAP <= 0)
+                    {
+                        FloatingTextStringOnCreature("You do not have enough AP to purchase this upgrade.", _target, false);
+                        return;
+                    }
 
-                    FloatingTextStringOnCreature($"Your {abilityName} attribute has increased!", _target, false);
-                    LoadData();
+                    dbPlayer.UnallocatedAP--;
+                    dbPlayer.UpgradedStats[ability]++;
                 }
-                finally
-                {
-                    RestoreSelectedTabPartial();
-                }
-            }, RestoreSelectedTabPartial);
+
+                CreaturePlugin.ModifyRawAbilityScore(_target, ability, 1);
+
+                DB.Set(dbPlayer);
+
+                FloatingTextStringOnCreature($"Your {abilityName} attribute has increased!", _target, false);
+                LoadData();
+            });
         }
 
-        private void SelectTab(int tabId)
-        {
-            if (SelectedTabId == tabId)
-            {
-                RefreshTabRowSelection();
-                RestoreSelectedTabPartial();
-                return;
-            }
-
-            SelectedTabId = tabId;
-        }
-
-        private void RefreshTabRowSelection()
-        {
-            _isSynchronizingTabRows = true;
-
-            TopTabId = SelectedTabId switch
-            {
-                AttributesTabId => 0,
-                StatsTabId => 1,
-                _ => -1
-            };
-
-            BottomTabId = SelectedTabId switch
-            {
-                ResistancesTabId => 0,
-                CraftingTabId => 1,
-                _ => -1
-            };
-
-            _isSynchronizingTabRows = false;
-        }
-
-        private void RestoreSelectedTabPartial()
-        {
-            void RefreshSelectedTabData()
-            {
-                if (!GetIsObjectValid(_target))
-                    return;
-
-                if (SelectedTabId == StatsTabId)
-                {
-                    RefreshCharacterStatsList();
-                }
-                else if (SelectedTabId == ResistancesTabId)
-                {
-                    RefreshResistances();
-                }
-                else if (SelectedTabId == CraftingTabId)
-                {
-                    RefreshCraftingStats();
-                }
-            }
-
-            void ApplySelectedTabPartial()
-            {
-                RefreshSelectedTabData();
-                ChangePartialView(TabContentPartialElement, GetTabPartialName(SelectedTabId));
-                RefreshSelectedTabData();
-            }
-
-            // Use the same root redraw path as modal close/open before replacing the nested tab panel.
-            ChangePartialView("_window_", "%%WINDOW_MAIN%%");
-            ApplySelectedTabPartial();
-            // NUI can drop nested partial layouts while its parent is being redrawn.
-            // Reapply on the next tick so tab switches use the same refresh path as modal swaps.
-            DelayCommand(0.0f, ApplySelectedTabPartial);
-        }
+        protected override void OnModalClosedRestore() =>
+            Tabs.Select(this, TabContentPartialElement, SelectedTabId);
 
         private bool IsAttributeUpgradeAvailable(Player dbPlayer, AbilityType ability, bool isRacialBonusAvailable)
         {
@@ -770,7 +782,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
         private void RefreshEquipmentStats()
         {
             // Builds a damage estimate using the player's stats as a baseline.
-            (string, string) GetCombatInfo( uint item)
+            (string, string) GetCombatInfo(uint item)
             {
                 var itemType = GetBaseItemType(item);
                 var skill = Skill.GetSkillTypeByBaseItem(itemType);
@@ -911,15 +923,10 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
 
         private void RefreshCharacterStatsList()
         {
-            var names = new GuiBindingList<string>();
-            var values = new GuiBindingList<string>();
-            var tooltips = new GuiBindingList<string>();
-
+            var rows = new List<StatEntry>();
             void AddStat(string name, string value, string tooltip)
             {
-                names.Add(name);
-                values.Add(value);
-                tooltips.Add(tooltip);
+                rows.Add(new StatEntry(name, value, tooltip));
             }
 
             var combatProfile = GetPrimaryCombatProfile();
@@ -964,9 +971,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             AddStat("Stealth", Stat.GetStealth(_target).ToString(), "Twice AGI plus equipment, perk, and status-effect bonuses.");
             AddStat("Experience", FormatPercent(Stat.GetStatAdjustment(_target, StatType.ExperiencePercentAdjustment)), "Bonus or penalty applied to experience gained from skill use.");
 
-            StatNames = names;
-            StatValues = values;
-            StatTooltips = tooltips;
+            StatsTable.Refresh(this, rows);
         }
 
         private void AddHighResourceAbilityDamageStats(Action<string, string, string> addStat)
@@ -1185,47 +1190,26 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             };
         }
 
-        private static string GetTabPartialName(int tabId)
-        {
-            return tabId switch
-            {
-                StatsTabId => StatsTabPartial,
-                ResistancesTabId => ResistancesTabPartial,
-                CraftingTabId => CraftingTabPartial,
-                _ => AttributesTabPartial
-            };
-        }
-
         private void RefreshResistances()
         {
-            var names = new GuiBindingList<string>();
-            var scores = new GuiBindingList<string>();
-            var damageTaken = new GuiBindingList<string>();
-            var statusDurations = new GuiBindingList<string>();
-
-            foreach (var resistanceType in Resistance.GetAllResistanceTypes())
+            var rows = Resistance.GetAllResistanceTypes().Select(resistanceType =>
             {
                 var score = Resistance.GetResistance(_target, resistanceType);
                 var takenPercent = (int)Math.Round(Resistance.CalculateResistanceDamageMultiplier(_target, resistanceType) * 100f);
 
-                names.Add(resistanceType.ToString());
-                scores.Add(score.ToString());
-                damageTaken.Add($"{takenPercent}% taken");
-                statusDurations.Add(GetStatusDurationLabel(score));
-            }
+                return new ResistanceEntry(
+                    resistanceType.ToString(),
+                    score.ToString(),
+                    $"{takenPercent}% taken",
+                    GetStatusDurationLabel(score));
+            });
 
-            ResistanceNames = names;
-            ResistanceScores = scores;
-            ResistanceDamageTaken = damageTaken;
-            ResistanceStatusDurations = statusDurations;
-
+            ResistancesTable.Refresh(this, rows);
         }
 
         private void RefreshCraftingStats()
         {
-            var names = new GuiBindingList<string>();
-            var controls = new GuiBindingList<string>();
-            var craftsmanship = new GuiBindingList<string>();
+            var rows = new List<CraftEntry>();
             var legacyControl = string.Empty;
             var legacyCraftsmanship = string.Empty;
 
@@ -1235,18 +1219,14 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
                 var control = Stat.CalculateControl(_target, skillType);
                 var craft = Stat.CalculateCraftsmanship(_target, skillType);
 
-                names.Add(detail.Name);
-                controls.Add(control.ToString());
-                craftsmanship.Add(craft.ToString());
+                rows.Add(new CraftEntry(detail.Name, control.ToString(), craft.ToString()));
 
                 legacyControl += index == 0 ? control.ToString() : $"/{control}";
                 legacyCraftsmanship += index == 0 ? craft.ToString() : $"/{craft}";
                 index++;
             }
 
-            CraftNames = names;
-            CraftControls = controls;
-            CraftCraftsmanship = craftsmanship;
+            CraftingTable.Refresh(this, rows);
             Control = legacyControl;
             Craftsmanship = legacyCraftsmanship;
         }

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/DebugNuiGalleryViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/DebugNuiGalleryViewModel.cs
@@ -1,0 +1,893 @@
+using System;
+using SWLOR.Game.Server.Enumeration;
+using SWLOR.Game.Server.Service;
+using SWLOR.Game.Server.Service.GuiService;
+using SWLOR.Game.Server.Service.GuiService.Component;
+using SWLOR.Game.Server.Service.LogService;
+
+namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
+{
+    public class DebugNuiGalleryViewModel : GuiViewModelBase<DebugNuiGalleryViewModel, GuiPayloadBase>
+    {
+        public const int ButtonsTabId = 0;
+        public const int TextTabId = 1;
+        public const int SelectionTabId = 2;
+        public const int SlidersTabId = 3;
+        public const int ListsTabId = 4;
+        public const int GroupsTabId = 5;
+        public const int DrawingTabId = 6;
+        public const int ChartsTabId = 7;
+        public const int BindingsTabId = 8;
+        public const int ModalsTabId = 9;
+        public const int HazardsTabId = 10;
+
+        public const string TabContentElement = "gallery_tab_content";
+        public const string HazardSlotElement = "gallery_hazard_slot";
+
+        public const string ButtonsTabPartial = "GALLERY_TAB_BUTTONS";
+        public const string TextTabPartial = "GALLERY_TAB_TEXT";
+        public const string SelectionTabPartial = "GALLERY_TAB_SELECTION";
+        public const string SlidersTabPartial = "GALLERY_TAB_SLIDERS";
+        public const string ListsTabPartial = "GALLERY_TAB_LISTS";
+        public const string GroupsTabPartial = "GALLERY_TAB_GROUPS";
+        public const string DrawingTabPartial = "GALLERY_TAB_DRAWING";
+        public const string ChartsTabPartial = "GALLERY_TAB_CHARTS";
+        public const string BindingsTabPartial = "GALLERY_TAB_BINDINGS";
+        public const string ModalsTabPartial = "GALLERY_TAB_MODALS";
+        public const string HazardsTabPartial = "GALLERY_TAB_HAZARDS";
+
+        public const string HazardSafePartial = "GALLERY_HAZARD_SAFE";
+        public const string HazardButtonRowPartial = "GALLERY_HAZARD_BUTTON_ROW";
+        public const string HazardListNonTerminalPartial = "GALLERY_HAZARD_LIST_NONTERMINAL";
+        public const string HazardTallStackPartial = "GALLERY_HAZARD_TALL_STACK";
+        public const string HazardZeroCellPartial = "GALLERY_HAZARD_ZERO_CELL";
+        public const string HazardWidthConflictPartial = "GALLERY_HAZARD_WIDTH_CONFLICT";
+
+        public const string ProbeRowCheckboxPartial = "GALLERY_PROBE_ROW_CHECKBOX";
+        public const string ProbeRowTextEditPartial = "GALLERY_PROBE_ROW_TEXTEDIT";
+        public const string ProbeRowComboPartial = "GALLERY_PROBE_ROW_COMBO";
+        public const string ProbeRowSliderPartial = "GALLERY_PROBE_ROW_SLIDER";
+        public const string ProbeRowOptionsPartial = "GALLERY_PROBE_ROW_OPTIONS";
+        public const string ProbeRowProgressPartial = "GALLERY_PROBE_ROW_PROGRESS";
+
+        public const string ProbeColWidthPartial = "GALLERY_PROBE_COL_WIDTH";
+        public const string ProbeAspectPartial = "GALLERY_PROBE_ASPECT";
+        public const string ProbeZeroDimPartial = "GALLERY_PROBE_ZERO_DIM";
+        public const string ProbeNegDimPartial = "GALLERY_PROBE_NEG_DIM";
+        public const string ProbeNestedHostPartial = "GALLERY_PROBE_NESTED_HOST";
+        public const string ProbeNestedSlotElement = "gallery_probe_nested_slot";
+
+        private const int MaxLogEntries = 100;
+
+        private static readonly GuiTabGroup<DebugNuiGalleryViewModel, GuiPayloadBase> Tabs =
+            new GuiTabGroup<DebugNuiGalleryViewModel, GuiPayloadBase>()
+                .AddTab(ButtonsTabId, ButtonsTabPartial)
+                .AddTab(TextTabId, TextTabPartial)
+                .AddTab(SelectionTabId, SelectionTabPartial)
+                .AddTab(SlidersTabId, SlidersTabPartial)
+                .AddTab(ListsTabId, ListsTabPartial)
+                .AddTab(GroupsTabId, GroupsTabPartial)
+                .AddTab(DrawingTabId, DrawingTabPartial)
+                .AddTab(ChartsTabId, ChartsTabPartial)
+                .AddTab(BindingsTabId, BindingsTabPartial)
+                .AddTab(ModalsTabId, ModalsTabPartial)
+                .AddTab(HazardsTabId, HazardsTabPartial);
+
+        private static readonly GuiToggleGroupSync RowAToggles = new(ButtonsTabId, TextTabId, SelectionTabId, SlidersTabId);
+        private static readonly GuiToggleGroupSync RowBToggles = new(ListsTabId, GroupsTabId, DrawingTabId, ChartsTabId);
+        private static readonly GuiToggleGroupSync RowCToggles = new(BindingsTabId, ModalsTabId, HazardsTabId);
+
+        private static readonly GuiColor[] ColorCycle =
+        {
+            GuiColor.White,
+            GuiColor.Red,
+            GuiColor.Green,
+            GuiColor.Cyan,
+            GuiColor.Grey
+        };
+
+        private static readonly string[] ImageCycle =
+        {
+            "arrow_up",
+            "arrow_right",
+            "arrow_down",
+            "arrow_left"
+        };
+
+        private bool _isInitializing;
+        private int _eventCount;
+        private int _clickCount;
+        private int _comboSetIndex;
+        private int _colorIndex;
+        private int _imageIndex;
+        private int _drawStep;
+        private int _chartRollIndex;
+        private int _listRowIndex;
+
+        public int SelectedTabId
+        {
+            get => Get<int>();
+            set => Set(value);
+        }
+
+        public int RowATabValue
+        {
+            get => Get<int>();
+            set
+            {
+                Set(value);
+                RowAToggles.HandleClientChange(value, SelectTab);
+            }
+        }
+
+        public int RowBTabValue
+        {
+            get => Get<int>();
+            set
+            {
+                Set(value);
+                RowBToggles.HandleClientChange(value, SelectTab);
+            }
+        }
+
+        public int RowCTabValue
+        {
+            get => Get<int>();
+            set
+            {
+                Set(value);
+                RowCToggles.HandleClientChange(value, SelectTab);
+            }
+        }
+
+        public GuiBindingList<string> EventLog { get => Get<GuiBindingList<string>>(); set => Set(value); }
+
+        // Buttons tab
+        public string ClickCountText { get => Get<string>(); set => Set(value); }
+        public string DynamicButtonText { get => Get<string>(); set => Set(value); }
+        public string SampleToggleText { get => Get<string>(); set => Set(value); }
+
+        public bool SampleToggle
+        {
+            get => Get<bool>();
+            set
+            {
+                Set(value);
+                SampleToggleText = value ? "Toggled ON" : "Toggled OFF";
+            }
+        }
+
+        // Text & Input tab
+        public string LongText { get => Get<string>(); set => Set(value); }
+
+        public string TextEditValue
+        {
+            get => Get<string>();
+            set
+            {
+                Set(value);
+                MirrorLabelText = $"Mirror: {value}";
+                LogEvent($"TextEditValue synced: '{value}'");
+            }
+        }
+
+        public string MultilineValue
+        {
+            get => Get<string>();
+            set
+            {
+                Set(value);
+                LogEvent($"MultilineValue synced ({(value ?? string.Empty).Length} chars)");
+            }
+        }
+
+        public string MirrorLabelText { get => Get<string>(); set => Set(value); }
+
+        // Selection tab
+        public bool IsChecked
+        {
+            get => Get<bool>();
+            set
+            {
+                Set(value);
+                CheckboxMirrorText = value ? "Checkbox is checked" : "Checkbox is unchecked";
+                LogEvent($"Checkbox changed: {value}");
+            }
+        }
+
+        public string CheckboxMirrorText { get => Get<string>(); set => Set(value); }
+
+        public int StaticComboSelection
+        {
+            get => Get<int>();
+            set
+            {
+                Set(value);
+                LogEvent($"Static combo selection: {value}");
+            }
+        }
+
+        public int DynamicComboSelection
+        {
+            get => Get<int>();
+            set
+            {
+                Set(value);
+                LogEvent($"Dynamic combo selection: {value}");
+            }
+        }
+
+        public GuiBindingList<GuiComboEntry> DynamicComboOptions { get => Get<GuiBindingList<GuiComboEntry>>(); set => Set(value); }
+
+        public int OptionsHorizontalValue
+        {
+            get => Get<int>();
+            set
+            {
+                Set(value);
+                LogEvent($"Horizontal options selection: {value}");
+            }
+        }
+
+        public int OptionsVerticalValue
+        {
+            get => Get<int>();
+            set
+            {
+                Set(value);
+                LogEvent($"Vertical options selection: {value}");
+            }
+        }
+
+        public GuiColor PickedColor
+        {
+            get => Get<GuiColor>();
+            set
+            {
+                Set(value);
+                LogEvent($"Color picked: R{value.R} G{value.G} B{value.B}");
+            }
+        }
+
+        // Sliders tab
+        public int SliderIntValue
+        {
+            get => Get<int>();
+            set
+            {
+                Set(value);
+                ProgressValue = value / 10f;
+                LogEvent($"SliderInt value: {value} (drives progress bar)");
+            }
+        }
+
+        public float SliderFloatValue
+        {
+            get => Get<float>();
+            set
+            {
+                Set(value);
+                LogEvent($"SliderFloat value: {value:F2}");
+            }
+        }
+
+        public float SliderFloatMax { get => Get<float>(); set => Set(value); }
+        public float ProgressValue { get => Get<float>(); set => Set(value); }
+
+        // Lists & Tables tab
+        public GuiBindingList<string> ListNames { get => Get<GuiBindingList<string>>(); set => Set(value); }
+        public GuiBindingList<string> ListDescriptions { get => Get<GuiBindingList<string>>(); set => Set(value); }
+        public GuiBindingList<float> ListProgress { get => Get<GuiBindingList<float>>(); set => Set(value); }
+        public GuiBindingList<string> ListResrefs { get => Get<GuiBindingList<string>>(); set => Set(value); }
+
+        public GuiBindingList<string> TableColA { get => Get<GuiBindingList<string>>(); set => Set(value); }
+        public GuiBindingList<string> TableColB { get => Get<GuiBindingList<string>>(); set => Set(value); }
+        public GuiBindingList<string> TableColC { get => Get<GuiBindingList<string>>(); set => Set(value); }
+        public GuiBindingList<string> TableTooltips { get => Get<GuiBindingList<string>>(); set => Set(value); }
+        public GuiBindingList<string> Table2Names { get => Get<GuiBindingList<string>>(); set => Set(value); }
+
+        // Images & Drawing tab
+        public string CycledImageResref { get => Get<string>(); set => Set(value); }
+        public GuiColor DrawColor { get => Get<GuiColor>(); set => Set(value); }
+        public GuiRectangle DrawCircleBounds { get => Get<GuiRectangle>(); set => Set(value); }
+
+        // Charts tab
+        public GuiBindingList<float> ChartData { get => Get<GuiBindingList<float>>(); set => Set(value); }
+        public string ChartLegend { get => Get<string>(); set => Set(value); }
+        public GuiColor ChartColor { get => Get<GuiColor>(); set => Set(value); }
+
+        // Bindings & Watches tab
+        public bool IsSampleEnabled { get => Get<bool>(); set => Set(value); }
+        public bool IsSampleVisible { get => Get<bool>(); set => Set(value); }
+        public GuiColor SampleColor { get => Get<GuiColor>(); set => Set(value); }
+        public string SampleTooltip { get => Get<string>(); set => Set(value); }
+        public string FloodCounterText { get => Get<string>(); set => Set(value); }
+
+        public string WatchDemoValue
+        {
+            get => Get<string>();
+            set
+            {
+                Set(value);
+                LogEvent($"WatchDemoValue synced: '{value}'");
+            }
+        }
+
+        // Hazards tab. Deliberately never assigned anywhere - hazard H6 watches it
+        // to demonstrate the R3 failure (WatchOnClient on a never-Set property).
+        public string NeverSetProperty { get => Get<string>(); set => Set(value); }
+
+        protected override void Initialize(GuiPayloadBase initialPayload)
+        {
+            _isInitializing = true;
+
+            EventLog = new GuiBindingList<string>();
+
+            // R3: every bound property is assigned here, before any WatchOnClient call
+            // below. NeverSetProperty is the single deliberate exception (hazard H6).
+            RowATabValue = 0;
+            RowBTabValue = -1;
+            RowCTabValue = -1;
+
+            _clickCount = 0;
+            ClickCountText = "Clicked 0 times";
+            DynamicButtonText = "Bound text button (click to change)";
+            SampleToggle = false;
+
+            LongText = "This is a GuiText block with a border and auto scrollbars. " +
+                       "It holds a long run of text so the scrollbar behavior can be verified. " +
+                       "Line two of the text block.\nLine three of the text block.\n" +
+                       "Line four.\nLine five.\nLine six.\nLine seven.\nLine eight.";
+            TextEditValue = string.Empty;
+            MultilineValue = "Multiline text edit.\nSecond line.";
+            MirrorLabelText = "Mirror:";
+
+            IsChecked = false;
+            StaticComboSelection = 0;
+            DynamicComboSelection = 0;
+            DynamicComboOptions = BuildComboOptions();
+            OptionsHorizontalValue = 0;
+            OptionsVerticalValue = 0;
+            PickedColor = GuiColor.White;
+
+            SliderIntValue = 5;
+            SliderFloatValue = 0.5f;
+            SliderFloatMax = 1f;
+            ProgressValue = 0.5f;
+
+            ListNames = new GuiBindingList<string> { "Alpha", "Beta", "Gamma" };
+            ListDescriptions = new GuiBindingList<string> { "First row", "Second row", "Third row" };
+            ListProgress = new GuiBindingList<float> { 0.25f, 0.5f, 0.75f };
+            ListResrefs = new GuiBindingList<string> { "arrow_up", "arrow_right", "arrow_down" };
+            _listRowIndex = 3;
+
+            TableColA = new GuiBindingList<string> { "A1", "A2", "A3", "A4" };
+            TableColB = new GuiBindingList<string> { "B1", "B2", "B3", "B4" };
+            TableColC = new GuiBindingList<string> { "Variable C1", "Variable C2", "Variable C3", "Variable C4" };
+            TableTooltips = new GuiBindingList<string> { "Tooltip 1", "Tooltip 2", "Tooltip 3", "Tooltip 4" };
+            Table2Names = new GuiBindingList<string> { "Component column row 1", "Component column row 2", "Component column row 3" };
+
+            CycledImageResref = ImageCycle[0];
+            _imageIndex = 0;
+            DrawColor = GuiColor.Cyan;
+            DrawCircleBounds = new GuiRectangle(10f, 10f, 40f, 40f);
+            _drawStep = 0;
+
+            ChartData = new GuiBindingList<float> { 1f, 3f, 2f, 5f, 4f };
+            ChartLegend = "Bound bar data";
+            ChartColor = GuiColor.FPColor;
+
+            IsSampleEnabled = true;
+            IsSampleVisible = true;
+            SampleColor = GuiColor.White;
+            SampleTooltip = "Initial tooltip";
+            FloodCounterText = "No flood yet";
+            WatchDemoValue = "watch me";
+
+            WatchOnClient(model => model.RowATabValue);
+            WatchOnClient(model => model.RowBTabValue);
+            WatchOnClient(model => model.RowCTabValue);
+            WatchOnClient(model => model.TextEditValue);
+            WatchOnClient(model => model.MultilineValue);
+            WatchOnClient(model => model.IsChecked);
+            WatchOnClient(model => model.StaticComboSelection);
+            WatchOnClient(model => model.DynamicComboSelection);
+            WatchOnClient(model => model.OptionsHorizontalValue);
+            WatchOnClient(model => model.OptionsVerticalValue);
+            WatchOnClient(model => model.PickedColor);
+            WatchOnClient(model => model.SliderIntValue);
+            WatchOnClient(model => model.SliderFloatValue);
+            WatchOnClient(model => model.WatchDemoValue);
+
+            _isInitializing = false;
+
+            SelectTab(ButtonsTabId);
+            LogEvent("Window initialized");
+        }
+
+        private void SelectTab(int tabId)
+        {
+            SelectedTabId = tabId;
+            RowAToggles.SyncTo(tabId, v => RowATabValue = v);
+            RowBToggles.SyncTo(tabId, v => RowBTabValue = v);
+            RowCToggles.SyncTo(tabId, v => RowCTabValue = v);
+            Tabs.Select(this, TabContentElement, tabId);
+            LogEvent($"Tab selected: {Tabs.GetPartialName(tabId)}");
+        }
+
+        private void LogEvent(string message)
+        {
+            if (_isInitializing)
+                return;
+
+            var log = EventLog;
+            if (log == null)
+                return;
+
+            _eventCount++;
+            log.Insert(0, $"[{_eventCount:D3}] {message}");
+
+            while (log.Count > MaxLogEntries)
+            {
+                log.RemoveAt(log.Count - 1);
+            }
+
+            var separator = message.IndexOf(':');
+            var eventName = separator >= 0 ? message[..separator] : message;
+            Log.WriteStructured(
+                LogGroup.Server,
+                "[NUI gallery] Event {EventNumber}: {EventName}",
+                _eventCount,
+                eventName);
+        }
+
+        private static GuiBindingList<GuiComboEntry> BuildComboOptions(int setIndex = 0)
+        {
+            var options = new GuiBindingList<GuiComboEntry>();
+            for (var index = 1; index <= 4; index++)
+            {
+                options.Add(new GuiComboEntry($"Set {setIndex} Option {index}", index - 1));
+            }
+
+            return options;
+        }
+
+        public Action OnWindowOpened() => () =>
+        {
+            LogEvent("Window opened event fired");
+        };
+
+        public override Action OnWindowClosed() => () =>
+        {
+            LogEvent("Window closed event fired");
+        };
+
+        public Action OnClickClearLog() => () =>
+        {
+            // Whole-object replacement on purpose: exercises the binding-list re-hook
+            // path in GuiViewModelBase.Set in addition to the in-place mutations
+            // LogEvent performs.
+            EventLog = new GuiBindingList<string>();
+            LogEvent("Event log cleared (list object replaced)");
+        };
+
+        // Buttons tab
+        public Action OnClickSimpleButton() => () =>
+        {
+            _clickCount++;
+            ClickCountText = $"Clicked {_clickCount} times";
+            LogEvent($"Simple button clicked ({_clickCount})");
+        };
+
+        public Action OnClickImageButton() => () =>
+        {
+            LogEvent("Image button clicked");
+        };
+
+        public Action OnClickBoundTextButton() => () =>
+        {
+            DynamicButtonText = $"Text changed at click {++_clickCount}";
+            LogEvent("Bound-text button clicked; its label was rewritten");
+        };
+
+        public Action OnClickSampleToggle() => () =>
+        {
+            SampleToggle = !SampleToggle;
+            LogEvent($"Toggle button clicked; now {(SampleToggle ? "ON" : "OFF")}");
+        };
+
+        public Action OnMouseDownLabel() => () =>
+        {
+            LogEvent("Label mouse DOWN event fired");
+        };
+
+        public Action OnMouseUpLabel() => () =>
+        {
+            LogEvent("Label mouse UP event fired");
+        };
+
+        // Selection tab
+        public Action OnClickReplaceComboOptions() => () =>
+        {
+            _comboSetIndex++;
+            // GuiBindingList<GuiComboEntry> is not one of the list types hooked by
+            // GuiViewModelBase.Set - the whole object must be replaced (the same
+            // pattern the pagination combos ship with); in-place .Add would not push.
+            DynamicComboOptions = BuildComboOptions(_comboSetIndex);
+            DynamicComboSelection = 0;
+            LogEvent($"Combo options replaced with set {_comboSetIndex}");
+        };
+
+        // Sliders tab
+        public Action OnClickProgressAdd() => () =>
+        {
+            ProgressValue = Math.Min(1f, ProgressValue + 0.1f);
+            LogEvent($"Progress bar increased to {ProgressValue:F1}");
+        };
+
+        public Action OnClickProgressReset() => () =>
+        {
+            ProgressValue = 0f;
+            LogEvent("Progress bar reset to 0");
+        };
+
+        public Action OnClickRaiseSliderMax() => () =>
+        {
+            SliderFloatMax = SliderFloatMax >= 4f ? 1f : SliderFloatMax + 1f;
+            LogEvent($"SliderFloat maximum changed to {SliderFloatMax:F0} while the window is open");
+        };
+
+        // Lists & Tables tab
+        public Action OnClickListRowButton() => () =>
+        {
+            var index = NuiGetEventArrayIndex();
+            LogEvent($"List row button clicked at index {index} ('{(index >= 0 && index < ListNames.Count ? ListNames[index] : "?")}')");
+        };
+
+        public Action OnClickTable2RowButton() => () =>
+        {
+            var index = NuiGetEventArrayIndex();
+            LogEvent($"Table component-column button clicked at index {index}");
+        };
+
+        public Action OnClickListAddRow() => () =>
+        {
+            _listRowIndex++;
+            ListNames.Add($"Row {_listRowIndex}");
+            ListDescriptions.Add($"Added at #{_eventCount + 1}");
+            ListProgress.Add((_listRowIndex % 10) / 10f);
+            ListResrefs.Add(ImageCycle[_listRowIndex % ImageCycle.Length]);
+            LogEvent($"List row added in place (now {ListNames.Count} rows)");
+        };
+
+        public Action OnClickListRemoveRow() => () =>
+        {
+            var rowCount = ListNames.Count;
+            if (rowCount == 0)
+            {
+                LogEvent("List remove skipped; no rows left");
+                return;
+            }
+
+            if (ListDescriptions.Count != rowCount ||
+                ListProgress.Count != rowCount ||
+                ListResrefs.Count != rowCount)
+            {
+                LogEvent("List remove skipped; bound column lengths differ");
+                return;
+            }
+
+            var last = rowCount - 1;
+            ListNames.RemoveAt(last);
+            ListDescriptions.RemoveAt(last);
+            ListProgress.RemoveAt(last);
+            ListResrefs.RemoveAt(last);
+            LogEvent($"List row removed in place (now {ListNames.Count} rows; exercises the row-shrink workaround)");
+        };
+
+        public Action OnClickListReplace() => () =>
+        {
+            ListNames = new GuiBindingList<string> { "Fresh A", "Fresh B" };
+            ListDescriptions = new GuiBindingList<string> { "Replaced list", "Replaced list" };
+            ListProgress = new GuiBindingList<float> { 0.9f, 0.1f };
+            ListResrefs = new GuiBindingList<string> { "arrow_left", "arrow_right" };
+            _listRowIndex = 2;
+            LogEvent("All list objects replaced wholesale (re-hook path)");
+        };
+
+        // Images & Drawing tab
+        public Action OnClickCycleImage() => () =>
+        {
+            _imageIndex = (_imageIndex + 1) % ImageCycle.Length;
+            CycledImageResref = ImageCycle[_imageIndex];
+            LogEvent($"Bound image resref cycled to '{CycledImageResref}'");
+        };
+
+        public Action OnClickAnimateDraw() => () =>
+        {
+            _drawStep = (_drawStep + 1) % 5;
+            DrawCircleBounds = new GuiRectangle(10f + _drawStep * 15f, 10f, 30f + _drawStep * 5f, 30f + _drawStep * 5f);
+            DrawColor = ColorCycle[_drawStep % ColorCycle.Length];
+            LogEvent($"Draw list circle stepped (step {_drawStep}); bounds and color rebound");
+        };
+
+        // Charts tab
+        public Action OnClickRandomizeChart() => () =>
+        {
+            _chartRollIndex++;
+            var data = new GuiBindingList<float>();
+            for (var point = 0; point < 5; point++)
+            {
+                data.Add(Service.Random.Next(1, 10));
+            }
+
+            ChartData = data;
+            ChartLegend = $"Bound bar data (roll {_chartRollIndex})";
+            ChartColor = ColorCycle[_chartRollIndex % ColorCycle.Length];
+            LogEvent($"Chart data replaced (roll {_chartRollIndex})");
+        };
+
+        // Bindings & Watches tab
+        public Action OnClickToggleVisible() => () =>
+        {
+            IsSampleVisible = !IsSampleVisible;
+            LogEvent($"Specimen IsVisible set to {IsSampleVisible}");
+        };
+
+        public Action OnClickToggleEnabled() => () =>
+        {
+            IsSampleEnabled = !IsSampleEnabled;
+            LogEvent($"Specimen IsEnabled set to {IsSampleEnabled}");
+        };
+
+        public Action OnClickCycleColor() => () =>
+        {
+            _colorIndex = (_colorIndex + 1) % ColorCycle.Length;
+            SampleColor = ColorCycle[_colorIndex];
+            LogEvent($"Specimen color cycled (index {_colorIndex})");
+        };
+
+        public Action OnClickCycleTooltip() => () =>
+        {
+            SampleTooltip = $"Tooltip updated at event {_eventCount + 1}";
+            LogEvent("Specimen tooltip rebound; hover to verify");
+        };
+
+        public Action OnClickLogGeometry() => () =>
+        {
+            var geometry = Geometry;
+            LogEvent($"Geometry: X{geometry.X:F0} Y{geometry.Y:F0} W{geometry.Width:F0} H{geometry.Height:F0}");
+        };
+
+        public Action OnClickRewatch() => () =>
+        {
+            // Re-issuing a watch on an already-watched, already-Set property must be
+            // harmless (the framework does the same for Geometry after root layout).
+            WatchOnClient(model => model.WatchDemoValue);
+            LogEvent("Re-issued WatchOnClient(WatchDemoValue)");
+        };
+
+        public Action OnClickBindFlood() => () =>
+        {
+            for (var update = 1; update <= 20; update++)
+            {
+                FloodCounterText = $"Flood update {update} of 20";
+            }
+
+            LogEvent("Pushed 20 rapid bind updates to one property in a single event");
+        };
+
+        // Modals & Events tab
+        // Closing a modal swaps %%WINDOW_MAIN%% back in, which resets the tab
+        // content group to its empty template state - the current tab partial
+        // must be re-applied afterwards (same as CharacterSheet's modal flow).
+        protected override void OnModalClosedRestore() => Tabs.Select(this, TabContentElement, SelectedTabId);
+
+        public Action OnClickShowModal() => () =>
+        {
+            LogEvent("Opening yes/no modal");
+            ShowModal(
+                "This is the stock confirmation modal. Choose either button.",
+                () => LogEvent("Modal CONFIRMED"),
+                () => LogEvent("Modal CANCELLED"));
+        };
+
+        public Action OnClickShowInputModal() => () =>
+        {
+            LogEvent("Opening input modal");
+            ShowInputModal(
+                "Type something and submit it.",
+                "prefilled text",
+                () => LogEvent($"Input modal submitted: '{ModalInputText}'"),
+                () => LogEvent("Input modal cancelled"));
+        };
+
+        public Action OnClickReapplyTab() => () =>
+        {
+            LogEvent("Re-applying the current tab partial redundantly");
+            Tabs.Select(this, TabContentElement, SelectedTabId);
+        };
+
+        // Hazards tab
+        private bool HazardsAreAvailable
+        {
+            get
+            {
+                var environment = ApplicationSettings.Get().ServerEnvironment;
+                return environment == ServerEnvironmentType.Development ||
+                       environment == ServerEnvironmentType.Test;
+            }
+        }
+
+        private void LoadHazard(string partialName, string expectedFailure)
+        {
+            if (!HazardsAreAvailable)
+            {
+                LogEvent("Hazards are disabled on this environment");
+                return;
+            }
+
+            // Logged BEFORE the swap so the culprit is identifiable in the log
+            // even if the window blanks out client-side.
+            LogEvent($"LOADING HAZARD {partialName} (expect: {expectedFailure})");
+
+            // The hazard slot is nested two partials deep (window root -> hazards tab
+            // partial -> slot). SwapNestedPartialView's root-redraw pass would reset
+            // the tab content and destroy the slot element, so apply directly and
+            // re-apply once after the redraw nudge settles instead.
+            ChangePartialView(HazardSlotElement, partialName);
+            DelayCommand(0.0f, () =>
+            {
+                if (Gui.IsWindowOpen(Player, WindowType))
+                    ChangePartialView(HazardSlotElement, partialName);
+            });
+        }
+
+        public Action OnClickHazardButtonRow() => () =>
+        {
+            LoadHazard(HazardButtonRowPartial, "unsolvable layout - row height equals button height (R2c)");
+        };
+
+        public Action OnClickHazardListNonTerminal() => () =>
+        {
+            LoadHazard(HazardListNonTerminalPartial, "verified working - expect it to render");
+        };
+
+        public Action OnClickHazardTallStack() => () =>
+        {
+            LoadHazard(HazardTallStackPartial, "verified working - expect it to render");
+        };
+
+        public Action OnClickHazardZeroCell() => () =>
+        {
+            LoadHazard(HazardZeroCellPartial, "verified working - expect it to render");
+        };
+
+        public Action OnClickHazardWidthConflict() => () =>
+        {
+            LoadHazard(HazardWidthConflictPartial, "verified working - expect it to render");
+        };
+
+        public Action OnClickHazardWatchUnset() => () =>
+        {
+            LogEvent("LOADING HAZARD watch-unset-property (expect: descriptive InvalidOperationException; window unaffected)");
+
+            // WatchOnClient fails fast on never-Set properties (rule R3). Before
+            // that guard existed this silently created a null-valued property entry
+            // that made every later reopen of the window throw, requiring a server
+            // restart - the exact failure this exhibit originally uncovered.
+            try
+            {
+                WatchOnClient(model => model.NeverSetProperty);
+                LogEvent("UNEXPECTED: watching a never-Set property did not throw");
+            }
+            catch (InvalidOperationException ex)
+            {
+                LogEvent($"Confirmed R3 guard: {ex.Message}");
+            }
+        };
+
+        public Action OnClickHazardReset() => () =>
+        {
+            if (!HazardsAreAvailable)
+                return;
+
+            LogEvent("Hazard slot reset to safe content");
+            ChangePartialView(HazardSlotElement, HazardSafePartial);
+        };
+
+        public Action OnClickProbeRowCheckbox() => () =>
+        {
+            LoadHazard(ProbeRowCheckboxPartial, "confirmed - checkbox has default margins; blanks the window (R2c)");
+        };
+
+        public Action OnClickProbeRowTextEdit() => () =>
+        {
+            LoadHazard(ProbeRowTextEditPartial, "confirmed - textedit has default margins; blanks the window (R2c)");
+        };
+
+        public Action OnClickProbeRowCombo() => () =>
+        {
+            LoadHazard(ProbeRowComboPartial, "confirmed - combo has default margins; blanks the window (R2c)");
+        };
+
+        public Action OnClickProbeRowSlider() => () =>
+        {
+            LoadHazard(ProbeRowSliderPartial, "confirmed - slider has default margins; blanks the window (R2c)");
+        };
+
+        public Action OnClickProbeRowOptions() => () =>
+        {
+            LoadHazard(ProbeRowOptionsPartial, "verified working - options is margin-free like toggles");
+        };
+
+        public Action OnClickProbeRowProgress() => () =>
+        {
+            LoadHazard(ProbeRowProgressPartial, "confirmed - progress has default margins; blanks the window (R2c)");
+        };
+
+        public Action OnClickProbeColWidth() => () =>
+        {
+            LoadHazard(ProbeColWidthPartial, "verified working - expect it to render");
+        };
+
+        public Action OnClickProbeAspect() => () =>
+        {
+            LoadHazard(ProbeAspectPartial, "verified working - expect it to render");
+        };
+
+        public Action OnClickProbeZeroDim() => () =>
+        {
+            LoadHazard(ProbeZeroDimPartial, "verified working - expect it to render");
+        };
+
+        public Action OnClickProbeNegDim() => () =>
+        {
+            LoadHazard(ProbeNegDimPartial, "verified working - expect it to render");
+        };
+
+        public Action OnClickProbeListMismatch() => () =>
+        {
+            LogEvent("PROBE: setting ListNames to 5 rows but ListDescriptions to 2 - check the Lists & Tables tab; recover via Replace Lists");
+            ListNames = new GuiBindingList<string> { "Mismatch 1", "Mismatch 2", "Mismatch 3", "Mismatch 4", "Mismatch 5" };
+            ListDescriptions = new GuiBindingList<string> { "Only two", "descriptions" };
+            ListProgress = new GuiBindingList<float> { 0.1f, 0.2f, 0.3f, 0.4f, 0.5f };
+            ListResrefs = new GuiBindingList<string> { "arrow_up", "arrow_up", "arrow_up", "arrow_up", "arrow_up" };
+            _listRowIndex = 5;
+        };
+
+        public Action OnClickProbeEmptyData() => () =>
+        {
+            LogEvent("PROBE: emptying ChartData and DynamicComboOptions - check Charts and Selection tabs; recover via Randomize Data / Replace Options");
+            ChartData = new GuiBindingList<float>();
+            DynamicComboOptions = new GuiBindingList<GuiComboEntry>();
+        };
+
+        public Action OnClickProbeBadElementId() => () =>
+        {
+            LogEvent("PROBE: applying a partial to a nonexistent element id 'no_such_element_id'");
+            try
+            {
+                ChangePartialView("no_such_element_id", HazardSafePartial);
+                LogEvent("PROBE result: no server-side exception (check client for errors)");
+            }
+            catch (Exception ex)
+            {
+                LogEvent($"PROBE result: server-side {ex.GetType().Name}: {ex.Message}");
+            }
+        };
+
+        public Action OnClickProbeNestedPartial() => () =>
+        {
+            LoadHazard(ProbeNestedHostPartial, "verified with caveat - renders, but the inner slot content is dropped by the parent re-apply");
+            DelayCommand(0.1f, () =>
+            {
+                if (Gui.IsWindowOpen(Player, WindowType))
+                {
+                    LogEvent("PROBE: applying safe partial into the 3rd-level nested slot");
+                    ChangePartialView(ProbeNestedSlotElement, HazardSafePartial);
+                }
+            });
+        };
+    }
+}

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/MarketBuyViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/MarketBuyViewModel.cs
@@ -19,6 +19,36 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
         private static readonly List<MarketCategoryType> _categoryTypes = new();
         private static readonly GuiBindingList<string> _categories = new();
 
+        // Row DTO for the item-listing table below - one list of these per
+        // Search(), instead of hand-synced parallel _itemIds/_itemPrices
+        // lists plus 4 separate GuiBindingList<T> builds.
+        private sealed class MarketListingEntry
+        {
+            public string ItemId { get; }
+            public string IconResref { get; }
+            public string Name { get; }
+            public string PriceName { get; }
+            public int Price { get; }
+            public bool BuyEnabled { get; }
+
+            public MarketListingEntry(string itemId, string iconResref, string name, string priceName, int price, bool buyEnabled)
+            {
+                ItemId = itemId;
+                IconResref = iconResref;
+                Name = name;
+                PriceName = priceName;
+                Price = price;
+                BuyEnabled = buyEnabled;
+            }
+        }
+
+        private static readonly GuiTableSource<MarketBuyViewModel, MarketListingEntry> ItemsTable =
+            new GuiTableSource<MarketBuyViewModel, MarketListingEntry>()
+                .Column((m, v) => m.ItemIconResrefs = v, r => r.IconResref, m => m.ItemIconResrefs)
+                .Column((m, v) => m.ItemNames = v, r => r.Name, m => m.ItemNames)
+                .Column((m, v) => m.ItemPriceNames = v, r => r.PriceName, m => m.ItemPriceNames)
+                .Column((m, v) => m.ItemBuyEnabled = v, r => r.BuyEnabled, m => m.ItemBuyEnabled);
+
         private bool _skipPaginationSearch;
         private readonly List<int> _activeCategoryIdFilters = new();
         private MarketRegionType _regionType;
@@ -68,8 +98,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             }
         }
 
-        private readonly List<string> _itemIds = new();
-        private readonly List<int> _itemPrices = new();
+        private IList<MarketListingEntry> _rows = new List<MarketListingEntry>();
 
         public GuiBindingList<string> CategoryNames
         {
@@ -175,27 +204,19 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             var credits = GetGold(Player);
             var results = DB.Search(query);
 
-            _itemIds.Clear();
-            _itemPrices.Clear();
-            var itemIconResrefs = new GuiBindingList<string>();
-            var itemNames = new GuiBindingList<string>();
-            var itemPriceNames = new GuiBindingList<string>();
-            var itemBuyEnabled = new GuiBindingList<bool>();
-
+            var rows = new List<MarketListingEntry>();
             foreach (var record in results)
             {
-                _itemIds.Add(record.Id);
-                _itemPrices.Add(record.Price);
-                itemIconResrefs.Add(record.IconResref);
-                itemNames.Add($"{record.Quantity}x {record.Name}");
-                itemPriceNames.Add($"{record.Price} cr");
-                itemBuyEnabled.Add(credits >= record.Price);
+                rows.Add(new MarketListingEntry(
+                    record.Id,
+                    record.IconResref,
+                    $"{record.Quantity}x {record.Name}",
+                    $"{record.Price} cr",
+                    record.Price,
+                    credits >= record.Price));
             }
 
-            ItemIconResrefs = itemIconResrefs;
-            ItemNames = itemNames;
-            ItemPriceNames = itemPriceNames;
-            ItemBuyEnabled = itemBuyEnabled;
+            _rows = ItemsTable.Refresh(this, rows);
         }
 
         private void UpdatePagination(long totalRecordCount)
@@ -246,7 +267,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
         public Action OnClickExamine() => () =>
         {
             var index = NuiGetEventArrayIndex();
-            var itemId = _itemIds[index];
+            var itemId = _rows[index].ItemId;
             var dbItem = DB.Get<MarketItem>(itemId);
 
             var item = ObjectPlugin.Deserialize(dbItem.Data);
@@ -258,9 +279,10 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
         public Action OnClickBuy() => () =>
         {
             var index = NuiGetEventArrayIndex();
-            var itemId = _itemIds[index];
-            var itemName = ItemNames[index];
-            var price = _itemPrices[index];
+            var row = _rows[index];
+            var itemId = row.ItemId;
+            var itemName = row.Name;
+            var price = row.Price;
 
             ShowModal($"Are you sure you want to buy '{itemName}' for {price} credits?", () =>
             {
@@ -293,7 +315,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
 
                 // Item's price has been changed since the player's search.
                 // Notify them and refresh the search.
-                if (dbItem.Price != _itemPrices[index])
+                if (dbItem.Price != row.Price)
                 {
                     FloatingTextStringOnCreature("The price of this item has been changed by the seller. Please try again.", Player, false);
                     Search();
@@ -315,12 +337,9 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
                 ObjectPlugin.AcquireItem(Player, item);
 
                 // Remove this item from the client's search results.
-                _itemIds.RemoveAt(index);
-                _itemPrices.RemoveAt(index);
-                ItemIconResrefs.RemoveAt(index);
-                ItemNames.RemoveAt(index);
-                ItemPriceNames.RemoveAt(index);
-                ItemBuyEnabled.RemoveAt(index);
+                var currentIndex = _rows.IndexOf(row);
+                if (currentIndex >= 0)
+                    ItemsTable.RemoveRowAt(this, _rows, currentIndex);
 
                 // Remove the item from the database.
                 DB.Delete<MarketItem>(itemId);

--- a/SWLOR.Game.Server/Readmes/Builders.md
+++ b/SWLOR.Game.Server/Readmes/Builders.md
@@ -411,6 +411,48 @@ builder.Create("rat_loot")
 - **IsRare()** - Mark as rare loot table
 - **AddItem(string, int, int, int)** - Add item with chance and quantity range
 
+### 17. GuiWindowBuilder
+
+**Location**: `Service/GuiService/GuiWindowBuilder.cs`
+
+The GuiWindowBuilder creates NUI windows (definition + partial views) for the MVVM GUI
+layer. Windows also need a `GuiWindowType` enum entry and a ViewModel deriving
+`GuiViewModelBase<TDerived, TPayload>`.
+
+#### Basic Usage
+
+```csharp
+var builder = new GuiWindowBuilder<ExampleViewModel>();
+var window = builder.CreateWindow(GuiWindowType.Example)
+    .SetInitialGeometry(0, 0, 900f, 560f)
+    .SetTitle("Example")
+    .SetIsResizable(true)
+    .DefinePartialView(ExampleViewModel.FirstTabPartial, AddFirstTab);
+
+// The only root layout shape proven to track window geometry (rule R5):
+window.AddStandardLayout(layout =>
+{
+    layout.SetTabPanelHeight(48f);
+    layout.AddTabRow(row => { /* toggles row */ });
+    layout.SetContentPartialElement(ExampleViewModel.TabContentElement);
+    layout.AddSideColumn(AddSideRail, 240f);
+});
+
+return builder.Build();
+```
+
+#### Key Methods
+
+- **CreateWindow(GuiWindowType)** - Initialize the window (returns `GuiWindow<T>`)
+- **SetInitialGeometry / SetTitle / SetIsResizable / SetIsCollapsible** - Window chrome
+- **DefinePartialView(string, Action<GuiGroup<T>>)** - Declare a swappable layout
+- **AddStandardLayout(Action<GuiStandardLayoutConfig<T>>)** - Emit the proven tab/content/rail shape (`GuiStandardLayout` extension)
+- **AddLeadingColumn / AddSideColumn** - Place fixed or flexible rails before or after the standard content column
+- **Build()** - Normalize and validate the root, log confirmed findings, and return the constructed window
+
+Full guide: `GuiWindowAuthoring.md`. Layout rules: `NuiLayoutRules.md`. Living widget
+reference: the DebugNuiGallery window (`/nuigallery`).
+
 ## Best Practices
 
 1. **Always call Build()** - Most builders require calling Build() to return the final result

--- a/SWLOR.Game.Server/Readmes/CoreSystems.md
+++ b/SWLOR.Game.Server/Readmes/CoreSystems.md
@@ -8,7 +8,7 @@ The Core layer contains fundamental systems, abstractions, and utilities that pr
 
 ## Directory Structure
 
-```
+```text
 Core/
 ├── Async/
 │   ├── Awaiters/
@@ -121,20 +121,25 @@ await NwTask.Run(() => {
 - `NuiChartType.cs` - Chart types
 - Various GUI components
 
-**Usage**:
-```csharp
-// Create NUI window
-var window = new NuiWindow("MyWindow", "My Window")
-{
-    Geometry = new NuiRect(0, 0, 400, 300)
-};
+**Usage**: Windows are NOT built against this low-level layer directly. Author them
+with the MVVM wrapper: an `IGuiWindowDefinition` using `GuiWindowBuilder<TViewModel>`
+plus a `GuiViewModelBase` ViewModel:
 
-// Add elements to window
-window.Elements.Add(new NuiLabel("Hello World")
+```csharp
+var window = _builder.CreateWindow(GuiWindowType.Example)
+    .SetInitialGeometry(0, 0, 900f, 560f)
+    .SetTitle("Example");
+
+window.AddStandardLayout(layout =>
 {
-    Geometry = new NuiRect(10, 10, 100, 20)
+    layout.SetContentPartialElement(ExampleViewModel.TabContentElement);
 });
+
+return _builder.Build();
 ```
+
+See `Readmes/GuiWindowAuthoring.md` for the full authoring guide and
+`Readmes/NuiLayoutRules.md` for the layout rules.
 
 ### 5. Bioware Extensions
 

--- a/SWLOR.Game.Server/Readmes/GuiWindowAuthoring.md
+++ b/SWLOR.Game.Server/Readmes/GuiWindowAuthoring.md
@@ -1,0 +1,334 @@
+# GUI Window Authoring Guide
+
+How to build a new NUI window in SWLOR, end to end. Companion docs:
+`NuiLayoutRules.md` (the layout rules R1–R7 referenced throughout) and the living
+widget reference: the DebugNuiGallery window (`/nuigallery` in-game;
+`Feature/GuiDefinition/DebugNuiGalleryDefinition.cs`), which renders every widget,
+binding path, and known-good/known-bad layout shape.
+
+## 1. End-to-end checklist
+
+A window is three classes plus one enum entry. Registration is automatic
+(reflection) — the enum entry is the only registry edit.
+
+1. **Enum entry** — add to `Service/GuiService/GuiWindowType.cs`. Player-facing
+   windows use the next sequential id; debug windows use the 900 range
+   (`DebugEnmity = 900`, `DebugNuiGallery = 901`). Duplicate ids throw at boot.
+2. **Definition** — `Feature/GuiDefinition/<Name>Definition.cs`, implements
+   `IGuiWindowDefinition`; builds the layout with `GuiWindowBuilder<TViewModel>`.
+3. **ViewModel** — `Feature/GuiDefinition/ViewModel/<Name>ViewModel.cs`, derives
+   `GuiViewModelBase<TDerived, TPayload>` (use `GuiPayloadBase` directly when no
+   open-time payload is needed).
+4. **Open path** — `Gui.TogglePlayerWindow(player, GuiWindowType.X)`. For a debug
+   window, add a chat command to
+   `Feature/ChatCommandDefinition/DebuggingChatCommand.cs` following `NuiGallery()`:
+
+```csharp
+private void NuiGallery()
+{
+    _builder.Create("nuigallery")
+        .Description("Opens the NUI control gallery debug window")
+        .Permissions(AuthorizationLevel.Admin)
+        .AvailableToAllOnTestEnvironment()
+        .Action((user, target, location, args) =>
+        {
+            Gui.TogglePlayerWindow(user, GuiWindowType.DebugNuiGallery);
+        });
+}
+```
+
+## 2. ViewModel lifecycle (what actually happens, in order)
+
+`GuiViewModelBase.Bind(...)` runs every time the window opens
+(`Service/GuiService/GuiViewModelBase.cs`):
+
+1. Geometry defaults to the definition's `SetInitialGeometry` if unset (per-player
+   geometry is persisted across sessions in `Player.WindowGeometries`).
+2. **Rebind loop**: every property value stored from a previous open is pushed to
+   the client again (null-valued entries are skipped defensively).
+3. `Geometry` is watched; `ModalInputText` is set then watched (the input modal only
+   reports typed text while watched — rule R3's canonical example).
+4. `%%WINDOW_MAIN%%` is swapped into the root.
+5. The Geometry watch is re-issued one tick later (the client can drop it during the
+   initial root layout).
+6. **`Initialize(payload)` runs** — your override. Assign every bound property FIRST,
+   then issue `WatchOnClient` calls, then select the default tab. `WatchOnClient`
+   throws a descriptive exception if the property was never assigned (R3).
+
+Client → server flow: a watched bind change invokes `UpdatePropertyFromClient`, which
+sets the property **through its public setter via reflection**. `SkipNotify` only
+suppresses the echo push back to the client — **your setter body still runs**. This is
+why setters with side effects (logging, driving other properties) fire on every client
+sync, and why tab-swap logic must not live in a widget-bound property setter (R4).
+
+Properties use the `Get`/`Set` dictionary pattern:
+
+```csharp
+public string StatusText { get => Get<string>(); set => Set(value); }
+```
+
+Assigning a property pushes it to the client immediately. `GuiBindingList<T>` values
+also push on in-place mutation (`Add`/`RemoveAt`/indexer) — see §5 for the exception.
+
+## 3. Canonical skeleton (copy this shape)
+
+A minimal two-tab window with a side rail, using the proven components:
+`GuiStandardLayout` (rule R5), `GuiTabGroup`/`GuiToggleGroupSync` (rule R4), and
+`OnModalClosedRestore` (rule R6). The skill assets
+(`.codex/skills/swlor-gui-window-generation/assets/`) carry this same pair as
+fill-in templates.
+
+**Definition:**
+
+```csharp
+public class ExampleDefinition : IGuiWindowDefinition
+{
+    private readonly GuiWindowBuilder<ExampleViewModel> _builder = new();
+
+    private const float TabRowHeight = 28f;      // tabbar rows: the ONE legal
+    private const float TabPanelHeight = 48f;    //   fixed-height-row pairing (R2c)
+    private const float ContentPanelWidth = 560f; // fixed-width tab panels (R5)
+    private const float SideRailWidth = 240f;
+
+    public GuiConstructedWindow BuildWindow()
+    {
+        var window = _builder.CreateWindow(GuiWindowType.Example)
+            .SetInitialGeometry(0, 0, 900f, 560f)
+            .SetTitle("Example")
+            .SetIsResizable(true)
+            .SetIsCollapsible(true)
+            .BindOnClosed(model => model.OnWindowClosed())
+            // One partial per tab; names live on the ViewModel as consts.
+            .DefinePartialView(ExampleViewModel.FirstTabPartial, AddFirstTab)
+            .DefinePartialView(ExampleViewModel.SecondTabPartial, AddSecondTab);
+
+        // R5: never hand-roll the root. This emits the only shape proven to
+        // track window geometry (content column + side rails in ONE root row).
+        window.AddStandardLayout(layout =>
+        {
+            layout.SetTabPanelHeight(TabPanelHeight);
+            layout.AddTabRow(row =>
+            {
+                row.SetHeight(TabRowHeight);
+                row.AddToggles()                     // toggles are margin-free,
+                    .AddOption("First")              //  so row+widget may share a
+                    .AddOption("Second")             //  fixed height (R2c exception)
+                    .BindSelectedValue(model => model.TabToggleValue)
+                    .SetWidth(232f)
+                    .SetHeight(TabRowHeight);
+            });
+            layout.SetContentPartialElement(ExampleViewModel.TabContentElement);
+            layout.AddSideColumn(AddSideRail, SideRailWidth);
+        });
+
+        return _builder.Build();
+    }
+
+    // Each tab: a fixed-width borderless panel (R5). Scrolling comes from the
+    // standard layout's content host group.
+    private static void AddFirstTab(GuiGroup<ExampleViewModel> host)
+    {
+        host.AddColumn(col =>
+        {
+            col.AddRow(row =>
+            {
+                row.AddGroup(panel =>
+                {
+                    panel.SetShowBorder(false);
+                    panel.SetScrollbars(NuiScrollbars.None);
+                    panel.AddColumn(content =>
+                    {
+                        content.AddRow(r => r.AddLabel()
+                            .BindText(model => model.StatusText)
+                            .SetHeight(20f)
+                            .SetHorizontalAlign(NuiHorizontalAlign.Left));
+                        content.AddRow(r =>
+                        {
+                            // No row height: rows with buttons derive their
+                            // height from children + margins (R2c).
+                            r.AddButton()
+                                .SetText("Do Something")
+                                .SetHeight(32f)
+                                .SetWidth(160f)
+                                .BindOnClicked(model => model.OnClickDoSomething());
+                            r.AddSpacer();
+                        });
+                    });
+                })
+                    .SetWidth(ContentPanelWidth);
+            });
+        });
+    }
+
+    private static void AddSecondTab(GuiGroup<ExampleViewModel> host) { /* same shape */ }
+
+    private static void AddSideRail(GuiColumn<ExampleViewModel> col) { /* labels, image, etc. */ }
+}
+```
+
+**ViewModel:**
+
+```csharp
+public class ExampleViewModel : GuiViewModelBase<ExampleViewModel, GuiPayloadBase>
+{
+    private const int FirstTabId = 0;
+    private const int SecondTabId = 1;
+    public const string TabContentElement = "example_tab_content";
+    public const string FirstTabPartial = "EXAMPLE_TAB_FIRST";
+    public const string SecondTabPartial = "EXAMPLE_TAB_SECOND";
+
+    // R4: tab registration + toggle sync are static, shared by all instances.
+    private static readonly GuiTabGroup<ExampleViewModel, GuiPayloadBase> Tabs =
+        new GuiTabGroup<ExampleViewModel, GuiPayloadBase>()
+            .AddTab(FirstTabId, FirstTabPartial)
+            .AddTab(SecondTabId, SecondTabPartial, m => m.RefreshSecondTab());
+
+    private static readonly GuiToggleGroupSync TabToggles = new(FirstTabId, SecondTabId);
+
+    public int SelectedTabId { get => Get<int>(); set => Set(value); }
+
+    // R4: the widget-bound value property only forwards GENUINE user clicks.
+    public int TabToggleValue
+    {
+        get => Get<int>();
+        set
+        {
+            Set(value);
+            TabToggles.HandleClientChange(value, SelectTab);
+        }
+    }
+
+    public string StatusText { get => Get<string>(); set => Set(value); }
+
+    protected override void Initialize(GuiPayloadBase initialPayload)
+    {
+        // R3: assign every bound property BEFORE any WatchOnClient call.
+        StatusText = "Ready.";            // TODO: data plumbing
+        TabToggleValue = 0;
+
+        WatchOnClient(model => model.TabToggleValue);
+
+        SelectTab(FirstTabId);
+    }
+
+    public override Action OnWindowClosed() => () => { };
+
+    private void SelectTab(int tabId)
+    {
+        SelectedTabId = tabId;
+        TabToggles.SyncTo(tabId, v => TabToggleValue = v);
+        Tabs.Select(this, TabContentElement, tabId);
+    }
+
+    // R6: modal close wipes the nested tab partial; the base hook restores it.
+    protected override void OnModalClosedRestore() => Tabs.Select(this, TabContentElement, SelectedTabId);
+
+    private void RefreshSecondTab()
+    {
+        // TODO: data plumbing
+    }
+
+    public Action OnClickDoSomething() => () =>
+    {
+        // Click handlers RETURN an Action (invoked by the event pipeline).
+        StatusText = "Clicked.";          // TODO: data plumbing
+    };
+}
+```
+
+## 4. Binding-type table
+
+| C# property type | Binds to (builder call) |
+|---|---|
+| `string` | `BindText` (label/button/checkbox/text), `BindTooltip`, `BindValue` (textedit), `BindResref`/`BindImageResref` (image/image button), `BindPlaceholder`, `BindLegend` (chart) |
+| `int` | `BindSelectedValue` (toggles/options), `BindSelectedIndex` (combo), `BindValue`/`BindMinimum`/`BindMaximum`/`BindStepSize` (slider int) |
+| `float` | `BindValue` (progress 0–1, slider float), slider float min/max/step |
+| `bool` | `BindIsChecked` (checkbox), `BindIsToggled` (toggle button), `BindIsEnabled`, `BindIsVisible`, `BindIsEncouraged` |
+| `GuiColor` | `BindColor` (any widget foreground), `BindSelectedColor` (color picker), chart slot color, draw-list item color |
+| `GuiRectangle` | `Geometry` (automatic), `BindRegion` (image), `BindBounds` (draw-list items) |
+| `GuiBindingList<string/int/bool/float/GuiRectangle/GuiVector2/GuiColor>` | list template cells + `BindRowCount`, chart `BindData` (`float`) |
+| `GuiBindingList<GuiComboEntry>` | `BindOptions` (combo) — **NOT change-hooked**: see §5 |
+
+Methods bound to events (`BindOnClicked`, `BindOnMouseDown/Up`, `BindOnOpened/Closed`)
+must be `public Action MethodName() => () => { ... };` — they return the action the
+event pipeline invokes.
+
+**Bind expressions must be bare property references** (`m => m.Prop`). Interpolation,
+concatenation, or method calls inside the lambda (e.g. `m => $"{m.Count} / {m.Max}"`)
+compile but throw `ArgumentException` in `GuiHelper.GetPropertyName` at boot, aborting
+window template loading. Computed display text gets its own string property that the
+ViewModel recomputes when its inputs change.
+
+## 5. Lists and tables
+
+**Row-templated lists** (`AddList`): each cell's widget binds a
+`GuiBindingList<T>` property; the row index is implicit. Always call
+`BindRowCount(model => model.SomeList)` — it wires the row count AND per-row
+visibility workarounds. Keep every cell's list the same length (mismatches render
+but show stale/blank cells — gallery P11).
+
+```csharp
+row.AddList(template =>
+{
+    template.AddCell(cell => cell.AddLabel().BindText(model => model.Names)
+        .SetHorizontalAlign(NuiHorizontalAlign.Left));
+    template.AddCell(cell =>
+    {
+        cell.SetIsVariable(false);            // element-sized fixed cell:
+        cell.AddButton().SetText("Pick")      //  the button's width sizes it
+            .SetWidth(44f)
+            .BindOnClicked(model => model.OnClickRow());
+    });
+})
+    .BindRowCount(model => model.Names)
+    .SetRowHeight(28f);
+```
+
+Per-row clicks recover their row via `NuiGetEventArrayIndex()` inside the handler.
+
+**Mutation:** in-place `Add`/`RemoveAt`/indexer on a `GuiBindingList<T>` pushes
+automatically. Replacing the whole list object also works and re-hooks events.
+**Exception:** `GuiBindingList<GuiComboEntry>` is not one of the hooked types — always
+replace the whole object (see the gallery's `OnClickReplaceComboOptions`).
+
+**Tables** (`AddTable` extension on `GuiColumn`, from
+`Service/GuiService/Component/GuiTable.cs`): declarative header + list. Fixed columns
+need `width > 0` (R1 — throws otherwise); only the last column defaults to variable.
+`AddComponentColumn` hosts buttons/widgets; `SetShowHeader(false)` + explicit
+`BindRowCount` for headerless lists. Pair with `GuiTableSource<TViewModel,TRow>` on
+the VM side to refresh all column lists from one row-DTO list.
+
+## 6. Partials, tabs, and modals
+
+- `DefinePartialView(name, builder)` declares a swappable layout; it renders only
+  when applied to an element via `ChangePartialView(elementId, partialName)` (direct)
+  or `SwapNestedPartialView(...)` (root-redraw-safe path used by `GuiTabGroup`).
+- Tabs: register in a static `GuiTabGroup`, sync toggle rows with
+  `GuiToggleGroupSync`, drive swaps from `SelectTab` — exactly as in §3. Never bind
+  the swap-driving property to the widget (R4).
+- **Windows without tabs still use `AddStandardLayout`** (R5 applies regardless):
+  zero `AddTabRow` calls, ONE partial holding the entire body (stacked sections as
+  rows inside it), applied at the end of `Initialize` via
+  `ChangePartialView(TabContentElement, MainContentPartial)` — and re-applied in
+  `OnModalClosedRestore` if the window shows modals (R6).
+- Element ids are NOT validated server-side; a typo produces a client-only error and
+  the window must be reopened (R7). Keep ids as ViewModel consts.
+- Maximum nesting: window root → partial → one nested slot. Three-deep content gets
+  dropped by parent re-applies (R7).
+- Modals: `ShowModal(prompt, onConfirm, onCancel)` / `ShowInputModal(...)` (read
+  `ModalInputText` in the confirm action). Any tabbed window MUST override
+  `OnModalClosedRestore` (R6) or its tab content vanishes when the modal closes.
+
+## 7. Validation gate (all four, in order)
+
+1. `dotnet build SWLOR.Game.Server.Tests/SWLOR.Game.Server.Tests.csproj -p:RunPostBuildEvent=Never`
+   followed by `dotnet test SWLOR.Game.Server.Tests/SWLOR.Game.Server.Tests.csproj
+   --no-build --filter "FullyQualifiedName~GuiLayoutValidationTests"` — the corpus test
+   builds every GUI definition without the live engine and rejects unexpected findings.
+2. Boot the dev server: **zero `[NUI layout warning]` Server-log entries mentioning your window.**
+   The only expected warnings anywhere are DebugNuiGallery's six R2c canaries.
+3. Optional: pull your window's `[NUI JSON]` lines from
+   `debugserver/app_logs/Server/` and sanity-check the structure (root row → content
+   column + rails). Available on non-production boots or with `SWLOR_NUI_DUMP_JSON=1`.
+4. Open in-game via your chat command: walk every tab, resize the window (content
+   must track), exercise every modal path (tab content must survive).

--- a/SWLOR.Game.Server/Readmes/NuiLayoutRules.md
+++ b/SWLOR.Game.Server/Readmes/NuiLayoutRules.md
@@ -1,0 +1,202 @@
+# NUI Layout Rules for SWLOR GUI Windows
+
+NWN:EE's NUI layouts are solved client-side by a Cassowary constraint solver. When a
+layout is unsolvable the client shows `NuiSetLayout failed: The constraint can not be
+satisfied` in an "Error layoutupdate" window — with **no indication of which element or
+window caused it** — and the window renders empty or collapsed. These rules exist so
+that authoring mistakes are caught (or at least flagged with a widget path) at server
+boot instead.
+
+Every rule below states its enforcement level: **throws** (build/boot fails or the
+call raises a descriptive exception), **warns** (a structured `[NUI layout warning]` Server-log entry
+at boot), or **doc-only** (not statically detectable — follow the prescription).
+
+Enforcement lives in:
+- `Service/GuiService/GuiLayoutValidator.cs` — invoked from `GuiWindowBuilder.Build()`
+  for every window at boot; findings are written as structured `[NUI layout warning]` entries. The
+  validator flags **only shapes confirmed to fail in-game** via the DebugNuiGallery
+  hazard harness (`/nuigallery`), so **zero warning lines for your window is a hard
+  authoring gate — every warning is a real defect.** The bar for adding a new rule is
+  a confirmed-failing hazard/probe partial in the gallery first.
+- `Service/GuiService/Component/GuiTable.cs` (`GuiTableBuilder.Build`) — hard throw for
+  fixed zero-width table columns (R1).
+- `Service/GuiService/GuiViewModelBase.cs` (`WatchOnClient`) — hard throw with a
+  descriptive message when watching a never-assigned property (R3).
+
+All "verified in-game" stamps below come from the July 2026 DebugNuiGallery
+verification sessions; the gallery keeps every confirmed-failing and verified-working
+shape loadable as regression exhibits on its Hazards tab.
+
+## How the solver sees the wrapper components
+
+Verified against `Core/Beamdog/Nui.cs` and the engine's layout source:
+
+1. **`group` and `list` never advertise a size to their parent.** (`Nui.Group`'s own doc
+   comment: "Will not advise parent of size, so you need to let it fill a span
+   (col/row) as if it was an element.") `Nui.List` emits `row_template`/`row_count`/
+   `row_height` but no `width`/`height` of its own. The solver derives their extent
+   entirely from context: an explicit `SetWidth`/`SetHeight`, or the space left over in
+   their span.
+2. **The window root is externally bounded; nested partials are not.** The root layout
+   (`%%WINDOW_MAIN%%`) is swapped into the special `_window_` group, which is hard-bound
+   to the window's `Geometry` rect. A named partial applied via `NuiSetGroupLayout` to
+   an ordinary element (an `AddPartialView` group) has no such bound of its own.
+3. **Rows/columns position children with REQUIRED-strength constraints** (sequential
+   placement, `span_size >= child_size + margins` on the cross axis) while "children
+   fill the span" is only a MEDIUM-strength suggestion. Hard sizes always win over fill
+   behavior — and hard sizes that cannot coexist *within one row's cross axis* fail the
+   whole layout update.
+4. **List template cells** are `[element, width, variable]` triplets. `width > 0` +
+   `variable: false` = hard fixed column; `width: 0` + `variable: true` = fill column.
+   A fixed cell (`variable: false`) with no width of its own is also solvable when its
+   inner element declares a positive width (e.g. a button with `SetWidth(32f)`) — and
+   in-game testing showed even a fixed cell with no width anywhere renders (see
+   "Verified-working shapes" below).
+
+## Authoring rules
+
+### R1 — Never declare a fixed table column without a positive width (throws)
+In `AddTable`, a column is only variable when you pass `isVariable: true` **or** it is
+the last declared column. Any other column resolves to fixed and must have `width > 0`.
+`GuiTableBuilder.Build` throws at boot naming the offending column.
+
+### R2c — Never give a row an explicit height equal to its margined children's height (warns; CONFIRMED)
+The engine's cross-axis constraint is REQUIRED-strength: `row_height >= child_height +
+child margins`, and **most widget families carry a nonzero default margin**. A row with
+`SetHeight(32f)` containing such a widget with `SetHeight(32f)` is mathematically
+unsolvable and blanks the whole window.
+
+Margin map, verified in-game 2026-07 via the gallery's margin-map probes:
+
+| Widget family | Default margin? | Fixed-height row + same-height child |
+|---|---|---|
+| Button / ButtonImage / ToggleButton | YES | **FAILS** (H1, original root cause) |
+| CheckBox | YES | **FAILS** (P1) |
+| TextEdit | YES | **FAILS** (P2) |
+| ComboBox | YES | **FAILS** (P3) |
+| SliderInt / SliderFloat | YES (float inferred: same engine widget) | **FAILS** (P4) |
+| ProgressBar | YES | **FAILS** (P6) |
+| Options | no | renders (P5) |
+| Toggles (tabbar) | no | renders (CharacterSheet tab rows) |
+| Label | untested; fixed-height labels in unheighted rows ship everywhere | — |
+
+Fix: **don't set a height on rows that contain fixed-height margined widgets** — let
+the row derive its height from children + margins. The only sanctioned equal-height
+pairings are `Toggles`/`Options` (the margin-free families), or controls that
+deliberately call `SetMargin(0f)` for a tightly packed grid such as Slicing tiles.
+The validator reads the explicit margin and keeps those layouts warning-free.
+
+### R3 — Assign a property before watching it (throws)
+`WatchOnClient(model => model.X)` serializes the property's **current** value.
+`GuiViewModelBase.WatchOnClient` now throws a descriptive `InvalidOperationException`
+if the property was never assigned. Always assign first:
+
+```csharp
+TabToggleValue = 0;                               // Set first
+WatchOnClient(model => model.TabToggleValue);     // then watch that property
+```
+
+History: before this guard existed, watching an unset property NRE'd mid-`Initialize`
+AND left a poisoned null-valued entry that made **every subsequent reopen of the
+window throw** for that player until a server restart (confirmed via gallery hazard
+H6). `Bind` also now skips null-valued entries defensively during its reopen rebind.
+
+### R4 — Keep toggle widgets and tab-content orchestration on separate properties (doc-only)
+Bind the `AddToggles` widget to a plain value property synchronized through
+`GuiToggleGroupSync`, and drive partial swaps from a separate selected-tab property via
+`GuiTabGroup`. Binding the swap-triggering property directly to the widget re-enters
+the swap logic on every client echo (client pushes re-run property setters — only the
+echo push is suppressed, not the setter body).
+
+### R5 — Use the standard root layout shape (doc-only; helper-enforced)
+Only ONE root layout shape has been proven to track window geometry correctly as the
+client resizes a window (CharacterSheet's shape):
+
+```text
+root column
+  └── single row ("main row")
+        ├── variable-width CONTENT column
+        │     ├── optional fixed-height borderless Auto-scroll group holding the
+        │     │   tab-bar rows (28f rows of Toggles — the margin-free pairing)
+        │     └── borderless Auto-scroll group hosting AddPartialView(contentElement)
+        └── side column(s) — e.g. an event log or actions rail
+```
+
+`GuiWindowBuilder` normalizes every authored window into the shared outer root shape.
+For a window with tabs, swappable content, or rails, call
+`GuiStandardLayout.AddStandardLayout(...)`
+(`Service/GuiService/Component/GuiStandardLayout.cs`) instead of hand-rolling that
+inner structure. Deviating — most notably putting tab rows as siblings of the body
+row — froze the content region at a constant width regardless of window resizing.
+The all-window corpus test builds every definition through this normalizer and rejects
+unexpected validator findings.
+
+Side rails may be fixed-width (`fixedWidth: 280f`) or variable (`fixedWidth: null`);
+both verified working in-game 2026-07 (the gallery ships a variable-width event log).
+
+Tab partials themselves should be **fixed-width borderless `Scrollbars(None)` panels**
+(CharacterSheet uses 250–460f; the gallery uses 560f). Scrolling comes from the
+content column's Auto-scroll host group, which keeps every partial compressible when
+a player's persisted window geometry is small. `Gui.CreatePlayerWindows` discards
+only non-positive persisted dimensions; legitimate compact HUD windows are as small
+as 72x52 and must retain their saved positions.
+
+### R6 — Re-apply the current tab partial after any modal closes (framework hook)
+Closing `ShowModal`/`ShowInputModal` swaps `%%WINDOW_MAIN%%` back into the root, which
+**wipes any partial applied to a nested element** — the selected tab's content
+disappears. Tabbed windows must override the base-class hook:
+
+```csharp
+protected override void OnModalClosedRestore() => Tabs.Select(this, TabContentElement, SelectedTabId);
+```
+
+The hook fires after every modal close (confirm and cancel, both modal kinds).
+
+### R7 — Partial-view element rules (doc-only; verified 2026-07)
+- **Element ids are not validated server-side.** `ChangePartialView` onto a
+  nonexistent element id produces a client-side `NuiSetLayout failed: element id not
+  found` error and the window must be closed/reopened (gallery P13a). Keep element-id
+  constants in the ViewModel and reference them from the definition.
+- **Do not nest partials more than 2 deep** (window root → partial → nested slot is
+  the proven maximum, used by every tabbed window). At 3 deep the innermost content
+  renders and is then dropped by the parent's re-apply pass (gallery P13b).
+- After a partial swap makes the whole window layout fail (e.g. loading an R2c shape),
+  subsequent `NuiSetGroupLayout` calls report `element id not found` because the
+  client discarded the layout — close and reopen the window.
+
+## Verified-working shapes (do not fear these)
+
+All verified in-game 2026-07 via DebugNuiGallery; each remains loadable on the
+Hazards tab as a regression exhibit. The validator deliberately does **not** warn on
+any of these:
+
+- **Unbounded non-terminal list in a named partial** (W1; also ships in
+  DMPlayerExamine NotesView, AppearanceEditor's part/color lists, Settings' Chat view).
+- **Tall fixed-height stacks with no scroll wrapper** (W2: 12 × 120f groups) — the
+  old "R2b" fear; keep partials compressible anyway per R5's scroll-host prescription.
+- **Fixed list template cell with no width anywhere** (W3).
+- **Fixed children wider than their fixed parent** (W4: two 150f buttons in a 200f
+  group; P7: 150f button in a 100f group) — width conflicts clip/overflow rather than
+  failing the solve. Only *cross-axis height* conflicts in rows (R2c) kill layouts.
+- **Aspect + explicit width AND height on one image** (P8), **invalid image resref**
+  (P8 — renders as blank), **zero dimensions** (P9), **negative dimensions** (P10).
+- **Length-mismatched binding lists across one list's cells** (P11) and **empty bound
+  chart/combo data** (P12) — render without failure.
+
+## Diagnosing a client-side layout error
+
+1. Check the Server log for `[NUI layout warning]` entries for that window. On dev/test the
+   ONLY expected warnings are the gallery's six R2c canaries (enumerated in
+   `DebugNuiGalleryDefinition.cs`'s header); anything else is a real defect.
+2. Read the built-in wire-JSON dump: every window's root and partial JSON is logged as
+   `[NUI JSON]` lines to the Server log group (`debugserver/app_logs/Server/`) on
+   non-production boots, or anywhere with `SWLOR_NUI_DUMP_JSON=1`. Diff the failing
+   window against a working one (`CharacterSheet`) rather than reasoning from the C#
+   builders. Note: element ids for event-bound widgets are fresh GUIDs each boot —
+   normalize them before diffing across boots.
+3. If geometry is suspect, temporarily log the rect in `Gui.TogglePlayerWindow`'s
+   open branch, `Gui.SaveWindowGeometry`, and `GuiViewModelBase.UpdatePropertyFromClient`
+   (for `Geometry`) — this exposes degenerate client pushes and persistence poisoning.
+4. Reproduce the suspect construct in DebugNuiGallery's hazard slot: add a probe
+   partial + button (see the existing `DefineFixedRowProbe` pattern), verify in-game,
+   then record the outcome here and — if it fails — promote it to a validator rule.

--- a/SWLOR.Game.Server/Service/Gui.cs
+++ b/SWLOR.Game.Server/Service/Gui.cs
@@ -119,6 +119,23 @@ namespace SWLOR.Game.Server.Service
                     playerGeometry.Height = defaultGeometry.Height;
                 }
 
+                // A window that failed a client-side layout solve can report a degenerate
+                // size, which then persists on close and poisons every future open of that
+                // window at the broken size. Discard implausibly small saved sizes.
+                // Some intentional HUD windows are as small as 72x52, so only
+                // reject the non-positive geometry produced by a failed solve.
+                // A broad pixel threshold would erase valid saved positions for
+                // PlayerStatusPortrait and the other compact status windows.
+                const float MinimumSaneDimension = 1f;
+                if (playerGeometry.Width < MinimumSaneDimension ||
+                    playerGeometry.Height < MinimumSaneDimension)
+                {
+                    playerGeometry.Width = defaultGeometry.Width;
+                    playerGeometry.Height = defaultGeometry.Height;
+                    playerGeometry.X = defaultGeometry.X;
+                    playerGeometry.Y = defaultGeometry.Y;
+                }
+
                 // Add the window
                 var playerWindow = window.CreatePlayerWindowAction();
                 playerWindow.ViewModel.Geometry = playerGeometry;
@@ -174,6 +191,29 @@ namespace SWLOR.Game.Server.Service
             dbPlayer.WindowGeometries[windowType] = geometry;
 
             DB.Set(dbPlayer);
+        }
+
+        private const float GeometrySaveDebounceSeconds = 2f;
+        private static readonly HashSet<string> _pendingGeometrySaves = new();
+
+        /// <summary>
+        /// Persists window geometry shortly after the client reports a move/resize.
+        /// Dragging fires a stream of watch events and each save is a full player
+        /// document write, so writes are coalesced to at most one per window per
+        /// debounce interval. The delayed save reads the view model's geometry at
+        /// fire time, so it always persists the latest reported rect.
+        /// </summary>
+        private static void QueueWindowGeometrySave(string playerId, GuiWindowType windowType, GuiPlayerWindow playerWindow)
+        {
+            var key = $"{playerId}:{windowType}";
+            if (!_pendingGeometrySaves.Add(key))
+                return;
+
+            DelayCommand(GeometrySaveDebounceSeconds, () =>
+            {
+                _pendingGeometrySaves.Remove(key);
+                SaveWindowGeometry(playerId, windowType, playerWindow.ViewModel.Geometry);
+            });
         }
 
         /// <summary>
@@ -270,6 +310,11 @@ namespace SWLOR.Game.Server.Service
             var playerWindow = playerWindows[windowType];
 
             playerWindow.ViewModel.UpdatePropertyFromClient(propertyName);
+
+            // Geometry changes are persisted as they happen (debounced) so window
+            // positions survive crashes and close paths that skip the close-time save.
+            if (propertyName == nameof(IGuiViewModel.Geometry))
+                QueueWindowGeometrySave(playerId, windowType, playerWindow);
         }
 
         /// <summary>

--- a/SWLOR.Game.Server/Service/GuiService/Component/GuiStandardLayout.cs
+++ b/SWLOR.Game.Server/Service/GuiService/Component/GuiStandardLayout.cs
@@ -1,0 +1,229 @@
+// ============================================================================
+// GuiStandardLayout.cs
+//
+// PROBLEM THIS SOLVES
+// --------------------
+// Only ONE root layout shape has been proven to correctly track window
+// geometry as the client resizes a window: a single root column containing
+// ONE row (the "main row"), whose first column is variable-width content
+// (an optional fixed-height borderless Auto-scroll group hosting tab-bar
+// rows, followed by a borderless Auto-scroll group hosting the swappable
+// tab-content partial) and whose remaining columns are fixed-width side
+// rails. CharacterSheetDefinition.cs's root block is the origin of this
+// shape.
+//
+// Deviating from it - most notably, putting the tab-bar rows as SIBLING
+// ROWS of the body row directly in the root column instead of nesting both
+// under one shared row - froze the content region at a constant width
+// regardless of window resizing. That mistake cost two failed iterations of
+// a debug gallery window before the shape above was confirmed correct by
+// direct comparison against CharacterSheet. See Readmes/NuiLayoutRules.md
+// (rule R5) for the layout-rule writeup.
+//
+// This helper exists so a new window author can declare "these are my tab
+// rows, this is my content partial, these are my side columns" and get the
+// proven-correct nesting automatically, instead of hand-rolling the root
+// block and risking that same regression again.
+// ============================================================================
+
+using System;
+using System.Collections.Generic;
+using SWLOR.Game.Server.Core.Beamdog;
+using SWLOR.Game.Server.Service.GuiService;
+
+namespace SWLOR.Game.Server.Service.GuiService.Component
+{
+    /// <summary>
+    /// Fluent configuration surface for <see cref="GuiStandardLayout.AddStandardLayout{T}"/>.
+    /// Collects tab rows, the swappable content partial, and side columns,
+    /// then hands them to the helper to emit in the proven-correct nesting.
+    /// </summary>
+    public class GuiStandardLayoutConfig<T> where T : IGuiViewModel
+    {
+        private readonly List<Action<GuiRow<T>>> _tabRows = new();
+        private readonly List<(Action<GuiColumn<T>> BuildColumn, float? FixedWidth)> _leadingColumns = new();
+        private readonly List<(Action<GuiColumn<T>> BuildColumn, float? FixedWidth)> _sideColumns = new();
+
+        internal float? TabPanelHeightValue { get; private set; }
+        internal string ContentElementId { get; private set; }
+        internal IReadOnlyList<Action<GuiRow<T>>> TabRows => _tabRows;
+        internal IReadOnlyList<(Action<GuiColumn<T>> BuildColumn, float? FixedWidth)> LeadingColumns => _leadingColumns;
+        internal IReadOnlyList<(Action<GuiColumn<T>> BuildColumn, float? FixedWidth)> SideColumns => _sideColumns;
+
+        /// <summary>
+        /// Sets the fixed height of the tab-bar panel (the group that hosts
+        /// every row added via <see cref="AddTabRow"/>). Required if any tab
+        /// rows are added.
+        /// </summary>
+        public GuiStandardLayoutConfig<T> SetTabPanelHeight(float height)
+        {
+            TabPanelHeightValue = height;
+            return this;
+        }
+
+        /// <summary>
+        /// Adds one row to the tab-bar panel. The row-building action is
+        /// passed through untouched - the caller is responsible for its own
+        /// SetHeight/AddToggles/etc. calls, exactly as if building a row
+        /// directly.
+        /// </summary>
+        public GuiStandardLayoutConfig<T> AddTabRow(Action<GuiRow<T>> buildRow)
+        {
+            _tabRows.Add(buildRow);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the partial-view element id hosted by the content region.
+        /// Required.
+        /// </summary>
+        public GuiStandardLayoutConfig<T> SetContentPartialElement(string elementId)
+        {
+            ContentElementId = elementId;
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a rail before the variable-width content column.
+        /// </summary>
+        public GuiStandardLayoutConfig<T> AddLeadingColumn(Action<GuiColumn<T>> buildColumn, float? fixedWidth = null)
+        {
+            _leadingColumns.Add((buildColumn, fixedWidth));
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a side column to the main row, after the content column.
+        /// Side columns are emitted in the order they are added. Pass
+        /// <paramref name="fixedWidth"/> to pin the column's width, matching
+        /// the fixed-width rail columns (e.g. an event log) used alongside
+        /// the variable-width content column.
+        /// </summary>
+        public GuiStandardLayoutConfig<T> AddSideColumn(Action<GuiColumn<T>> buildColumn, float? fixedWidth = null)
+        {
+            _sideColumns.Add((buildColumn, fixedWidth));
+            return this;
+        }
+    }
+
+    /// <summary>
+    /// Emits the only root layout shape proven to track window geometry
+    /// correctly: root column -> single row -> [variable-width content
+    /// column | fixed-width side column(s)]. The content column holds an
+    /// optional fixed-height borderless Auto-scroll group for tab-bar rows,
+    /// then a borderless Auto-scroll group hosting the swappable tab-content
+    /// partial. Deviating from this shape - e.g. putting tab rows as SIBLING
+    /// ROWS of the body row in the root column - freezes the content region
+    /// at a constant width regardless of window resizing (see
+    /// Readmes/NuiLayoutRules.md rule R5; CharacterSheet is the origin of
+    /// this shape).
+    /// </summary>
+    public static class GuiStandardLayout
+    {
+        /// <summary>
+        /// Normalizes every window's authored root elements into the shared root shape
+        /// before the main partial is serialized. GuiWindowBuilder applies this to the
+        /// complete window corpus; specialized layouts still compose their content with
+        /// <see cref="AddStandardLayout{T}"/> first.
+        /// </summary>
+        internal static GuiWindow<T> DefineStandardMainPartial<T>(
+            this GuiWindow<T> window,
+            IReadOnlyList<IGuiWidget> authoredElements)
+            where T : IGuiViewModel
+        {
+            return window.DefinePartialView("%%WINDOW_MAIN%%", group =>
+            {
+                group.AddColumn(root =>
+                {
+                    root.AddRow(mainRow =>
+                    {
+                        mainRow.Elements.AddRange(authoredElements);
+                    });
+                });
+            });
+        }
+
+        public static GuiWindow<T> AddStandardLayout<T>(this GuiWindow<T> window, Action<GuiStandardLayoutConfig<T>> configure)
+            where T : IGuiViewModel
+        {
+            var config = new GuiStandardLayoutConfig<T>();
+            configure(config);
+
+            if (string.IsNullOrEmpty(config.ContentElementId))
+            {
+                throw new InvalidOperationException(
+                    "GuiStandardLayout requires SetContentPartialElement to be called.");
+            }
+
+            if (config.TabRows.Count > 0 && !config.TabPanelHeightValue.HasValue)
+            {
+                throw new InvalidOperationException(
+                    "GuiStandardLayout requires SetTabPanelHeight to be called when one or more AddTabRow rows are configured.");
+            }
+
+            window.AddColumn(root =>
+            {
+                root.AddRow(mainRow =>
+                {
+                    AddColumns(mainRow, config.LeadingColumns);
+
+                    mainRow.AddColumn(contentCol =>
+                    {
+                        if (config.TabRows.Count > 0)
+                        {
+                            contentCol.AddRow(tabPanelRow =>
+                            {
+                                tabPanelRow.AddGroup(tabPanel =>
+                                {
+                                    tabPanel.SetShowBorder(false);
+                                    tabPanel.SetScrollbars(NuiScrollbars.Auto);
+                                    tabPanel.AddColumn(tabCol =>
+                                    {
+                                        foreach (var buildRow in config.TabRows)
+                                        {
+                                            tabCol.AddRow(buildRow);
+                                        }
+                                    });
+                                })
+                                    .SetHeight(config.TabPanelHeightValue.Value);
+                            });
+                        }
+
+                        contentCol.AddRow(contentRow =>
+                        {
+                            contentRow.AddGroup(host =>
+                            {
+                                host.SetShowBorder(false);
+                                host.SetScrollbars(NuiScrollbars.Auto);
+                                host.AddColumn(hostCol =>
+                                {
+                                    hostCol.AddRow(hostRow =>
+                                    {
+                                        hostRow.AddPartialView(config.ContentElementId);
+                                    });
+                                });
+                            });
+                        });
+                    });
+
+                    AddColumns(mainRow, config.SideColumns);
+                });
+            });
+
+            return window;
+        }
+
+        private static void AddColumns<T>(
+            GuiRow<T> row,
+            IReadOnlyList<(Action<GuiColumn<T>> BuildColumn, float? FixedWidth)> columns)
+            where T : IGuiViewModel
+        {
+            foreach (var configuredColumn in columns)
+            {
+                var column = row.AddColumn(configuredColumn.BuildColumn);
+                if (configuredColumn.FixedWidth.HasValue)
+                    column.SetWidth(configuredColumn.FixedWidth.Value);
+            }
+        }
+    }
+}

--- a/SWLOR.Game.Server/Service/GuiService/Component/GuiTabGroup.cs
+++ b/SWLOR.Game.Server/Service/GuiService/Component/GuiTabGroup.cs
@@ -1,0 +1,132 @@
+// ============================================================================
+// GuiTabGroup.cs
+//
+// PROBLEM THIS SOLVES
+// --------------------
+// CharacterSheetViewModel.RestoreSelectedTabPartial() layers a SECOND,
+// manual redraw workaround on top of a fix ChangePartialView already does
+// automatically (GuiViewModelBase.ApplyRefreshBugFix nudges Geometry.Height
+// on every ChangePartialView call). The manual layer exists specifically
+// because *nested* partials (a partial swapped inside another partial's
+// content area) can still get dropped mid-redraw - per the existing code
+// comment: "NUI can drop nested partial layouts while its parent is being
+// redrawn." The workaround is: force a full root redraw, apply the target
+// partial, then reapply it again one tick later.
+//
+// Separately, TopTabId/BottomTabId require a hand-written re-entrancy guard
+// (_isSynchronizingTabRows) purely to keep two paired toggle groups and one
+// logical SelectedTabId from feeding back into each other.
+//
+// Both of these are generic problems, not specific to the character sheet.
+// This file moves them into reusable helpers so a new window author doesn't
+// need to know the nested-partial bug exists at all.
+// ============================================================================
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using SWLOR.Game.Server.Service.GuiService;
+
+namespace SWLOR.Game.Server.Service.GuiService.Component
+{
+    // ------------------------------------------------------------------
+    // GuiViewModelBase<TDerived, TPayload> ALREADY HAS SwapNestedPartialView
+    // as of the patch applied directly to that file (see the diff added
+    // right after ChangePartialView). GuiTabGroup.Select below calls it
+    // directly - TViewModel must derive from a GuiViewModelBase to expose it.
+    // ------------------------------------------------------------------
+
+    // ------------------------------------------------------------------
+    // TAB REGISTRATION - replaces GetTabPartialName + the RefreshSelectedTabData
+    // switch statement + RestoreSelectedTabPartial's manual sequencing
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Registers a set of tabs (id -> partial name -> optional refresh action)
+    /// and drives selection through the nested-partial-safe swap path, so a
+    /// window author just describes "what tabs exist" instead of re-deriving
+    /// the redraw sequencing per window.
+    /// </summary>
+    public class GuiTabGroup<TViewModel, TPayload>
+        where TViewModel : GuiViewModelBase<TViewModel, TPayload>
+        where TPayload : GuiPayloadBase
+    {
+        private readonly Dictionary<int, (string PartialId, Action<TViewModel> OnSelected)> _tabs = new();
+
+        public GuiTabGroup<TViewModel, TPayload> AddTab(int tabId, string partialId, Action<TViewModel> onSelected = null)
+        {
+            _tabs[tabId] = (partialId, onSelected);
+            return this;
+        }
+
+        public string GetPartialName(int tabId) => _tabs[tabId].PartialId;
+
+        /// <summary>
+        /// Applies the given tab: runs its refresh action (if any) then swaps
+        /// the nested partial in via the safe double-reapply path.
+        /// </summary>
+        public void Select(TViewModel model, string contentElementId, int tabId)
+        {
+            if (!_tabs.TryGetValue(tabId, out var tab))
+                throw new KeyNotFoundException($"Tab id '{tabId}' was not registered in this GuiTabGroup.");
+
+            model.SwapNestedPartialView(contentElementId, tab.PartialId, () => tab.OnSelected?.Invoke(model));
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // PAIRED TOGGLE SYNC - replaces TopTabId/BottomTabId/_isSynchronizingTabRows
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Synchronizes N independent toggle-pair properties (e.g. TopTabId,
+    /// BottomTabId) against one logical selected-tab id, without a hand-written
+    /// re-entrancy flag per window. Each toggle group maps its local index
+    /// (0, 1, ...) to a shared tab id; selecting a tab drives all groups to
+    /// the right local index (or -1 if the tab isn't in that group), and a
+    /// toggle change routes back to the shared SelectTab call.
+    /// </summary>
+    public class GuiToggleGroupSync
+    {
+        private readonly List<int> _tabIdsInOrder;
+        private bool _isSyncing;
+
+        public GuiToggleGroupSync(params int[] tabIdsInOrder)
+        {
+            _tabIdsInOrder = tabIdsInOrder.ToList();
+        }
+
+        /// <summary>Local toggle index for a given tab id, or -1 if this group doesn't contain it.</summary>
+        public int LocalIndexFor(int tabId) => _tabIdsInOrder.IndexOf(tabId);
+
+        /// <summary>Tab id for a given local toggle index.</summary>
+        public int TabIdFor(int localIndex) => _tabIdsInOrder[localIndex];
+
+        /// <summary>
+        /// Wraps a toggle-group's setter so it ignores changes caused by
+        /// programmatic sync (avoiding the feedback loop _isSynchronizingTabRows
+        /// exists to prevent) and only forwards genuine user clicks.
+        /// </summary>
+        public void HandleClientChange(int localIndex, Action<int> onUserSelectedTab)
+        {
+            if (_isSyncing || localIndex < 0 || localIndex >= _tabIdsInOrder.Count)
+                return;
+
+            onUserSelectedTab(TabIdFor(localIndex));
+        }
+
+        /// <summary>Call when driving the toggle group's value programmatically (not from user input).</summary>
+        public void SyncTo(int tabId, Action<int> setLocalIndex)
+        {
+            _isSyncing = true;
+            try
+            {
+                setLocalIndex(LocalIndexFor(tabId));
+            }
+            finally
+            {
+                _isSyncing = false;
+            }
+        }
+    }
+}

--- a/SWLOR.Game.Server/Service/GuiService/Component/GuiTable.cs
+++ b/SWLOR.Game.Server/Service/GuiService/Component/GuiTable.cs
@@ -1,0 +1,460 @@
+// ============================================================================
+// GuiTable.cs
+//
+// PROBLEM THIS SOLVES
+// --------------------
+// CharacterSheetDefinition.cs currently repeats this shape 3 times (Stats,
+// Resistances, Crafting tabs): a manually-built header row (AddTableHeader
+// per column, width typed twice - once in the header, once in the cell),
+// an AddList/AddCell template with one GuiBindingList<string> per column,
+// and a BindRowCount pointing at an arbitrary "first" column as a row-count
+// proxy.
+//
+// CharacterSheetViewModel.cs mirrors this with 3 near-identical Refresh*
+// methods that build N parallel GuiBindingList<string> instances and .Add()
+// to all of them in lockstep inside a loop - nothing stops these from
+// drifting out of sync in length.
+//
+// This file does NOT change the underlying wire protocol. GuiViewModelBase
+// already has real, working machinery for GuiBindingList<T> (MaxSize
+// high-water-mark + ListItemVisibility bookkeeping to work around the
+// Beamdog/nwn-issues/427 bug, see OnPropertyChanged). NUI's AddList/AddCell
+// model binds each cell in the row template to a *separate top-level
+// property* (row index is implicit) - so column-per-property is a hard
+// framework constraint, not a design choice we're free to change here.
+//
+// Instead, this collapses the *boilerplate* around that constraint:
+//   - Definition side: one AddTable(...) call generates the header row +
+//     the AddList/AddCell block + BindRowCount, from column definitions.
+//   - ViewModel side: one GuiTableSource<TRow> holds the column mappings
+//     and does the parallel-list rebuild in one method, so a window author
+//     works with a single list of row DTOs instead of N hand-synced lists.
+//
+// COMPONENT COLUMNS
+// ------------------
+// A column doesn't have to be a bound text label. AddComponentColumn takes a
+// cell-builder callback instead of a bound expression, so a column can host
+// a button, toggle, image, or any other GuiExpandableComponent widget - the
+// same thing MarketBuyDefinition/AchievementsDefinition already do by hand
+// with raw AddList/AddCell blocks (row identity for a per-row click handler
+// is recovered via the engine-native NuiGetEventArrayIndex(), same as those).
+// A table's column list is no longer required to contain a text column at
+// all: SetShowHeader(false) drops the header row (some lists, like
+// MarketBuy's item list, never had one), and BindRowCount(...) lets the
+// caller name an explicit row-count source instead of relying on "the first
+// column happens to have a bound text expression". A column can also opt
+// into being width-flexible via isVariable regardless of position - by
+// default only the last column is flexible, matching the old behavior.
+// ============================================================================
+
+using SWLOR.Game.Server.Core.Beamdog;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using SWLOR.Game.Server.Service.GuiService;
+
+namespace SWLOR.Game.Server.Service.GuiService.Component
+{
+    // ------------------------------------------------------------------
+    // DEFINITION-SIDE: declarative column list -> header row + list template
+    // ------------------------------------------------------------------
+
+    public class GuiTableColumn<TViewModel> where TViewModel : IGuiViewModel
+    {
+        public string Header { get; }
+        public float Width { get; }
+        public string HeaderTooltip { get; }
+        public Expression<Func<TViewModel, GuiBindingList<string>>> ValueExpression { get; }
+        public Expression<Func<TViewModel, GuiBindingList<string>>> TooltipExpression { get; }
+
+        /// <summary>
+        /// When set, the cell is built by this callback instead of the default bound
+        /// label (see AddComponentColumn). Null for ordinary text columns.
+        /// </summary>
+        public Action<GuiTemplateCell<TViewModel>> CellBuilder { get; }
+
+        /// <summary>
+        /// Null means "auto": variable only if this is the last column, matching the
+        /// original behavior. Non-null lets a column opt in/out explicitly, since more
+        /// than one column in a row may need to flex (see MarketBuy's item list).
+        /// </summary>
+        public bool? IsVariable { get; }
+
+        public GuiTableColumn(
+            string header,
+            float width,
+            Expression<Func<TViewModel, GuiBindingList<string>>> valueExpression,
+            Expression<Func<TViewModel, GuiBindingList<string>>> tooltipExpression,
+            string headerTooltip,
+            Action<GuiTemplateCell<TViewModel>> cellBuilder = null,
+            bool? isVariable = null)
+        {
+            Header = header;
+            Width = width;
+            ValueExpression = valueExpression;
+            TooltipExpression = tooltipExpression;
+            HeaderTooltip = headerTooltip;
+            CellBuilder = cellBuilder;
+            IsVariable = isVariable;
+        }
+    }
+
+    public class GuiTableBuilder<TViewModel> where TViewModel : IGuiViewModel
+    {
+        private readonly List<GuiTableColumn<TViewModel>> _columns = new();
+        private float _rowHeight = 24f;
+        private bool _showHeader = true;
+        private float? _padding;
+        private Expression<Func<TViewModel, GuiBindingList<string>>> _rowCountExpression;
+
+        /// <summary>
+        /// Adds a bound text column. Unless BindRowCount is used, the row-count
+        /// source is the first column (in declared order) with a value expression.
+        /// </summary>
+        public GuiTableBuilder<TViewModel> AddColumn(
+            string header,
+            float width,
+            Expression<Func<TViewModel, GuiBindingList<string>>> valueExpression,
+            Expression<Func<TViewModel, GuiBindingList<string>>> tooltipExpression = null,
+            string headerTooltip = null,
+            bool? isVariable = null)
+        {
+            _columns.Add(new GuiTableColumn<TViewModel>(header, width, valueExpression, tooltipExpression, headerTooltip, null, isVariable));
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a text column with the player-facing header tooltip placed next
+        /// to the header declaration. This overload keeps table definitions easy
+        /// to scan when cells do not require their own tooltip binding.
+        /// </summary>
+        public GuiTableBuilder<TViewModel> AddColumn(
+            string header,
+            float width,
+            string headerTooltip,
+            Expression<Func<TViewModel, GuiBindingList<string>>> valueExpression,
+            Expression<Func<TViewModel, GuiBindingList<string>>> tooltipExpression = null,
+            bool? isVariable = null)
+        {
+            return AddColumn(header, width, valueExpression, tooltipExpression, headerTooltip, isVariable);
+        }
+
+        /// <summary>
+        /// Adds a column whose cell is built by the given callback instead of a bound
+        /// label - e.g. a button, toggle button, image, or any other
+        /// GuiExpandableComponent widget. Row identity for a per-row click handler is
+        /// recovered the same way any hand-rolled AddList/AddCell button already does:
+        /// via NuiGetEventArrayIndex() inside the bound method.
+        /// </summary>
+        public GuiTableBuilder<TViewModel> AddComponentColumn(
+            string header,
+            float width,
+            Action<GuiTemplateCell<TViewModel>> cellBuilder,
+            string headerTooltip = null,
+            bool? isVariable = null)
+        {
+            _columns.Add(new GuiTableColumn<TViewModel>(header, width, null, null, headerTooltip, cellBuilder, isVariable));
+            return this;
+        }
+
+        public GuiTableBuilder<TViewModel> SetRowHeight(float height)
+        {
+            _rowHeight = height;
+            return this;
+        }
+
+        /// <summary>
+        /// Shows or hides the header row. Defaults to true. Some lists (e.g.
+        /// MarketBuy's item list) never had a header row at all.
+        /// </summary>
+        public GuiTableBuilder<TViewModel> SetShowHeader(bool showHeader)
+        {
+            _showHeader = showHeader;
+            return this;
+        }
+
+        public GuiTableBuilder<TViewModel> SetPadding(float padding)
+        {
+            _padding = padding;
+            return this;
+        }
+
+        /// <summary>
+        /// Explicitly names the row-count source instead of relying on "the first
+        /// column with a bound text expression" - required when no text column
+        /// exists, and recommended whenever the natural row-count column isn't the
+        /// first one declared, so a later column reorder can't silently change it.
+        /// </summary>
+        public GuiTableBuilder<TViewModel> BindRowCount(Expression<Func<TViewModel, GuiBindingList<string>>> expression)
+        {
+            _rowCountExpression = expression;
+            return this;
+        }
+
+        internal void Build(GuiColumn<TViewModel> col)
+        {
+            if (_columns.Count == 0)
+                throw new InvalidOperationException("GuiTable requires at least one column.");
+
+            // A column that resolves to fixed-width (not variable) with no positive width
+            // produces a template cell the NUI solver can neither size nor grow. Fail at
+            // build time with the column named rather than as a client-side draw error.
+            for (var i = 0; i < _columns.Count; i++)
+            {
+                var column = _columns[i];
+                var isVariable = column.IsVariable ?? i == _columns.Count - 1;
+
+                if (!isVariable && column.Width <= 0f)
+                {
+                    var headerLabel = string.IsNullOrWhiteSpace(column.Header) ? $"index {i}" : $"'{column.Header}'";
+                    throw new InvalidOperationException(
+                        $"GuiTable column {headerLabel} resolves to a fixed width of {column.Width}. " +
+                        "Fixed columns must declare a positive width; pass isVariable: true if the column should flex. " +
+                        "Note that only the last column defaults to variable.");
+                }
+            }
+
+            if (_showHeader)
+            {
+                col.AddRow(headerRow =>
+                {
+                    for (var i = 0; i < _columns.Count; i++)
+                    {
+                        var column = _columns[i];
+                        var variable = column.IsVariable ?? i == _columns.Count - 1;
+                        // Variable columns get width 0 (fill remaining space), matching
+                        // the existing AddTableHeader convention in CharacterSheetDefinition.
+                        var width = variable ? 0f : column.Width;
+                        AddTableHeader(headerRow, column.Header, width, column.HeaderTooltip);
+                    }
+                });
+            }
+
+            var rowCountExpression = _rowCountExpression
+                ?? _columns.Select(c => c.ValueExpression).FirstOrDefault(e => e != null)
+                ?? throw new InvalidOperationException("GuiTable requires a row-count source: either a text column (AddColumn) or an explicit BindRowCount(...) call.");
+
+            col.AddRow(row =>
+            {
+                row.AddList(template =>
+                {
+                    for (var i = 0; i < _columns.Count; i++)
+                    {
+                        var column = _columns[i];
+                        var variable = column.IsVariable ?? i == _columns.Count - 1;
+
+                        template.AddCell(cell =>
+                        {
+                            if (!variable)
+                            {
+                                cell.SetIsVariable(false);
+                                cell.SetWidth(column.Width);
+                            }
+
+                            if (column.CellBuilder != null)
+                            {
+                                column.CellBuilder(cell);
+                            }
+                            else
+                            {
+                                var label = cell.AddLabel()
+                                    .BindText(column.ValueExpression)
+                                    .SetHorizontalAlign(NuiHorizontalAlign.Left);
+
+                                if (column.TooltipExpression != null)
+                                    label.BindTooltip(column.TooltipExpression);
+                            }
+                        });
+                    }
+
+                    if (_padding.HasValue)
+                        template.SetPadding(_padding.Value);
+                })
+                    .BindRowCount(rowCountExpression)
+                    .SetRowHeight(_rowHeight)
+                    .SetShowBorders(false)
+                    .SetScrollbars(NuiScrollbars.Y);
+            });
+        }
+
+        private static void AddTableHeader(GuiRow<TViewModel> row, string text, float width, string tooltip)
+        {
+            var label = row.AddLabel()
+                .SetText(text)
+                .SetHeight(22f)
+                .SetHorizontalAlign(NuiHorizontalAlign.Left);
+
+            if (width > 0f)
+                label.SetWidth(width);
+
+            if (!string.IsNullOrWhiteSpace(tooltip))
+                label.SetTooltip(tooltip);
+        }
+    }
+
+    public static class GuiTableExtensions
+    {
+        /// <summary>
+        /// Declares a table: header row + scrollable row-templated list, wired
+        /// to the given columns. Replaces the manual AddTableHeader + AddList/
+        /// AddCell + BindRowCount block previously duplicated per tab.
+        ///
+        /// Example (Stats tab, was ~35 lines, becomes):
+        ///
+        ///   tableCol.AddTable&lt;CharacterSheetViewModel&gt;(t => t
+        ///       .AddColumn("STAT", 190f, m => m.StatNames, m => m.StatTooltips, "Character stat.")
+        ///       .AddColumn("VALUE", 0f, m => m.StatValues, m => m.StatTooltips, "Current value.")
+        ///       .SetRowHeight(24f));
+        /// </summary>
+        public static void AddTable<TViewModel>(
+            this GuiColumn<TViewModel> col,
+            Action<GuiTableBuilder<TViewModel>> configure)
+            where TViewModel : IGuiViewModel
+        {
+            var builder = new GuiTableBuilder<TViewModel>();
+            configure(builder);
+            builder.Build(col);
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // VIEWMODEL-SIDE: one row-DTO list -> N parallel GuiBindingList<string>
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Owns the column mappings for a table and rebuilds the bound
+    /// GuiBindingList&lt;TValue&gt; properties from a single sequence of row
+    /// DTOs in one call, instead of a hand-rolled loop with N separate
+    /// .Add() calls that must stay in lockstep (see RefreshCharacterStatsList,
+    /// RefreshResistances, RefreshCraftingStats for the current duplicated
+    /// pattern this replaces). Columns aren't limited to string: any bound
+    /// value type (bool for a per-row enabled flag, etc.) is supported.
+    /// </summary>
+    public class GuiTableSource<TViewModel, TRow>
+    {
+        private sealed class ColumnBinding
+        {
+            public Action<TViewModel, IEnumerable<TRow>> Refresh;
+
+            /// <summary>Null if this column's Column(...) call didn't supply a getter - see RemoveRowAt.</summary>
+            public Action<TViewModel, int> Remove;
+            public Func<TViewModel, int, bool> CanRemove;
+        }
+
+        private readonly List<ColumnBinding> _columns = new();
+
+        /// <summary>
+        /// Registers a bound column: which ViewModel property receives the
+        /// values, and how to pull that column's value out of a row DTO.
+        /// The optional getter lets RemoveRowAt find this column's current
+        /// live bound list to remove a single row from it directly (a
+        /// GuiBindingList&lt;T&gt; mutation propagates to the client without
+        /// reassigning the property) - only needed if RemoveRowAt will be used.
+        /// </summary>
+        public GuiTableSource<TViewModel, TRow> Column<TValue>(
+            Action<TViewModel, GuiBindingList<TValue>> setter,
+            Func<TRow, TValue> valueSelector,
+            Func<TViewModel, GuiBindingList<TValue>> getter = null)
+        {
+            _columns.Add(new ColumnBinding
+            {
+                Refresh = (viewModel, rows) =>
+                {
+                    var list = new GuiBindingList<TValue>();
+                    foreach (var row in rows)
+                        list.Add(valueSelector(row));
+                    setter(viewModel, list);
+                },
+                Remove = getter == null ? null : (viewModel, index) => getter(viewModel).RemoveAt(index),
+                CanRemove = getter == null
+                    ? null
+                    : (viewModel, index) =>
+                    {
+                        var values = getter(viewModel);
+                        return values != null && index >= 0 && index < values.Count;
+                    }
+            });
+            return this;
+        }
+
+        /// <summary>
+        /// Rebuilds every bound column from the given rows in one pass.
+        /// Guarantees all columns stay the same length - the exact class of
+        /// bug the hand-rolled parallel-list pattern doesn't protect against.
+        /// Returns the row list that was refreshed from, so the caller can
+        /// hold onto it (e.g. for NuiGetEventArrayIndex() row lookups) the
+        /// same way it would hold any other per-instance state.
+        /// </summary>
+        public IList<TRow> Refresh(TViewModel viewModel, IEnumerable<TRow> rows)
+        {
+            var rowList = rows as IList<TRow> ?? rows.ToList();
+
+            foreach (var column in _columns)
+                column.Refresh(viewModel, rowList);
+
+            return rowList;
+        }
+
+        /// <summary>
+        /// Removes a single row: from the given row list, and from every
+        /// registered column's bound list. Throws if any column was
+        /// registered without a getter, since that column's bound list would
+        /// otherwise silently drift out of length-sync with the rest.
+        /// </summary>
+        public void RemoveRowAt(TViewModel viewModel, IList<TRow> rows, int index)
+        {
+            if (index < 0 || index >= rows.Count)
+                throw new ArgumentOutOfRangeException(nameof(index));
+
+            // Validate every bound list before any mutation.
+            for (var i = 0; i < _columns.Count; i++)
+            {
+                if (_columns[i].Remove == null)
+                    throw new InvalidOperationException($"Column {i} has no getter registered; cannot RemoveRowAt without leaving it out of sync. Pass a getter to Column(...) for every bound column before calling RemoveRowAt.");
+
+                if (!_columns[i].CanRemove(viewModel, index))
+                    throw new InvalidOperationException($"Column {i} does not contain row {index}; cannot RemoveRowAt without leaving the table out of sync. Refresh all bound columns before removing a row.");
+            }
+
+            rows.RemoveAt(index);
+            for (var i = 0; i < _columns.Count; i++)
+            {
+                var column = _columns[i];
+                column.Remove(viewModel, index);
+            }
+        }
+    }
+}
+
+// ============================================================================
+// USAGE EXAMPLE - how CharacterSheetViewModel's stats table would change
+// ============================================================================
+//
+// Row DTO (new):
+//
+//   public readonly record struct StatEntry(string Name, string Value, string Tooltip);
+//
+// Static table source, defined once:
+//
+//   private static readonly GuiTableSource<CharacterSheetViewModel, StatEntry> StatsTable =
+//       new GuiTableSource<CharacterSheetViewModel, StatEntry>()
+//           .Column((m, v) => m.StatNames = v, r => r.Name)
+//           .Column((m, v) => m.StatValues = v, r => r.Value)
+//           .Column((m, v) => m.StatTooltips = v, r => r.Tooltip);
+//
+// RefreshCharacterStatsList becomes:
+//
+//   private void RefreshCharacterStatsList()
+//   {
+//       var rows = new List<StatEntry>
+//       {
+//           new("HP Regen", GetHPRegenValue().ToString(), "Amount of HP restored automatically by natural regeneration."),
+//           new("FP Regen", GetFPRegenValue().ToString(), "Amount of FP restored automatically by natural regeneration."),
+//           // ... rest of the AddStat(...) calls become record entries here
+//       };
+//
+//       StatsTable.Refresh(this, rows);
+//   }
+//
+// The same GuiTableSource pattern applies directly to RefreshResistances and
+// RefreshCraftingStats - each becomes: build a List<TRow>, call .Refresh().

--- a/SWLOR.Game.Server/Service/GuiService/Component/GuiWidget.cs
+++ b/SWLOR.Game.Server/Service/GuiService/Component/GuiWidget.cs
@@ -14,6 +14,12 @@ namespace SWLOR.Game.Server.Service.GuiService.Component
         public List<IGuiWidget> Elements { get; }
         protected float Width { get; private set; }
         protected float Height { get; private set; }
+
+        /// <inheritdoc />
+        public float DeclaredHeight => Height;
+
+        /// <inheritdoc />
+        public float DeclaredMargin => Margin;
         private float AspectRatio { get; set; }
         private float Margin { get; set; } = -1f;
         private float Padding { get; set; }

--- a/SWLOR.Game.Server/Service/GuiService/GuiConstructedWindow.cs
+++ b/SWLOR.Game.Server/Service/GuiService/GuiConstructedWindow.cs
@@ -12,6 +12,7 @@ namespace SWLOR.Game.Server.Service.GuiService
         public CreatePlayerWindowDelegate CreatePlayerWindowAction { get; set; }
         public GuiRectangle InitialGeometry { get; set; }
         public Dictionary<string, Json> PartialViews { get; set; }
+        public IReadOnlyList<string> LayoutFindings { get; set; }
 
         public GuiConstructedWindow(
             GuiWindowType type,
@@ -19,6 +20,7 @@ namespace SWLOR.Game.Server.Service.GuiService
             Json window,
             GuiRectangle initialGeometry,
             Dictionary<string, Json> partialViews,
+            IReadOnlyList<string> layoutFindings,
             CreatePlayerWindowDelegate createPlayerWindowAction)
         {
             Type = type;
@@ -26,6 +28,7 @@ namespace SWLOR.Game.Server.Service.GuiService
             Window = window;
             InitialGeometry = initialGeometry;
             PartialViews = partialViews;
+            LayoutFindings = layoutFindings;
             CreatePlayerWindowAction = createPlayerWindowAction;
         }
     }

--- a/SWLOR.Game.Server/Service/GuiService/GuiLayoutValidator.cs
+++ b/SWLOR.Game.Server/Service/GuiService/GuiLayoutValidator.cs
@@ -1,0 +1,133 @@
+using System.Collections.Generic;
+using System.Threading;
+using SWLOR.Game.Server.Service.GuiService.Component;
+
+namespace SWLOR.Game.Server.Service.GuiService
+{
+    /// <summary>
+    /// Reports layout shapes confirmed to fail in-game via the DebugNuiGallery hazard harness
+    /// (/nuigallery); suspected-but-unconfirmed shapes are deliberately NOT flagged, because zero
+    /// `[NUI layout warning]` lines is a hard authoring gate—every warning must be a real defect.
+    /// The bar for adding a new rule: a confirmed-failing hazard partial in DebugNuiGallery first.
+    /// See Readmes/NuiLayoutRules.md.
+    /// </summary>
+    public static class GuiLayoutValidator
+    {
+        private static readonly AsyncLocal<int> ValidationOnlyBuildDepth = new();
+
+        internal static bool IsValidationOnlyBuild => ValidationOnlyBuildDepth.Value > 0;
+
+        /// <summary>
+        /// Builds window widget trees without serializing them through the live NWN engine.
+        /// This allows corpus validation in ordinary unit tests.
+        /// </summary>
+        public static IDisposable BeginValidationOnlyBuild()
+        {
+            ValidationOnlyBuildDepth.Value++;
+            return new ValidationOnlyBuildScope();
+        }
+
+        private sealed class ValidationOnlyBuildScope : IDisposable
+        {
+            private bool _disposed;
+
+            public void Dispose()
+            {
+                if (_disposed)
+                    return;
+
+                ValidationOnlyBuildDepth.Value--;
+                _disposed = true;
+            }
+        }
+
+        /// <summary>
+        /// Validates every partial view of a constructed window.
+        /// </summary>
+        /// <param name="windowId">The window id, used to prefix finding paths.</param>
+        /// <param name="partialViews">All partial views defined on the window, including the main/modal wrappers.</param>
+        /// <returns>Human-readable findings; empty when nothing suspicious was found.</returns>
+        public static List<string> Validate(string windowId, IReadOnlyDictionary<string, IGuiWidget> partialViews)
+        {
+            var findings = new List<string>();
+
+            foreach (var (partialName, partial) in partialViews)
+            {
+                Walk(
+                    partial,
+                    $"{windowId} > partial '{partialName}'",
+                    findings);
+            }
+
+            return findings;
+        }
+
+        private static void Walk(
+            IGuiWidget widget,
+            string path,
+            List<string> findings)
+        {
+            // A row with an explicit height must leave room for its children's default
+            // margins: the engine's REQUIRED constraint is row_height >= child_height
+            // + margins, and most widget families carry a nonzero default margin. A
+            // fixed row whose margined children are the same height (or taller) is
+            // therefore unsolvable. Buttons were the confirmed root cause of the
+            // the original failing window's layout; the DebugNuiGallery margin-map probes
+            // (2026-07, P1-P4/P6) confirmed checkbox, textedit, combo, slider, and
+            // progress fail identically. Only options and toggles (tabbar) are
+            // margin-free - which is why CharacterSheet's equal-height toggle rows
+            // are fine. GuiSliderFloat is included by inference: it is the same
+            // engine slider widget as the confirmed GuiSliderInt.
+            if (IsWidgetOfType(widget, typeof(GuiRow<>)) && widget.DeclaredHeight > 0f)
+            {
+                foreach (var child in widget.Elements)
+                {
+                    var hasDefaultMargin =
+                        IsWidgetOfType(child, typeof(GuiButton<>)) ||
+                        IsWidgetOfType(child, typeof(GuiButtonImage<>)) ||
+                        IsWidgetOfType(child, typeof(GuiToggleButton<>)) ||
+                        IsWidgetOfType(child, typeof(GuiCheckBox<>)) ||
+                        IsWidgetOfType(child, typeof(GuiTextEdit<>)) ||
+                        IsWidgetOfType(child, typeof(GuiComboBox<>)) ||
+                        IsWidgetOfType(child, typeof(GuiSliderInt<>)) ||
+                        IsWidgetOfType(child, typeof(GuiSliderFloat<>)) ||
+                        IsWidgetOfType(child, typeof(GuiProgressBar<>));
+
+                    if (hasDefaultMargin &&
+                        child.DeclaredMargin != 0f &&
+                        child.DeclaredHeight >= widget.DeclaredHeight)
+                    {
+                        findings.Add(
+                            $"{path}: row has explicit height {widget.DeclaredHeight} but contains a " +
+                            $"{DescribeWidget(child)} of height {child.DeclaredHeight}, leaving no room for the " +
+                            "widget's default margins (row_height >= child_height + margins is required). " +
+                            "Remove the row's SetHeight and let it derive from its children.");
+                    }
+                }
+            }
+
+            for (var index = 0; index < widget.Elements.Count; index++)
+            {
+                var child = widget.Elements[index];
+
+                Walk(
+                    child,
+                    $"{path} > {DescribeWidget(child)}[{index}]",
+                    findings);
+            }
+        }
+
+        private static bool IsWidgetOfType(IGuiWidget widget, Type openGenericType)
+        {
+            var type = widget.GetType();
+            return type.IsGenericType && type.GetGenericTypeDefinition() == openGenericType;
+        }
+
+        private static string DescribeWidget(IGuiWidget widget)
+        {
+            var name = widget.GetType().Name;
+            var backtickIndex = name.IndexOf('`');
+            return backtickIndex >= 0 ? name[..backtickIndex] : name;
+        }
+    }
+}

--- a/SWLOR.Game.Server/Service/GuiService/GuiViewModelBase.cs
+++ b/SWLOR.Game.Server/Service/GuiService/GuiViewModelBase.cs
@@ -8,9 +8,9 @@ using SWLOR.NWN.API.Engine;
 
 namespace SWLOR.Game.Server.Service.GuiService
 {
-    public abstract class GuiViewModelBase<TDerived, TPayload>: IGuiViewModel, INotifyPropertyChanged
-        where TDerived: GuiViewModelBase<TDerived, TPayload>
-        where TPayload: GuiPayloadBase
+    public abstract class GuiViewModelBase<TDerived, TPayload> : IGuiViewModel, INotifyPropertyChanged
+        where TDerived : GuiViewModelBase<TDerived, TPayload>
+        where TPayload : GuiPayloadBase
     {
         public uint TetherObject { get; private set; }
 
@@ -47,7 +47,7 @@ namespace SWLOR.Game.Server.Service.GuiService
         /// <typeparam name="T">The type of data to retrieve</typeparam>
         /// <param name="propertyName">The name of the property.</param>
         /// <returns>The retrieved object.</returns>
-        protected T Get<T>([CallerMemberName]string propertyName = null)
+        protected T Get<T>([CallerMemberName] string propertyName = null)
         {
             if (string.IsNullOrWhiteSpace(propertyName))
                 return default(T);
@@ -64,7 +64,7 @@ namespace SWLOR.Game.Server.Service.GuiService
         /// <typeparam name="T">The type of data to set.</typeparam>
         /// <param name="value">The new value to set.</param>
         /// <param name="propertyName">The name of the property.</param>
-        protected void Set<T>(T value, [CallerMemberName]string propertyName = null)
+        protected void Set<T>(T value, [CallerMemberName] string propertyName = null)
         {
             if (string.IsNullOrWhiteSpace(propertyName))
             {
@@ -145,13 +145,13 @@ namespace SWLOR.Game.Server.Service.GuiService
                 _propertyValues[propertyName].IsGuiList = true;
             }
 
-            if(!_propertyValues[propertyName].SkipNotify)
+            if (!_propertyValues[propertyName].SkipNotify)
                 OnPropertyChanged(propertyName);
         }
 
         private void OnListChanged(object sender, ListChangedEventArgs e)
         {
-            var list = ((IGuiBindingList) sender);
+            var list = ((IGuiBindingList)sender);
             OnPropertyChanged(list.PropertyName);
         }
 
@@ -248,13 +248,36 @@ namespace SWLOR.Game.Server.Service.GuiService
             // Rebind any existing properties (in the event the window was closed and reopened)
             foreach (var (name, propertyDetail) in _propertyValues)
             {
+                // A null value means the property was never assigned. Serializing it
+                // would throw and permanently prevent this window from ever reopening
+                // for this player - confirmed via the DebugNuiGallery hazard harness
+                // (H6), where recovery required a full server restart. Skip instead.
+                if (propertyDetail.Value == null)
+                    continue;
+
                 var json = _converter.ToJson(propertyDetail.Value);
                 NuiSetBind(Player, WindowToken, name, json);
             }
 
             WatchOnClient(model => model.Geometry);
 
+            // The input modal's text box only reports typed text back to the server
+            // while this bind is watched. Set before watching (layout rule R3).
+            ModalInputText = string.Empty;
+            WatchOnClient(model => model.ModalInputText);
+
             ChangePartialView("_window_", "%%WINDOW_MAIN%%");
+
+            // The client can drop the Geometry watch while the initial root layout is
+            // applied; until a relayout re-arms it, window moves never reach the server
+            // and the stale open position is what gets persisted at close. Re-issue the
+            // watch once the root layout has settled so the first move is captured.
+            DelayCommand(0.0f, () =>
+            {
+                if (Gui.IsWindowOpen(Player, WindowType))
+                    WatchOnClient(model => model.Geometry);
+            });
+
             var convertedPayload = payload == null ? default : (TPayload)payload;
             Initialize(convertedPayload);
         }
@@ -271,6 +294,20 @@ namespace SWLOR.Game.Server.Service.GuiService
             var value = _converter.ToObject(json, property.Type);
             var currentValue = GetType().GetProperty(propertyName)?.GetValue(this);
 
+            // The client transiently reports a 0x0 geometry while it relayouts a window
+            // (e.g. during the ChangePartialView redraw nudges). Accepting it corrupts the
+            // server-side geometry: a pending redraw nudge can then push a negative height
+            // (client shows "constraint can not be satisfied"), or - if no server push
+            // follows - the window permanently collapses to a bare title bar. Reject the
+            // degenerate rect and re-assert the last known-good geometry instead.
+            if (propertyName == nameof(Geometry) &&
+                value is GuiRectangle degenerateCheck &&
+                (degenerateCheck.Width < 1f || degenerateCheck.Height < 1f))
+            {
+                NuiSetBind(Player, WindowToken, nameof(Geometry), Geometry.ToJson());
+                return;
+            }
+
             _propertyValues[propertyName].Value = value;
             _propertyValues[propertyName].SkipNotify = true;
             if (!currentValue.Equals(value))
@@ -282,11 +319,9 @@ namespace SWLOR.Game.Server.Service.GuiService
         }
 
         /// <summary>
-        /// Called after a client-watched property (e.g. Geometry on window resize) has been applied to
-        /// the view model. Client updates suppress the standard change notification to avoid echo loops,
-        /// so view models which need to react to them (e.g. resize-driven layout binds) override this.
+        /// Called after a client-watched property has been applied to this view model.
+        /// Client updates suppress normal property notification to avoid echo loops.
         /// </summary>
-        /// <param name="propertyName">The name of the property that was updated by the client.</param>
         protected virtual void OnClientPropertyUpdated(string propertyName)
         {
         }
@@ -299,8 +334,19 @@ namespace SWLOR.Game.Server.Service.GuiService
         protected void WatchOnClient<TProperty>(Expression<Func<TDerived, TProperty>> expression)
         {
             var propertyName = GuiHelper<TDerived>.GetPropertyName(expression);
-            if (!_propertyValues.ContainsKey(propertyName))
-                _propertyValues[propertyName] = new PropertyDetail();
+
+            // Watching serializes the property's CURRENT value, so the property must
+            // have been assigned first (layout rule R3). Fail fast with a clear
+            // message instead of an NRE - and without creating a null-valued entry,
+            // which would poison every subsequent Bind/reopen of this window
+            // (confirmed via the DebugNuiGallery hazard harness, H6).
+            if (!_propertyValues.ContainsKey(propertyName) ||
+                _propertyValues[propertyName].Value == null)
+            {
+                throw new InvalidOperationException(
+                    $"Property '{propertyName}' must be assigned a value before WatchOnClient is called " +
+                    "(layout rule R3 - see Readmes/NuiLayoutRules.md). Assign it in Initialize first, then watch.");
+            }
 
             var value = _propertyValues[propertyName].Value;
             var json = _converter.ToJson(value);
@@ -333,6 +379,35 @@ namespace SWLOR.Game.Server.Service.GuiService
             ChangePartialView("_window_", "%%WINDOW_MODAL%%");
         }
 
+        /// <summary>
+        /// Displays an input modal on top of the active window. Unlike ShowModal's
+        /// yes/no prompt, this presents a multiline text box the player can type into.
+        /// The confirm action reads the submitted text from <see cref="ModalInputText"/>.
+        /// </summary>
+        /// <param name="prompt">The text to display above the text box.</param>
+        /// <param name="initialText">The text pre-filled into the text box.</param>
+        /// <param name="confirmAction">The action to run when the player confirms.</param>
+        /// <param name="cancelAction">The action to run when the player cancels.</param>
+        /// <param name="confirmText">The confirmation text to display.</param>
+        /// <param name="cancelText">The cancel text to display.</param>
+        protected void ShowInputModal(
+            string prompt,
+            string initialText,
+            Action confirmAction,
+            Action cancelAction = null,
+            string confirmText = "Send",
+            string cancelText = "Cancel")
+        {
+            ModalPromptText = prompt;
+            ModalConfirmButtonText = confirmText;
+            ModalCancelButtonText = cancelText;
+            ModalInputText = initialText ?? string.Empty;
+            _callerConfirmAction = confirmAction;
+            _callerCancelAction = cancelAction;
+
+            ChangePartialView("_window_", "%%WINDOW_INPUT_MODAL%%");
+        }
+
         /// <inheritdoc />
         public void ChangePartialView(string elementId, string partialName)
         {
@@ -344,19 +419,55 @@ namespace SWLOR.Game.Server.Service.GuiService
         }
 
         /// <summary>
-        /// Swaps a group element's layout for one generated at runtime. NUI layout attributes
-        /// (width/height) are static and cannot be bound, so layouts which must react to window
-        /// geometry (e.g. stretching content on resize) are regenerated and swapped in via this
-        /// method. Event handlers keep working as long as the regenerated elements reuse the same
-        /// element Ids that were registered when the window was built.
+        /// Swaps a group element's layout for one generated at runtime. Event handlers
+        /// remain valid when regenerated elements reuse their registered element IDs.
         /// </summary>
-        /// <param name="elementId">The Id of the group element to swap.</param>
-        /// <param name="layout">The new layout to apply.</param>
         protected void SetGroupLayout(string elementId, Json layout)
         {
             NuiSetGroupLayout(Player, WindowToken, elementId, layout);
-
             ApplyRefreshBugFix();
+        }
+
+        /// <summary>
+        /// Swaps a partial view that is nested inside another partial (e.g. a
+        /// tab's content area within a window whose own root is a partial).
+        /// NUI can silently drop a nested partial layout while its parent is
+        /// being redrawn. This forces a root redraw first, applies the target
+        /// partial, then reapplies it once more on the next tick to guarantee
+        /// it survives the parent's redraw pass.
+        /// </summary>
+        /// <param name="elementId">The nested element id to change.</param>
+        /// <param name="partialName">The partial view to apply.</param>
+        /// <param name="onBeforeApply">
+        /// Optional callback run immediately before each apply (e.g. to refresh
+        /// the data the partial will display). Runs twice - once per apply -
+        /// matching the existing RestoreSelectedTabPartial behavior.
+        /// </param>
+        /// <remarks>
+        /// Public rather than protected: orchestrator helpers like GuiTabGroup
+        /// live outside the ViewModel's own type hierarchy and need to call
+        /// this from the outside, the same way ChangePartialView already is.
+        /// </remarks>
+        public void SwapNestedPartialView(string elementId, string partialName, Action onBeforeApply = null)
+        {
+            void Apply()
+            {
+                onBeforeApply?.Invoke();
+                ChangePartialView(elementId, partialName);
+            }
+
+            ChangePartialView("_window_", "%%WINDOW_MAIN%%");
+            Apply();
+
+            // The delayed re-apply can fire after the player has already closed (or
+            // rapidly toggled) the window; NuiSetGroupLayout against a destroyed window
+            // raises a client-side "element id not found" error. Only re-apply while
+            // the window is still open.
+            DelayCommand(0.0f, () =>
+            {
+                if (Gui.IsWindowOpen(Player, WindowType))
+                    Apply();
+            });
         }
 
 
@@ -378,6 +489,14 @@ namespace SWLOR.Game.Server.Service.GuiService
             private set => Set(value);
         }
 
+        // Public setter (unlike the other modal properties): the client pushes typed
+        // text back through the watch pipeline, which sets this via reflection.
+        public string ModalInputText
+        {
+            get => Get<string>();
+            set => Set(value);
+        }
+
         private Action _callerConfirmAction;
         private Action _callerCancelAction;
 
@@ -388,37 +507,67 @@ namespace SWLOR.Game.Server.Service.GuiService
 
             ModalConfirmButtonText = "Yes";
             ModalCancelButtonText = "No";
+            ModalInputText = string.Empty;
 
             _callerConfirmAction = null;
             _callerCancelAction = null;
         };
 
-        public Action OnModalConfirmClick() => () =>
+        /// <summary>
+        /// Called after ANY modal (ShowModal / ShowInputModal) closes - confirm or
+        /// cancel - after the caller's confirm/cancel action has run. Closing a
+        /// modal swaps %%WINDOW_MAIN%% back into the root, which wipes any partial
+        /// currently applied to a nested element (e.g. the selected tab's content).
+        /// Tabbed windows should override this and re-apply their current tab
+        /// partial. Default: no-op.
+        /// </summary>
+        protected virtual void OnModalClosedRestore()
         {
-            ChangePartialView("_window_", "%%WINDOW_MAIN%%");
-            OnMainViewRestored();
-
-            if (_callerConfirmAction != null)
-                _callerConfirmAction();
-        };
-
-        public Action OnModalCancelClick() => () =>
-        {
-            ChangePartialView("_window_", "%%WINDOW_MAIN%%");
-            OnMainViewRestored();
-
-            if (_callerCancelAction != null)
-                _callerCancelAction();
-        };
+        }
 
         /// <summary>
-        /// Called after the main window view is restored (e.g. when a modal closes). Windows which
-        /// swap runtime-generated layouts into nested groups must reapply them here: restoring the
-        /// main view re-renders the static window template, whose nested placeholder groups are empty.
+        /// Called immediately after the static main view is restored. Windows that
+        /// install runtime-generated nested layouts should reapply them here.
         /// </summary>
         protected virtual void OnMainViewRestored()
         {
         }
+
+        private void CloseModalAndRestore(Action callerAction)
+        {
+            ChangePartialView("_window_", "%%WINDOW_MAIN%%");
+            OnMainViewRestored();
+            try
+            {
+                callerAction?.Invoke();
+            }
+            finally
+            {
+                // A failed confirm action must not leave a tabbed window with
+                // its nested content erased by the root-modal swap.
+                OnModalClosedRestore();
+            }
+        }
+
+        public Action OnModalConfirmClick() => () =>
+        {
+            CloseModalAndRestore(_callerConfirmAction);
+        };
+
+        public Action OnModalCancelClick() => () =>
+        {
+            CloseModalAndRestore(_callerCancelAction);
+        };
+
+        public Action OnInputModalConfirmClick() => () =>
+        {
+            CloseModalAndRestore(_callerConfirmAction);
+        };
+
+        public Action OnInputModalCancelClick() => () =>
+        {
+            CloseModalAndRestore(_callerCancelAction);
+        };
 
         /// <summary>
         /// Default implementation for OnWindowClosed.

--- a/SWLOR.Game.Server/Service/GuiService/GuiWindowBuilder.cs
+++ b/SWLOR.Game.Server/Service/GuiService/GuiWindowBuilder.cs
@@ -1,7 +1,9 @@
 using System.Collections.Generic;
 using System.Linq;
 using SWLOR.Game.Server.Core.Beamdog;
+using SWLOR.Game.Server.Enumeration;
 using SWLOR.Game.Server.Service.GuiService.Component;
+using SWLOR.Game.Server.Service.LogService;
 using SWLOR.NWN.API.Engine;
 
 namespace SWLOR.Game.Server.Service.GuiService
@@ -70,17 +72,10 @@ namespace SWLOR.Game.Server.Service.GuiService
         /// <returns>A constructed window.</returns>
         public GuiConstructedWindow Build()
         {
+            var authoredElements = _activeWindow.Elements.ToList();
+
             _activeWindow
-                .DefinePartialView("%%WINDOW_MAIN%%", group =>
-                {
-                    group.AddColumn(col =>
-                    {
-                        col.AddRow(row =>
-                        {
-                            row.Elements.AddRange(_activeWindow.Elements.ToList());
-                        });
-                    });
-                })
+                .DefineStandardMainPartial(authoredElements)
                 .DefinePartialView("%%WINDOW_MODAL%%", group =>
                 {
                     group.AddColumn(mainCol =>
@@ -115,6 +110,67 @@ namespace SWLOR.Game.Server.Service.GuiService
                             });
                         });
                     });
+                })
+                .DefinePartialView("%%WINDOW_INPUT_MODAL%%", group =>
+                {
+                    // Like %%WINDOW_MODAL%%, but with a multiline text box the player
+                    // can type into. The typed text flows back to the server through
+                    // the always-watched ModalInputText bind (see GuiViewModelBase.Bind).
+                    group.AddColumn(mainCol =>
+                    {
+                        mainCol.AddRow(mainRow =>
+                        {
+                            mainRow.AddColumn(col =>
+                            {
+                                col.AddRow(row =>
+                                {
+                                    row.AddText()
+                                        .BindText(model => model.ModalPromptText)
+                                        .SetScrollbars(NuiScrollbars.None)
+                                        .SetShowBorder(false)
+                                        .SetHeight(64f);
+                                });
+
+                                // Unsized scrollable wrapper so the fixed-height editor
+                                // can never make the layout's required height exceed the
+                                // window viewport (layout rule R2b).
+                                col.AddRow(row =>
+                                {
+                                    row.AddGroup(editorGroup =>
+                                    {
+                                        editorGroup.SetShowBorder(false);
+                                        editorGroup.SetScrollbars(NuiScrollbars.Auto);
+                                        editorGroup.AddColumn(editorCol =>
+                                        {
+                                            editorCol.AddRow(editorRow =>
+                                            {
+                                                editorRow.AddTextEdit()
+                                                    .SetIsMultiline(true)
+                                                    .SetMaxLength(4000)
+                                                    .BindValue(model => model.ModalInputText)
+                                                    .SetHeight(450f);
+                                            });
+                                        });
+                                    });
+                                });
+
+                                col.AddRow(row =>
+                                {
+                                    row.AddSpacer();
+                                    row.AddButton()
+                                        .BindText(model => model.ModalConfirmButtonText)
+                                        .BindOnClicked(model => model.OnInputModalConfirmClick())
+                                        .SetHeight(35f);
+
+                                    row.AddButton()
+                                        .BindText(model => model.ModalCancelButtonText)
+                                        .BindOnClicked(model => model.OnInputModalCancelClick())
+                                        .SetHeight(35f);
+                                    row.AddSpacer();
+                                });
+                            });
+                        });
+                    });
                 });
 
             _activeWindow.Elements.Clear();
@@ -128,6 +184,34 @@ namespace SWLOR.Game.Server.Service.GuiService
                     });
                 });
 
+            var windowId = Gui.BuildWindowId(_type);
+
+            // Surface layout shapes confirmed to fail NUI's client-side constraint
+            // solver, with a widget path - the client error itself carries no context.
+            // Every warning is a real defect; see GuiLayoutValidator and Readmes/NuiLayoutRules.md.
+            var layoutFindings = GuiLayoutValidator.Validate(windowId, _activeWindow.PartialViews);
+
+            if (GuiLayoutValidator.IsValidationOnlyBuild)
+            {
+                return new GuiConstructedWindow(
+                    _type,
+                    windowId,
+                    default,
+                    _activeWindow.Geometry,
+                    new Dictionary<string, Json>(),
+                    layoutFindings,
+                    () =>
+                    {
+                        var dataModelInstance = Activator.CreateInstance<T>();
+                        return new GuiPlayerWindow(dataModelInstance);
+                    });
+            }
+
+            foreach (var finding in layoutFindings)
+            {
+                Log.WriteStructured(LogGroup.Server, "[NUI layout warning] {Finding}", finding);
+            }
+
             var partialViews = new Dictionary<string, Json>();
             foreach (var (key, partial) in _activeWindow.PartialViews)
             {
@@ -135,7 +219,30 @@ namespace SWLOR.Game.Server.Service.GuiService
             }
 
             var json = _activeWindow.Build();
-            var windowId = Gui.BuildWindowId(_type);
+
+            // Dump the exact wire JSON for layout debugging (see Readmes/NuiLayoutRules.md,
+            // "Diagnosing a client-side layout error"). Lands in the Server log group.
+            var environment = ApplicationSettings.Get().ServerEnvironment;
+            if (environment == ServerEnvironmentType.Development ||
+                environment == ServerEnvironmentType.Test ||
+                Environment.GetEnvironmentVariable("SWLOR_NUI_DUMP_JSON") == "1")
+            {
+                Log.WriteStructured(
+                    LogGroup.Server,
+                    "[NUI JSON] window={WindowId} root={RootJson}",
+                    windowId,
+                    JsonDump(json));
+                foreach (var (partialName, partialJson) in partialViews)
+                {
+                    Log.WriteStructured(
+                        LogGroup.Server,
+                        "[NUI JSON] window={WindowId} partial={PartialName} json={PartialJson}",
+                        windowId,
+                        partialName,
+                        JsonDump(partialJson));
+                }
+            }
+
             RegisterAllElementEvents();
 
             var constructedWindow = new GuiConstructedWindow(
@@ -144,6 +251,7 @@ namespace SWLOR.Game.Server.Service.GuiService
                 json,
                 _activeWindow.Geometry,
                 partialViews,
+                layoutFindings,
                 () =>
             {
                 var dataModelInstance = Activator.CreateInstance<T>();

--- a/SWLOR.Game.Server/Service/GuiService/GuiWindowType.cs
+++ b/SWLOR.Game.Server/Service/GuiService/GuiWindowType.cs
@@ -73,6 +73,7 @@ namespace SWLOR.Game.Server.Service.GuiService
         Conversation = 68,
 
         DebugEnmity = 900,
+        DebugNuiGallery = 901,
         ChangePortrait = 9999
     }
 }

--- a/SWLOR.Game.Server/Service/GuiService/IGuiViewModel.cs
+++ b/SWLOR.Game.Server/Service/GuiService/IGuiViewModel.cs
@@ -63,6 +63,11 @@ namespace SWLOR.Game.Server.Service.GuiService
         string ModalCancelButtonText { get; }
 
         /// <summary>
+        /// Retrieves the text typed into the input modal partial view's text box.
+        /// </summary>
+        string ModalInputText { get; }
+
+        /// <summary>
         /// Runs when the modal closes.
         /// </summary>
         Action OnModalClose();
@@ -76,6 +81,16 @@ namespace SWLOR.Game.Server.Service.GuiService
         /// Runs when the modal cancel button is clicked.
         /// </summary>
         Action OnModalCancelClick();
+
+        /// <summary>
+        /// Runs when the input modal confirmation button is clicked.
+        /// </summary>
+        Action OnInputModalConfirmClick();
+
+        /// <summary>
+        /// Runs when the input modal cancel button is clicked.
+        /// </summary>
+        Action OnInputModalCancelClick();
 
         /// <summary>
         /// Runs when the window is closed.

--- a/SWLOR.Game.Server/Service/GuiService/IGuiWidget.cs
+++ b/SWLOR.Game.Server/Service/GuiService/IGuiWidget.cs
@@ -16,6 +16,18 @@ namespace SWLOR.Game.Server.Service.GuiService
         public List<IGuiWidget> Elements { get; }
 
         /// <summary>
+        /// The explicit height declared on this widget, or 0 if none was set.
+        /// Used by layout validation; only values &gt; 0 are emitted to NUI.
+        /// </summary>
+        float DeclaredHeight { get; }
+
+        /// <summary>
+        /// The explicit margin declared on this widget. A negative value means the
+        /// engine default; zero means the author deliberately removed the margin.
+        /// </summary>
+        float DeclaredMargin { get; }
+
+        /// <summary>
         /// Retrieves the set of events registered for this widget.
         /// </summary>
         public Dictionary<string, GuiMethodDetail> Events { get; }

--- a/SWLOR.Game.Server/Service/Log.cs
+++ b/SWLOR.Game.Server/Service/Log.cs
@@ -74,7 +74,11 @@ namespace SWLOR.Game.Server.Service
         public static void Write(LogGroup group, string details, bool printToConsole = false)
         {
             var settings = ApplicationSettings.Get();
-            var logDetail = _logGroups[group];
+            if (!_logGroups.TryGetValue(group, out var logDetail) ||
+                !_loggers.TryGetValue(group, out var logger))
+            {
+                return;
+            }
 
             // If the log group isn't configured for this environment, skip it.
             if (logDetail.Environment != ServerEnvironmentType.All &&
@@ -90,13 +94,17 @@ namespace SWLOR.Game.Server.Service
                 Console.WriteLine(details);
             }
 
-            _loggers[group].Information(details);
+            logger.Information(details);
         }
 
         public static void WriteStructured(LogGroup group, string messageTemplate, params object[] propertyValues)
         {
             var settings = ApplicationSettings.Get();
-            var logDetail = _logGroups[group];
+            if (!_logGroups.TryGetValue(group, out var logDetail) ||
+                !_loggers.TryGetValue(group, out var logger))
+            {
+                return;
+            }
 
             if (logDetail.Environment != ServerEnvironmentType.All &&
                 !logDetail.Environment.HasFlag(settings.ServerEnvironment))
@@ -104,7 +112,7 @@ namespace SWLOR.Game.Server.Service
                 return;
             }
 
-            _loggers[group].Information(messageTemplate, propertyValues);
+            logger.Information(messageTemplate, propertyValues);
         }
     }
 }


### PR DESCRIPTION
## Summary

Extracts the reusable GUI framework work from #2054 onto the latest `feature/combat-upgrade` base.

- adds standard root-layout, tab orchestration, table, modal-input, validation, geometry, and structured-diagnostic infrastructure
- applies root normalization centrally through `GuiWindowBuilder`, so all 68 registered GUI definitions use the compatible outer layout
- migrates Character Sheet and Market Buy to the reusable layout/table helpers while preserving current combat-upgrade behavior
- adds a development/test-only NUI gallery and warning canaries
- adds GUI authoring documentation and the synchronized `swlor-gui-window-generation` agent skill
- excludes all HoloCom implementation changes

## Hardening included

- fail-fast assign-before-watch checks without poisoning window reopen state
- nested-partial and modal-close restoration
- non-positive geometry recovery without resetting legitimate 72x52 HUD windows
- debounced geometry persistence
- atomic pre-validation for table row removal
- fail-closed debug hazards
- structured layout and gallery diagnostics without raw entered text
- corpus validation for every `IGuiWindowDefinition`

## Verification

- `dotnet build SWLOR.Game.Server.Tests/SWLOR.Game.Server.Tests.csproj -p:RunPostBuildEvent=Never` — passed
- 64 focused GUI/Character Sheet/pagination/settings tests — passed
- full suite attempted: 1,825 passed, 110 failed, 1 skipped; failures are from the uninitialized `SWLOR_Haks` submodule and existing `feature/combat-upgrade` coverage/engine-harness issues (for example ForceBurst coverage and stance tests calling NWN outside the engine harness)
- `tools/SyncAgentSkills.ps1 -CheckOnly` — passed
- `git diff --check` — passed

Related extraction source: #2054
