### PR TITLE
Fix Force Push damage application

### DIFF
--- a/SWLOR.Game.Server.Tests/Feature/AbilityDamageQueueTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/AbilityDamageQueueTests.cs
@@ -94,6 +94,46 @@ public class AbilityDamageQueueTests
     }
 
     [Test]
+    public void UnscaledCombatImpacts_RetainPrimaryDamageHandlingWithoutFormulaScaling()
+    {
+        var root = FindRepositoryRoot();
+        var source = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "SWLOR.Game.Server",
+            "Service",
+            "Ability.cs")).Replace("\r\n", "\n");
+        var primaryImpactBody = source.Substring(
+            source.IndexOf("public static int ApplyHostileCombatImpact(", StringComparison.Ordinal),
+            source.IndexOf("private static int ApplyHostileCombatImpact(", StringComparison.Ordinal) -
+            source.IndexOf("public static int ApplyHostileCombatImpact(", StringComparison.Ordinal));
+        var formulaSelectionBody = source.Substring(
+            source.IndexOf("private static int ApplyHostileCombatImpact(", StringComparison.Ordinal),
+            source.IndexOf("private static bool ShouldResolveCombatImpactHit", StringComparison.Ordinal) -
+            source.IndexOf("private static int ApplyHostileCombatImpact(", StringComparison.Ordinal));
+        var unscaledDamageBody = source.Substring(
+            source.IndexOf("private static int CalculateUnscaledCombatImpactDamage(", StringComparison.Ordinal),
+            source.IndexOf("private static int CalculateCombatImpactDamage(", StringComparison.Ordinal) -
+            source.IndexOf("private static int CalculateUnscaledCombatImpactDamage(", StringComparison.Ordinal));
+
+        source.Should().Contain("useUnscaledDamage: useUnscaledDamage",
+            "the public combat-impact entry points must propagate unscaled damage through every area path");
+        formulaSelectionBody.Should().Contain("useUnscaledDamage\n                ? CalculateUnscaledCombatImpactDamage(");
+        formulaSelectionBody.Should().Contain("return ApplyHostileCombatImpact(",
+            "unscaled damage must retain the primary ability damage, rider, and enmity path");
+        primaryImpactBody.Should().Contain("Combat.SendTemporaryHitPointDamageFeedback(activator, target, damage);");
+        primaryImpactBody.Should().Contain("trackedImpact.QueueDamageEffect(");
+
+        unscaledDamageBody.Should().Contain("Combat.ApplyDamageDealtModifiers(");
+        unscaledDamageBody.Should().Contain("isAbilityDamage: true");
+        unscaledDamageBody.Should().Contain("ApplyCombatReadinessToActivatedAbilityMagnitude(activator, damage)");
+        unscaledDamageBody.Should().Contain("Resistance.ApplyResistanceToDamage(target, damageType, damage)");
+        unscaledDamageBody.Should().Contain("Combat.ApplyDamageTakenModifiers(");
+        unscaledDamageBody.Should().NotContain("CalculateDamageWithCriticalMitigation");
+        unscaledDamageBody.Should().NotContain("Perk.ApplyForceAffinityMagnitude");
+        unscaledDamageBody.Should().NotContain("Combat.GetAbilityDamageBonus");
+    }
+
+    [Test]
     public void FailedAbilityImpacts_AbortTrackedStateForCastAndQueuedPaths()
     {
         var root = FindRepositoryRoot();

--- a/SWLOR.Game.Server.Tests/Feature/AbilityDamageQueueTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/AbilityDamageQueueTests.cs
@@ -123,6 +123,9 @@ public class AbilityDamageQueueTests
         primaryImpactBody.Should().Contain("Combat.SendTemporaryHitPointDamageFeedback(activator, target, damage);");
         primaryImpactBody.Should().Contain("trackedImpact.QueueDamageEffect(");
 
+        unscaledDamageBody.Should().Contain("var trackedImpact = GetTrackedAbilityImpact(activator);");
+        unscaledDamageBody.Should().Contain("baseDamage + (trackedImpact?.NextAbilityDamageBonus ?? 0)",
+            "queued flat next-ability damage must not be consumed without affecting an unscaled hit");
         unscaledDamageBody.Should().Contain("Combat.ApplyDamageDealtModifiers(");
         unscaledDamageBody.Should().Contain("isAbilityDamage: true");
         unscaledDamageBody.Should().Contain("ApplyCombatReadinessToActivatedAbilityMagnitude(activator, damage)");

--- a/SWLOR.Game.Server.Tests/Perks/ForceUniversalTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/ForceUniversalTests.cs
@@ -71,12 +71,13 @@ public class ForceUniversalTests
         var source = File.ReadAllText((root / "SWLOR.Game.Server" / "Feature" / "AbilityDefinition" / "Force" / "ForcePushAbilityDefinition.cs").FullName)
             .Replace("\r\n", "\n");
 
-        source.Should().Contain("hitTarget,\n                    ForcePush1BaseDamage,\n                    ForcePush1HobbleDurationSeconds");
-        source.Should().Contain("hitTarget,\n                    ForcePush2BaseDamage,\n                    ForcePush2HobbleDurationSeconds");
-        source.Should().Contain("hitTarget,\n                    ForcePush3BaseDamage,\n                    ForcePush3HobbleDurationSeconds");
-        source.Split("SkillType.Force,\n                0,", StringSplitOptions.None)
-            .Should().HaveCount(4, "all three Force Push ranks must bypass the stat-scaled combat formula");
-        source.Should().Contain("Combat.ApplyTriggeredDamage(\n                activator,\n                target,\n                baseDamage,\n                CombatDamageType.Force,\n                SkillType.Force);");
+        source.Should().Contain("SkillType.Force,\n                ForcePush1BaseDamage,");
+        source.Should().Contain("SkillType.Force,\n                ForcePush2BaseDamage,");
+        source.Should().Contain("SkillType.Force,\n                ForcePush3BaseDamage,");
+        source.Split("useUnscaledDamage: true", StringSplitOptions.None)
+            .Should().HaveCount(4, "all three Force Push ranks must bypass stat and critical scaling");
+        source.Should().NotContain("Combat.ApplyTriggeredDamage(",
+            "Force Push damage should retain the primary ability-damage pipeline");
     }
 
     [Test]

--- a/SWLOR.Game.Server.Tests/Perks/ForceUniversalTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/ForceUniversalTests.cs
@@ -61,6 +61,22 @@ public class ForceUniversalTests
     }
 
     [Test]
+    public void ForcePush_UsesBibleBaseDamageForEveryRank()
+    {
+        AssertForcePushBaseDamage("ForcePush1BaseDamage", 8);
+        AssertForcePushBaseDamage("ForcePush2BaseDamage", 12);
+        AssertForcePushBaseDamage("ForcePush3BaseDamage", 18);
+
+        var root = FindRepositoryRoot();
+        var source = File.ReadAllText((root / "SWLOR.Game.Server" / "Feature" / "AbilityDefinition" / "Force" / "ForcePushAbilityDefinition.cs").FullName)
+            .Replace("\r\n", "\n");
+
+        source.Should().Contain("SkillType.Force,\n                ForcePush1BaseDamage,");
+        source.Should().Contain("SkillType.Force,\n                ForcePush2BaseDamage,");
+        source.Should().Contain("SkillType.Force,\n                ForcePush3BaseDamage,");
+    }
+
+    [Test]
     public void ForcePush_UsesOnlyKotorImpactSfx()
     {
         var root = FindRepositoryRoot();
@@ -261,6 +277,17 @@ public class ForceUniversalTests
         ability.Targeting.SizeY.Should().Be(5f);
         ability.Targeting.Flags.Should().Be(
             AbilityTargetingFlags.HarmsEnemies | AbilityTargetingFlags.OriginOnSelf);
+    }
+
+    private static void AssertForcePushBaseDamage(string fieldName, int expectedDamage)
+    {
+        var field = typeof(ForcePushAbilityDefinition).GetField(
+            fieldName,
+            BindingFlags.NonPublic | BindingFlags.Static);
+
+        field.Should().NotBeNull($"Force Push should declare {fieldName}");
+        field!.IsLiteral.Should().BeTrue();
+        field.GetRawConstantValue().Should().Be(expectedDamage);
     }
 
     private static bool InvokeThrowLightsaberPathCheck(Vector3 origin, Vector3 destination, Vector3 candidate)

--- a/SWLOR.Game.Server.Tests/Perks/ForceUniversalTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/ForceUniversalTests.cs
@@ -71,9 +71,12 @@ public class ForceUniversalTests
         var source = File.ReadAllText((root / "SWLOR.Game.Server" / "Feature" / "AbilityDefinition" / "Force" / "ForcePushAbilityDefinition.cs").FullName)
             .Replace("\r\n", "\n");
 
-        source.Should().Contain("SkillType.Force,\n                ForcePush1BaseDamage,");
-        source.Should().Contain("SkillType.Force,\n                ForcePush2BaseDamage,");
-        source.Should().Contain("SkillType.Force,\n                ForcePush3BaseDamage,");
+        source.Should().Contain("hitTarget,\n                    ForcePush1BaseDamage,\n                    ForcePush1HobbleDurationSeconds");
+        source.Should().Contain("hitTarget,\n                    ForcePush2BaseDamage,\n                    ForcePush2HobbleDurationSeconds");
+        source.Should().Contain("hitTarget,\n                    ForcePush3BaseDamage,\n                    ForcePush3HobbleDurationSeconds");
+        source.Split("SkillType.Force,\n                0,", StringSplitOptions.None)
+            .Should().HaveCount(4, "all three Force Push ranks must bypass the stat-scaled combat formula");
+        source.Should().Contain("Combat.ApplyTriggeredDamage(\n                activator,\n                target,\n                baseDamage,\n                CombatDamageType.Force,\n                SkillType.Force);");
     }
 
     [Test]

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Force/ForcePushAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Force/ForcePushAbilityDefinition.cs
@@ -124,7 +124,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 target,
                 targetLocation,
                 SkillType.Force,
-                ForcePush1BaseDamage,
+                0,
                 KnockdownDurationSeconds,
                 typeof(KnockdownStatusEffect),
                 CombatImpactAreaShape.Cone,
@@ -136,7 +136,11 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 targetVisualEffect: VisualEffect.Vfx_Fnf_Sound_Burst_Silent,
                 areaVisualEffect: VisualEffect.None,
                 maxTargets: 1,
-                afterSuccessfulHit: hitTarget => ApplyHobble(activator, hitTarget, ForcePush1HobbleDurationSeconds),
+                afterSuccessfulHit: hitTarget => ApplyForcePushHit(
+                    activator,
+                    hitTarget,
+                    ForcePush1BaseDamage,
+                    ForcePush1HobbleDurationSeconds),
                 playImpactAnimation: false);
             LightGuardianPowerSupport.ApplyDeflectivePresence(activator);
         }
@@ -148,7 +152,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 target,
                 targetLocation,
                 SkillType.Force,
-                ForcePush2BaseDamage,
+                0,
                 KnockdownDurationSeconds,
                 typeof(KnockdownStatusEffect),
                 CombatImpactAreaShape.Cone,
@@ -160,7 +164,11 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 targetVisualEffect: VisualEffect.Vfx_Fnf_Sound_Burst_Silent,
                 areaVisualEffect: VisualEffect.None,
                 maxTargets: 2,
-                afterSuccessfulHit: hitTarget => ApplyHobble(activator, hitTarget, ForcePush2HobbleDurationSeconds),
+                afterSuccessfulHit: hitTarget => ApplyForcePushHit(
+                    activator,
+                    hitTarget,
+                    ForcePush2BaseDamage,
+                    ForcePush2HobbleDurationSeconds),
                 playImpactAnimation: false);
             LightGuardianPowerSupport.ApplyDeflectivePresence(activator);
         }
@@ -172,7 +180,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 target,
                 targetLocation,
                 SkillType.Force,
-                ForcePush3BaseDamage,
+                0,
                 KnockdownDurationSeconds,
                 typeof(KnockdownStatusEffect),
                 CombatImpactAreaShape.Cone,
@@ -184,9 +192,28 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 targetVisualEffect: VisualEffect.Vfx_Fnf_Sound_Burst_Silent,
                 areaVisualEffect: VisualEffect.None,
                 maxTargets: 3,
-                afterSuccessfulHit: hitTarget => ApplyHobble(activator, hitTarget, ForcePush3HobbleDurationSeconds),
+                afterSuccessfulHit: hitTarget => ApplyForcePushHit(
+                    activator,
+                    hitTarget,
+                    ForcePush3BaseDamage,
+                    ForcePush3HobbleDurationSeconds),
                 playImpactAnimation: false);
             LightGuardianPowerSupport.ApplyDeflectivePresence(activator);
+        }
+
+        private static void ApplyForcePushHit(
+            uint activator,
+            uint target,
+            int baseDamage,
+            int hobbleDurationSeconds)
+        {
+            Combat.ApplyTriggeredDamage(
+                activator,
+                target,
+                baseDamage,
+                CombatDamageType.Force,
+                SkillType.Force);
+            ApplyHobble(activator, target, hobbleDurationSeconds);
         }
 
         private static void ApplyHobble(uint activator, uint target, int durationSeconds)

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Force/ForcePushAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Force/ForcePushAbilityDefinition.cs
@@ -124,7 +124,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 target,
                 targetLocation,
                 SkillType.Force,
-                0,
+                ForcePush1BaseDamage,
                 KnockdownDurationSeconds,
                 typeof(KnockdownStatusEffect),
                 CombatImpactAreaShape.Cone,
@@ -136,12 +136,9 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 targetVisualEffect: VisualEffect.Vfx_Fnf_Sound_Burst_Silent,
                 areaVisualEffect: VisualEffect.None,
                 maxTargets: 1,
-                afterSuccessfulHit: hitTarget => ApplyForcePushHit(
-                    activator,
-                    hitTarget,
-                    ForcePush1BaseDamage,
-                    ForcePush1HobbleDurationSeconds),
-                playImpactAnimation: false);
+                afterSuccessfulHit: hitTarget => ApplyHobble(activator, hitTarget, ForcePush1HobbleDurationSeconds),
+                playImpactAnimation: false,
+                useUnscaledDamage: true);
             LightGuardianPowerSupport.ApplyDeflectivePresence(activator);
         }
 
@@ -152,7 +149,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 target,
                 targetLocation,
                 SkillType.Force,
-                0,
+                ForcePush2BaseDamage,
                 KnockdownDurationSeconds,
                 typeof(KnockdownStatusEffect),
                 CombatImpactAreaShape.Cone,
@@ -164,12 +161,9 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 targetVisualEffect: VisualEffect.Vfx_Fnf_Sound_Burst_Silent,
                 areaVisualEffect: VisualEffect.None,
                 maxTargets: 2,
-                afterSuccessfulHit: hitTarget => ApplyForcePushHit(
-                    activator,
-                    hitTarget,
-                    ForcePush2BaseDamage,
-                    ForcePush2HobbleDurationSeconds),
-                playImpactAnimation: false);
+                afterSuccessfulHit: hitTarget => ApplyHobble(activator, hitTarget, ForcePush2HobbleDurationSeconds),
+                playImpactAnimation: false,
+                useUnscaledDamage: true);
             LightGuardianPowerSupport.ApplyDeflectivePresence(activator);
         }
 
@@ -180,7 +174,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 target,
                 targetLocation,
                 SkillType.Force,
-                0,
+                ForcePush3BaseDamage,
                 KnockdownDurationSeconds,
                 typeof(KnockdownStatusEffect),
                 CombatImpactAreaShape.Cone,
@@ -192,28 +186,10 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 targetVisualEffect: VisualEffect.Vfx_Fnf_Sound_Burst_Silent,
                 areaVisualEffect: VisualEffect.None,
                 maxTargets: 3,
-                afterSuccessfulHit: hitTarget => ApplyForcePushHit(
-                    activator,
-                    hitTarget,
-                    ForcePush3BaseDamage,
-                    ForcePush3HobbleDurationSeconds),
-                playImpactAnimation: false);
+                afterSuccessfulHit: hitTarget => ApplyHobble(activator, hitTarget, ForcePush3HobbleDurationSeconds),
+                playImpactAnimation: false,
+                useUnscaledDamage: true);
             LightGuardianPowerSupport.ApplyDeflectivePresence(activator);
-        }
-
-        private static void ApplyForcePushHit(
-            uint activator,
-            uint target,
-            int baseDamage,
-            int hobbleDurationSeconds)
-        {
-            Combat.ApplyTriggeredDamage(
-                activator,
-                target,
-                baseDamage,
-                CombatDamageType.Force,
-                SkillType.Force);
-            ApplyHobble(activator, target, hobbleDurationSeconds);
         }
 
         private static void ApplyHobble(uint activator, uint target, int durationSeconds)

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Force/ForcePushAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Force/ForcePushAbilityDefinition.cs
@@ -17,6 +17,9 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
     public sealed class ForcePushAbilityDefinition : IAbilityListDefinition
     {
         private const int KnockdownDurationSeconds = 6;
+        private const int ForcePush1BaseDamage = 8;
+        private const int ForcePush2BaseDamage = 12;
+        private const int ForcePush3BaseDamage = 18;
         private const int ForcePush1HobbleDurationSeconds = 12;
         private const int ForcePush2HobbleDurationSeconds = 12;
         private const int ForcePush3HobbleDurationSeconds = 12;
@@ -121,7 +124,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 target,
                 targetLocation,
                 SkillType.Force,
-                0,
+                ForcePush1BaseDamage,
                 KnockdownDurationSeconds,
                 typeof(KnockdownStatusEffect),
                 CombatImpactAreaShape.Cone,
@@ -145,7 +148,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 target,
                 targetLocation,
                 SkillType.Force,
-                0,
+                ForcePush2BaseDamage,
                 KnockdownDurationSeconds,
                 typeof(KnockdownStatusEffect),
                 CombatImpactAreaShape.Cone,
@@ -169,7 +172,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 target,
                 targetLocation,
                 SkillType.Force,
-                0,
+                ForcePush3BaseDamage,
                 KnockdownDurationSeconds,
                 typeof(KnockdownStatusEffect),
                 CombatImpactAreaShape.Cone,

--- a/SWLOR.Game.Server/Service/Ability.cs
+++ b/SWLOR.Game.Server/Service/Ability.cs
@@ -1165,7 +1165,8 @@ namespace SWLOR.Game.Server.Service
             bool playImpactAnimation = true,
             AbilityType combatImpactDamageAbility = AbilityType.Invalid,
             bool resolvesHit = true,
-            bool canCritical = true)
+            bool canCritical = true,
+            bool useUnscaledDamage = false)
         {
             var totalDamage = 0;
             RecordAbilityImpactShape(activator, skillType, isArea);
@@ -1213,7 +1214,8 @@ namespace SWLOR.Game.Server.Service
                     effectDamageType: effectDamageType,
                     combatImpactDamageAbility: combatImpactDamageAbility,
                     resolvesHit: resolvesHit,
-                    canCritical: canCritical);
+                    canCritical: canCritical,
+                    useUnscaledDamage: useUnscaledDamage);
             }
             else if (GetIsObjectValid(target))
             {
@@ -1241,7 +1243,8 @@ namespace SWLOR.Game.Server.Service
                     effectDamageType: effectDamageType,
                     combatImpactDamageAbility: combatImpactDamageAbility,
                     resolvesHit: resolvesHit,
-                    canCritical: canCritical);
+                    canCritical: canCritical,
+                    useUnscaledDamage: useUnscaledDamage);
             }
 
             if (playImpactAnimation)
@@ -1292,7 +1295,8 @@ namespace SWLOR.Game.Server.Service
             bool sendsNoTargetMessage = true,
             bool resolvesHit = true,
             bool canCritical = true,
-            float impactFlashDuration = DefaultImpactFlashDuration)
+            float impactFlashDuration = DefaultImpactFlashDuration,
+            bool useUnscaledDamage = false)
         {
             RecordAbilityImpactShape(activator, skillType, true);
 
@@ -1345,7 +1349,8 @@ namespace SWLOR.Game.Server.Service
                     combatImpactDamageAbility,
                     sendsNoTargetMessage,
                     resolvesHit,
-                    canCritical);
+                    canCritical,
+                    useUnscaledDamage);
                 if (playImpactAnimation)
                     PlayCombatImpactAnimation(activator, impactAnimation);
 
@@ -1398,7 +1403,8 @@ namespace SWLOR.Game.Server.Service
                 combatImpactDamageAbility,
                 sendsNoTargetMessage,
                 resolvesHit,
-                canCritical);
+                canCritical,
+                useUnscaledDamage);
 
             switch (shape)
             {
@@ -1535,7 +1541,8 @@ namespace SWLOR.Game.Server.Service
             AbilityType combatImpactDamageAbility,
             bool sendsNoTargetMessage,
             bool resolvesHit,
-            bool canCritical)
+            bool canCritical,
+            bool useUnscaledDamage)
         {
             RecordAbilityImpactShape(activator, skillType, true);
 
@@ -1586,7 +1593,8 @@ namespace SWLOR.Game.Server.Service
                 combatImpactDamageAbility: combatImpactDamageAbility,
                 sendsNoTargetMessage: sendsNoTargetMessage,
                 resolvesHit: resolvesHit,
-                canCritical: canCritical);
+                canCritical: canCritical,
+                useUnscaledDamage: useUnscaledDamage);
         }
 
         private static ApplyTelegraphEffect BuildTelegraphedCombatImpactAction(
@@ -1624,7 +1632,8 @@ namespace SWLOR.Game.Server.Service
             AbilityType combatImpactDamageAbility,
             bool sendsNoTargetMessage,
             bool resolvesHit,
-            bool canCritical)
+            bool canCritical,
+            bool useUnscaledDamage)
         {
             return (creator, creatures) =>
             {
@@ -1713,7 +1722,8 @@ namespace SWLOR.Game.Server.Service
                         combatImpactDamageAbility: combatImpactDamageAbility,
                         sendsNoTargetMessage: sendsNoTargetMessage,
                         resolvesHit: resolvesHit,
-                        canCritical: canCritical);
+                        canCritical: canCritical,
+                        useUnscaledDamage: useUnscaledDamage);
 
                     if (ability != null)
                     {
@@ -1763,7 +1773,8 @@ namespace SWLOR.Game.Server.Service
             AbilityType combatImpactDamageAbility = AbilityType.Invalid,
             bool sendsNoTargetMessage = true,
             bool resolvesHit = true,
-            bool canCritical = true)
+            bool canCritical = true,
+            bool useUnscaledDamage = false)
         {
             var totalDamage = 0;
             var affectedCount = 0;
@@ -1803,7 +1814,8 @@ namespace SWLOR.Game.Server.Service
                     effectDamageType,
                     combatImpactDamageAbility,
                     resolvesHit,
-                    canCritical);
+                    canCritical,
+                    useUnscaledDamage);
                 affectedCount++;
             }
 
@@ -2165,7 +2177,8 @@ namespace SWLOR.Game.Server.Service
             DamageType? effectDamageType = null,
             AbilityType combatImpactDamageAbility = AbilityType.Invalid,
             bool resolvesHit = true,
-            bool canCritical = true)
+            bool canCritical = true,
+            bool useUnscaledDamage = false)
         {
             using var damageDerivedHealing = Combat.BeginDamageDerivedHealing(activator);
             var trackedImpact = GetTrackedAbilityImpact(activator);
@@ -2217,9 +2230,11 @@ namespace SWLOR.Game.Server.Service
                 activator,
                 skillType,
                 appliedStatusCategories);
-            var damage = usesNPCStatScaling
-                ? CalculateNPCCombatImpactDamage(activator, target, skillType, adjustedBaseDamage, damageType, criticalRatePercentAdjustment, damageAbility, canCritical)
-                : CalculateCombatImpactDamage(activator, target, skillType, adjustedBaseDamage, damageType, criticalRatePercentAdjustment, damageAbility, canCritical);
+            var damage = useUnscaledDamage
+                ? CalculateUnscaledCombatImpactDamage(activator, target, skillType, adjustedBaseDamage, damageType)
+                : usesNPCStatScaling
+                    ? CalculateNPCCombatImpactDamage(activator, target, skillType, adjustedBaseDamage, damageType, criticalRatePercentAdjustment, damageAbility, canCritical)
+                    : CalculateCombatImpactDamage(activator, target, skillType, adjustedBaseDamage, damageType, criticalRatePercentAdjustment, damageAbility, canCritical);
             damage = ApplyDamagePercentAdjustment(target, damage, damagePercentAdjustment);
             damage = ApplyDarkForceTargetLowHPDamageModifier(activator, target, damage);
             return ApplyHostileCombatImpact(
@@ -2431,6 +2446,37 @@ namespace SWLOR.Game.Server.Service
             hpCost = Math.Min(hpCost, Math.Max(0, GetCurrentHitPoints(activator) - 1));
             if (hpCost > 0)
                 AssignCommand(activator, () => ApplyEffectToObject(DurationType.Instant, EffectDamage(hpCost), activator));
+        }
+
+        private static int CalculateUnscaledCombatImpactDamage(
+            uint activator,
+            uint target,
+            SkillType skillType,
+            int baseDamage,
+            CombatDamageType damageType)
+        {
+            if (baseDamage <= 0)
+                return 0;
+
+            var damage = Combat.ApplyDamageDealtModifiers(
+                activator,
+                target,
+                baseDamage,
+                skillType,
+                damageType,
+                isAbilityDamage: true);
+            damage = ApplyCombatReadinessToActivatedAbilityMagnitude(activator, damage);
+            Combat.ApplyIncomingPhysicalToForceConversion(activator, target, damageType, ref damage);
+            damage = Combat.ApplyTypedLeadershipDamageTakenModifier(target, damage, damageType);
+            damage = Resistance.ApplyResistanceToDamage(target, damageType, damage);
+            damage = Combat.ApplyDamageTakenModifiers(
+                target,
+                damage,
+                activator,
+                damageType,
+                typedLeadershipReductionAlreadyApplied: true);
+
+            return damage;
         }
 
         private static int CalculateCombatImpactDamage(

--- a/SWLOR.Game.Server/Service/Ability.cs
+++ b/SWLOR.Game.Server/Service/Ability.cs
@@ -2458,10 +2458,12 @@ namespace SWLOR.Game.Server.Service
             if (baseDamage <= 0)
                 return 0;
 
-            var damage = Combat.ApplyDamageDealtModifiers(
+            var trackedImpact = GetTrackedAbilityImpact(activator);
+            var damage = baseDamage + (trackedImpact?.NextAbilityDamageBonus ?? 0);
+            damage = Combat.ApplyDamageDealtModifiers(
                 activator,
                 target,
-                baseDamage,
+                damage,
                 skillType,
                 damageType,
                 isAbilityDamage: true);


### PR DESCRIPTION
## Summary
- apply the Design Bible's 8/12/18 Force Push base damage by rank
- add an explicit unscaled primary-damage mode that bypasses Willpower/critical formula scaling while retaining shared outgoing and incoming damage modifiers
- keep damage in the tracked primary-impact path for temporary-HP feedback and activator-attributed combat-log entries
- preserve queued flat next-ability damage bonuses, knockdown, hobble, and rank target caps
- add regression coverage for Force Push wiring and the shared unscaled-damage path

## Testing
- `dotnet build SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj -p:RunPostBuildEvent=Never` (succeeded; 8 pre-existing nullable warnings)
- `dotnet test SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj --no-build --filter "FullyQualifiedName~AbilityDamageQueueTests|Name~ForcePush_"` (14 passed)

## Note
- An earlier broader `ForceUniversalTests` run passed 10 tests; its unrelated icon-resource test could not run because this worktree does not contain the `SWLOR_Haks` submodule files.