### PR TITLE
Add biographies to disguises

### DIFF
--- a/SWLOR.Game.Server.Tests/Feature/PlayerGuideContentTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/PlayerGuideContentTests.cs
@@ -167,6 +167,9 @@ public class PlayerGuideContentTests
         disguiseText.Should().Contain("Each observer may label the same disguise differently");
         disguiseText.Should().Contain("does not hide your underlying character from staff");
         disguiseText.Should().Contain("audit logs retain the real character and account identity");
+        disguiseText.Should().Contain("Each disguise has its own biography");
+        disguiseText.Should().Contain("deactivation restores your normal biography");
+        disguiseText.Should().Contain("do not change your equipped clothing or armor");
     }
 
     private static List<object> GetTopics()

--- a/SWLOR.Game.Server.Tests/Feature/PlayerNameRecognitionTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/PlayerNameRecognitionTests.cs
@@ -512,6 +512,36 @@ public class PlayerNameRecognitionTests
     }
 
     [Test]
+    public void NormalBiographyEditor_CannotOverwriteAnActiveDisguiseBiography()
+    {
+        var root = FindRepositoryRoot();
+        var settingsSource = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "SWLOR.Game.Server",
+            "Feature",
+            "GuiDefinition",
+            "ViewModel",
+            "SettingsViewModel.cs"));
+        var descriptionSource = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "SWLOR.Game.Server",
+            "Feature",
+            "GuiDefinition",
+            "ViewModel",
+            "ChangeDescriptionViewModel.cs"));
+
+        var openEditorMethod = ExtractMethod(settingsSource, "public Action OnClickChangeDescription()");
+        openEditorMethod.Should().Contain("Disguise.GetActiveDisguise(Player) != null");
+        openEditorMethod.Should().Contain("Deactivate it to edit your normal biography.");
+        openEditorMethod.Should().Contain("return;");
+
+        var saveMethod = ExtractMethod(descriptionSource, "public Action OnClickSave()");
+        saveMethod.Should().Contain("Disguise.GetActiveDisguise(Player) != null");
+        saveMethod.Should().Contain("Edit your active disguise's biography from the Disguises window.");
+        saveMethod.Should().Contain("return;");
+    }
+
+    [Test]
     public void DisguiseIdentityMutations_AreAuditedWithCanonicalIdentityAndRelevantState()
     {
         var root = FindRepositoryRoot();
@@ -529,9 +559,11 @@ public class PlayerNameRecognitionTests
         var saveMethod = ExtractMethod(source, "public static SaveDisguiseResult SaveDisguise(");
         saveMethod.Should().Contain("var previousPrivateName = disguise.PrivateName;");
         saveMethod.Should().Contain("var previousDescriptor = disguise.Descriptor;");
+        saveMethod.Should().Contain("var previousBiography = disguise.Biography ?? string.Empty;");
         saveMethod.Should().Contain("Disguise saved: PlayerId={PlayerId} PlayerName={PlayerName} DisguiseId={DisguiseId}");
         saveMethod.Should().Contain("PreviousPrivateName={PreviousPrivateName} PrivateName={PrivateName}");
         saveMethod.Should().Contain("PreviousDescriptor={PreviousDescriptor} Descriptor={Descriptor}");
+        saveMethod.Should().Contain("PreviousBiographyLength={PreviousBiographyLength} BiographyLength={BiographyLength}");
         saveMethod.Should().Contain("PreviousPortraitInternalId={PreviousPortraitInternalId} PortraitInternalId={PortraitInternalId}");
         saveMethod.Should().Contain("PreviousSoundSetId={PreviousSoundSetId} SoundSetId={SoundSetId}");
         saveMethod.Should().Contain("PreviousScrambleAccountId={PreviousScrambleAccountId} ScrambleAccountId={ScrambleAccountId}");
@@ -656,10 +688,15 @@ public class PlayerNameRecognitionTests
         entitySource.Should().Contain("public string PlayerId { get; set; }");
         entitySource.Should().Contain("public bool IsRetired { get; set; }");
         entitySource.Should().Contain("public bool ScrambleAccountId { get; set; }");
+        entitySource.Should().Contain("Biography = string.Empty;");
+        entitySource.Should().Contain("public string Biography { get; set; }");
         playerSource.Should().Contain("public const int DefaultDisguiseSlotLimit = 1;");
         playerSource.Should().Contain("DisguiseSlotLimit = DefaultDisguiseSlotLimit;");
         playerSource.Should().Contain("UndisguisedPortraitResref = string.Empty;");
         playerSource.Should().Contain("public string UndisguisedPortraitResref { get; set; }");
+        playerSource.Should().Contain("UndisguisedDescription = string.Empty;");
+        playerSource.Should().Contain("public string UndisguisedDescription { get; set; }");
+        playerSource.Should().Contain("public bool HasUndisguisedDescriptionSnapshot { get; set; }");
 
         viewModelSource.Should().Contain("public bool IsAvailableSelected");
         viewModelSource.Should().Contain("public bool IsRetiredSelected");
@@ -667,6 +704,7 @@ public class PlayerNameRecognitionTests
         viewModelSource.Should().Contain("public string EmptyStateTitle");
         viewModelSource.Should().Contain("public string EmptyStateText");
         viewModelSource.Should().Contain("public bool ScrambleAccountId");
+        viewModelSource.Should().Contain("public string Biography");
         viewModelSource.Should().Contain("public bool ShowUnretireButton");
         viewModelSource.Should().NotContain("public bool ShowDetailActionRow");
         viewModelSource.Should().Contain("public const string ContentPartialElement");
@@ -676,7 +714,10 @@ public class PlayerNameRecognitionTests
         viewModelSource.Should().Contain("public const string ContentEmptyPartial");
         disguiseSource.Should().Contain("PrivateName = $\"Disguise #{usedSlots + 1}\"");
         disguiseSource.Should().Contain("public const int MaxPrivateNameLength = 32;");
+        disguiseSource.Should().Contain("public const int MaxBiographyLength = 5000;");
         disguiseSource.Should().Contain("privateName.Length > MaxPrivateNameLength");
+        disguiseSource.Should().Contain("biography.Length > MaxBiographyLength");
+        disguiseSource.Should().Contain("disguise.Biography = biography;");
         disguiseSource.Should().Contain("Private disguise names may be no longer than {MaxPrivateNameLength} characters.");
         disguiseSource.Should().Contain("Unable to locate that disguise.");
         disguiseSource.Should().Contain("Retired disguises cannot be edited.");
@@ -686,6 +727,17 @@ public class PlayerNameRecognitionTests
         disguiseSource.Should().Contain("if (!string.IsNullOrWhiteSpace(dbPlayer.UndisguisedPortraitResref))");
         disguiseSource.Should().Contain("SetPortraitResRef(player, dbPlayer.UndisguisedPortraitResref);");
         disguiseSource.Should().Contain("dbPlayer.UndisguisedPortraitResref = string.Empty;");
+        disguiseSource.Should().Contain("dbPlayer.UndisguisedDescription = GetDescription(player) ?? string.Empty;");
+        disguiseSource.Should().Contain("dbPlayer.HasUndisguisedDescriptionSnapshot = true;");
+        disguiseSource.Should().Contain("SetDescription(player, disguise.Biography ?? string.Empty);");
+        disguiseSource.Should().Contain("SetDescription(player, dbPlayer.UndisguisedDescription ?? string.Empty);");
+        disguiseSource.Should().Contain("dbPlayer.HasUndisguisedDescriptionSnapshot = false;");
+        var ensureDescriptionSnapshotMethod = ExtractMethod(disguiseSource, "private static void EnsureUndisguisedDescriptionSnapshot(uint player)");
+        ensureDescriptionSnapshotMethod.Should().Contain("dbPlayer.UndisguisedDescription = GetDescription(player) ?? string.Empty;");
+        ensureDescriptionSnapshotMethod.Should().Contain("dbPlayer.HasUndisguisedDescriptionSnapshot = true;");
+        ensureDescriptionSnapshotMethod.Should().Contain("DB.Set(dbPlayer);");
+        ExtractMethod(disguiseSource, "private static void ApplyAppearance(uint player, PlayerDisguise disguise)")
+            .Should().Contain("EnsureUndisguisedDescriptionSnapshot(player);");
         viewModelSource.Should().Contain("Creating a new disguise will consume one of your disguise slots. Retired disguises also occupy disguise slots until they are wiped. Are you sure?");
         viewModelSource.Should().Contain("ActivateButtonText = IsSelectedDisguiseActive() ? \"Deactivate\" : \"Activate\";");
         viewModelSource.Should().Contain("Disguise.Deactivate(Player)");
@@ -713,6 +765,10 @@ public class PlayerNameRecognitionTests
         viewModelSource.Should().Contain("private bool _suppressSoundSetPageChange");
         viewModelSource.Should().Contain("private int _selectedSoundSetId");
         viewModelSource.Should().Contain("SelectSoundSet(disguise.SoundSetId);");
+        viewModelSource.Should().Contain("Biography = disguise.Biography ?? string.Empty;");
+        viewModelSource.Should().Contain("WatchOnClient(model => model.Biography);");
+        ExtractMethod(viewModelSource, "public Action OnClickSave()")
+            .Should().Contain("Biography,");
         viewModelSource.Should().Contain("private void LoadSoundSetPageOptions");
         viewModelSource.Should().Contain("private void LoadSoundSetPageNumbers");
         viewModelSource.Should().Contain("private int GetSelectedSoundSetIndexOnCurrentPage");
@@ -826,6 +882,9 @@ public class PlayerNameRecognitionTests
         // Field labels spell out who sees each value; lengths come from constants, never magic numbers.
         disguiseDefinitionSource.Should().Contain("AddTextField(col, \"Private Slot Label  (only you see this)\", model => model.PrivateName, Disguise.MaxPrivateNameLength);");
         disguiseDefinitionSource.Should().Contain("AddTextField(col, \"Public Description  (shown to others)\", model => model.Descriptor, PlayerName.MaxKnownNameLength);");
+        disguiseDefinitionSource.Should().Contain(".SetText(\"Biography  (shown when examined)\")");
+        disguiseDefinitionSource.Should().Contain(".BindValue(model => model.Biography)");
+        disguiseDefinitionSource.Should().Contain(".SetMaxLength(Disguise.MaxBiographyLength)");
         disguiseDefinitionSource.Should().NotContain(", model => model.PrivateName, 32)");
         disguiseDefinitionSource.Should().NotContain(", model => model.Descriptor, 64)");
         disguiseDefinitionSource.Should().Contain("Hide Account Name");

--- a/SWLOR.Game.Server.Tests/Feature/PlayerNameRecognitionTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/PlayerNameRecognitionTests.cs
@@ -729,7 +729,11 @@ public class PlayerNameRecognitionTests
         disguiseSource.Should().Contain("dbPlayer.UndisguisedPortraitResref = string.Empty;");
         disguiseSource.Should().Contain("dbPlayer.UndisguisedDescription = GetDescription(player) ?? string.Empty;");
         disguiseSource.Should().Contain("dbPlayer.HasUndisguisedDescriptionSnapshot = true;");
-        disguiseSource.Should().Contain("SetDescription(player, disguise.Biography ?? string.Empty);");
+        disguiseSource.Should().Contain("private const string BlankBiographyPlaceholder = \"No description is available.\";");
+        disguiseSource.Should().Contain("string.IsNullOrWhiteSpace(disguise.Biography)");
+        disguiseSource.Should().Contain("? BlankBiographyPlaceholder");
+        disguiseSource.Should().Contain("SetDescription(player, biography);");
+        disguiseSource.Should().NotContain("SetDescription(player, disguise.Biography ?? string.Empty);");
         disguiseSource.Should().Contain("SetDescription(player, dbPlayer.UndisguisedDescription ?? string.Empty);");
         disguiseSource.Should().Contain("dbPlayer.HasUndisguisedDescriptionSnapshot = false;");
         var ensureDescriptionSnapshotMethod = ExtractMethod(disguiseSource, "private static void EnsureUndisguisedDescriptionSnapshot(uint player)");

--- a/SWLOR.Game.Server/Entity/Player.cs
+++ b/SWLOR.Game.Server/Entity/Player.cs
@@ -99,6 +99,8 @@ namespace SWLOR.Game.Server.Entity
             UndisguisedPortraitId = -1;
             UndisguisedPortraitResref = string.Empty;
             UndisguisedSoundSetId = -1;
+            UndisguisedDescription = string.Empty;
+            HasUndisguisedDescriptionSnapshot = false;
         }
 
 
@@ -173,6 +175,8 @@ namespace SWLOR.Game.Server.Entity
         public int UndisguisedPortraitId { get; set; }
         public string UndisguisedPortraitResref { get; set; }
         public int UndisguisedSoundSetId { get; set; }
+        public string UndisguisedDescription { get; set; }
+        public bool HasUndisguisedDescriptionSnapshot { get; set; }
 
         public PlayerSettings Settings { get; set; }
         public Dictionary<SkillType, int> Control { get; set; }

--- a/SWLOR.Game.Server/Entity/PlayerDisguise.cs
+++ b/SWLOR.Game.Server/Entity/PlayerDisguise.cs
@@ -7,6 +7,7 @@ namespace SWLOR.Game.Server.Entity
             PlayerId = string.Empty;
             PrivateName = string.Empty;
             Descriptor = string.Empty;
+            Biography = string.Empty;
             PortraitInternalId = 1;
             SoundSetId = -1;
             IsRetired = false;
@@ -21,6 +22,7 @@ namespace SWLOR.Game.Server.Entity
         public bool IsRetired { get; set; }
         public string PrivateName { get; set; }
         public string Descriptor { get; set; }
+        public string Biography { get; set; }
         public int PortraitInternalId { get; set; }
         public int SoundSetId { get; set; }
         public bool ScrambleAccountId { get; set; }

--- a/SWLOR.Game.Server/Feature/GuiDefinition/DisguiseDefinition.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/DisguiseDefinition.cs
@@ -15,7 +15,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
         // group does not stretch to fill a row - without them the fields collapse and the
         // longer labels clip.
         private const float WindowWidth = 792f;
-        private const float WindowHeight = 468f;
+        private const float WindowHeight = 600f;
 
         private const float RailWidth = 236f;
 
@@ -27,6 +27,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
         private const float HeaderHeight = 26f;
         private const float LabelHeight = 20f;
         private const float FieldHeight = 30f;
+        private const float BiographyFieldHeight = 120f;
         private const float ButtonHeight = 32f;
 
         private const float PortraitColWidth = 138f;
@@ -263,6 +264,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
             {
                 AddTextField(col, "Private Slot Label  (only you see this)", model => model.PrivateName, Disguise.MaxPrivateNameLength);
                 AddTextField(col, "Public Description  (shown to others)", model => model.Descriptor, PlayerName.MaxKnownNameLength);
+                AddBiographyField(col);
                 AddSoundSetField(col);
 
                 col.AddRow(row =>
@@ -297,6 +299,29 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition
                     .SetMaxLength(maxLength)
                     .SetWidth(FormFieldWidth)
                     .SetHeight(FieldHeight)
+                    .BindIsEnabled(model => model.IsEditMode);
+            });
+        }
+
+        private static void AddBiographyField(GuiColumn<DisguiseViewModel> col)
+        {
+            col.AddRow(row =>
+            {
+                row.AddLabel()
+                    .SetText("Biography  (shown when examined)")
+                    .SetHeight(LabelHeight)
+                    .SetHorizontalAlign(NuiHorizontalAlign.Left);
+            });
+
+            col.AddRow(row =>
+            {
+                row.AddTextEdit()
+                    .BindValue(model => model.Biography)
+                    .SetPlaceholder("Describe what others can observe while this disguise is active.")
+                    .SetIsMultiline(true)
+                    .SetMaxLength(Disguise.MaxBiographyLength)
+                    .SetWidth(FormFieldWidth)
+                    .SetHeight(BiographyFieldHeight)
                     .BindIsEnabled(model => model.IsEditMode);
             });
         }

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/ChangeDescriptionViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/ChangeDescriptionViewModel.cs
@@ -31,6 +31,12 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
 
         public Action OnClickSave() => () =>
         {
+            if (Disguise.GetActiveDisguise(Player) != null)
+            {
+                FloatingTextStringOnCreature("Edit your active disguise's biography from the Disguises window.", Player, false);
+                return;
+            }
+
             if (string.IsNullOrWhiteSpace(Description))
             {
                 FloatingTextStringOnCreature("Please enter a description.", Player, false);

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/DisguiseViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/DisguiseViewModel.cs
@@ -247,6 +247,12 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             set => Set(value);
         }
 
+        public string Biography
+        {
+            get => Get<string>();
+            set => Set(value);
+        }
+
         public string PortraitInternalId
         {
             get => Get<string>();
@@ -295,6 +301,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             IsViewMode = false;
             PrivateName = string.Empty;
             Descriptor = string.Empty;
+            Biography = string.Empty;
             PortraitInternalId = "1";
             SoundSetName = string.Empty;
             PortraitResref = string.Empty;
@@ -317,6 +324,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
 
             WatchOnClient(model => model.PrivateName);
             WatchOnClient(model => model.Descriptor);
+            WatchOnClient(model => model.Biography);
             WatchOnClient(model => model.PortraitInternalId);
             WatchOnClient(model => model.SelectedSoundSetIndex);
             WatchOnClient(model => model.SelectedSoundSetPageIndex);
@@ -404,6 +412,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
                 _selectedDisguiseId,
                 PrivateName,
                 Descriptor,
+                Biography,
                 _activePortraitInternalId,
                 _selectedSoundSetId,
                 ScrambleAccountId);
@@ -667,6 +676,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             IsViewMode = !IsEditMode;
             PrivateName = disguise.PrivateName;
             Descriptor = disguise.Descriptor;
+            Biography = disguise.Biography ?? string.Empty;
             PortraitInternalId = disguise.PortraitInternalId.ToString();
             ScrambleAccountId = disguise.ScrambleAccountId;
             SelectSoundSet(disguise.SoundSetId);
@@ -687,6 +697,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             IsViewMode = false;
             PrivateName = string.Empty;
             Descriptor = string.Empty;
+            Biography = string.Empty;
             PortraitInternalId = "1";
             SoundSetName = string.Empty;
             PortraitResref = string.Empty;

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/PlayerGuideViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/PlayerGuideViewModel.cs
@@ -746,13 +746,15 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
                     new[]
                     {
                         new ArticleBlock("Opening Disguises",
-                            "Open Disguises from the Character Sheet, or use /disguise or /disguises. A disguise stores a private slot label only you can see, plus a public description, appearance, portrait, sound set, and optional scrambled account identifier."),
+                            "Open Disguises from the Character Sheet, or use /disguise or /disguises. A disguise stores a private slot label only you can see, plus a public description, biography, portrait, sound set, and optional scrambled account identifier."),
                         new ArticleBlock("Separate Presented Identities",
                             "Your normal identity and every disguise are remembered separately. A private label someone saved for your normal identity does not carry over to a disguise, and a label saved for one disguise does not carry over to another. Each observer may label the same disguise differently. Activating or deactivating a disguise automatically restores the labels that observer previously saved for the identity you are presenting."),
                         new ArticleBlock("Identity Slots",
                             "You begin with 1 identity slot. Each False Identities rank adds 1, up to 4 total slots. Every saved identity, including a retired one, occupies a slot. Retiring does not free it; only permanently wiping it does."),
                         new ArticleBlock("Activating",
-                            "An active disguise changes your presented identity and appearance. The base wait between disguise activations is 30 minutes. Cover Story reduces that wait by 40 or 70 percent, with a minimum wait of 5 minutes. Deactivating a disguise is immediate."),
+                            "An active disguise changes your presented identity, portrait, sound set, and examine biography. The base wait between disguise activations is 30 minutes. Cover Story reduces that wait by 40 or 70 percent, with a minimum wait of 5 minutes. Deactivating a disguise is immediate and restores your normal biography, portrait, and sound set."),
+                        new ArticleBlock("Biography and Outfit",
+                            "Each disguise has its own biography, shown when another player examines you while that disguise is active. Write only what someone could observe about that disguised identity. Edit it in the Disguises window; deactivate the disguise before editing your normal biography. Disguises do not change your equipped clothing or armor, so you remain responsible for changing your outfit."),
                         new ArticleBlock("Retiring and Restoring",
                             "Retiring an identity deactivates it and prevents activation, but keeps its saved setup. You can restore a retired identity from the Disguises window if you want to use it again."),
                         new ArticleBlock("Permanently Wiping",
@@ -767,6 +769,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
                         new QuestionAnswer("Does retiring free the slot?", "No. Restore it for reuse, or permanently wipe it at an Identity Broker to free the slot."),
                         new QuestionAnswer("What does a permanent wipe remove?", "The saved identity and other characters' private-label references to it. The wipe cannot be undone."),
                         new QuestionAnswer("Does a saved name carry between disguises?", "No. Your normal identity and every disguise are remembered separately."),
+                        new QuestionAnswer("Does a disguise have its own biography?", "Yes. Activation shows that disguise's biography when examined, and deactivation restores your normal biography."),
                         new QuestionAnswer("Can a disguise hide my identity from staff?", "No. Staff tools and audit logs retain your real character and account identity.")
                     },
                     new[] { "Communication", "Useful Windows", "Skills", "Perks" }),

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/SettingsViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/SettingsViewModel.cs
@@ -378,6 +378,12 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
 
         public Action OnClickChangeDescription() => () =>
         {
+            if (Disguise.GetActiveDisguise(Player) != null)
+            {
+                SendMessageToPC(Player, ColorToken.Red("Edit your active disguise's biography from the Disguises window. Deactivate it to edit your normal biography."));
+                return;
+            }
+
             Gui.TogglePlayerWindow(Player, GuiWindowType.ChangeDescription);
         };
 

--- a/SWLOR.Game.Server/Service/Disguise.cs
+++ b/SWLOR.Game.Server/Service/Disguise.cs
@@ -21,6 +21,7 @@ namespace SWLOR.Game.Server.Service
         public const int MinimumActivationDelayMinutes = 5;
 
         public const int MaxPrivateNameLength = 32;
+        public const int MaxBiographyLength = 5000;
         private const int DisguiseQueryPageSize = 50;
 
         [NWNEventHandler(ScriptName.OnModuleEnter)]
@@ -195,6 +196,7 @@ namespace SWLOR.Game.Server.Service
                 PlayerId = playerId,
                 PrivateName = $"Disguise #{usedSlots + 1}",
                 Descriptor = PlayerDescriptor.GetUnknownDisplayName(player),
+                Biography = string.Empty,
                 PortraitInternalId = portraitInternalId,
                 SoundSetId = GetSoundset(player),
                 ScrambleAccountId = true
@@ -204,12 +206,13 @@ namespace SWLOR.Game.Server.Service
 
             Log.WriteStructured(
                 LogGroup.PlayerName,
-                "Disguise created: PlayerId={PlayerId} PlayerName={PlayerName} DisguiseId={DisguiseId} PrivateName={PrivateName} Descriptor={Descriptor} PortraitInternalId={PortraitInternalId} SoundSetId={SoundSetId} ScrambleAccountId={ScrambleAccountId}",
+                "Disguise created: PlayerId={PlayerId} PlayerName={PlayerName} DisguiseId={DisguiseId} PrivateName={PrivateName} Descriptor={Descriptor} BiographyLength={BiographyLength} PortraitInternalId={PortraitInternalId} SoundSetId={SoundSetId} ScrambleAccountId={ScrambleAccountId}",
                 playerId,
                 GetName(player),
                 disguise.Id,
                 disguise.PrivateName,
                 disguise.Descriptor,
+                disguise.Biography.Length,
                 disguise.PortraitInternalId,
                 disguise.SoundSetId,
                 disguise.ScrambleAccountId);
@@ -222,6 +225,7 @@ namespace SWLOR.Game.Server.Service
             string disguiseId,
             string privateName,
             string descriptor,
+            string biography,
             int portraitInternalId,
             int soundSetId,
             bool scrambleAccountId)
@@ -242,17 +246,23 @@ namespace SWLOR.Game.Server.Service
             if (!string.IsNullOrWhiteSpace(descriptorError))
                 return SaveDisguiseResult.Failure(descriptorError);
 
+            biography ??= string.Empty;
+            if (biography.Length > MaxBiographyLength)
+                return SaveDisguiseResult.Failure($"Disguise biographies may be no longer than {MaxBiographyLength} characters.");
+
             portraitInternalId = Math.Clamp(portraitInternalId, 1, GetMaxPortraitCount());
             soundSetId = ResolveSoundSetId(soundSetId);
 
             var previousPrivateName = disguise.PrivateName;
             var previousDescriptor = disguise.Descriptor;
+            var previousBiography = disguise.Biography ?? string.Empty;
             var previousPortraitInternalId = disguise.PortraitInternalId;
             var previousSoundSetId = disguise.SoundSetId;
             var previousScrambleAccountId = disguise.ScrambleAccountId;
 
             disguise.PrivateName = PlayerName.SanitizeKnownName(privateName);
             disguise.Descriptor = PlayerName.SanitizeKnownName(descriptor);
+            disguise.Biography = biography;
             disguise.PortraitInternalId = portraitInternalId;
             disguise.SoundSetId = soundSetId;
             disguise.ScrambleAccountId = scrambleAccountId;
@@ -260,7 +270,7 @@ namespace SWLOR.Game.Server.Service
 
             Log.WriteStructured(
                 LogGroup.PlayerName,
-                "Disguise saved: PlayerId={PlayerId} PlayerName={PlayerName} DisguiseId={DisguiseId} PreviousPrivateName={PreviousPrivateName} PrivateName={PrivateName} PreviousDescriptor={PreviousDescriptor} Descriptor={Descriptor} PreviousPortraitInternalId={PreviousPortraitInternalId} PortraitInternalId={PortraitInternalId} PreviousSoundSetId={PreviousSoundSetId} SoundSetId={SoundSetId} PreviousScrambleAccountId={PreviousScrambleAccountId} ScrambleAccountId={ScrambleAccountId}",
+                "Disguise saved: PlayerId={PlayerId} PlayerName={PlayerName} DisguiseId={DisguiseId} PreviousPrivateName={PreviousPrivateName} PrivateName={PrivateName} PreviousDescriptor={PreviousDescriptor} Descriptor={Descriptor} PreviousBiographyLength={PreviousBiographyLength} BiographyLength={BiographyLength} PreviousPortraitInternalId={PreviousPortraitInternalId} PortraitInternalId={PortraitInternalId} PreviousSoundSetId={PreviousSoundSetId} SoundSetId={SoundSetId} PreviousScrambleAccountId={PreviousScrambleAccountId} ScrambleAccountId={ScrambleAccountId}",
                 playerId,
                 GetName(player),
                 disguise.Id,
@@ -268,6 +278,8 @@ namespace SWLOR.Game.Server.Service
                 disguise.PrivateName,
                 previousDescriptor,
                 disguise.Descriptor,
+                previousBiography.Length,
+                disguise.Biography.Length,
                 previousPortraitInternalId,
                 disguise.PortraitInternalId,
                 previousSoundSetId,
@@ -321,6 +333,8 @@ namespace SWLOR.Game.Server.Service
                 dbPlayer.UndisguisedPortraitId = GetPortraitId(player);
                 dbPlayer.UndisguisedPortraitResref = GetPortraitResRef(player);
                 dbPlayer.UndisguisedSoundSetId = GetSoundset(player);
+                dbPlayer.UndisguisedDescription = GetDescription(player) ?? string.Empty;
+                dbPlayer.HasUndisguisedDescriptionSnapshot = true;
             }
 
             dbPlayer.ActiveDisguiseId = disguise.Id;
@@ -367,10 +381,17 @@ namespace SWLOR.Game.Server.Service
             if (dbPlayer.UndisguisedSoundSetId >= 0)
                 SetSoundset(player, dbPlayer.UndisguisedSoundSetId);
 
+            if (dbPlayer.HasUndisguisedDescriptionSnapshot)
+                SetDescription(player, dbPlayer.UndisguisedDescription ?? string.Empty);
+            else
+                SetDescription(player, GetDescription(player, true) ?? string.Empty);
+
             dbPlayer.ActiveDisguiseId = string.Empty;
             dbPlayer.UndisguisedPortraitId = -1;
             dbPlayer.UndisguisedPortraitResref = string.Empty;
             dbPlayer.UndisguisedSoundSetId = -1;
+            dbPlayer.UndisguisedDescription = string.Empty;
+            dbPlayer.HasUndisguisedDescriptionSnapshot = false;
             DB.Set(dbPlayer);
 
             Log.WriteStructured(
@@ -682,6 +703,25 @@ namespace SWLOR.Game.Server.Service
             var soundSetId = ResolveSoundSetId(disguise.SoundSetId);
             if (soundSetId >= 0)
                 SetSoundset(player, soundSetId);
+
+            EnsureUndisguisedDescriptionSnapshot(player);
+            SetDescription(player, disguise.Biography ?? string.Empty);
+        }
+
+        private static void EnsureUndisguisedDescriptionSnapshot(uint player)
+        {
+            var playerId = GetObjectUUID(player);
+            var dbPlayer = DB.Get<Player>(playerId);
+            if (dbPlayer == null ||
+                string.IsNullOrWhiteSpace(dbPlayer.ActiveDisguiseId) ||
+                dbPlayer.HasUndisguisedDescriptionSnapshot)
+            {
+                return;
+            }
+
+            dbPlayer.UndisguisedDescription = GetDescription(player) ?? string.Empty;
+            dbPlayer.HasUndisguisedDescriptionSnapshot = true;
+            DB.Set(dbPlayer);
         }
 
         private static void RefreshDisguiseDisplay(uint player)

--- a/SWLOR.Game.Server/Service/Disguise.cs
+++ b/SWLOR.Game.Server/Service/Disguise.cs
@@ -22,6 +22,7 @@ namespace SWLOR.Game.Server.Service
 
         public const int MaxPrivateNameLength = 32;
         public const int MaxBiographyLength = 5000;
+        private const string BlankBiographyPlaceholder = "No description is available.";
         private const int DisguiseQueryPageSize = 50;
 
         [NWNEventHandler(ScriptName.OnModuleEnter)]
@@ -705,7 +706,10 @@ namespace SWLOR.Game.Server.Service
                 SetSoundset(player, soundSetId);
 
             EnsureUndisguisedDescriptionSnapshot(player);
-            SetDescription(player, disguise.Biography ?? string.Empty);
+            var biography = string.IsNullOrWhiteSpace(disguise.Biography)
+                ? BlankBiographyPlaceholder
+                : disguise.Biography;
+            SetDescription(player, biography);
         }
 
         private static void EnsureUndisguisedDescriptionSnapshot(uint player)


### PR DESCRIPTION
## Summary
- add a separate, editable biography to every disguise
- apply the disguise biography on activation and restore the normal biography on deactivation
- preserve the normal biography across disguise switches, relogs, and rollout for already-active disguises
- prevent the normal description editor from overwriting an active disguise biography
- clarify disguise biographies and outfit behavior in the player guide
- audit biography changes by length without recording biography content

## Verification
- `dotnet build SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj -p:RunPostBuildEvent=Never`
- `dotnet test SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj --no-build --filter "FullyQualifiedName~PlayerNameRecognitionTests|FullyQualifiedName~PlayerGuideContentTests"` (23 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Disguises now support individual biographies up to 5,000 characters.
  * Added biography editing to the Disguises window.
  * Activating a disguise displays its biography; deactivating restores the normal biography.
  * Disguises continue to leave equipped clothing and armor unchanged.

* **Bug Fixes**
  * Prevented normal biography edits while a disguise is active, with an explanatory message.

* **Documentation**
  * Updated the player guide with disguise biography behavior and editing instructions.

* **Tests**
  * Expanded coverage for biography validation, editing, and restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->