### PR TITLE
Prevent Mimicry technique swap buff persistence

### DIFF
--- a/SWLOR.Game.Server.Tests/Perks/MimicryTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/MimicryTests.cs
@@ -836,6 +836,67 @@ public class MimicryTests
     }
 
     [Test]
+    public void MimicryTechniqueActivation_RequiresTheTechniqueToRemainEquipped()
+    {
+        var root = FindRepositoryRoot();
+        var abilitySource = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "SWLOR.Game.Server",
+            "Service",
+            "Ability.cs"));
+
+        abilitySource.Should().Contain("ability.IsMimicryTechnique &&");
+        abilitySource.Should().Contain("!Mimicry.IsTechniqueEquipped(activator, abilityType)",
+            "both the initial and post-cast activation checks use CanUseAbility, so an unequipped technique cannot resolve");
+
+        var equipped = new Player();
+        equipped.EquippedTechniques.Add(FeatType.WardenWallTechnique);
+
+        Mimicry.IsTechniqueEquipped(equipped, FeatType.WardenWallTechnique).Should().BeTrue();
+        Mimicry.IsTechniqueEquipped(equipped, FeatType.SustainBurnTechnique).Should().BeFalse();
+        Mimicry.IsTechniqueEquipped((Player)null, FeatType.WardenWallTechnique).Should().BeFalse();
+    }
+
+    [Test]
+    public void MimicryTechniqueUnequip_RemovesDeclaredPersistentEffects()
+    {
+        var techniques = BuildAllAbilities(MimicryTechniqueNamespace)
+            .ToDictionary(technique => technique.Feat, technique => technique.Detail);
+
+        foreach (var feat in new[]
+                 {
+                     FeatType.ApexCollapseTechnique,
+                     FeatType.SustainBurnTechnique,
+                     FeatType.WardenWallTechnique
+                 })
+        {
+            techniques[feat].IsMimicryStance.Should().BeTrue();
+            techniques[feat].StatusEffectTypesRemovedOnPerkRefund.Should().ContainSingle(
+                $"{feat} must declare its permanent wearer effect for revocation cleanup");
+        }
+
+        techniques[FeatType.WardenWallTechnique]
+            .SourceOwnedStatusEffectTypesRemovedOnPerkRefund
+            .Should().Contain(typeof(WardenWallAuraStatusEffect),
+                "unequipping Warden Wall must also remove the aura it granted to nearby allies");
+
+        var root = FindRepositoryRoot();
+        var mimicrySource = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "SWLOR.Game.Server",
+            "Service",
+            "Mimicry.cs"));
+        var revokeStart = mimicrySource.IndexOf("private static void RevokeTechniqueFeat", StringComparison.Ordinal);
+        var revokeEnd = mimicrySource.IndexOf("private static bool IsFeatOnHotBar", revokeStart, StringComparison.Ordinal);
+        var revokeBody = mimicrySource[revokeStart..revokeEnd];
+
+        revokeBody.Should().Contain("detail.StatusEffectTypesRemovedOnPerkRefund");
+        revokeBody.Should().Contain("StatusEffect.RemoveStatusEffect(player, statusEffectType, false);");
+        revokeBody.Should().Contain("detail.SourceOwnedStatusEffectTypesRemovedOnPerkRefund");
+        revokeBody.Should().Contain("StatusEffect.RemoveStatusEffectsFromAllTargetsBySource(");
+    }
+
+    [Test]
     public void Mimicry_LearnChanceScalesWithSkillRankPatternRecognitionAndPerception()
     {
         // Baseline: Mimicry rank at the technique requirement, no Pattern Recognition, Perception at the

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Mimicry/WardenWallTechniqueAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Mimicry/WardenWallTechniqueAbilityDefinition.cs
@@ -23,6 +23,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Mimicry
                 .MimicryStance(FeatType.WardenWall, 47, 3);
 
             ConfigureToggle(ability, typeof(WardenWallStatusEffect));
+            ability.RemoveSourceOwnedStatusEffectOnPerkRefund(typeof(WardenWallAuraStatusEffect));
 
             return _builder.Build();
         }

--- a/SWLOR.Game.Server/Service/Ability.cs
+++ b/SWLOR.Game.Server/Service/Ability.cs
@@ -430,6 +430,15 @@ namespace SWLOR.Game.Server.Service
                 return Deny("A newer rank has replaced this ability.");
             }
 
+            // Mimicry techniques are granted through the equipped technique loadout rather than
+            // directly by Combat Analyzer. Re-check the loadout at both activation gates so a stale
+            // feat, or a technique unequipped while its cast is winding up, cannot still resolve.
+            if (ability.IsMimicryTechnique &&
+                !Mimicry.IsTechniqueEquipped(activator, abilityType))
+            {
+                return Deny("That technique is not equipped.");
+            }
+
             // Activator is dead.
             if (GetCurrentHitPoints(activator) <= 0)
             {

--- a/SWLOR.Game.Server/Service/Mimicry.cs
+++ b/SWLOR.Game.Server/Service/Mimicry.cs
@@ -865,13 +865,31 @@ namespace SWLOR.Game.Server.Service
         }
 
         /// <summary>
-        /// Removes the technique's feat and any hotbar slot referencing it. Trait stats need no
-        /// revoke step; they stop applying as soon as the feat leaves the equipped list.
+        /// Removes the technique's feat, any hotbar slot referencing it, and persistent effects
+        /// declared by the ability. Trait stats need no explicit revoke step; they stop applying as
+        /// soon as the feat leaves the equipped list.
         /// </summary>
         private static void RevokeTechniqueFeat(uint player, FeatType feat)
         {
             if (!GetIsObjectValid(player))
                 return;
+
+            var detail = GetTechniqueDetail(feat);
+            if (detail != null)
+            {
+                foreach (var statusEffectType in detail.StatusEffectTypesRemovedOnPerkRefund)
+                {
+                    StatusEffect.RemoveStatusEffect(player, statusEffectType, false);
+                }
+
+                foreach (var statusEffectType in detail.SourceOwnedStatusEffectTypesRemovedOnPerkRefund)
+                {
+                    StatusEffect.RemoveStatusEffectsFromAllTargetsBySource(
+                        player,
+                        statusEffectType,
+                        false);
+                }
+            }
 
             CreaturePlugin.RemoveFeat(player, feat);
             RemoveFeatFromHotBar(player, feat);
@@ -973,6 +991,27 @@ namespace SWLOR.Game.Server.Service
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Returns true when a technique feat is present in a player's equipped loadout.
+        /// </summary>
+        public static bool IsTechniqueEquipped(uint player, FeatType feat)
+        {
+            if (!GetIsPC(player) || GetIsDM(player))
+                return false;
+
+            var playerId = GetObjectUUID(player);
+            return IsTechniqueEquipped(DB.Get<Player>(playerId), feat);
+        }
+
+        /// <summary>
+        /// Returns true when a technique feat is present in an already-fetched player record's
+        /// equipped loadout.
+        /// </summary>
+        public static bool IsTechniqueEquipped(Player dbPlayer, FeatType feat)
+        {
+            return dbPlayer?.EquippedTechniques.Contains(feat) == true;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

- remove permanent wearer effects when a Mimicry technique is unequipped or forcibly revoked
- remove Warden Wall's source-owned ally aura when Warden Wall leaves the loadout
- require a Mimicry technique to remain equipped at both ability activation gates, preventing stale feats and mid-cast swaps from resolving
- add regression coverage for loadout validation and persistent-effect cleanup

## Validation

- `dotnet build SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj -p:RunPostBuildEvent=Never`
- `dotnet test SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj --no-build --filter "FullyQualifiedName~SWLOR.Game.Server.Tests.Perks.MimicryTests|FullyQualifiedName~SWLOR.Game.Server.Tests.Service.PerkRefundStatusEffectCleanupTests"`
- 35 focused tests passed
- `git diff --check`

## Review

- Codex review is clean on head `8a5e0f980e`
- CodeRabbit completed successfully
- zero unresolved review threads
