### PR TITLE
Fix queued beast weapon damage

### DIFF
--- a/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
@@ -173,13 +173,13 @@ public class CombatDamageTests
         var impactWeaponDamage = ExtractMethod(combatSource, "public static int GetCombatImpactWeaponDamage");
         var impactWeaponSelection = ExtractMethod(combatSource, "private static uint GetCombatImpactWeapon");
 
-        abilitySource.Should().Contain("Combat.GetCombatImpactWeaponDamage(activator, skillType)");
+        abilitySource.Should().Contain("Combat.GetCombatImpactWeaponDamage(activator, skillType");
         abilitySource.Should().Contain("effectDamageType ?? damageType.GetNWScriptDamageType()");
         abilitySource.Should().NotContain("GetNWScriptDamagePower");
         abilitySource.Should().NotContain("GetCombatImpactEffectDamagePower");
         abilitySource.Should().NotContain("private static int GetCombatImpactWeaponDamage");
         combatSource.Should().NotContain("IsWeaponForSkill");
-        impactWeaponDamage.Should().Contain("var weapon = GetCombatImpactWeapon(activator, skillType);");
+        impactWeaponDamage.Should().Contain("var weapon = GetCombatImpactWeapon(activator, skillType");
         impactWeaponSelection.Should().Contain("CanItemTriggerWeaponAbility(rightHand, skillType)");
         impactWeaponSelection.Should().Contain("CanItemTriggerWeaponAbility(leftHand, skillType)");
         damageTypeSource.Should().NotContain("GetNWScriptDamagePower");
@@ -561,6 +561,33 @@ public class CombatDamageTests
         queuedAccuracyIndex.Should().BeGreaterThanOrEqualTo(0);
         queuedAccuracyIndex.Should().BeLessThan(hitRateIndex,
             "Patience Accuracy must affect the native roll that lands a queued Headshot");
+    }
+
+    [Test]
+    public void QueuedBeastWeaponAbilities_IncludeNaturalWeaponDamage()
+    {
+        var root = FindRepositoryRoot();
+        var abilitySource = File.ReadAllText(Path.Combine(root.FullName, "SWLOR.Game.Server", "Service", "Ability.cs"));
+        var combatSource = File.ReadAllText(Path.Combine(root.FullName, "SWLOR.Game.Server", "Service", "Combat.cs"));
+        var playerDamage = ExtractMethod(abilitySource, "private static int CalculateCombatImpactDamage");
+        var npcDamage = ExtractMethod(abilitySource, "private static int CalculateNPCCombatImpactDamage");
+        var impactWeaponDamage = ExtractMethod(combatSource, "public static int GetCombatImpactWeaponDamage");
+        var impactWeaponSelection = ExtractMethod(combatSource, "private static uint GetCombatImpactWeapon");
+
+        foreach (var damageCalculation in new[] { playerDamage, npcDamage })
+        {
+            damageCalculation.Should().Contain(
+                "trackedImpact?.Ability?.ActivationType == AbilityActivationType.Weapon");
+            damageCalculation.Should().Contain("skillType == SkillType.BeastMastery");
+            damageCalculation.Should().Contain("!usesQueuedNaturalWeapon");
+            damageCalculation.Should().Contain(
+                "Combat.GetCombatImpactWeaponDamage(activator, skillType, usesQueuedNaturalWeapon)");
+        }
+
+        impactWeaponDamage.Should().Contain(
+            "usesQueuedNaturalWeapon && skillType == SkillType.BeastMastery");
+        impactWeaponSelection.Should().Contain(
+            "return GetCreatureNaturalWeapon(activator);");
     }
 
     [Test]

--- a/SWLOR.Game.Server/Service/Ability.cs
+++ b/SWLOR.Game.Server/Service/Ability.cs
@@ -2443,15 +2443,22 @@ namespace SWLOR.Game.Server.Service
             AbilityType combatImpactDamageAbility = AbilityType.Invalid,
             bool canCritical = true)
         {
-            if (baseDamage <= 0 && !Combat.IsWeaponSkillType(skillType))
-                return 0;
-
             var trackedImpact = GetTrackedAbilityImpact(activator);
+            var usesQueuedNaturalWeapon =
+                trackedImpact?.Ability?.ActivationType == AbilityActivationType.Weapon &&
+                skillType == SkillType.BeastMastery;
+            if (baseDamage <= 0 &&
+                !Combat.IsWeaponSkillType(skillType) &&
+                !usesQueuedNaturalWeapon)
+            {
+                return 0;
+            }
+
             var ability = GetCombatImpactDamageAbility(activator, combatImpactDamageAbility);
             var perkType = trackedImpact?.Ability?.EffectiveLevelPerkType ?? PerkType.Invalid;
             var idleBonuses = Combat.GetIdleSkillAbilityBonuses(activator, skillType);
             var damage = baseDamage +
-                Combat.GetCombatImpactWeaponDamage(activator, skillType) +
+                Combat.GetCombatImpactWeaponDamage(activator, skillType, usesQueuedNaturalWeapon) +
                 Combat.GetAbilityDamageBonus(activator, skillType) +
                 Combat.GetAbilityDamageFlatAdjustment(activator, perkType, skillType) +
                 Combat.GetCostlyAbilityDamageBonus(activator, trackedImpact?.Ability, skillType) +
@@ -2661,16 +2668,23 @@ namespace SWLOR.Game.Server.Service
             AbilityType combatImpactDamageAbility = AbilityType.Invalid,
             bool canCritical = true)
         {
-            if (baseDamage <= 0 && !Combat.IsWeaponSkillType(skillType))
-                return 0;
-
             var trackedImpact = GetTrackedAbilityImpact(activator);
+            var usesQueuedNaturalWeapon =
+                trackedImpact?.Ability?.ActivationType == AbilityActivationType.Weapon &&
+                skillType == SkillType.BeastMastery;
+            if (baseDamage <= 0 &&
+                !Combat.IsWeaponSkillType(skillType) &&
+                !usesQueuedNaturalWeapon)
+            {
+                return 0;
+            }
+
             var ability = GetCombatImpactDamageAbility(activator, combatImpactDamageAbility);
             var perkType = trackedImpact?.Ability?.EffectiveLevelPerkType ?? PerkType.Invalid;
             var idleBonuses = Combat.GetIdleSkillAbilityBonuses(activator, skillType);
             var scalingRank = GetNPCAbilityScalingRank(activator, skillType, damageType, combatImpactDamageAbility);
             var damage = baseDamage +
-                Combat.GetCombatImpactWeaponDamage(activator, skillType) +
+                Combat.GetCombatImpactWeaponDamage(activator, skillType, usesQueuedNaturalWeapon) +
                 (int)Math.Ceiling(scalingRank * 0.15f) +
                 Combat.GetAbilityDamageFlatAdjustment(activator, perkType, skillType) +
                 Combat.GetCostlyAbilityDamageBonus(activator, trackedImpact?.Ability, skillType) +

--- a/SWLOR.Game.Server/Service/Combat.cs
+++ b/SWLOR.Game.Server/Service/Combat.cs
@@ -10956,19 +10956,31 @@ namespace SWLOR.Game.Server.Service
                    IsWeaponSkillType(skillType);
         }
 
-        public static int GetCombatImpactWeaponDamage(uint activator, SkillType skillType)
+        public static int GetCombatImpactWeaponDamage(
+            uint activator,
+            SkillType skillType,
+            bool usesQueuedNaturalWeapon = false)
         {
-            if (!IsWeaponSkillType(skillType))
+            if (!IsWeaponSkillType(skillType) &&
+                !(usesQueuedNaturalWeapon && skillType == SkillType.BeastMastery))
+            {
                 return 0;
+            }
 
-            var weapon = GetCombatImpactWeapon(activator, skillType);
+            var weapon = GetCombatImpactWeapon(activator, skillType, usesQueuedNaturalWeapon);
             return GetIsObjectValid(weapon)
                 ? Item.GetDMG(weapon)
                 : 0;
         }
 
-        private static uint GetCombatImpactWeapon(uint activator, SkillType skillType)
+        private static uint GetCombatImpactWeapon(
+            uint activator,
+            SkillType skillType,
+            bool usesQueuedNaturalWeapon = false)
         {
+            if (usesQueuedNaturalWeapon && skillType == SkillType.BeastMastery)
+                return GetCreatureNaturalWeapon(activator);
+
             var rightHand = GetItemInSlot(InventorySlot.RightHand, activator);
             if (CanItemTriggerWeaponAbility(rightHand, skillType))
                 return rightHand;


### PR DESCRIPTION
## Summary

- include a beast's natural-weapon DMG when queued Beast Mastery attacks replace the native swing
- preserve natural attack damage for zero-base-damage queued beast abilities such as Distracting Feint
- keep casted Beast Mastery ability damage unchanged
- add regression coverage for player and NPC combat-impact paths

## Testing

- `dotnet build SWLOR.Game.Server.Tests\\SWLOR.Game.Server.Tests.csproj -p:RunPostBuildEvent=Never`
- `dotnet test SWLOR.Game.Server.Tests\\SWLOR.Game.Server.Tests.csproj --no-build --filter "FullyQualifiedName~QueuedBeastWeaponAbilities_IncludeNaturalWeaponDamage|FullyQualifiedName~AbilityCombatImpact_IncludesWeaponDamageAndKeepsPhysicalEffectDamagePhysical"`
- `dotnet test SWLOR.Game.Server.Tests\\SWLOR.Game.Server.Tests.csproj --no-build --filter "FullyQualifiedName~BeastmasterCombatUpgradeTests"`