### PR TITLE
Fix Predatory Bond accuracy and refund cooldown resets

### DIFF
--- a/SWLOR.Game.Server.Tests/Feature/DMChatCommandTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/DMChatCommandTests.cs
@@ -95,6 +95,28 @@ public class DMChatCommandTests
         dmChatCommandSource.Should().Contain("ActionJumpToLocation(location)");
     }
 
+    [Test]
+    public void ResetCooldowns_IncludesThePerkRefundTimer()
+    {
+        var commands = new DMChatCommand().BuildChatCommands();
+
+        commands.Should().ContainKey("resetcooldowns");
+        commands["resetcooldowns"].Description.Should().Contain("perk refund");
+
+        var root = FindRepositoryRoot();
+        var source = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "SWLOR.Game.Server",
+            "Feature",
+            "ChatCommandDefinition",
+            "DMChatCommand.cs"));
+        var methodStart = source.IndexOf("private void ResetAbilityRecastTimers()", StringComparison.Ordinal);
+        var methodEnd = source.IndexOf("private void AdjustFactionStanding()", methodStart, StringComparison.Ordinal);
+        var method = source[methodStart..methodEnd];
+
+        method.Should().Contain("dbPlayer.DatePerkRefundAvailable = DateTime.UtcNow;");
+    }
+
     private static DirectoryInfo FindRepositoryRoot()
     {
         var directory = new DirectoryInfo(TestContext.CurrentContext.TestDirectory);

--- a/SWLOR.Game.Server.Tests/Feature/DMChatCommandTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/DMChatCommandTests.cs
@@ -113,8 +113,19 @@ public class DMChatCommandTests
         var methodStart = source.IndexOf("private void ResetAbilityRecastTimers()", StringComparison.Ordinal);
         var methodEnd = source.IndexOf("private void AdjustFactionStanding()", methodStart, StringComparison.Ordinal);
         var method = source[methodStart..methodEnd];
+        var perksViewModelSource = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "SWLOR.Game.Server",
+            "Feature",
+            "GuiDefinition",
+            "ViewModel",
+            "PerksViewModel.cs"));
 
         method.Should().Contain("dbPlayer.DatePerkRefundAvailable = DateTime.UtcNow;");
+        method.Should().Contain("Gui.PublishRefreshEvent(target, new PerkRefundCooldownResetRefreshEvent());");
+        perksViewModelSource.Should().Contain("IGuiRefreshable<PerkRefundCooldownResetRefreshEvent>");
+        perksViewModelSource.Should().Contain("public void Refresh(PerkRefundCooldownResetRefreshEvent payload)");
+        perksViewModelSource.Should().Contain("SelectPerkAt(selectedPerkIndex);");
     }
 
     private static DirectoryInfo FindRepositoryRoot()

--- a/SWLOR.Game.Server.Tests/Feature/PlayerNameRecognitionTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/PlayerNameRecognitionTests.cs
@@ -675,7 +675,7 @@ public class PlayerNameRecognitionTests
         disguiseSource.Should().Contain("dbPlayer.UnallocatedXP -= amount");
         disguiseSource.Should().Contain("new RPXPRefreshEvent()");
         disguiseSource.Should().Contain("new DisguiseChangedRefreshEvent()");
-        dmChatCommandSource.Should().Contain(".Description(\"Resets a player's ability and disguise cooldowns.\")");
+        dmChatCommandSource.Should().Contain(".Description(\"Resets a player's ability, disguise, and perk refund cooldowns.\")");
         dmChatCommandSource.Should().Contain("AbilityCooldownVisual.ClearAllRecastDelays(target);");
         dmChatCommandSource.Should().Contain("Disguise.ResetActivationCooldowns(target);");
 

--- a/SWLOR.Game.Server.Tests/Perks/BeastmasterCombatUpgradeTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/BeastmasterCombatUpgradeTests.cs
@@ -76,7 +76,8 @@ public class BeastmasterCombatUpgradeTests
         new GuardingBondBeastStatusEffect().StatGroup.Stats[StatType.EnmityPercentAdjustment].Should().Be(75);
         new PredatoryBondBeastStatusEffect().StatGroup.Stats[StatType.DamageDealtPercentAdjustment].Should().Be(25);
         new PredatoryBondBeastStatusEffect().StatGroup.Stats[StatType.AttackDelayReductionPercent].Should().Be(15);
-        new PredatoryBondBeastStatusEffect().StatGroup.Stats[StatType.AbilityHitChancePercentAdjustment].Should().Be(10);
+        new PredatoryBondBeastStatusEffect().StatGroup.Stats[StatType.PhysicalAndForceAbilityHitChancePercentAdjustment].Should().Be(10);
+        new PredatoryBondBeastStatusEffect().StatGroup.Stats[StatType.AbilityHitChancePercentAdjustment].Should().Be(0);
         new PredatoryBondBeastStatusEffect().StatGroup.Stats[StatType.EnmityPercentAdjustment].Should().Be(-40);
     }
 

--- a/SWLOR.Game.Server/Feature/ChatCommandDefinition/DMChatCommand.cs
+++ b/SWLOR.Game.Server/Feature/ChatCommandDefinition/DMChatCommand.cs
@@ -790,6 +790,7 @@ namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
                     dbPlayer.DatePerkRefundAvailable = DateTime.UtcNow;
 
                     DB.Set(dbPlayer);
+                    Gui.PublishRefreshEvent(target, new PerkRefundCooldownResetRefreshEvent());
                     SendMessageToPC(target, $"A DM has reset your perk refund cooldown.");
                 });
         }
@@ -855,6 +856,7 @@ namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
                     dbPlayer.RecastTimes.Clear();
                     dbPlayer.DatePerkRefundAvailable = DateTime.UtcNow;
                     DB.Set(dbPlayer);
+                    Gui.PublishRefreshEvent(target, new PerkRefundCooldownResetRefreshEvent());
                     AbilityCooldownVisual.ClearAllRecastDelays(target);
                     Disguise.ResetActivationCooldowns(target);
 

--- a/SWLOR.Game.Server/Feature/ChatCommandDefinition/DMChatCommand.cs
+++ b/SWLOR.Game.Server/Feature/ChatCommandDefinition/DMChatCommand.cs
@@ -836,7 +836,7 @@ namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
         private void ResetAbilityRecastTimers()
         {
             _builder.Create("resetcooldown", "resetcooldowns")
-                .Description("Resets a player's ability and disguise cooldowns.")
+                .Description("Resets a player's ability, disguise, and perk refund cooldowns.")
                 .Permissions(AuthorizationLevel.DM, AuthorizationLevel.Admin)
                 .AvailableToAllOnTestEnvironment()
                 .RequiresTarget()
@@ -853,6 +853,7 @@ namespace SWLOR.Game.Server.Feature.ChatCommandDefinition
                     var dbPlayer = DB.Get<Player>(playerId);
                     dbPlayer.RecastTimes ??= new();
                     dbPlayer.RecastTimes.Clear();
+                    dbPlayer.DatePerkRefundAvailable = DateTime.UtcNow;
                     DB.Set(dbPlayer);
                     AbilityCooldownVisual.ClearAllRecastDelays(target);
                     Disguise.ResetActivationCooldowns(target);

--- a/SWLOR.Game.Server/Feature/GuiDefinition/RefreshEvent/PerkRefundCooldownResetRefreshEvent.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/RefreshEvent/PerkRefundCooldownResetRefreshEvent.cs
@@ -1,0 +1,8 @@
+using SWLOR.Game.Server.Service.GuiService;
+
+namespace SWLOR.Game.Server.Feature.GuiDefinition.RefreshEvent
+{
+    public class PerkRefundCooldownResetRefreshEvent: IGuiRefreshEvent
+    {
+    }
+}

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/PerksViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/PerksViewModel.cs
@@ -20,7 +20,8 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
 {
     public class PerksViewModel : GuiViewModelBase<PerksViewModel, GuiPayloadBase>,
         IGuiRefreshable<SkillXPRefreshEvent>,
-        IGuiRefreshable<PerkResetAcquiredRefreshEvent>
+        IGuiRefreshable<PerkResetAcquiredRefreshEvent>,
+        IGuiRefreshable<PerkRefundCooldownResetRefreshEvent>
     {
         private const int ItemsPerPage = 30;
         private const int AutoAddHotBarSlots = 11;
@@ -1408,6 +1409,17 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
         public void Refresh(PerkResetAcquiredRefreshEvent payload)
         {
             LoadDetails();
+        }
+
+        public void Refresh(PerkRefundCooldownResetRefreshEvent payload)
+        {
+            var selectedPerkIndex = SelectedPerkIndex;
+            LoadDetails();
+
+            if (selectedPerkIndex > -1)
+            {
+                SelectPerkAt(selectedPerkIndex);
+            }
         }
 
         public Action OnClickMyPerks() => () =>

--- a/SWLOR.Game.Server/Feature/StatusEffectDefinition/PredatoryBondBeastStatusEffect.cs
+++ b/SWLOR.Game.Server/Feature/StatusEffectDefinition/PredatoryBondBeastStatusEffect.cs
@@ -16,7 +16,7 @@ namespace SWLOR.Game.Server.Feature.StatusEffectDefinition
         {
             StatGroup.Stats[StatType.DamageDealtPercentAdjustment] = 25;
             StatGroup.Stats[StatType.AttackDelayReductionPercent] = 15;
-            StatGroup.Stats[StatType.AbilityHitChancePercentAdjustment] = 10;
+            StatGroup.Stats[StatType.PhysicalAndForceAbilityHitChancePercentAdjustment] = 10;
             StatGroup.Stats[StatType.EnmityPercentAdjustment] = -40;
         }
     }


### PR DESCRIPTION
## Summary

- apply Predatory Bond's +10% ability accuracy through the general physical/Force ability hit-chance stat used by Beast Mastery abilities and the character sheet
- make `/resetcooldowns` reset the persisted perk-refund timer alongside ability and disguise cooldowns
- immediately refresh an open Perks window after either DM refund-cooldown reset while preserving the selected perk and recomputing refund eligibility
- add regression coverage for the stat mapping, command reset, and GUI refresh wiring

## Verification

- `dotnet build SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj -p:RunPostBuildEvent=Never`
- `dotnet test SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj --no-build --filter "FullyQualifiedName~BeastmasterCombatUpgradeTests|FullyQualifiedName~DMChatCommandTests|FullyQualifiedName~PlayerNameRecognitionTests.Disguises_UseDisguiseIdentityKeysAndHardDeleteRetiredIdentities"` (14 passed)
- `git diff --check`

## Review

- addressed Codex's open-Perks-window refresh finding in `7a2a3c14da`
- Codex re-reviewed `7a2a3c14da` and reported no remaining major issues
