### PR TITLE
Add SWLOR custom TLK editor

### DIFF
--- a/SWLOR.NWN.Formats.Tests/TlkReaderTests.cs
+++ b/SWLOR.NWN.Formats.Tests/TlkReaderTests.cs
@@ -108,7 +108,7 @@ public class TlkReaderTests
         BinaryPrimitives.WriteUInt32LittleEndian(bytes.AsSpan(12), (uint)count);
         BinaryPrimitives.WriteUInt32LittleEndian(bytes.AsSpan(16), (uint)bytes.Length);
 
-        for (var index = 0; index < 2; index++)
+        for (var index = 0; index < 3; index++)
         {
             var entryOffset = 20 + index * 40;
             BinaryPrimitives.WriteUInt32LittleEndian(bytes.AsSpan(entryOffset), 0x0002);
@@ -119,5 +119,31 @@ public class TlkReaderTests
 
         read.Should().Throw<NwnFormatException>()
             .WithMessage("*allocation budget*TLK sound ResRef*");
+    }
+
+    [Test]
+    public void UniqueDecodedTextRangesIncludeStringAndDictionaryOverheadInTheBudget()
+    {
+        var count = TlkFormatLimits.MaximumEntryCount;
+        var stringsOffset = checked(20 + count * 40);
+        var bytes = new byte[stringsOffset + 2];
+        "TLK "u8.CopyTo(bytes);
+        "V3.0"u8.CopyTo(bytes.AsSpan(4));
+        BinaryPrimitives.WriteUInt32LittleEndian(bytes.AsSpan(12), (uint)count);
+        BinaryPrimitives.WriteUInt32LittleEndian(bytes.AsSpan(16), (uint)stringsOffset);
+
+        for (var index = 0; index < 2; index++)
+        {
+            var entryOffset = 20 + index * 40;
+            BinaryPrimitives.WriteUInt32LittleEndian(bytes.AsSpan(entryOffset), 0x0001);
+            BinaryPrimitives.WriteUInt32LittleEndian(bytes.AsSpan(entryOffset + 28), (uint)index);
+            BinaryPrimitives.WriteUInt32LittleEndian(bytes.AsSpan(entryOffset + 32), 1);
+            bytes[stringsOffset + index] = (byte)('a' + index);
+        }
+
+        Action read = () => TlkReader.Read(bytes);
+
+        read.Should().Throw<NwnFormatException>()
+            .WithMessage("*allocation budget*TLK string 1*");
     }
 }

--- a/SWLOR.NWN.Formats.Tests/TlkReaderTests.cs
+++ b/SWLOR.NWN.Formats.Tests/TlkReaderTests.cs
@@ -97,4 +97,27 @@ public class TlkReaderTests
 
         read.Should().Throw<NwnFormatException>().WithMessage("*allocation budget*");
     }
+
+    [Test]
+    public void SoundResRefsAreChargedAgainstTheDecodedAllocationBudget()
+    {
+        var count = TlkFormatLimits.MaximumEntryCount;
+        var bytes = new byte[checked(20 + count * 40)];
+        "TLK "u8.CopyTo(bytes);
+        "V3.0"u8.CopyTo(bytes.AsSpan(4));
+        BinaryPrimitives.WriteUInt32LittleEndian(bytes.AsSpan(12), (uint)count);
+        BinaryPrimitives.WriteUInt32LittleEndian(bytes.AsSpan(16), (uint)bytes.Length);
+
+        for (var index = 0; index < 2; index++)
+        {
+            var entryOffset = 20 + index * 40;
+            BinaryPrimitives.WriteUInt32LittleEndian(bytes.AsSpan(entryOffset), 0x0002);
+            Encoding.ASCII.GetBytes("sixteen_char_ref").CopyTo(bytes, entryOffset + 4);
+        }
+
+        Action read = () => TlkReader.Read(bytes);
+
+        read.Should().Throw<NwnFormatException>()
+            .WithMessage("*allocation budget*TLK sound ResRef*");
+    }
 }

--- a/SWLOR.NWN.Formats.Tests/TlkReaderTests.cs
+++ b/SWLOR.NWN.Formats.Tests/TlkReaderTests.cs
@@ -77,4 +77,24 @@ public class TlkReaderTests
         Action wrongVersion = () => TlkReader.Read(bytes);
         wrongVersion.Should().Throw<NwnFormatException>();
     }
+
+    [Test]
+    public void SingleByteTextCannotExceedTheDecodedUtf16AllocationBudget()
+    {
+        var encodedLength = checked((int)(
+            (TlkFormatLimits.MaximumDecodedAllocationBytes -
+             TlkFormatLimits.EstimatedManagedBytesPerEntry) / sizeof(char) + 1));
+        var bytes = new byte[60 + encodedLength];
+        "TLK "u8.CopyTo(bytes);
+        "V3.0"u8.CopyTo(bytes.AsSpan(4));
+        BinaryPrimitives.WriteUInt32LittleEndian(bytes.AsSpan(12), 1);
+        BinaryPrimitives.WriteUInt32LittleEndian(bytes.AsSpan(16), 60);
+        BinaryPrimitives.WriteUInt32LittleEndian(bytes.AsSpan(20), 1);
+        BinaryPrimitives.WriteUInt32LittleEndian(bytes.AsSpan(48), 0);
+        BinaryPrimitives.WriteUInt32LittleEndian(bytes.AsSpan(52), (uint)encodedLength);
+
+        Action read = () => TlkReader.Read(bytes);
+
+        read.Should().Throw<NwnFormatException>().WithMessage("*allocation budget*");
+    }
 }

--- a/SWLOR.NWN.Formats.Tests/TlkWriterTests.cs
+++ b/SWLOR.NWN.Formats.Tests/TlkWriterTests.cs
@@ -68,7 +68,7 @@ public class TlkWriterTests
     [Test]
     public void FormatLimits_ExposeConsistentEntryCountAndIdBoundaries()
     {
-        TlkFormatLimits.MaximumEntryCount.Should().Be(1_048_575);
+        TlkFormatLimits.MaximumEntryCount.Should().Be(1_048_574);
         TlkFormatLimits.MaximumEntryId.Should().Be(TlkFormatLimits.MaximumEntryCount - 1);
     }
 
@@ -89,7 +89,7 @@ public class TlkWriterTests
 
         Action exceedDecodedBudget = () => TlkWriter.Write(0, new Dictionary<int, string>
         {
-            [TlkFormatLimits.MaximumEntryId] = new string('x', 33)
+            [TlkFormatLimits.MaximumEntryId] = new string('x', 29)
         });
         exceedDecodedBudget.Should().Throw<ArgumentException>()
             .WithMessage("*decoded metadata and text*");
@@ -103,7 +103,7 @@ public class TlkWriterTests
         uint languageId,
         string character)
     {
-        var text = string.Concat(Enumerable.Repeat(character, 32));
+        var text = string.Concat(Enumerable.Repeat(character, 28));
         var bytes = TlkWriter.Write(languageId, new Dictionary<int, string>
         {
             [TlkFormatLimits.MaximumEntryId] = text

--- a/SWLOR.NWN.Formats.Tests/TlkWriterTests.cs
+++ b/SWLOR.NWN.Formats.Tests/TlkWriterTests.cs
@@ -89,7 +89,7 @@ public class TlkWriterTests
 
         Action exceedDecodedBudget = () => TlkWriter.Write(0, new Dictionary<int, string>
         {
-            [TlkFormatLimits.MaximumEntryId] = new string('x', 65)
+            [TlkFormatLimits.MaximumEntryId] = new string('x', 33)
         });
         exceedDecodedBudget.Should().Throw<ArgumentException>()
             .WithMessage("*decoded metadata and text*");

--- a/SWLOR.NWN.Formats.Tests/TlkWriterTests.cs
+++ b/SWLOR.NWN.Formats.Tests/TlkWriterTests.cs
@@ -1,0 +1,146 @@
+using System.Buffers.Binary;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using NUnit.Framework;
+using SWLOR.NWN.Formats.Tlk;
+
+namespace SWLOR.NWN.Formats.Tests;
+
+public class TlkWriterTests
+{
+    [Test]
+    public void Writer_RoundTripsSparseMultilineAndExplicitEmptyEntries()
+    {
+        var source = new Dictionary<int, string>
+        {
+            [2] = "First line\nSecond line",
+            [5] = string.Empty
+        };
+
+        var bytes = TlkWriter.Write(0, source);
+        var tlk = TlkReader.Read(bytes);
+
+        tlk.LanguageId.Should().Be(0);
+        tlk.Entries.Should().HaveCount(6);
+        tlk.GetString(0).Should().BeNull();
+        tlk.GetString(1).Should().BeNull();
+        tlk.GetString(2).Should().Be("First line\nSecond line");
+        tlk.GetString(3).Should().BeNull();
+        tlk.GetString(4).Should().BeNull();
+        tlk.GetString(5).Should().BeEmpty();
+        tlk.Entries[5].Flags.Should().Be(1);
+    }
+
+    [Test]
+    public void Writer_UsesTheLanguageCodePageWithoutLossyReplacement()
+    {
+        var bytes = TlkWriter.Write(5, new Dictionary<int, string> { [0] = "Łódź" });
+
+        bytes.AsSpan(60).ToArray().Should().Equal(0xA3, 0xF3, 0x64, 0x9F);
+        TlkReader.Read(bytes).GetString(0).Should().Be("Łódź");
+
+        Action writeUnencodable = () =>
+            TlkWriter.Write(0, new Dictionary<int, string> { [0] = "Not Windows-1252: 😀" });
+        writeUnencodable.Should().Throw<ArgumentException>()
+            .WithMessage("*entry 0*cannot be encoded*")
+            .WithInnerException<EncoderFallbackException>();
+    }
+
+    [Test]
+    public void Writer_RejectsInvalidIdsAndNullText()
+    {
+        Action negativeId = () =>
+            TlkWriter.Write(0, new Dictionary<int, string> { [-1] = "invalid" });
+        Action excessiveId = () =>
+            TlkWriter.Write(0, new Dictionary<int, string>
+            {
+                [TlkFormatLimits.MaximumEntryId + 1] = "invalid"
+            });
+        var nullTextEntries = new Dictionary<int, string> { [0] = null! };
+        Action nullText = () => TlkWriter.Write(0, nullTextEntries);
+
+        negativeId.Should().Throw<ArgumentOutOfRangeException>();
+        excessiveId.Should().Throw<ArgumentOutOfRangeException>();
+        nullText.Should().Throw<ArgumentException>().WithMessage("*entry 0 has null text*");
+    }
+
+    [Test]
+    public void FormatLimits_ExposeConsistentEntryCountAndIdBoundaries()
+    {
+        TlkFormatLimits.MaximumEntryCount.Should().Be(1_048_575);
+        TlkFormatLimits.MaximumEntryId.Should().Be(TlkFormatLimits.MaximumEntryCount - 1);
+    }
+
+    [Test]
+    public void WriterAndReader_AgreeAtTheEffectiveEntryAndAllocationBoundary()
+    {
+        var source = new Dictionary<int, string>
+        {
+            [TlkFormatLimits.MaximumEntryId] = "last"
+        };
+
+        var bytes = TlkWriter.Write(0, source);
+        BinaryPrimitives.ReadUInt32LittleEndian(bytes.AsSpan(12))
+            .Should().Be((uint)TlkFormatLimits.MaximumEntryCount);
+        var roundTripped = TlkReader.Read(bytes);
+        roundTripped.Entries.Should().HaveCount(TlkFormatLimits.MaximumEntryCount);
+        roundTripped.GetString((uint)TlkFormatLimits.MaximumEntryId).Should().Be("last");
+
+        Action exceedDecodedBudget = () => TlkWriter.Write(0, new Dictionary<int, string>
+        {
+            [TlkFormatLimits.MaximumEntryId] = new string('x', 65)
+        });
+        exceedDecodedBudget.Should().Throw<ArgumentException>()
+            .WithMessage("*decoded metadata and text*");
+    }
+
+    [Test]
+    public void Writer_EmptyInputProducesAValidEmptyTlk()
+    {
+        var bytes = TlkWriter.Write(0, new Dictionary<int, string>());
+
+        bytes.Should().HaveCount(20);
+        BinaryPrimitives.ReadUInt32LittleEndian(bytes.AsSpan(12)).Should().Be(0);
+        BinaryPrimitives.ReadUInt32LittleEndian(bytes.AsSpan(16)).Should().Be(20);
+        TlkReader.Read(bytes).Entries.Should().BeEmpty();
+    }
+
+    [Test]
+    public void Writer_ReproducesTheCheckedInSwlorCustomTlk()
+    {
+        var repoRoot = FindRepositoryRoot();
+        var tlkDirectory = Path.Combine(repoRoot, "SWLOR_Haks", "sw_tlk");
+        using var json = JsonDocument.Parse(File.ReadAllBytes(Path.Combine(tlkDirectory, "sw_tlk.tlk.json")));
+        var languageId = json.RootElement.GetProperty("language").GetUInt32();
+        var entries = json.RootElement.GetProperty("entries")
+            .EnumerateArray()
+            .ToDictionary(
+                entry => entry.GetProperty("id").GetInt32(),
+                entry => entry.GetProperty("text").GetString()!);
+
+        var generated = TlkWriter.Write(languageId, entries);
+        var checkedIn = File.ReadAllBytes(Path.Combine(tlkDirectory, "sw_tlk.tlk"));
+
+        generated.Should().Equal(checkedIn);
+        var roundTripped = TlkReader.Read(generated);
+        roundTripped.Entries.Should().HaveCount(entries.Keys.Max() + 1);
+        roundTripped.GetString(80_831).Should().BeNull();
+        foreach (var (id, text) in entries)
+            roundTripped.GetString((uint)id).Should().Be(text);
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(TestContext.CurrentContext.TestDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "SWLOR.Game.Server.sln")))
+                return directory.FullName;
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate the SWLOR repository root.");
+    }
+}

--- a/SWLOR.NWN.Formats.Tests/TlkWriterTests.cs
+++ b/SWLOR.NWN.Formats.Tests/TlkWriterTests.cs
@@ -95,6 +95,25 @@ public class TlkWriterTests
             .WithMessage("*decoded metadata and text*");
     }
 
+    [TestCase(128u, "가")]
+    [TestCase(129u, "繁")]
+    [TestCase(130u, "汉")]
+    [TestCase(131u, "あ")]
+    public void WriterAndReader_AgreeNearTheAllocationBoundaryForDbcsLanguages(
+        uint languageId,
+        string character)
+    {
+        var text = string.Concat(Enumerable.Repeat(character, 32));
+        var bytes = TlkWriter.Write(languageId, new Dictionary<int, string>
+        {
+            [TlkFormatLimits.MaximumEntryId] = text
+        });
+
+        var roundTripped = TlkReader.Read(bytes);
+
+        roundTripped.GetString((uint)TlkFormatLimits.MaximumEntryId).Should().Be(text);
+    }
+
     [Test]
     public void Writer_EmptyInputProducesAValidEmptyTlk()
     {

--- a/SWLOR.NWN.Formats/Internal/NwnTextEncoding.cs
+++ b/SWLOR.NWN.Formats/Internal/NwnTextEncoding.cs
@@ -24,7 +24,20 @@ internal static class NwnTextEncoding
 
     public static Encoding ForLanguage(uint languageId)
     {
-        var codePage = languageId switch
+        return Encoding.GetEncoding(GetCodePage(languageId));
+    }
+
+    public static Encoding ForLanguageStrict(uint languageId)
+    {
+        return Encoding.GetEncoding(
+            GetCodePage(languageId),
+            EncoderFallback.ExceptionFallback,
+            DecoderFallback.ExceptionFallback);
+    }
+
+    private static int GetCodePage(uint languageId)
+    {
+        return languageId switch
         {
             5 => 1250,
             128 => 949,
@@ -33,7 +46,5 @@ internal static class NwnTextEncoding
             131 => 932,
             _ => 1252
         };
-
-        return Encoding.GetEncoding(codePage);
     }
 }

--- a/SWLOR.NWN.Formats/Tlk/TlkFormatLimits.cs
+++ b/SWLOR.NWN.Formats/Tlk/TlkFormatLimits.cs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+
+namespace SWLOR.NWN.Formats.Tlk;
+
+/// <summary>Shared safety and addressability limits for BioWare TLK files.</summary>
+public static class TlkFormatLimits
+{
+    /// <summary>
+    /// Allocation ceiling shared by the reader and writer for decoded entry metadata and text.
+    /// </summary>
+    public const long MaximumDecodedAllocationBytes = 64L * 1024 * 1024;
+
+    /// <summary>Conservative managed-allocation estimate charged for every entry record.</summary>
+    public const int EstimatedManagedBytesPerEntry = 64;
+
+    /// <summary>
+    /// Greatest number of entry records accepted by the TLK reader and writer. One record's worth
+    /// of the allocation budget remains for the non-empty final row that makes this count necessary.
+    /// </summary>
+    public const int MaximumEntryCount =
+        (int)(MaximumDecodedAllocationBytes / EstimatedManagedBytesPerEntry) - 1;
+
+    /// <summary>Greatest zero-based entry ID accepted by the TLK reader and writer.</summary>
+    public const int MaximumEntryId = MaximumEntryCount - 1;
+}

--- a/SWLOR.NWN.Formats/Tlk/TlkFormatLimits.cs
+++ b/SWLOR.NWN.Formats/Tlk/TlkFormatLimits.cs
@@ -16,12 +16,16 @@ public static class TlkFormatLimits
     /// <summary>Conservative object/header charge for each separately decoded managed string.</summary>
     public const int EstimatedManagedStringOverheadBytes = 24;
 
+    /// <summary>Conservative hash-table bucket/entry charge for each unique decoded text range.</summary>
+    public const int EstimatedDecodedRangeDictionaryBytes = 48;
+
     /// <summary>
-    /// Greatest number of entry records accepted by the TLK reader and writer. One record's worth
-    /// of the allocation budget remains for the non-empty final row that makes this count necessary.
+    /// Greatest number of entry records accepted by the TLK reader and writer. The remaining
+    /// allocation covers one unique final-row string, its range-index entry, and 28 UTF-16 characters.
     /// </summary>
     public const int MaximumEntryCount =
-        (int)(MaximumDecodedAllocationBytes / EstimatedManagedBytesPerEntry) - 1;
+        (int)((MaximumDecodedAllocationBytes - EstimatedManagedStringOverheadBytes -
+               EstimatedDecodedRangeDictionaryBytes) / EstimatedManagedBytesPerEntry);
 
     /// <summary>Greatest zero-based entry ID accepted by the TLK reader and writer.</summary>
     public const int MaximumEntryId = MaximumEntryCount - 1;

--- a/SWLOR.NWN.Formats/Tlk/TlkFormatLimits.cs
+++ b/SWLOR.NWN.Formats/Tlk/TlkFormatLimits.cs
@@ -13,6 +13,9 @@ public static class TlkFormatLimits
     /// <summary>Conservative managed-allocation estimate charged for every entry record.</summary>
     public const int EstimatedManagedBytesPerEntry = 64;
 
+    /// <summary>Conservative object/header charge for each separately decoded managed string.</summary>
+    public const int EstimatedManagedStringOverheadBytes = 24;
+
     /// <summary>
     /// Greatest number of entry records accepted by the TLK reader and writer. One record's worth
     /// of the allocation budget remains for the non-empty final row that makes this count necessary.

--- a/SWLOR.NWN.Formats/Tlk/TlkReader.cs
+++ b/SWLOR.NWN.Formats/Tlk/TlkReader.cs
@@ -94,7 +94,9 @@ public static class TlkReader
                     var textBytes = reader.Slice(absoluteTextOffset, textLength, $"TLK string {index}");
                     var characterCount = encoding.GetCharCount(textBytes);
                     allocationBudget.Reserve(
-                        checked((long)characterCount * sizeof(char)),
+                        checked(TlkFormatLimits.EstimatedManagedStringOverheadBytes +
+                                TlkFormatLimits.EstimatedDecodedRangeDictionaryBytes +
+                                (long)characterCount * sizeof(char)),
                         $"TLK string {index}");
                     text = encoding.GetString(textBytes);
                     decodedStrings[(relativeTextOffset, textLength)] = text;

--- a/SWLOR.NWN.Formats/Tlk/TlkReader.cs
+++ b/SWLOR.NWN.Formats/Tlk/TlkReader.cs
@@ -84,13 +84,12 @@ public static class TlkReader
                 {
                     var absoluteTextOffset = checked((long)stringsOffset + relativeTextOffset);
                     reader.ValidateRange(absoluteTextOffset, textLength, $"TLK string {index}");
-                    // NWN encodings are byte-oriented, but System.String stores UTF-16 code units.
-                    // Charge twice the encoded size before GetString so single-byte text cannot
-                    // bypass the managed decoded-allocation ceiling.
+                    var textBytes = reader.Slice(absoluteTextOffset, textLength, $"TLK string {index}");
+                    var characterCount = encoding.GetCharCount(textBytes);
                     allocationBudget.Reserve(
-                        checked((long)textLength * sizeof(char)),
+                        checked((long)characterCount * sizeof(char)),
                         $"TLK string {index}");
-                    text = encoding.GetString(reader.Slice(absoluteTextOffset, textLength, $"TLK string {index}"));
+                    text = encoding.GetString(textBytes);
                     decodedStrings[(relativeTextOffset, textLength)] = text;
                 }
             }

--- a/SWLOR.NWN.Formats/Tlk/TlkReader.cs
+++ b/SWLOR.NWN.Formats/Tlk/TlkReader.cs
@@ -15,7 +15,6 @@ public static class TlkReader
     private const uint TextPresent = 0x0001;
     private const uint SoundPresent = 0x0002;
     private const uint SoundLengthPresent = 0x0004;
-    private const int MaximumEntries = 8_000_000;
 
     public static TlkFile Read(string path)
     {
@@ -35,10 +34,17 @@ public static class TlkReader
 
         var languageId = reader.ReadUInt32(8);
         var count = reader.ReadUInt32(12);
-        if (count > MaximumEntries)
-            throw new NwnFormatException($"TLK entry count {count} exceeds {MaximumEntries}.");
+        if (count > TlkFormatLimits.MaximumEntryCount)
+        {
+            throw new NwnFormatException(
+                $"TLK entry count {count} exceeds {TlkFormatLimits.MaximumEntryCount}.");
+        }
         var stringsOffset = reader.ReadUInt32(16);
-        var tableBytes = GuardedBinaryReader.CheckedCount(count, EntrySize, MaximumEntries, "TLK entries");
+        var tableBytes = GuardedBinaryReader.CheckedCount(
+            count,
+            EntrySize,
+            TlkFormatLimits.MaximumEntryCount,
+            "TLK entries");
         reader.ValidateRange(HeaderSize, tableBytes, "TLK entry table");
         if (stringsOffset < HeaderSize + tableBytes || stringsOffset > reader.Length)
             throw new NwnFormatException("TLK string-data offset is outside the valid data region.");
@@ -47,8 +53,13 @@ public static class TlkReader
         // The entry list, entry objects, and sound resrefs are allocations too - charge them
         // before building anything so an 8M-entry table cannot blow past the budget on metadata
         // alone, the same way the KEY and BIF readers budget their tables.
-        var allocationBudget = new AllocationBudget("TLK");
-        allocationBudget.ReserveElements(count, 64, "TLK entry table");
+        var allocationBudget = new AllocationBudget(
+            "TLK",
+            TlkFormatLimits.MaximumDecodedAllocationBytes);
+        allocationBudget.ReserveElements(
+            count,
+            TlkFormatLimits.EstimatedManagedBytesPerEntry,
+            "TLK entry table");
         var entries = new List<TlkEntry>(checked((int)count));
         // Aliased entries (many records pointing at the same string-data range) share one decoded
         // string, and every unique decode is charged against a cumulative budget so a small file

--- a/SWLOR.NWN.Formats/Tlk/TlkReader.cs
+++ b/SWLOR.NWN.Formats/Tlk/TlkReader.cs
@@ -84,7 +84,12 @@ public static class TlkReader
                 {
                     var absoluteTextOffset = checked((long)stringsOffset + relativeTextOffset);
                     reader.ValidateRange(absoluteTextOffset, textLength, $"TLK string {index}");
-                    allocationBudget.Reserve(textLength, $"TLK string {index}");
+                    // NWN encodings are byte-oriented, but System.String stores UTF-16 code units.
+                    // Charge twice the encoded size before GetString so single-byte text cannot
+                    // bypass the managed decoded-allocation ceiling.
+                    allocationBudget.Reserve(
+                        checked((long)textLength * sizeof(char)),
+                        $"TLK string {index}");
                     text = encoding.GetString(reader.Slice(absoluteTextOffset, textLength, $"TLK string {index}"));
                     decodedStrings[(relativeTextOffset, textLength)] = text;
                 }

--- a/SWLOR.NWN.Formats/Tlk/TlkReader.cs
+++ b/SWLOR.NWN.Formats/Tlk/TlkReader.cs
@@ -73,6 +73,13 @@ public static class TlkReader
                 ? string.Empty
                 : reader.ReadAscii(
                     entryOffset + 4, NwnResRef.MaxLength, "TLK sound ResRef", trimNull: true);
+            if ((flags & SoundPresent) != 0)
+            {
+                allocationBudget.Reserve(
+                    checked(TlkFormatLimits.EstimatedManagedStringOverheadBytes +
+                            (long)soundResRef.Length * sizeof(char)),
+                    $"TLK sound ResRef {index}");
+            }
             var relativeTextOffset = reader.ReadUInt32(entryOffset + 28);
             var textLength = reader.ReadUInt32(entryOffset + 32);
             var soundLength = (flags & SoundLengthPresent) == 0 ? 0f : reader.ReadSingle(entryOffset + 36);

--- a/SWLOR.NWN.Formats/Tlk/TlkWriter.cs
+++ b/SWLOR.NWN.Formats/Tlk/TlkWriter.cs
@@ -75,7 +75,11 @@ public static class TlkWriter
             }
 
             totalTextLength = checked(totalTextLength + encodedText.Length);
-            totalDecodedTextBytes = checked(totalDecodedTextBytes + (long)text.Length * sizeof(char));
+            totalDecodedTextBytes = checked(
+                totalDecodedTextBytes +
+                TlkFormatLimits.EstimatedManagedStringOverheadBytes +
+                TlkFormatLimits.EstimatedDecodedRangeDictionaryBytes +
+                (long)text.Length * sizeof(char));
             maximumId = Math.Max(maximumId, id);
         }
 

--- a/SWLOR.NWN.Formats/Tlk/TlkWriter.cs
+++ b/SWLOR.NWN.Formats/Tlk/TlkWriter.cs
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: MIT
+
+using System.Buffers.Binary;
+using System.Text;
+using SWLOR.NWN.Formats.Internal;
+
+namespace SWLOR.NWN.Formats.Tlk;
+
+/// <summary>
+/// Writes text-only BioWare TLK V3.0 talk tables.
+/// </summary>
+public static class TlkWriter
+{
+    private const int HeaderSize = 20;
+    private const int EntrySize = 40;
+    private const uint TextPresent = 0x0001;
+
+    /// <summary>
+    /// Writes a sparse set of text entries to a TLK file. Missing IDs are emitted as blank records.
+    /// </summary>
+    public static void Write(
+        string path,
+        uint languageId,
+        IReadOnlyDictionary<int, string> entries)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        File.WriteAllBytes(path, Write(languageId, entries));
+    }
+
+    /// <summary>
+    /// Creates a TLK containing the supplied text entries. The table extends through the greatest
+    /// supplied ID, leaving all missing IDs blank.
+    /// </summary>
+    public static byte[] Write(uint languageId, IReadOnlyDictionary<int, string> entries)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+
+        var encoding = NwnTextEncoding.ForLanguageStrict(languageId);
+        var encodedEntries = new SortedDictionary<int, byte[]>();
+        var maximumId = -1;
+        long totalTextLength = 0;
+
+        foreach (var (id, text) in entries)
+        {
+            if (id < 0 || id > TlkFormatLimits.MaximumEntryId)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(entries),
+                    id,
+                    $"TLK entry IDs must be between 0 and {TlkFormatLimits.MaximumEntryId}.");
+            }
+
+            if (text is null)
+            {
+                throw new ArgumentException($"TLK entry {id} has null text.", nameof(entries));
+            }
+
+            byte[] encodedText;
+            try
+            {
+                encodedText = encoding.GetBytes(text);
+            }
+            catch (EncoderFallbackException exception)
+            {
+                throw new ArgumentException(
+                    $"TLK entry {id} contains text that cannot be encoded for language {languageId}.",
+                    nameof(entries),
+                    exception);
+            }
+
+            if (!encodedEntries.TryAdd(id, encodedText))
+            {
+                throw new ArgumentException($"TLK entry ID {id} occurs more than once.", nameof(entries));
+            }
+
+            totalTextLength = checked(totalTextLength + encodedText.Length);
+            maximumId = Math.Max(maximumId, id);
+        }
+
+        var entryCount = maximumId + 1;
+        var estimatedDecodedAllocation = checked(
+            (long)entryCount * TlkFormatLimits.EstimatedManagedBytesPerEntry + totalTextLength);
+        if (estimatedDecodedAllocation > TlkFormatLimits.MaximumDecodedAllocationBytes)
+        {
+            throw new ArgumentException(
+                $"TLK decoded metadata and text require an estimated {estimatedDecodedAllocation} bytes, " +
+                $"exceeding the supported {TlkFormatLimits.MaximumDecodedAllocationBytes}-byte budget.",
+                nameof(entries));
+        }
+
+        var tableLength = checked((long)entryCount * EntrySize);
+        var stringsOffset = checked(HeaderSize + tableLength);
+        var fileLength = checked(stringsOffset + totalTextLength);
+        if (fileLength > int.MaxValue)
+        {
+            throw new ArgumentException(
+                $"TLK output is {fileLength} bytes, exceeding the supported maximum of {int.MaxValue} bytes.",
+                nameof(entries));
+        }
+
+        var bytes = new byte[(int)fileLength];
+        "TLK "u8.CopyTo(bytes);
+        "V3.0"u8.CopyTo(bytes.AsSpan(4));
+        BinaryPrimitives.WriteUInt32LittleEndian(bytes.AsSpan(8), languageId);
+        BinaryPrimitives.WriteUInt32LittleEndian(bytes.AsSpan(12), (uint)entryCount);
+        BinaryPrimitives.WriteUInt32LittleEndian(bytes.AsSpan(16), (uint)stringsOffset);
+
+        var relativeTextOffset = 0;
+        foreach (var (id, encodedText) in encodedEntries)
+        {
+            var entryOffset = HeaderSize + id * EntrySize;
+            BinaryPrimitives.WriteUInt32LittleEndian(bytes.AsSpan(entryOffset), TextPresent);
+            BinaryPrimitives.WriteUInt32LittleEndian(
+                bytes.AsSpan(entryOffset + 28),
+                (uint)relativeTextOffset);
+            BinaryPrimitives.WriteUInt32LittleEndian(
+                bytes.AsSpan(entryOffset + 32),
+                (uint)encodedText.Length);
+
+            encodedText.CopyTo(bytes, checked((int)stringsOffset + relativeTextOffset));
+            relativeTextOffset = checked(relativeTextOffset + encodedText.Length);
+        }
+
+        return bytes;
+    }
+}

--- a/SWLOR.NWN.Formats/Tlk/TlkWriter.cs
+++ b/SWLOR.NWN.Formats/Tlk/TlkWriter.cs
@@ -39,6 +39,7 @@ public static class TlkWriter
         var encodedEntries = new SortedDictionary<int, byte[]>();
         var maximumId = -1;
         long totalTextLength = 0;
+        long totalDecodedTextBytes = 0;
 
         foreach (var (id, text) in entries)
         {
@@ -74,12 +75,13 @@ public static class TlkWriter
             }
 
             totalTextLength = checked(totalTextLength + encodedText.Length);
+            totalDecodedTextBytes = checked(totalDecodedTextBytes + (long)text.Length * sizeof(char));
             maximumId = Math.Max(maximumId, id);
         }
 
         var entryCount = maximumId + 1;
         var estimatedDecodedAllocation = checked(
-            (long)entryCount * TlkFormatLimits.EstimatedManagedBytesPerEntry + totalTextLength);
+            (long)entryCount * TlkFormatLimits.EstimatedManagedBytesPerEntry + totalDecodedTextBytes);
         if (estimatedDecodedAllocation > TlkFormatLimits.MaximumDecodedAllocationBytes)
         {
             throw new ArgumentException(

--- a/SWLOR.Toolset.Domain/GameData/Tlk/TlkDocument.cs
+++ b/SWLOR.Toolset.Domain/GameData/Tlk/TlkDocument.cs
@@ -41,7 +41,7 @@ namespace SWLOR.Toolset.Domain.GameData.Tlk
         public int Count => _entries.Count;
 
         /// <summary>The greatest populated row id, or -1 when the document has no entries.</summary>
-        public int MaxEntryId => _entries.Count == 0 ? -1 : _entries.Last().Key;
+        public int MaxEntryId => _entries.Count == 0 ? -1 : Entries[^1].Id;
 
         /// <summary>A stable, id-sorted snapshot of the populated rows.</summary>
         public IReadOnlyList<TlkEntry> Entries =>

--- a/SWLOR.Toolset.Domain/GameData/Tlk/TlkDocument.cs
+++ b/SWLOR.Toolset.Domain/GameData/Tlk/TlkDocument.cs
@@ -29,11 +29,13 @@ namespace SWLOR.Toolset.Domain.GameData.Tlk
 
         private readonly SortedDictionary<int, string> _entries;
         private TlkEntry[]? _entrySnapshot;
+        private int _maxEntryId;
 
         private TlkDocument(int language, SortedDictionary<int, string> entries)
         {
             Language = language;
             _entries = entries;
+            _maxEntryId = entries.Count == 0 ? -1 : entries.Keys.Last();
         }
 
         public int Language { get; }
@@ -41,7 +43,7 @@ namespace SWLOR.Toolset.Domain.GameData.Tlk
         public int Count => _entries.Count;
 
         /// <summary>The greatest populated row id, or -1 when the document has no entries.</summary>
-        public int MaxEntryId => _entries.Count == 0 ? -1 : Entries[^1].Id;
+        public int MaxEntryId => _maxEntryId;
 
         /// <summary>A stable, id-sorted snapshot of the populated rows.</summary>
         public IReadOnlyList<TlkEntry> Entries =>
@@ -130,6 +132,8 @@ namespace SWLOR.Toolset.Domain.GameData.Tlk
                 return;
 
             _entries[entryId] = text;
+            if (entryId > _maxEntryId)
+                _maxEntryId = entryId;
             _entrySnapshot = null;
         }
 
@@ -139,7 +143,11 @@ namespace SWLOR.Toolset.Domain.GameData.Tlk
             ValidateEntryId(entryId);
             var removed = _entries.Remove(entryId);
             if (removed)
+            {
+                if (entryId == _maxEntryId)
+                    _maxEntryId = _entries.Count == 0 ? -1 : _entries.Keys.Last();
                 _entrySnapshot = null;
+            }
             return removed;
         }
 

--- a/SWLOR.Toolset.Domain/GameData/Tlk/TlkDocument.cs
+++ b/SWLOR.Toolset.Domain/GameData/Tlk/TlkDocument.cs
@@ -1,0 +1,263 @@
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using SWLOR.NWN.Formats.Tlk;
+
+namespace SWLOR.Toolset.Domain.GameData.Tlk
+{
+    /// <summary>One explicitly populated row in SWLOR's sparse custom TLK source.</summary>
+    public readonly record struct TlkEntry(int Id, string Text);
+
+    /// <summary>
+    /// Editable, text-only representation of <c>SWLOR_Haks/sw_tlk/sw_tlk.tlk.json</c>.
+    /// Rows are stored sparsely and serialized in ascending id order so editing one row does not
+    /// renumber any other custom StrRef.
+    /// </summary>
+    public sealed class TlkDocument
+    {
+        private static readonly JsonSerializerOptions ReadOptions = new()
+        {
+            PropertyNameCaseInsensitive = true
+        };
+
+        private static readonly JsonSerializerOptions WriteOptions = new()
+        {
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+            WriteIndented = true
+        };
+
+        private readonly SortedDictionary<int, string> _entries;
+        private TlkEntry[]? _entrySnapshot;
+
+        private TlkDocument(int language, SortedDictionary<int, string> entries)
+        {
+            Language = language;
+            _entries = entries;
+        }
+
+        public int Language { get; }
+
+        public int Count => _entries.Count;
+
+        /// <summary>The greatest populated row id, or -1 when the document has no entries.</summary>
+        public int MaxEntryId => _entries.Count == 0 ? -1 : _entries.Last().Key;
+
+        /// <summary>A stable, id-sorted snapshot of the populated rows.</summary>
+        public IReadOnlyList<TlkEntry> Entries =>
+            _entrySnapshot ??= _entries.Select(pair => new TlkEntry(pair.Key, pair.Value)).ToArray();
+
+        public static TlkDocument Load(string path)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(path);
+            using var stream = File.OpenRead(path);
+            return Parse(stream);
+        }
+
+        public static TlkDocument Parse(Stream stream)
+        {
+            ArgumentNullException.ThrowIfNull(stream);
+            TlkJsonDocument source;
+            try
+            {
+                source = JsonSerializer.Deserialize<TlkJsonDocument>(stream, ReadOptions)
+                    ?? throw new InvalidDataException("sw_tlk.tlk.json is empty or malformed.");
+            }
+            catch (JsonException exception)
+            {
+                throw new InvalidDataException("sw_tlk.tlk.json is malformed.", exception);
+            }
+
+            if (!source.Language.HasValue || source.Language.Value < 0)
+                throw new InvalidDataException("TLK language must be a nonnegative integer.");
+            if (source.Entries == null)
+                throw new InvalidDataException("TLK entries must be a non-null array.");
+
+            var entries = new SortedDictionary<int, string>();
+            var seenIds = new HashSet<int>();
+            foreach (var entry in source.Entries)
+            {
+                if (!entry.Id.HasValue ||
+                    entry.Id.Value < 0 ||
+                    entry.Id.Value > TlkFormatLimits.MaximumEntryId)
+                {
+                    throw new InvalidDataException(
+                        $"TLK entry id {entry.Id?.ToString() ?? "<missing>"} must be between 0 and " +
+                        $"{TlkFormatLimits.MaximumEntryId}.");
+                }
+                if (!seenIds.Add(entry.Id.Value))
+                    throw new InvalidDataException($"TLK entry id {entry.Id.Value} appears more than once.");
+                if (entry.Text == null)
+                    throw new InvalidDataException($"TLK entry id {entry.Id.Value} must have non-null text.");
+
+                // Empty text is the editor's definition of a blank row. Normalize legacy explicit
+                // empty entries to the sparse representation used by SetText/Clear and blank search.
+                if (entry.Text.Length > 0)
+                    entries.Add(entry.Id.Value, entry.Text);
+            }
+
+            return new TlkDocument(source.Language.Value, entries);
+        }
+
+        public static TlkDocument Parse(string json)
+        {
+            ArgumentNullException.ThrowIfNull(json);
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+            return Parse(stream);
+        }
+
+        public bool ContainsEntry(int entryId) => entryId >= 0 && _entries.ContainsKey(entryId);
+
+        public string? GetText(int entryId) =>
+            entryId >= 0 && _entries.TryGetValue(entryId, out var text) ? text : null;
+
+        /// <summary>
+        /// Creates or replaces a row without trimming its text. An empty string clears the row;
+        /// whitespace-only text is preserved because it may be intentional localized content.
+        /// </summary>
+        public void SetText(int entryId, string text)
+        {
+            ValidateEntryId(entryId);
+            ArgumentNullException.ThrowIfNull(text);
+
+            if (text.Length == 0)
+            {
+                Clear(entryId);
+                return;
+            }
+
+            if (_entries.TryGetValue(entryId, out var previous) && previous == text)
+                return;
+
+            _entries[entryId] = text;
+            _entrySnapshot = null;
+        }
+
+        /// <summary>Removes a populated row without shifting or renumbering any other row.</summary>
+        public bool Clear(int entryId)
+        {
+            ValidateEntryId(entryId);
+            var removed = _entries.Remove(entryId);
+            if (removed)
+                _entrySnapshot = null;
+            return removed;
+        }
+
+        /// <summary>
+        /// Serializes two-space, LF-delimited JSON with rows sorted by id and a final newline.
+        /// The relaxed encoder keeps ordinary UTF-8 text readable while still escaping JSON
+        /// control characters.
+        /// </summary>
+        public string ToJson()
+        {
+            var source = new TlkJsonDocument
+            {
+                Language = Language,
+                Entries = _entries
+                    .Select(pair => new TlkJsonEntry { Id = pair.Key, Text = pair.Value })
+                    .ToList()
+            };
+
+            return JsonSerializer.Serialize(source, WriteOptions)
+                       .Replace("\r\n", "\n", StringComparison.Ordinal) +
+                   "\n";
+        }
+
+        /// <summary>Finds the first absent, unreferenced row beginning at row zero.</summary>
+        public int FindFirstAvailableBlank(TlkReferenceIndex references)
+        {
+            ArgumentNullException.ThrowIfNull(references);
+            return FindAvailableInRange(0, MaximumKnownId(references), references) ??
+                   FindAvailableAfter(MaximumKnownId(references), references);
+        }
+
+        /// <summary>
+        /// Finds the next absent, unreferenced row, wrapping to row zero after the greatest known
+        /// populated or referenced id. Only when no safe gap exists does it return a new row after
+        /// that known range.
+        /// </summary>
+        public int FindNextAvailableBlank(int currentEntryId, TlkReferenceIndex references)
+        {
+            ValidateEntryId(currentEntryId);
+            ArgumentNullException.ThrowIfNull(references);
+
+            var maximum = MaximumKnownId(references);
+            if (currentEntryId < maximum)
+            {
+                var afterCurrent = FindAvailableInRange(currentEntryId + 1, maximum, references);
+                if (afterCurrent.HasValue)
+                    return afterCurrent.Value;
+            }
+
+            var wrapEnd = Math.Min(currentEntryId - 1, maximum);
+            var wrapped = FindAvailableInRange(0, wrapEnd, references);
+            return wrapped ?? FindAvailableAfter(maximum, references);
+        }
+
+        private int MaximumKnownId(TlkReferenceIndex references) =>
+            Math.Max(MaxEntryId, references.MaxReferencedEntryId);
+
+        private int? FindAvailableInRange(int start, int end, TlkReferenceIndex references)
+        {
+            if (end < start)
+                return null;
+
+            for (var id = start; id <= end; id++)
+            {
+                if (!_entries.ContainsKey(id) && !references.IsReferenced(id))
+                    return id;
+                if (id == int.MaxValue)
+                    break;
+            }
+
+            return null;
+        }
+
+        private int FindAvailableAfter(int maximum, TlkReferenceIndex references)
+        {
+            if (maximum >= TlkFormatLimits.MaximumEntryId)
+                throw new InvalidOperationException("No additional TLK row ids are available.");
+
+            for (var id = maximum + 1; id <= TlkFormatLimits.MaximumEntryId; id++)
+            {
+                if (!_entries.ContainsKey(id) && !references.IsReferenced(id))
+                    return id;
+            }
+
+            throw new InvalidOperationException("No additional TLK row ids are available.");
+        }
+
+        private static void ValidateEntryId(int entryId)
+        {
+            if (entryId < 0 || entryId > TlkFormatLimits.MaximumEntryId)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(entryId),
+                    entryId,
+                    $"TLK entry ids must be between 0 and {TlkFormatLimits.MaximumEntryId}.");
+            }
+        }
+
+        private sealed class TlkJsonDocument
+        {
+            [JsonPropertyOrder(0)]
+            [JsonPropertyName("language")]
+            public int? Language { get; set; }
+
+            [JsonPropertyOrder(1)]
+            [JsonPropertyName("entries")]
+            public List<TlkJsonEntry>? Entries { get; set; }
+        }
+
+        private sealed class TlkJsonEntry
+        {
+            [JsonPropertyOrder(0)]
+            [JsonPropertyName("id")]
+            public int? Id { get; set; }
+
+            [JsonPropertyOrder(1)]
+            [JsonPropertyName("text")]
+            public string? Text { get; set; }
+        }
+    }
+}

--- a/SWLOR.Toolset.Domain/GameData/Tlk/TlkReferenceIndex.cs
+++ b/SWLOR.Toolset.Domain/GameData/Tlk/TlkReferenceIndex.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Security.Cryptography;
 using Serilog;
 using SWLOR.NWN.Formats;
 using SWLOR.NWN.Formats.Tlk;
@@ -78,7 +79,7 @@ namespace SWLOR.Toolset.Domain.GameData.Tlk
         /// <summary>Files that could neither be parsed nor read by the raw-text fallback.</summary>
         public IReadOnlyList<string> UnscannableFiles { get; }
 
-        /// <summary>Number of changed or new files whose contents were read by the latest refresh.</summary>
+        /// <summary>Number of changed or new files whose references were parsed by the latest refresh.</summary>
         internal int LastRefreshScannedSourceCount { get; }
 
         /// <summary>Builds the index from the repository's <c>SWLOR_Haks/sw_2da</c> directory.</summary>
@@ -90,8 +91,8 @@ namespace SWLOR.Toolset.Domain.GameData.Tlk
 
         /// <summary>
         /// Refreshes repository references while reusing every unchanged file's parsed result.
-        /// Interactive editor commands therefore pay only for directory metadata unless a source
-        /// file was added, removed, or changed since the preceding generation.
+        /// Content hashes prevent timestamp-preserving file replacements from reusing stale
+        /// references; unchanged sources are fingerprinted but do not need to be parsed again.
         /// </summary>
         public TlkReferenceIndex Refresh(
             string sw2DaDirectoryPath,
@@ -130,7 +131,7 @@ namespace SWLOR.Toolset.Domain.GameData.Tlk
                 SourceFingerprint fingerprint;
                 try
                 {
-                    fingerprint = SourceFingerprint.Capture(descriptor.Path);
+                    fingerprint = SourceFingerprint.Capture(descriptor.Path, cancellationToken);
                 }
                 catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
                 {
@@ -191,7 +192,7 @@ namespace SWLOR.Toolset.Domain.GameData.Tlk
             SourceFingerprint after;
             try
             {
-                after = SourceFingerprint.Capture(descriptor.Path);
+                after = SourceFingerprint.Capture(descriptor.Path, cancellationToken);
             }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
             {
@@ -503,15 +504,36 @@ namespace SWLOR.Toolset.Domain.GameData.Tlk
             TlkReferenceUsage[] Usages,
             string? Warning);
 
-        private readonly record struct SourceFingerprint(long Length, DateTime LastWriteUtc)
+        private readonly record struct SourceFingerprint(
+            long Length,
+            DateTime LastWriteUtc,
+            string ContentHash)
         {
-            public static SourceFingerprint Capture(string path)
+            public static SourceFingerprint Capture(string path, CancellationToken cancellationToken)
             {
                 var info = new FileInfo(path);
                 info.Refresh();
                 if (!info.Exists)
                     throw new FileNotFoundException("TLK reference source no longer exists.", path);
-                return new SourceFingerprint(info.Length, info.LastWriteTimeUtc);
+
+                using var stream = new FileStream(
+                    path,
+                    FileMode.Open,
+                    FileAccess.Read,
+                    FileShare.ReadWrite | FileShare.Delete);
+                using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+                Span<byte> buffer = stackalloc byte[16 * 1024];
+                int read;
+                while ((read = stream.Read(buffer)) > 0)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    hash.AppendData(buffer[..read]);
+                }
+
+                return new SourceFingerprint(
+                    info.Length,
+                    info.LastWriteTimeUtc,
+                    Convert.ToHexString(hash.GetHashAndReset()));
             }
         }
 

--- a/SWLOR.Toolset.Domain/GameData/Tlk/TlkReferenceIndex.cs
+++ b/SWLOR.Toolset.Domain/GameData/Tlk/TlkReferenceIndex.cs
@@ -229,6 +229,7 @@ namespace SWLOR.Toolset.Domain.GameData.Tlk
             }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
             {
+                Logger.Warning(ex, "Could not scan TLK reference source {ReferencePath}", path);
                 return false;
             }
         }

--- a/SWLOR.Toolset.Domain/GameData/Tlk/TlkReferenceIndex.cs
+++ b/SWLOR.Toolset.Domain/GameData/Tlk/TlkReferenceIndex.cs
@@ -24,6 +24,22 @@ namespace SWLOR.Toolset.Domain.GameData.Tlk
         /// <summary>Column marker used when a malformed 2DA is covered by raw-text fallback.</summary>
         public const string FallbackColumnName = "<raw-text>";
 
+        /// <summary>Column marker used for conservative references in non-2DA repository text.</summary>
+        public const string RepositoryTextColumnName = "<repository-text>";
+
+        private static readonly HashSet<string> RepositoryTextExtensions = new(
+            new[]
+            {
+                ".axaml", ".bat", ".cmd", ".config", ".cs", ".csproj", ".csv", ".ini",
+                ".json", ".md", ".nss", ".props", ".ps1", ".py", ".resx", ".sh", ".slnx",
+                ".sql", ".targets", ".tml", ".toml", ".txt", ".xml", ".yaml", ".yml"
+            },
+            StringComparer.OrdinalIgnoreCase);
+
+        private static readonly HashSet<string> IgnoredDirectoryNames = new(
+            new[] { ".git", ".idea", ".vs", "bin", "node_modules", "obj" },
+            StringComparer.OrdinalIgnoreCase);
+
         private readonly IReadOnlyDictionary<int, IReadOnlyList<TlkReferenceUsage>> _usagesByEntryId;
 
         public static TlkReferenceIndex Empty { get; } = new(
@@ -50,6 +66,7 @@ namespace SWLOR.Toolset.Domain.GameData.Tlk
         /// <summary>Builds the index from the repository's <c>SWLOR_Haks/sw_2da</c> directory.</summary>
         public static TlkReferenceIndex Build(
             string sw2DaDirectoryPath,
+            string? repositoryRootPath = null,
             CancellationToken cancellationToken = default)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(sw2DaDirectoryPath);
@@ -92,6 +109,9 @@ namespace SWLOR.Toolset.Domain.GameData.Tlk
 
                 ScanTable(fileName, table, usages, cancellationToken);
             }
+
+            if (!string.IsNullOrWhiteSpace(repositoryRootPath))
+                ScanRepositoryText(repositoryRootPath, usages, unscannable, cancellationToken);
 
             var frozen = usages.ToDictionary(
                 pair => pair.Key,
@@ -209,6 +229,132 @@ namespace SWLOR.Toolset.Domain.GameData.Tlk
                 return false;
             }
         }
+
+        private static void ScanRepositoryText(
+            string repositoryRootPath,
+            Dictionary<int, List<TlkReferenceUsage>> usages,
+            List<string> unscannable,
+            CancellationToken cancellationToken)
+        {
+            var root = Path.GetFullPath(repositoryRootPath);
+            try
+            {
+                foreach (var path in EnumerateRepositoryFiles(root))
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var relativePath = Path.GetRelativePath(root, path);
+                    if (IsIgnoredRepositoryPath(relativePath) ||
+                        Path.GetExtension(path).Equals(".2da", StringComparison.OrdinalIgnoreCase) ||
+                        !RepositoryTextExtensions.Contains(Path.GetExtension(path)))
+                    {
+                        continue;
+                    }
+
+                    if (!TryScanRepositoryTextFile(path, relativePath, usages, cancellationToken))
+                        unscannable.Add(relativePath.Replace('\\', '/'));
+                }
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                unscannable.Add($"{root} (repository enumeration failed)");
+            }
+        }
+
+        private static IEnumerable<string> EnumerateRepositoryFiles(string root)
+        {
+            var pending = new Stack<string>();
+            pending.Push(root);
+            while (pending.Count > 0)
+            {
+                var directory = pending.Pop();
+                foreach (var path in Directory.EnumerateFiles(directory))
+                    yield return path;
+                foreach (var child in Directory.EnumerateDirectories(directory))
+                {
+                    var name = Path.GetFileName(child);
+                    if (!IgnoredDirectoryNames.Contains(name) &&
+                        (File.GetAttributes(child) & FileAttributes.ReparsePoint) == 0)
+                    {
+                        pending.Push(child);
+                    }
+                }
+            }
+        }
+
+        private static bool TryScanRepositoryTextFile(
+            string path,
+            string relativePath,
+            Dictionary<int, List<TlkReferenceUsage>> usages,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                var lineNumber = 0;
+                foreach (var line in File.ReadLines(path))
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    lineNumber++;
+                    ScanDecimalTokens(
+                        line,
+                        relativePath.Replace('\\', '/'),
+                        lineNumber,
+                        RepositoryTextColumnName,
+                        usages);
+                }
+                return true;
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                return false;
+            }
+        }
+
+        private static void ScanDecimalTokens(
+            string text,
+            string fileName,
+            int rowIndex,
+            string columnName,
+            Dictionary<int, List<TlkReferenceUsage>> usages)
+        {
+            var span = text.AsSpan();
+            var cursor = 0;
+            while (cursor < span.Length)
+            {
+                while (cursor < span.Length && !char.IsAsciiDigit(span[cursor]))
+                    cursor++;
+                var start = cursor;
+                while (cursor < span.Length && char.IsAsciiDigit(span[cursor]))
+                    cursor++;
+                if (start == cursor ||
+                    start > 0 && span[start - 1] == '.' ||
+                    cursor < span.Length && span[cursor] == '.' ||
+                    !uint.TryParse(
+                        span[start..cursor],
+                        NumberStyles.None,
+                        CultureInfo.InvariantCulture,
+                        out var strRef) ||
+                    strRef < TlkService.CustomTlkBase)
+                {
+                    continue;
+                }
+
+                var rawEntryId = (long)strRef - TlkService.CustomTlkBase;
+                if (rawEntryId > TlkFormatLimits.MaximumEntryId)
+                    continue;
+
+                AddUsage(usages, new TlkReferenceUsage(
+                    fileName,
+                    rowIndex,
+                    rowIndex.ToString(CultureInfo.InvariantCulture),
+                    columnName,
+                    strRef,
+                    (int)rawEntryId));
+            }
+        }
+
+        private static bool IsIgnoredRepositoryPath(string relativePath) =>
+            relativePath.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                .Any(IgnoredDirectoryNames.Contains);
 
         private static string BestEffortRowLabel(string line, int lineIndex)
         {

--- a/SWLOR.Toolset.Domain/GameData/Tlk/TlkReferenceIndex.cs
+++ b/SWLOR.Toolset.Domain/GameData/Tlk/TlkReferenceIndex.cs
@@ -42,7 +42,10 @@ namespace SWLOR.Toolset.Domain.GameData.Tlk
             StringComparer.OrdinalIgnoreCase);
 
         private static readonly HashSet<string> IgnoredDirectoryNames = new(
-            new[] { ".git", ".idea", ".vs", "bin", "node_modules", "obj" },
+            new[]
+            {
+                ".agents", ".claude", ".codex", ".git", ".idea", ".vs", "bin", "node_modules", "obj"
+            },
             StringComparer.OrdinalIgnoreCase);
 
         private readonly IReadOnlyDictionary<int, IReadOnlyList<TlkReferenceUsage>> _usagesByEntryId;

--- a/SWLOR.Toolset.Domain/GameData/Tlk/TlkReferenceIndex.cs
+++ b/SWLOR.Toolset.Domain/GameData/Tlk/TlkReferenceIndex.cs
@@ -1,0 +1,234 @@
+using System.Globalization;
+using SWLOR.NWN.Formats.Tlk;
+using SWLOR.Toolset.Domain.GameData.TwoDa;
+
+namespace SWLOR.Toolset.Domain.GameData.Tlk
+{
+    /// <summary>One 2DA cell that contains a custom TLK StrRef.</summary>
+    public sealed record TlkReferenceUsage(
+        string FileName,
+        int RowIndex,
+        string RowLabel,
+        string ColumnName,
+        uint StrRef,
+        int EntryId);
+
+    /// <summary>
+    /// Immutable index of custom TLK StrRefs found in structured cells across SWLOR's 2DAs.
+    /// Quoting, real column headers, empty markers, and source row labels are handled by the shared
+    /// 2DA parser. Malformed files receive a conservative raw-text scan so reference safety does
+    /// not depend on every legacy file having a valid header.
+    /// </summary>
+    public sealed class TlkReferenceIndex
+    {
+        /// <summary>Column marker used when a malformed 2DA is covered by raw-text fallback.</summary>
+        public const string FallbackColumnName = "<raw-text>";
+
+        private readonly IReadOnlyDictionary<int, IReadOnlyList<TlkReferenceUsage>> _usagesByEntryId;
+
+        public static TlkReferenceIndex Empty { get; } = new(
+            new Dictionary<int, IReadOnlyList<TlkReferenceUsage>>(),
+            Array.Empty<string>());
+
+        private TlkReferenceIndex(
+            IReadOnlyDictionary<int, IReadOnlyList<TlkReferenceUsage>> usagesByEntryId,
+            IReadOnlyList<string> unscannableFiles)
+        {
+            _usagesByEntryId = usagesByEntryId;
+            UnscannableFiles = unscannableFiles;
+            ReferencedEntryIds = usagesByEntryId.Keys.OrderBy(id => id).ToArray();
+            MaxReferencedEntryId = ReferencedEntryIds.Count == 0 ? -1 : ReferencedEntryIds[^1];
+        }
+
+        public IReadOnlyList<int> ReferencedEntryIds { get; }
+
+        public int MaxReferencedEntryId { get; }
+
+        /// <summary>Files that could neither be parsed nor read by the raw-text fallback.</summary>
+        public IReadOnlyList<string> UnscannableFiles { get; }
+
+        /// <summary>Builds the index from the repository's <c>SWLOR_Haks/sw_2da</c> directory.</summary>
+        public static TlkReferenceIndex Build(
+            string sw2DaDirectoryPath,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(sw2DaDirectoryPath);
+            var service = new TwoDaService(sw2DaDirectoryPath);
+            var usages = new Dictionary<int, List<TlkReferenceUsage>>();
+            var unscannable = new List<string>();
+
+            foreach (var tableName in service.GetTableNames().OrderBy(name => name, StringComparer.OrdinalIgnoreCase))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var fileName = tableName + ".2da";
+                TwoDaTable? table;
+                try
+                {
+                    if (!service.TryGetTable(tableName, out table) || table == null)
+                    {
+                        if (!TryScanRawText(
+                                Path.Combine(sw2DaDirectoryPath, fileName),
+                                fileName,
+                                usages,
+                                cancellationToken))
+                        {
+                            unscannable.Add(fileName);
+                        }
+                        continue;
+                    }
+                }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                {
+                    if (!TryScanRawText(
+                            Path.Combine(sw2DaDirectoryPath, fileName),
+                            fileName,
+                            usages,
+                            cancellationToken))
+                    {
+                        unscannable.Add(fileName);
+                    }
+                    continue;
+                }
+
+                ScanTable(fileName, table, usages, cancellationToken);
+            }
+
+            var frozen = usages.ToDictionary(
+                pair => pair.Key,
+                pair => (IReadOnlyList<TlkReferenceUsage>)pair.Value.ToArray());
+            return new TlkReferenceIndex(frozen, unscannable.ToArray());
+        }
+
+        public bool IsReferenced(int entryId) =>
+            entryId >= 0 && _usagesByEntryId.ContainsKey(entryId);
+
+        public int UsageCountFor(int entryId) =>
+            entryId >= 0 && _usagesByEntryId.TryGetValue(entryId, out var usages) ? usages.Count : 0;
+
+        public IReadOnlyList<TlkReferenceUsage> UsagesOf(int entryId) =>
+            entryId >= 0 && _usagesByEntryId.TryGetValue(entryId, out var usages)
+                ? usages
+                : Array.Empty<TlkReferenceUsage>();
+
+        private static void ScanTable(
+            string fileName,
+            TwoDaTable table,
+            Dictionary<int, List<TlkReferenceUsage>> usages,
+            CancellationToken cancellationToken)
+        {
+            for (var rowIndex = 0; rowIndex < table.RowCount; rowIndex++)
+            {
+                if ((rowIndex & 255) == 0)
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                var rowLabel = table.GetRowLabel(rowIndex) ?? rowIndex.ToString(CultureInfo.InvariantCulture);
+                foreach (var columnName in table.ColumnNames)
+                {
+                    var raw = table.GetString(rowIndex, columnName);
+                    if (raw == null ||
+                        !uint.TryParse(raw, NumberStyles.None, CultureInfo.InvariantCulture, out var strRef) ||
+                        strRef < TlkService.CustomTlkBase)
+                    {
+                        continue;
+                    }
+
+                    var rawEntryId = (long)strRef - TlkService.CustomTlkBase;
+                    if (rawEntryId > TlkFormatLimits.MaximumEntryId)
+                        continue;
+
+                    AddUsage(usages, new TlkReferenceUsage(
+                        fileName,
+                        rowIndex,
+                        rowLabel,
+                        columnName,
+                        strRef,
+                        (int)rawEntryId));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Conservatively covers malformed 2DAs. Every run of decimal digits is considered so a
+        /// quoted or punctuated token cannot hide a custom StrRef. This may reserve a numeric value
+        /// that was not semantically a StrRef, which is safer than offering a referenced row as a
+        /// writable blank.
+        /// </summary>
+        private static bool TryScanRawText(
+            string path,
+            string fileName,
+            Dictionary<int, List<TlkReferenceUsage>> usages,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                var lineIndex = 0;
+                foreach (var line in File.ReadLines(path))
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var rowLabel = BestEffortRowLabel(line, lineIndex);
+                    var span = line.AsSpan();
+                    var cursor = 0;
+                    while (cursor < span.Length)
+                    {
+                        while (cursor < span.Length && !char.IsAsciiDigit(span[cursor]))
+                            cursor++;
+                        var start = cursor;
+                        while (cursor < span.Length && char.IsAsciiDigit(span[cursor]))
+                            cursor++;
+                        if (start == cursor ||
+                            !uint.TryParse(
+                                span[start..cursor],
+                                NumberStyles.None,
+                                CultureInfo.InvariantCulture,
+                                out var strRef) ||
+                            strRef < TlkService.CustomTlkBase)
+                        {
+                            continue;
+                        }
+
+                        var rawEntryId = (long)strRef - TlkService.CustomTlkBase;
+                        if (rawEntryId > TlkFormatLimits.MaximumEntryId)
+                            continue;
+
+                        AddUsage(usages, new TlkReferenceUsage(
+                            fileName,
+                            lineIndex,
+                            rowLabel,
+                            FallbackColumnName,
+                            strRef,
+                            (int)rawEntryId));
+                    }
+
+                    lineIndex++;
+                }
+
+                return true;
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                return false;
+            }
+        }
+
+        private static string BestEffortRowLabel(string line, int lineIndex)
+        {
+            var trimmed = line.AsSpan().TrimStart();
+            var length = 0;
+            while (length < trimmed.Length && !char.IsWhiteSpace(trimmed[length]))
+                length++;
+
+            return length == 0
+                ? lineIndex.ToString(CultureInfo.InvariantCulture)
+                : trimmed[..length].Trim('"').ToString();
+        }
+
+        private static void AddUsage(
+            Dictionary<int, List<TlkReferenceUsage>> usages,
+            TlkReferenceUsage usage)
+        {
+            if (!usages.TryGetValue(usage.EntryId, out var entryUsages))
+                usages[usage.EntryId] = entryUsages = new List<TlkReferenceUsage>();
+            entryUsages.Add(usage);
+        }
+    }
+}

--- a/SWLOR.Toolset.Domain/GameData/Tlk/TlkReferenceIndex.cs
+++ b/SWLOR.Toolset.Domain/GameData/Tlk/TlkReferenceIndex.cs
@@ -1,6 +1,8 @@
 using System.Globalization;
 using Serilog;
+using SWLOR.NWN.Formats;
 using SWLOR.NWN.Formats.Tlk;
+using SWLOR.NWN.Formats.TwoDA;
 using SWLOR.Toolset.Domain.GameData.TwoDa;
 
 namespace SWLOR.Toolset.Domain.GameData.Tlk
@@ -44,19 +46,26 @@ namespace SWLOR.Toolset.Domain.GameData.Tlk
             StringComparer.OrdinalIgnoreCase);
 
         private readonly IReadOnlyDictionary<int, IReadOnlyList<TlkReferenceUsage>> _usagesByEntryId;
+        private readonly IReadOnlyDictionary<string, SourceSnapshot> _sourceSnapshots;
 
         public static TlkReferenceIndex Empty { get; } = new(
             new Dictionary<int, IReadOnlyList<TlkReferenceUsage>>(),
-            Array.Empty<string>());
+            Array.Empty<string>(),
+            new Dictionary<string, SourceSnapshot>(StringComparer.OrdinalIgnoreCase),
+            0);
 
         private TlkReferenceIndex(
             IReadOnlyDictionary<int, IReadOnlyList<TlkReferenceUsage>> usagesByEntryId,
-            IReadOnlyList<string> unscannableFiles)
+            IReadOnlyList<string> unscannableFiles,
+            IReadOnlyDictionary<string, SourceSnapshot> sourceSnapshots,
+            int scannedSourceCount)
         {
             _usagesByEntryId = usagesByEntryId;
+            _sourceSnapshots = sourceSnapshots;
             UnscannableFiles = unscannableFiles;
             ReferencedEntryIds = usagesByEntryId.Keys.OrderBy(id => id).ToArray();
             MaxReferencedEntryId = ReferencedEntryIds.Count == 0 ? -1 : ReferencedEntryIds[^1];
+            LastRefreshScannedSourceCount = scannedSourceCount;
         }
 
         public IReadOnlyList<int> ReferencedEntryIds { get; }
@@ -66,60 +75,194 @@ namespace SWLOR.Toolset.Domain.GameData.Tlk
         /// <summary>Files that could neither be parsed nor read by the raw-text fallback.</summary>
         public IReadOnlyList<string> UnscannableFiles { get; }
 
+        /// <summary>Number of changed or new files whose contents were read by the latest refresh.</summary>
+        internal int LastRefreshScannedSourceCount { get; }
+
         /// <summary>Builds the index from the repository's <c>SWLOR_Haks/sw_2da</c> directory.</summary>
         public static TlkReferenceIndex Build(
+            string sw2DaDirectoryPath,
+            string? repositoryRootPath = null,
+            CancellationToken cancellationToken = default) =>
+            Empty.Refresh(sw2DaDirectoryPath, repositoryRootPath, cancellationToken);
+
+        /// <summary>
+        /// Refreshes repository references while reusing every unchanged file's parsed result.
+        /// Interactive editor commands therefore pay only for directory metadata unless a source
+        /// file was added, removed, or changed since the preceding generation.
+        /// </summary>
+        public TlkReferenceIndex Refresh(
             string sw2DaDirectoryPath,
             string? repositoryRootPath = null,
             CancellationToken cancellationToken = default)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(sw2DaDirectoryPath);
-            var service = new TwoDaService(sw2DaDirectoryPath);
-            var usages = new Dictionary<int, List<TlkReferenceUsage>>();
-            var unscannable = new List<string>();
+            if (!Directory.Exists(sw2DaDirectoryPath))
+                throw new DirectoryNotFoundException($"2DA directory not found: {sw2DaDirectoryPath}");
 
-            foreach (var tableName in service.GetTableNames().OrderBy(name => name, StringComparer.OrdinalIgnoreCase))
+            var descriptors = new List<SourceDescriptor>();
+            var enumerationWarnings = new List<string>();
+            try
             {
-                cancellationToken.ThrowIfCancellationRequested();
-                var fileName = tableName + ".2da";
-                TwoDaTable? table;
-                try
-                {
-                    if (!service.TryGetTable(tableName, out table) || table == null)
-                    {
-                        if (!TryScanRawText(
-                                Path.Combine(sw2DaDirectoryPath, fileName),
-                                fileName,
-                                usages,
-                                cancellationToken))
-                        {
-                            unscannable.Add(fileName);
-                        }
-                        continue;
-                    }
-                }
-                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
-                {
-                    if (!TryScanRawText(
-                            Path.Combine(sw2DaDirectoryPath, fileName),
-                            fileName,
-                            usages,
-                            cancellationToken))
-                    {
-                        unscannable.Add(fileName);
-                    }
-                    continue;
-                }
-
-                ScanTable(fileName, table, usages, cancellationToken);
+                descriptors.AddRange(Directory.EnumerateFiles(sw2DaDirectoryPath, "*.2da")
+                    .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+                    .Select(path => new SourceDescriptor(
+                        Path.GetFullPath(path),
+                        Path.GetFileName(path),
+                        SourceKind.TwoDa)));
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                Logger.Warning(ex, "Could not enumerate TLK reference sources under {TwoDaRoot}", sw2DaDirectoryPath);
+                enumerationWarnings.Add($"{Path.GetFullPath(sw2DaDirectoryPath)} (2DA enumeration failed)");
             }
 
             if (!string.IsNullOrWhiteSpace(repositoryRootPath))
-                ScanRepositoryText(repositoryRootPath, usages, unscannable, cancellationToken);
+                AddRepositorySourceDescriptors(repositoryRootPath, descriptors, enumerationWarnings, cancellationToken);
+
+            var snapshots = new Dictionary<string, SourceSnapshot>(StringComparer.OrdinalIgnoreCase);
+            var scannedSourceCount = 0;
+            foreach (var descriptor in descriptors)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                SourceFingerprint fingerprint;
+                try
+                {
+                    fingerprint = SourceFingerprint.Capture(descriptor.Path);
+                }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                {
+                    Logger.Warning(ex, "Could not inspect TLK reference source {ReferencePath}", descriptor.Path);
+                    snapshots[descriptor.Path] = new SourceSnapshot(
+                        descriptor,
+                        default,
+                        Array.Empty<TlkReferenceUsage>(),
+                        descriptor.DisplayName);
+                    scannedSourceCount++;
+                    continue;
+                }
+
+                if (_sourceSnapshots.TryGetValue(descriptor.Path, out var previous) &&
+                    previous.Warning == null &&
+                    previous.Descriptor.Kind == descriptor.Kind &&
+                    previous.Descriptor.DisplayName == descriptor.DisplayName &&
+                    previous.Fingerprint == fingerprint)
+                {
+                    snapshots[descriptor.Path] = previous;
+                    continue;
+                }
+
+                snapshots[descriptor.Path] = ScanSource(descriptor, fingerprint, cancellationToken);
+                scannedSourceCount++;
+            }
+
+            var usages = new Dictionary<int, List<TlkReferenceUsage>>();
+            var unscannable = new List<string>(enumerationWarnings);
+            foreach (var snapshot in snapshots.Values)
+            {
+                foreach (var usage in snapshot.Usages)
+                    AddUsage(usages, usage);
+                if (snapshot.Warning != null)
+                    unscannable.Add(snapshot.Warning);
+            }
 
             var frozen = usages.ToDictionary(
                 pair => pair.Key,
                 pair => (IReadOnlyList<TlkReferenceUsage>)pair.Value.ToArray());
-            return new TlkReferenceIndex(frozen, unscannable.ToArray());
+            return new TlkReferenceIndex(frozen, unscannable.ToArray(), snapshots, scannedSourceCount);
+        }
+
+        private static SourceSnapshot ScanSource(
+            SourceDescriptor descriptor,
+            SourceFingerprint fingerprint,
+            CancellationToken cancellationToken)
+        {
+            var usages = new Dictionary<int, List<TlkReferenceUsage>>();
+            var scanned = descriptor.Kind == SourceKind.TwoDa
+                ? TryScanTwoDa(descriptor.Path, descriptor.DisplayName, usages, cancellationToken)
+                : TryScanRepositoryTextFile(
+                    descriptor.Path,
+                    descriptor.DisplayName,
+                    usages,
+                    cancellationToken);
+
+            SourceFingerprint after;
+            try
+            {
+                after = SourceFingerprint.Capture(descriptor.Path);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                Logger.Warning(ex, "Could not verify TLK reference source {ReferencePath}", descriptor.Path);
+                return new SourceSnapshot(
+                    descriptor,
+                    fingerprint,
+                    Flatten(usages),
+                    descriptor.DisplayName);
+            }
+
+            var warning = scanned && after == fingerprint
+                ? null
+                : descriptor.DisplayName;
+            return new SourceSnapshot(descriptor, after, Flatten(usages), warning);
+        }
+
+        private static bool TryScanTwoDa(
+            string path,
+            string fileName,
+            Dictionary<int, List<TlkReferenceUsage>> usages,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                var table = new TwoDaTable(Path.GetFileNameWithoutExtension(fileName), TwoDAReader.Read(path));
+                ScanTable(fileName, table, usages, cancellationToken);
+                return true;
+            }
+            catch (NwnFormatException)
+            {
+                return TryScanRawText(path, fileName, usages, cancellationToken);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                Logger.Warning(ex, "Could not parse TLK reference source {ReferencePath}", path);
+                return TryScanRawText(path, fileName, usages, cancellationToken);
+            }
+        }
+
+        private static TlkReferenceUsage[] Flatten(Dictionary<int, List<TlkReferenceUsage>> usages) =>
+            usages.OrderBy(pair => pair.Key).SelectMany(pair => pair.Value).ToArray();
+
+        private static void AddRepositorySourceDescriptors(
+            string repositoryRootPath,
+            List<SourceDescriptor> descriptors,
+            List<string> unscannable,
+            CancellationToken cancellationToken)
+        {
+            var root = Path.GetFullPath(repositoryRootPath);
+            try
+            {
+                foreach (var path in EnumerateRepositoryFiles(root))
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var relativePath = Path.GetRelativePath(root, path);
+                    if (IsIgnoredRepositoryPath(relativePath) ||
+                        Path.GetExtension(path).Equals(".2da", StringComparison.OrdinalIgnoreCase) ||
+                        !RepositoryTextExtensions.Contains(Path.GetExtension(path)))
+                    {
+                        continue;
+                    }
+
+                    descriptors.Add(new SourceDescriptor(
+                        Path.GetFullPath(path),
+                        relativePath.Replace('\\', '/'),
+                        SourceKind.RepositoryText));
+                }
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                Logger.Warning(ex, "Could not enumerate TLK reference sources under {RepositoryRoot}", root);
+                unscannable.Add($"{root} (repository enumeration failed)");
+            }
         }
 
         public bool IsReferenced(int entryId) =>
@@ -234,37 +377,6 @@ namespace SWLOR.Toolset.Domain.GameData.Tlk
             }
         }
 
-        private static void ScanRepositoryText(
-            string repositoryRootPath,
-            Dictionary<int, List<TlkReferenceUsage>> usages,
-            List<string> unscannable,
-            CancellationToken cancellationToken)
-        {
-            var root = Path.GetFullPath(repositoryRootPath);
-            try
-            {
-                foreach (var path in EnumerateRepositoryFiles(root))
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    var relativePath = Path.GetRelativePath(root, path);
-                    if (IsIgnoredRepositoryPath(relativePath) ||
-                        Path.GetExtension(path).Equals(".2da", StringComparison.OrdinalIgnoreCase) ||
-                        !RepositoryTextExtensions.Contains(Path.GetExtension(path)))
-                    {
-                        continue;
-                    }
-
-                    if (!TryScanRepositoryTextFile(path, relativePath, usages, cancellationToken))
-                        unscannable.Add(relativePath.Replace('\\', '/'));
-                }
-            }
-            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
-            {
-                Logger.Warning(ex, "Could not enumerate TLK reference sources under {RepositoryRoot}", root);
-                unscannable.Add($"{root} (repository enumeration failed)");
-            }
-        }
-
         private static IEnumerable<string> EnumerateRepositoryFiles(string root)
         {
             var pending = new Stack<string>();
@@ -372,6 +484,32 @@ namespace SWLOR.Toolset.Domain.GameData.Tlk
             return length == 0
                 ? lineIndex.ToString(CultureInfo.InvariantCulture)
                 : trimmed[..length].Trim('"').ToString();
+        }
+
+        private enum SourceKind
+        {
+            TwoDa,
+            RepositoryText
+        }
+
+        private sealed record SourceDescriptor(string Path, string DisplayName, SourceKind Kind);
+
+        private sealed record SourceSnapshot(
+            SourceDescriptor Descriptor,
+            SourceFingerprint Fingerprint,
+            TlkReferenceUsage[] Usages,
+            string? Warning);
+
+        private readonly record struct SourceFingerprint(long Length, DateTime LastWriteUtc)
+        {
+            public static SourceFingerprint Capture(string path)
+            {
+                var info = new FileInfo(path);
+                info.Refresh();
+                if (!info.Exists)
+                    throw new FileNotFoundException("TLK reference source no longer exists.", path);
+                return new SourceFingerprint(info.Length, info.LastWriteTimeUtc);
+            }
         }
 
         private static void AddUsage(

--- a/SWLOR.Toolset.Domain/GameData/Tlk/TlkReferenceIndex.cs
+++ b/SWLOR.Toolset.Domain/GameData/Tlk/TlkReferenceIndex.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Serilog;
 using SWLOR.NWN.Formats.Tlk;
 using SWLOR.Toolset.Domain.GameData.TwoDa;
 
@@ -21,6 +22,8 @@ namespace SWLOR.Toolset.Domain.GameData.Tlk
     /// </summary>
     public sealed class TlkReferenceIndex
     {
+        private static readonly ILogger Logger = Log.ForContext<TlkReferenceIndex>();
+
         /// <summary>Column marker used when a malformed 2DA is covered by raw-text fallback.</summary>
         public const string FallbackColumnName = "<raw-text>";
 
@@ -256,6 +259,7 @@ namespace SWLOR.Toolset.Domain.GameData.Tlk
             }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
             {
+                Logger.Warning(ex, "Could not enumerate TLK reference sources under {RepositoryRoot}", root);
                 unscannable.Add($"{root} (repository enumeration failed)");
             }
         }
@@ -305,6 +309,7 @@ namespace SWLOR.Toolset.Domain.GameData.Tlk
             }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
             {
+                Logger.Warning(ex, "Could not scan TLK reference source {ReferencePath}", path);
                 return false;
             }
         }

--- a/SWLOR.Toolset.Domain/GameData/Tlk/TlkService.cs
+++ b/SWLOR.Toolset.Domain/GameData/Tlk/TlkService.cs
@@ -139,5 +139,17 @@ namespace SWLOR.Toolset.Domain.GameData.Tlk
             Volatile.Write(ref _customBinaryOverride, replacement);
             CustomTlkReloaded?.Invoke();
         }
+
+        /// <summary>
+        /// Publishes an already parsed and verified custom TLK generation. Editors use this form so
+        /// a later file replacement cannot make runtime labels diverge from the document generation
+        /// the editor accepted.
+        /// </summary>
+        public void PublishCustomTlk(TlkFile customTlk)
+        {
+            ArgumentNullException.ThrowIfNull(customTlk);
+            Volatile.Write(ref _customBinaryOverride, customTlk);
+            CustomTlkReloaded?.Invoke();
+        }
     }
 }

--- a/SWLOR.Toolset.Domain/GameData/Tlk/TlkService.cs
+++ b/SWLOR.Toolset.Domain/GameData/Tlk/TlkService.cs
@@ -14,7 +14,8 @@ namespace SWLOR.Toolset.Domain.GameData.Tlk
         public const uint CustomTlkBase = 16777216;
 
         private readonly Lazy<(TlkJsonFile Custom, TlkFile? Base)> _data;
-        private TlkFile? _customBinaryOverride;
+        private TlkFile? _selectedCustomBinary;
+        private TlkFile? _publishedRepositoryBinary;
 
         /// <summary>Raised after the module's selected custom TLK has been atomically replaced.</summary>
         public event Action? CustomTlkReloaded;
@@ -121,7 +122,8 @@ namespace SWLOR.Toolset.Domain.GameData.Tlk
         /// </summary>
         public string? GetCustomText(int id)
         {
-            var binary = Volatile.Read(ref _customBinaryOverride);
+            var binary = Volatile.Read(ref _publishedRepositoryBinary) ??
+                         Volatile.Read(ref _selectedCustomBinary);
             return binary != null
                 ? binary.GetString((uint)id)
                 : _data.Value.Custom.GetText(id);
@@ -136,7 +138,7 @@ namespace SWLOR.Toolset.Domain.GameData.Tlk
             var replacement = string.IsNullOrWhiteSpace(binaryTlkPath)
                 ? null
                 : TlkReader.Read(binaryTlkPath);
-            Volatile.Write(ref _customBinaryOverride, replacement);
+            Volatile.Write(ref _selectedCustomBinary, replacement);
             CustomTlkReloaded?.Invoke();
         }
 
@@ -148,7 +150,7 @@ namespace SWLOR.Toolset.Domain.GameData.Tlk
         public void PublishCustomTlk(TlkFile customTlk)
         {
             ArgumentNullException.ThrowIfNull(customTlk);
-            Volatile.Write(ref _customBinaryOverride, customTlk);
+            Volatile.Write(ref _publishedRepositoryBinary, customTlk);
             CustomTlkReloaded?.Invoke();
         }
     }

--- a/SWLOR.Toolset.Domain/GameData/Tlk/TlkService.cs
+++ b/SWLOR.Toolset.Domain/GameData/Tlk/TlkService.cs
@@ -17,7 +17,7 @@ namespace SWLOR.Toolset.Domain.GameData.Tlk
         private TlkFile? _selectedCustomBinary;
         private TlkFile? _publishedRepositoryBinary;
 
-        /// <summary>Raised after the module's selected custom TLK has been atomically replaced.</summary>
+        /// <summary>Raised after either custom TLK source has been atomically replaced.</summary>
         public event Action? CustomTlkReloaded;
 
         public TlkService(TlkJsonFile customTlk, TlkFile? baseTlk = null)
@@ -130,8 +130,9 @@ namespace SWLOR.Toolset.Domain.GameData.Tlk
         }
 
         /// <summary>
-        /// Parses a packed custom TLK away from readers, then publishes it in one pointer swap.
-        /// Passing null restores the repository JSON custom table used at startup.
+        /// Parses a packed module-selected TLK away from readers, then publishes it in one pointer
+        /// swap. Passing null removes that selected layer. A repository generation explicitly
+        /// published by the editor remains authoritative over this module-content layer.
         /// </summary>
         public void ReloadCustomTlk(string? binaryTlkPath)
         {
@@ -143,9 +144,9 @@ namespace SWLOR.Toolset.Domain.GameData.Tlk
         }
 
         /// <summary>
-        /// Publishes an already parsed and verified custom TLK generation. Editors use this form so
-        /// a later file replacement cannot make runtime labels diverge from the document generation
-        /// the editor accepted.
+        /// Publishes an already parsed and verified repository TLK generation. Editors use this
+        /// form so later module-content reloads or file replacements cannot make runtime labels
+        /// diverge from the repository document generation the editor accepted.
         /// </summary>
         public void PublishCustomTlk(TlkFile customTlk)
         {

--- a/SWLOR.Toolset.Domain/GameData/TwoDa/TwoDaTable.cs
+++ b/SWLOR.Toolset.Domain/GameData/TwoDa/TwoDaTable.cs
@@ -25,7 +25,13 @@ namespace SWLOR.Toolset.Domain.GameData.TwoDa
 
         public IReadOnlyList<string> ColumnNames => _file.Columns;
 
+        public IReadOnlyList<string> RowLabels => _file.RowLabels;
+
         public bool HasColumn(string column) => _file.HasColumn(column);
+
+        /// <summary>Returns the source row label, or null when the position is out of range.</summary>
+        public string? GetRowLabel(int row) =>
+            row >= 0 && row < _file.RowLabels.Count ? _file.RowLabels[row] : null;
 
         /// <summary>
         /// Returns the raw cell text, or null if the row/column is out of range, the column does

--- a/SWLOR.Toolset.Domain/Workspace/BlueprintCatalog.cs
+++ b/SWLOR.Toolset.Domain/Workspace/BlueprintCatalog.cs
@@ -50,6 +50,8 @@ namespace SWLOR.Toolset.Domain.Workspace
         private readonly object _snapshotLock = new();
         private readonly ConcurrentDictionary<string, CatalogEntry> _indexedEntries =
             new(StringComparer.OrdinalIgnoreCase);
+        private readonly ConcurrentDictionary<string, CatalogNameSource> _nameSources =
+            new(StringComparer.OrdinalIgnoreCase);
         private IReadOnlyList<CatalogEntry> _entries = Array.Empty<CatalogEntry>();
         private bool _snapshotStale;
         private int _processedCount;
@@ -245,6 +247,7 @@ namespace SWLOR.Toolset.Domain.Workspace
         {
             var key = IdentityKey(type, resRef);
             _removed[key] = true;
+            _nameSources.TryRemove(key, out _);
 
             if (_indexedEntries.TryRemove(key, out _))
             {
@@ -276,11 +279,13 @@ namespace SWLOR.Toolset.Domain.Workspace
         private CatalogEntry? BuildEntry(ResourceType type, string resRef)
         {
             var path = _workspace.GetResourcePath(type, resRef);
+            var key = IdentityKey(type, resRef);
 
             try
             {
                 var bytes = File.ReadAllBytes(path);
                 var metadata = ExtractMetadata(type, bytes);
+                _nameSources[key] = metadata.NameSource;
                 return new CatalogEntry(
                     type,
                     resRef,
@@ -291,14 +296,17 @@ namespace SWLOR.Toolset.Domain.Workspace
             }
             catch (FileNotFoundException)
             {
+                _nameSources.TryRemove(key, out _);
                 return null;
             }
             catch (DirectoryNotFoundException)
             {
+                _nameSources.TryRemove(key, out _);
                 return null;
             }
             catch (Exception)
             {
+                _nameSources.TryRemove(key, out _);
                 // A file that fails to parse still gets an entry (resref/path are known from the
                 // directory listing) - just without a Name/Tag. The corpus round-trip gate is the
                 // place that should catch a genuinely malformed file; this index tolerates it.
@@ -306,7 +314,7 @@ namespace SWLOR.Toolset.Domain.Workspace
             }
         }
 
-        private (string? Name, string? Tag, int? BaseItem) ExtractMetadata(
+        private EntryMetadata ExtractMetadata(
             ResourceType type,
             byte[] bytes)
         {
@@ -315,61 +323,104 @@ namespace SWLOR.Toolset.Domain.Workspace
                 case ResourceType.Area:
                 {
                     var doc = AreDocument.Parse(bytes);
-                    return (ResolveLocString(doc.Name), doc.Tag, null);
+                    var name = CaptureName(doc.Name);
+                    return new EntryMetadata(ResolveName(name), doc.Tag, null, new CatalogNameSource(name));
                 }
                 case ResourceType.Utc:
                 {
                     var doc = UtcDocument.Parse(bytes);
-                    return (JoinName(
-                        ResolveLocString(doc.FirstName),
-                        ResolveLocString(doc.LastName)), doc.Tag, null);
+                    var firstName = CaptureName(doc.FirstName);
+                    var lastName = CaptureName(doc.LastName);
+                    var nameSource = new CatalogNameSource(firstName, lastName);
+                    return new EntryMetadata(ResolveName(nameSource), doc.Tag, null, nameSource);
                 }
                 case ResourceType.Uti:
                 {
                     var doc = UtiDocument.Parse(bytes);
-                    return (ResolveLocString(doc.LocalizedName), doc.Tag, doc.BaseItem);
+                    var name = CaptureName(doc.LocalizedName);
+                    return new EntryMetadata(
+                        ResolveName(name), doc.Tag, doc.BaseItem, new CatalogNameSource(name));
                 }
                 case ResourceType.Utp:
                 {
                     var doc = UtpDocument.Parse(bytes);
-                    return (ResolveLocString(doc.LocName), doc.Tag, null);
+                    var name = CaptureName(doc.LocName);
+                    return new EntryMetadata(ResolveName(name), doc.Tag, null, new CatalogNameSource(name));
                 }
                 case ResourceType.Utd:
                 {
                     var doc = UtdDocument.Parse(bytes);
-                    return (ResolveLocString(doc.LocName), doc.Tag, null);
+                    var name = CaptureName(doc.LocName);
+                    return new EntryMetadata(ResolveName(name), doc.Tag, null, new CatalogNameSource(name));
                 }
                 case ResourceType.Utm:
                 {
                     var doc = UtmDocument.Parse(bytes);
-                    return (ResolveLocString(doc.LocName), doc.Tag, null);
+                    var name = CaptureName(doc.LocName);
+                    return new EntryMetadata(ResolveName(name), doc.Tag, null, new CatalogNameSource(name));
                 }
                 case ResourceType.Utt:
                 {
                     var doc = UttDocument.Parse(bytes);
-                    return (ResolveLocString(doc.LocalizedName), doc.Tag, null);
+                    var name = CaptureName(doc.LocalizedName);
+                    return new EntryMetadata(ResolveName(name), doc.Tag, null, new CatalogNameSource(name));
                 }
                 case ResourceType.Uts:
                 {
                     var doc = UtsDocument.Parse(bytes);
-                    return (ResolveLocString(doc.LocName), doc.Tag, null);
+                    var name = CaptureName(doc.LocName);
+                    return new EntryMetadata(ResolveName(name), doc.Tag, null, new CatalogNameSource(name));
                 }
                 case ResourceType.Utw:
                 {
                     var doc = UtwDocument.Parse(bytes);
-                    return (ResolveLocString(doc.LocalizedName), doc.Tag, null);
+                    var name = CaptureName(doc.LocalizedName);
+                    return new EntryMetadata(ResolveName(name), doc.Tag, null, new CatalogNameSource(name));
                 }
                 default:
                     throw new ArgumentOutOfRangeException(nameof(type), type, "Unknown resource type.");
             }
         }
 
-        private string? ResolveLocString(LocString value)
+        /// <summary>
+        /// Re-resolves every materialized catalog name from the LocString metadata captured during
+        /// the file's last parse. No resource files are reopened when a TLK generation changes.
+        /// </summary>
+        public bool RefreshTlkLabels()
         {
-            if (!string.IsNullOrEmpty(value.Text))
-                return value.Text;
+            var changed = false;
+            foreach (var (key, source) in _nameSources)
+            {
+                if (!_indexedEntries.TryGetValue(key, out var entry))
+                    continue;
 
-            return value.StrRef is { } strRef && strRef != uint.MaxValue
+                var name = ResolveName(source);
+                if (string.Equals(name, entry.Name, StringComparison.Ordinal))
+                    continue;
+
+                _indexedEntries[key] = entry with { Name = name };
+                changed = true;
+            }
+
+            if (changed)
+                PublishSnapshot();
+            return changed;
+        }
+
+        private static LocStringNameSource CaptureName(LocString value) =>
+            new(value.Text, value.StrRef);
+
+        private string? ResolveName(CatalogNameSource source) =>
+            source.Last == null
+                ? ResolveName(source.First)
+                : JoinName(ResolveName(source.First), ResolveName(source.Last.Value));
+
+        private string? ResolveName(LocStringNameSource source)
+        {
+            if (!string.IsNullOrEmpty(source.InlineText))
+                return source.InlineText;
+
+            return source.StrRef is { } strRef && strRef != uint.MaxValue
                 ? _resolveStrRef?.Invoke(strRef)
                 : null;
         }
@@ -381,6 +432,18 @@ namespace SWLOR.Toolset.Domain.Workspace
 
             return string.Join(" ", new[] { first, last }.Where(part => !string.IsNullOrEmpty(part)));
         }
+
+        private sealed record EntryMetadata(
+            string? Name,
+            string? Tag,
+            int? BaseItem,
+            CatalogNameSource NameSource);
+
+        private readonly record struct LocStringNameSource(string? InlineText, uint? StrRef);
+
+        private sealed record CatalogNameSource(
+            LocStringNameSource First,
+            LocStringNameSource? Last = null);
 
         /// <summary>
         /// Searches the current snapshot of <see cref="Entries"/> for resref/name/tag matches

--- a/SWLOR.Toolset.Domain/Workspace/BlueprintCatalog.cs
+++ b/SWLOR.Toolset.Domain/Workspace/BlueprintCatalog.cs
@@ -48,6 +48,7 @@ namespace SWLOR.Toolset.Domain.Workspace
         private readonly ModuleWorkspace _workspace;
         private readonly Func<uint, string?>? _resolveStrRef;
         private readonly object _snapshotLock = new();
+        private readonly object _tlkLabelLock = new();
         private readonly ConcurrentDictionary<string, CatalogEntry> _indexedEntries =
             new(StringComparer.OrdinalIgnoreCase);
         private readonly ConcurrentDictionary<string, CatalogNameSource> _nameSources =
@@ -191,8 +192,25 @@ namespace SWLOR.Toolset.Domain.Workspace
                     return;
 
                 var entry = BuildEntry(item.Type, item.ResRef);
-                if (entry != null && !_removed.ContainsKey(key))
-                    _indexedEntries.TryAdd(key, entry);
+                if (entry != null)
+                {
+                    lock (_tlkLabelLock)
+                    {
+                        if (_removed.ContainsKey(key))
+                        {
+                            _nameSources.TryRemove(key, out _);
+                        }
+                        else
+                        {
+                            // A TLK publication can race this initial build between parsing and
+                            // insertion. Resolve once more while sharing the refresh lock so either
+                            // this insertion or RefreshTlkLabels observes the new generation.
+                            if (_nameSources.TryGetValue(key, out var source))
+                                entry = entry with { Name = ResolveName(source) };
+                            _indexedEntries.TryAdd(key, entry);
+                        }
+                    }
+                }
                 var processed = Interlocked.Increment(ref _processedCount);
                 if (processed % publishInterval == 0)
                     PublishSnapshot();
@@ -230,10 +248,15 @@ namespace SWLOR.Toolset.Domain.Workspace
                 return null;
             }
 
-            if (_indexedEntries.TryGetValue(key, out var existing) && existing == entry)
-                return existing;
+            lock (_tlkLabelLock)
+            {
+                if (_nameSources.TryGetValue(key, out var source))
+                    entry = entry with { Name = ResolveName(source) };
+                if (_indexedEntries.TryGetValue(key, out var existing) && existing == entry)
+                    return existing;
 
-            _indexedEntries[key] = entry;
+                _indexedEntries[key] = entry;
+            }
             PublishSnapshot();
             changed = true;
 
@@ -246,16 +269,17 @@ namespace SWLOR.Toolset.Domain.Workspace
         public bool RemoveEntry(ResourceType type, string resRef)
         {
             var key = IdentityKey(type, resRef);
-            _removed[key] = true;
-            _nameSources.TryRemove(key, out _);
-
-            if (_indexedEntries.TryRemove(key, out _))
+            bool removed;
+            lock (_tlkLabelLock)
             {
-                PublishSnapshot();
-                return true;
+                _removed[key] = true;
+                _nameSources.TryRemove(key, out _);
+                removed = _indexedEntries.TryRemove(key, out _);
             }
 
-            return false;
+            if (removed)
+                PublishSnapshot();
+            return removed;
         }
 
         /// <summary>
@@ -389,17 +413,20 @@ namespace SWLOR.Toolset.Domain.Workspace
         public bool RefreshTlkLabels()
         {
             var changed = false;
-            foreach (var (key, source) in _nameSources)
+            lock (_tlkLabelLock)
             {
-                if (!_indexedEntries.TryGetValue(key, out var entry))
-                    continue;
+                foreach (var (key, source) in _nameSources)
+                {
+                    if (!_indexedEntries.TryGetValue(key, out var entry))
+                        continue;
 
-                var name = ResolveName(source);
-                if (string.Equals(name, entry.Name, StringComparison.Ordinal))
-                    continue;
+                    var name = ResolveName(source);
+                    if (string.Equals(name, entry.Name, StringComparison.Ordinal))
+                        continue;
 
-                _indexedEntries[key] = entry with { Name = name };
-                changed = true;
+                    _indexedEntries[key] = entry with { Name = name };
+                    changed = true;
+                }
             }
 
             if (changed)

--- a/SWLOR.Toolset.Domain/Workspace/BlueprintCatalog.cs
+++ b/SWLOR.Toolset.Domain/Workspace/BlueprintCatalog.cs
@@ -191,8 +191,8 @@ namespace SWLOR.Toolset.Domain.Workspace
                 if (_removed.ContainsKey(key))
                     return;
 
-                var entry = BuildEntry(item.Type, item.ResRef);
-                if (entry != null)
+                var built = BuildEntry(item.Type, item.ResRef);
+                if (built != null)
                 {
                     lock (_tlkLabelLock)
                     {
@@ -202,12 +202,19 @@ namespace SWLOR.Toolset.Domain.Workspace
                         }
                         else
                         {
+                            var entry = built.Entry;
                             // A TLK publication can race this initial build between parsing and
                             // insertion. Resolve once more while sharing the refresh lock so either
                             // this insertion or RefreshTlkLabels observes the new generation.
-                            if (_nameSources.TryGetValue(key, out var source))
-                                entry = entry with { Name = ResolveName(source) };
-                            _indexedEntries.TryAdd(key, entry);
+                            if (built.NameSource != null)
+                                entry = entry with { Name = ResolveName(built.NameSource) };
+                            if (_indexedEntries.TryAdd(key, entry))
+                            {
+                                if (built.NameSource != null)
+                                    _nameSources[key] = built.NameSource;
+                                else
+                                    _nameSources.TryRemove(key, out _);
+                            }
                         }
                     }
                 }
@@ -241,20 +248,31 @@ namespace SWLOR.Toolset.Domain.Workspace
             // would be published here and then dropped again by a still-running build.
             _removed.TryRemove(key, out _);
 
-            var entry = BuildEntry(type, resRef);
-            if (entry == null)
+            var built = BuildEntry(type, resRef);
+            if (built == null)
             {
                 changed = RemoveEntry(type, resRef);
                 return null;
             }
 
+            var entry = built.Entry;
             lock (_tlkLabelLock)
             {
-                if (_nameSources.TryGetValue(key, out var source))
-                    entry = entry with { Name = ResolveName(source) };
-                if (_indexedEntries.TryGetValue(key, out var existing) && existing == entry)
+                if (built.NameSource != null)
+                    entry = entry with { Name = ResolveName(built.NameSource) };
+
+                var sourceUnchanged = built.NameSource == null
+                    ? !_nameSources.ContainsKey(key)
+                    : _nameSources.TryGetValue(key, out var existingSource) &&
+                      existingSource == built.NameSource;
+                if (_indexedEntries.TryGetValue(key, out var existing) &&
+                    existing == entry && sourceUnchanged)
                     return existing;
 
+                if (built.NameSource != null)
+                    _nameSources[key] = built.NameSource;
+                else
+                    _nameSources.TryRemove(key, out _);
                 _indexedEntries[key] = entry;
             }
             PublishSnapshot();
@@ -300,41 +318,40 @@ namespace SWLOR.Toolset.Domain.Workspace
 
         private static string IdentityKey(ResourceType type, string resRef) => $"{(int)type}:{resRef}";
 
-        private CatalogEntry? BuildEntry(ResourceType type, string resRef)
+        private CatalogBuildResult? BuildEntry(ResourceType type, string resRef)
         {
             var path = _workspace.GetResourcePath(type, resRef);
-            var key = IdentityKey(type, resRef);
 
             try
             {
                 var bytes = File.ReadAllBytes(path);
                 var metadata = ExtractMetadata(type, bytes);
-                _nameSources[key] = metadata.NameSource;
-                return new CatalogEntry(
-                    type,
-                    resRef,
-                    metadata.Name,
-                    metadata.Tag,
-                    path,
-                    metadata.BaseItem);
+                return new CatalogBuildResult(
+                    new CatalogEntry(
+                        type,
+                        resRef,
+                        metadata.Name,
+                        metadata.Tag,
+                        path,
+                        metadata.BaseItem),
+                    metadata.NameSource);
             }
             catch (FileNotFoundException)
             {
-                _nameSources.TryRemove(key, out _);
                 return null;
             }
             catch (DirectoryNotFoundException)
             {
-                _nameSources.TryRemove(key, out _);
                 return null;
             }
             catch (Exception)
             {
-                _nameSources.TryRemove(key, out _);
                 // A file that fails to parse still gets an entry (resref/path are known from the
                 // directory listing) - just without a Name/Tag. The corpus round-trip gate is the
                 // place that should catch a genuinely malformed file; this index tolerates it.
-                return new CatalogEntry(type, resRef, null, null, path);
+                return new CatalogBuildResult(
+                    new CatalogEntry(type, resRef, null, null, path),
+                    null);
             }
         }
 
@@ -465,6 +482,10 @@ namespace SWLOR.Toolset.Domain.Workspace
             string? Tag,
             int? BaseItem,
             CatalogNameSource NameSource);
+
+        private sealed record CatalogBuildResult(
+            CatalogEntry Entry,
+            CatalogNameSource? NameSource);
 
         private readonly record struct LocStringNameSource(string? InlineText, uint? StrRef);
 

--- a/SWLOR.Toolset.Domain/Workspace/BlueprintCatalog.cs
+++ b/SWLOR.Toolset.Domain/Workspace/BlueprintCatalog.cs
@@ -258,6 +258,12 @@ namespace SWLOR.Toolset.Domain.Workspace
             var entry = built.Entry;
             lock (_tlkLabelLock)
             {
+                if (_removed.ContainsKey(key))
+                {
+                    _nameSources.TryRemove(key, out _);
+                    return null;
+                }
+
                 if (built.NameSource != null)
                     entry = entry with { Name = ResolveName(built.NameSource) };
 

--- a/SWLOR.Toolset.Tests/DropdownFieldViewModelTests.cs
+++ b/SWLOR.Toolset.Tests/DropdownFieldViewModelTests.cs
@@ -10,6 +10,41 @@ namespace SWLOR.Toolset.Tests;
 public class DropdownFieldViewModelTests
 {
     [Test]
+    public void RefreshOptions_ReplacesCachedLabelsWithoutWritingTheDocument()
+    {
+        var document = JsonGffDocument.Parse(Encoding.UTF8.GetBytes(
+            "{\"__data_type\":\"UTP \",\"Appearance\":{\"type\":\"dword\",\"value\":7}}"));
+        var editCount = 0;
+        var context = new EditorFieldContext(
+            document,
+            (_, mutation) =>
+            {
+                editCount++;
+                mutation();
+                return true;
+            });
+        var descriptor = new FieldDescriptor
+        {
+            Label = "Appearance",
+            FieldName = "Appearance",
+            Kind = EditorKind.TwoDaDropdown,
+            FieldType = GffFieldType.Dword,
+            LookupKey = "appearance"
+        };
+        var field = new DropdownFieldViewModel(
+            descriptor,
+            context,
+            new[] { new LookupOption(7, "Old TLK label") });
+
+        field.RefreshOptions(new[] { new LookupOption(7, "New TLK label") });
+
+        field.SelectedOption!.Display.Should().Be("New TLK label");
+        field.Options.Should().ContainSingle(option => option.Id == 7 && option.Display == "New TLK label");
+        editCount.Should().Be(0);
+        document.Root.GetOrNull("Appearance")!.GetInteger().Should().Be(7);
+    }
+
+    [Test]
     public void MissingLookup_ShowsRawValueWithoutAllowingItToBeWritten()
     {
         var document = JsonGffDocument.Parse(Encoding.UTF8.GetBytes(

--- a/SWLOR.Toolset.Tests/PaletteChoiceInvalidationTests.cs
+++ b/SWLOR.Toolset.Tests/PaletteChoiceInvalidationTests.cs
@@ -5,7 +5,10 @@ using SWLOR.Toolset.Domain.Editors.Behaviors;
 using SWLOR.Toolset.Domain.Editors.Waypoints;
 using SWLOR.Toolset.Domain.Gff;
 using SWLOR.Toolset.Editors.Behaviors;
+using SWLOR.Toolset.Editors.Creatures;
 using SWLOR.Toolset.Editors.Doors;
+using SWLOR.Toolset.Editors.Items;
+using SWLOR.Toolset.Editors.Merchants;
 using SWLOR.Toolset.Editors.Sounds;
 using SWLOR.Toolset.Editors.Triggers;
 using SWLOR.Toolset.Editors.Waypoints;
@@ -16,7 +19,7 @@ namespace SWLOR.Toolset.Tests
     public sealed class PaletteChoiceInvalidationTests
     {
         [Test]
-        public void OpenBehaviorEditorsRebuildTheirMaterializedPaletteChoices()
+        public void OpenSpecializedEditorsRebuildTheirMaterializedTlkChoices()
         {
             var revision = 0;
             IReadOnlyList<BehaviorChoice> ResolveChoices(string _) =>
@@ -26,6 +29,27 @@ namespace SWLOR.Toolset.Tests
                 NewStruct("UTD "),
                 "door",
                 isInstance: false,
+                Run,
+                resolveChoices: ResolveChoices);
+            using var creature = new CreatureEditorViewModel(
+                NewStruct("UTC "),
+                Path.Combine(Path.GetTempPath(), "utc", "creature.utc.json"),
+                "creature",
+                Run,
+                gameCodeIndex: null,
+                resolveChoices: ResolveChoices,
+                resourceIndex: null,
+                resolveModel: null,
+                appearance: _ => null,
+                armorParts: null);
+            using var item = new ItemEditorViewModel(
+                NewStruct("UTI "),
+                "item",
+                Run,
+                resolveChoices: ResolveChoices);
+            using var merchant = new MerchantEditorViewModel(
+                NewStruct("UTM "),
+                "merchant",
                 Run,
                 resolveChoices: ResolveChoices);
             var trigger = new TriggerEditorViewModel(
@@ -48,26 +72,41 @@ namespace SWLOR.Toolset.Tests
                 Run,
                 resolveChoices: ResolveChoices);
 
-            CategoryDisplay(door.BasicRows).Should().Be("Category 0");
-            CategoryDisplay(trigger.BasicRows).Should().Be("Category 0");
-            CategoryDisplay(waypoint.BasicRows).Should().Be("Category 0");
-            CategoryDisplay(sound.BasicRows).Should().Be("Category 0");
+            ChoiceDisplay(door.BasicRows, "PaletteID").Should().Be("Category 0");
+            ChoiceDisplay(creature.BasicRows, "PaletteID").Should().Be("Category 0");
+            ChoiceDisplay(item.BasicRows, "PaletteID").Should().Be("Category 0");
+            ChoiceDisplay(merchant.DetailRows, "ID").Should().Be("Category 0");
+            ChoiceDisplay(trigger.BasicRows, "PaletteID").Should().Be("Category 0");
+            ChoiceDisplay(waypoint.BasicRows, "PaletteID").Should().Be("Category 0");
+            ChoiceDisplay(sound.BasicRows, "PaletteID").Should().Be("Category 0");
+            ChoiceDisplay(door.BasicRows, "Faction").Should().Be("Category 0");
+            ChoiceDisplay(creature.BasicRows, "WalkRate").Should().Be("Category 0");
+            ChoiceDisplay(item.BasicRows, "BaseItem").Should().Be("Category 0");
 
             revision = 1;
-            door.RefreshPaletteChoices();
+            door.RefreshTlkLabels();
+            creature.RefreshTlkLabels();
+            item.RefreshTlkLabels();
+            merchant.RefreshTlkLabels();
             trigger.RefreshTlkLabels();
             waypoint.RefreshTlkLabels();
             sound.RefreshTlkLabels();
 
-            CategoryDisplay(door.BasicRows).Should().Be("Category 1");
-            CategoryDisplay(trigger.BasicRows).Should().Be("Category 1");
-            CategoryDisplay(waypoint.BasicRows).Should().Be("Category 1");
-            CategoryDisplay(sound.BasicRows).Should().Be("Category 1");
+            ChoiceDisplay(door.BasicRows, "PaletteID").Should().Be("Category 1");
+            ChoiceDisplay(creature.BasicRows, "PaletteID").Should().Be("Category 1");
+            ChoiceDisplay(item.BasicRows, "PaletteID").Should().Be("Category 1");
+            ChoiceDisplay(merchant.DetailRows, "ID").Should().Be("Category 1");
+            ChoiceDisplay(trigger.BasicRows, "PaletteID").Should().Be("Category 1");
+            ChoiceDisplay(waypoint.BasicRows, "PaletteID").Should().Be("Category 1");
+            ChoiceDisplay(sound.BasicRows, "PaletteID").Should().Be("Category 1");
+            ChoiceDisplay(door.BasicRows, "Faction").Should().Be("Category 1");
+            ChoiceDisplay(creature.BasicRows, "WalkRate").Should().Be("Category 1");
+            ChoiceDisplay(item.BasicRows, "BaseItem").Should().Be("Category 1");
         }
 
-        private static string CategoryDisplay<T>(IEnumerable<T> rows)
+        private static string ChoiceDisplay<T>(IEnumerable<T> rows, string fieldName)
             where T : BehaviorRowViewModel =>
-            rows.Single(row => row.Definition.Name == "PaletteID").Choices.Single().Display;
+            rows.Single(row => row.Definition.Name == fieldName).Choices.Single().Display;
 
         private static bool Run(string _, Action mutation)
         {

--- a/SWLOR.Toolset.Tests/PaletteChoiceInvalidationTests.cs
+++ b/SWLOR.Toolset.Tests/PaletteChoiceInvalidationTests.cs
@@ -55,9 +55,9 @@ namespace SWLOR.Toolset.Tests
 
             revision = 1;
             door.RefreshPaletteChoices();
-            trigger.RefreshPaletteChoices();
-            waypoint.RefreshPaletteChoices();
-            sound.RefreshPaletteChoices();
+            trigger.RefreshTlkLabels();
+            waypoint.RefreshTlkLabels();
+            sound.RefreshTlkLabels();
 
             CategoryDisplay(door.BasicRows).Should().Be("Category 1");
             CategoryDisplay(trigger.BasicRows).Should().Be("Category 1");

--- a/SWLOR.Toolset.Tests/TlkDocumentTests.cs
+++ b/SWLOR.Toolset.Tests/TlkDocumentTests.cs
@@ -32,6 +32,26 @@ namespace SWLOR.Toolset.Tests
         }
 
         [Test]
+        public void MaxEntryIdTracksSparseAddsAndRemovals()
+        {
+            var document = TlkDocument.Parse(
+                """{ "language": 0, "entries": [ { "id": 2, "text": "two" }, { "id": 8, "text": "eight" } ] }""");
+
+            document.MaxEntryId.Should().Be(8);
+            document.SetText(5, "five");
+            document.MaxEntryId.Should().Be(8);
+            document.SetText(12, "twelve");
+            document.MaxEntryId.Should().Be(12);
+            document.Clear(8);
+            document.MaxEntryId.Should().Be(12);
+            document.Clear(12);
+            document.MaxEntryId.Should().Be(5);
+            document.Clear(5);
+            document.Clear(2);
+            document.MaxEntryId.Should().Be(-1);
+        }
+
+        [Test]
         public void Parse_RejectsNegativeAndDuplicateEntryIds()
         {
             Action negative = () => TlkDocument.Parse(

--- a/SWLOR.Toolset.Tests/TlkDocumentTests.cs
+++ b/SWLOR.Toolset.Tests/TlkDocumentTests.cs
@@ -1,0 +1,168 @@
+using FluentAssertions;
+using NUnit.Framework;
+using SWLOR.NWN.Formats.Tlk;
+using SWLOR.Toolset.Domain.GameData.Tlk;
+
+namespace SWLOR.Toolset.Tests
+{
+    public class TlkDocumentTests
+    {
+        [Test]
+        public void Parse_Edit_Clear_KeepSparseRowsAndMeaningfulWhitespace()
+        {
+            var document = TlkDocument.Parse(
+                """
+                {
+                  "language": 0,
+                  "entries": [
+                    { "id": 8, "text": "eight" },
+                    { "id": 2, "text": "two" }
+                  ]
+                }
+                """);
+
+            document.Entries.Select(entry => entry.Id).Should().Equal(2, 8);
+            document.SetText(5, "  deliberately padded  ");
+            document.GetText(5).Should().Be("  deliberately padded  ");
+            document.SetText(8, string.Empty);
+
+            document.ContainsEntry(8).Should().BeFalse("empty text clears rather than reserving a row");
+            document.Clear(12345).Should().BeFalse();
+            document.Entries.Select(entry => entry.Id).Should().Equal(2, 5);
+        }
+
+        [Test]
+        public void Parse_RejectsNegativeAndDuplicateEntryIds()
+        {
+            Action negative = () => TlkDocument.Parse(
+                """{ "language": 0, "entries": [ { "id": -1, "text": "bad" } ] }""");
+            Action duplicate = () => TlkDocument.Parse(
+                """{ "language": 0, "entries": [ { "id": 7, "text": "a" }, { "id": 7, "text": "b" } ] }""");
+
+            negative.Should().Throw<InvalidDataException>().WithMessage("*between 0 and*");
+            duplicate.Should().Throw<InvalidDataException>().WithMessage("*appears more than once*");
+        }
+
+        [TestCase("{}")]
+        [TestCase("{ \"language\": 0 }")]
+        [TestCase("{ \"entries\": [] }")]
+        [TestCase("{ \"language\": -1, \"entries\": [] }")]
+        [TestCase("{ \"language\": 0, \"entries\": null }")]
+        [TestCase("{ \"language\": 0, \"entries\": [ { \"text\": \"missing id\" } ] }")]
+        [TestCase("{ \"language\": 0, \"entries\": [ { \"id\": 1 } ] }")]
+        [TestCase("{ \"language\": 0, \"entries\": [ { \"id\": 1, \"text\": null } ] }")]
+        public void Parse_RejectsTruncatedOrSemanticallyInvalidDocuments(string json)
+        {
+            Action parse = () => TlkDocument.Parse(json);
+
+            parse.Should().Throw<InvalidDataException>();
+        }
+
+        [Test]
+        public void Parse_NormalizesExplicitEmptyTextToAnAvailableBlank()
+        {
+            var document = TlkDocument.Parse(
+                """{ "language": 0, "entries": [ { "id": 4, "text": "" } ] }""");
+
+            document.ContainsEntry(4).Should().BeFalse();
+            document.FindFirstAvailableBlank(TlkReferenceIndex.Empty).Should().Be(0);
+            document.ToJson().Should().NotContain("\"id\": 4");
+        }
+
+        [Test]
+        public void EntryIds_EnforceTheSharedBinaryFormatBoundary()
+        {
+            var lastValidId = TlkFormatLimits.MaximumEntryId;
+            var firstInvalidId = lastValidId + 1;
+            var document = TlkDocument.Parse(
+                $$"""{ "language": 0, "entries": [ { "id": {{lastValidId}}, "text": "last" } ] }""");
+
+            document.GetText(lastValidId).Should().Be("last");
+            document.SetText(lastValidId, "changed");
+            document.FindNextAvailableBlank(lastValidId, TlkReferenceIndex.Empty).Should().Be(0,
+                "navigation wraps inside the supported range instead of returning an unsaveable id");
+
+            Action parsePastEnd = () => TlkDocument.Parse(
+                $$"""{ "language": 0, "entries": [ { "id": {{firstInvalidId}}, "text": "bad" } ] }""");
+            Action setPastEnd = () => document.SetText(firstInvalidId, "bad");
+            Action clearPastEnd = () => document.Clear(firstInvalidId);
+            Action navigatePastEnd = () => document.FindNextAvailableBlank(firstInvalidId, TlkReferenceIndex.Empty);
+
+            parsePastEnd.Should().Throw<InvalidDataException>().WithMessage("*between 0 and*");
+            setPastEnd.Should().Throw<ArgumentOutOfRangeException>();
+            clearPastEnd.Should().Throw<ArgumentOutOfRangeException>();
+            navigatePastEnd.Should().Throw<ArgumentOutOfRangeException>();
+        }
+
+        [Test]
+        public void ToJson_IsDeterministicSortedReadableUtf8AndLfOnly()
+        {
+            var document = TlkDocument.Parse("""{ "language": 0, "entries": [] }""");
+            document.SetText(9, "Line one\nLine two");
+            document.SetText(3, "Café");
+
+            var json = document.ToJson();
+
+            json.Should().Be(
+                "{\n" +
+                "  \"language\": 0,\n" +
+                "  \"entries\": [\n" +
+                "    {\n" +
+                "      \"id\": 3,\n" +
+                "      \"text\": \"Café\"\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"id\": 9,\n" +
+                "      \"text\": \"Line one\\nLine two\"\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}\n");
+            json.Should().NotContain("\r");
+
+            var reparsed = TlkDocument.Parse(json);
+            reparsed.Entries.Should().Equal(document.Entries);
+        }
+
+        [Test]
+        public void BlankNavigation_WrapsBeforeAppendingAndNeverReturnsReferencedRows()
+        {
+            using var directory = TemporaryTwoDaDirectory.Create(
+                """
+                2DA V2.0
+
+                    Name        Description
+                zero Filled      16777217
+                one  "Quoted"    16777219
+                """);
+            var references = TlkReferenceIndex.Build(directory.Path);
+            var document = TlkDocument.Parse(
+                """{ "language": 0, "entries": [ { "id": 0, "text": "zero" }, { "id": 2, "text": "two" } ] }""");
+
+            document.FindFirstAvailableBlank(references).Should().Be(4,
+                "rows 0 and 2 are populated while rows 1 and 3 are referenced");
+            document.FindNextAvailableBlank(2, references).Should().Be(4);
+
+            document.Clear(2);
+            document.FindNextAvailableBlank(3, references).Should().Be(2,
+                "next-blank navigation wraps through safe gaps before appending");
+        }
+
+        private sealed class TemporaryTwoDaDirectory : IDisposable
+        {
+            private TemporaryTwoDaDirectory(string path) => Path = path;
+
+            public string Path { get; }
+
+            public static TemporaryTwoDaDirectory Create(string twoDa)
+            {
+                var path = System.IO.Path.Combine(
+                    System.IO.Path.GetTempPath(), "SWLOR.Toolset.Tests", Guid.NewGuid().ToString("N"));
+                Directory.CreateDirectory(path);
+                File.WriteAllText(System.IO.Path.Combine(path, "sample.2da"), twoDa);
+                return new TemporaryTwoDaDirectory(path);
+            }
+
+            public void Dispose() => Directory.Delete(Path, recursive: true);
+        }
+    }
+}

--- a/SWLOR.Toolset.Tests/TlkEditorTests.cs
+++ b/SWLOR.Toolset.Tests/TlkEditorTests.cs
@@ -943,6 +943,39 @@ public class TlkEditorTests
     }
 
     [Test]
+    public void StablePairFingerprintRejectsJsonChangedWhileTheBinaryIsBeingChecked()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "swlor-tlk-pair-fingerprint-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        var jsonPath = Path.Combine(root, "sw_tlk.tlk.json");
+        var binaryPath = Path.Combine(root, "sw_tlk.tlk");
+        File.WriteAllText(jsonPath, "accepted JSON generation");
+        File.WriteAllText(binaryPath, "accepted binary generation");
+        var captureCount = 0;
+
+        try
+        {
+            var pair = TlkEditorBackend.FileFingerprintPair.CaptureStable(
+                jsonPath,
+                binaryPath,
+                path =>
+                {
+                    var fingerprint = TlkEditorBackend.FileFingerprint.Capture(path);
+                    if (++captureCount == 2)
+                        File.WriteAllText(jsonPath, "external JSON generation");
+                    return fingerprint;
+                });
+
+            pair.Should().BeNull(
+                "the reverse pass must observe a JSON replacement made during the binary check");
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Test]
     public void ProductionBackendRefreshesReferencesChangedAfterOpen()
     {
         var root = Path.Combine(Path.GetTempPath(), "swlor-tlk-reference-refresh-tests", Guid.NewGuid().ToString("N"));

--- a/SWLOR.Toolset.Tests/TlkEditorTests.cs
+++ b/SWLOR.Toolset.Tests/TlkEditorTests.cs
@@ -21,7 +21,7 @@ namespace SWLOR.Toolset.Tests;
 public class TlkEditorTests
 {
     [Test]
-    public void NavigationFilteringAndBlankSearchUseRawIdsAndCustomStrRefs()
+    public async Task NavigationFilteringAndBlankSearchUseRawIdsAndCustomStrRefs()
     {
         var backend = new MemoryBackend(
             new Dictionary<int, string> { [0] = "Alpha", [2] = "Beta", [190000] = "Alpha Two" },
@@ -57,7 +57,7 @@ public class TlkEditorTests
             "the filtered snapshot is refreshed explicitly rather than on every keystroke");
         editor.Rows.Count.Should().Be(2);
 
-        editor.FindFirstBlankCommand.Execute(null);
+        await editor.FindFirstBlankCommand.ExecuteAsync(null);
         editor.SelectedId.Should().Be(3, "row 1 is referenced and row 2 is populated");
         editor.FilterText.Should().BeEmpty("blank navigation must reveal its result in the grid");
     }
@@ -177,14 +177,14 @@ public class TlkEditorTests
     }
 
     [Test]
-    public void IncompleteReferenceCoverageFailsClosedForBlankAllocation()
+    public async Task IncompleteReferenceCoverageFailsClosedForBlankAllocation()
     {
         var backend = new MemoryBackend(
             new Dictionary<int, string> { [0] = "used" },
             warnings: new[] { "broken.2da" });
         var editor = CreateEditor(backend);
 
-        editor.FindFirstBlankCommand.Execute(null);
+        await editor.FindFirstBlankCommand.ExecuteAsync(null);
 
         editor.SelectedId.Should().Be(0);
         editor.NavigationStatus.Should().Contain("unavailable");
@@ -194,6 +194,57 @@ public class TlkEditorTests
 
         backend.ContainsEntry(1).Should().BeFalse();
         editor.NavigationStatus.Should().Contain("unavailable");
+    }
+
+    [Test]
+    public async Task BlankAndClearOperationsRefreshReferencesAddedAfterOpen()
+    {
+        var backend = new MemoryBackend(new Dictionary<int, string>
+        {
+            [0] = "zero",
+            [2] = "two"
+        })
+        {
+            ReferencesAfterRefresh = new[] { 1, 2 }
+        };
+        var prompts = new StubPrompts { ConfirmDestructive = false };
+        var editor = CreateEditor(backend, prompts);
+
+        await editor.FindFirstBlankCommand.ExecuteAsync(null);
+
+        editor.SelectedId.Should().Be(3, "row 1 became referenced after the editor opened");
+        editor.SelectId(2);
+        await editor.ClearRowCommand.ExecuteAsync(null);
+
+        backend.ContainsEntry(2).Should().BeTrue();
+        prompts.DestructiveMessages.Should().ContainSingle(message => message.Contains("row 2"));
+        backend.ReferenceRefreshCount.Should().Be(2);
+    }
+
+    [Test]
+    public async Task EmptyTextRequiresClearAndSaveRechecksRowsReferencedAfterClearing()
+    {
+        var backend = new MemoryBackend(new Dictionary<int, string> { [4] = "four" });
+        var prompts = new StubPrompts { ConfirmDestructive = true };
+        var editor = CreateEditor(backend, prompts);
+        editor.SelectId(4);
+
+        editor.SelectedText = string.Empty;
+
+        backend.ContainsEntry(4).Should().BeTrue();
+        editor.NavigationStatus.Should().Contain("Clear row");
+        prompts.DestructiveMessages.Should().BeEmpty();
+
+        await editor.ClearRowCommand.ExecuteAsync(null);
+        backend.ContainsEntry(4).Should().BeFalse();
+        prompts.DestructiveMessages.Should().BeEmpty("the row was unreferenced when it was cleared");
+
+        backend.ReferencesAfterRefresh = new[] { 4 };
+        (await editor.TrySaveAsync()).Should().BeTrue();
+
+        prompts.DestructiveMessages.Should().ContainSingle(message =>
+            message.Contains("now referenced", StringComparison.OrdinalIgnoreCase));
+        backend.Saved.Should().BeTrue();
     }
 
     [Test]
@@ -372,6 +423,39 @@ public class TlkEditorTests
     }
 
     [Test]
+    public void ProductionBackendRefreshesReferencesChangedAfterOpen()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "swlor-tlk-reference-refresh-tests", Guid.NewGuid().ToString("N"));
+        var tlkDirectory = Path.Combine(root, "sw_tlk");
+        var twoDaDirectory = Path.Combine(root, "sw_2da");
+        Directory.CreateDirectory(tlkDirectory);
+        Directory.CreateDirectory(twoDaDirectory);
+        var jsonPath = Path.Combine(tlkDirectory, "sw_tlk.tlk.json");
+        var binaryPath = Path.Combine(tlkDirectory, "sw_tlk.tlk");
+        var twoDaPath = Path.Combine(twoDaDirectory, "test.2da");
+        File.WriteAllText(jsonPath,
+            "{\"language\":0,\"entries\":[{\"id\":0,\"text\":\"zero\"}]}");
+        File.WriteAllText(twoDaPath,
+            "2DA V2.0\n\nLABEL STRREF\n0 test ****\n");
+
+        try
+        {
+            var backend = new TlkEditorBackend(new TlkEditorSource(jsonPath, binaryPath, twoDaDirectory));
+            backend.IsReferenced(1).Should().BeFalse();
+            File.WriteAllText(twoDaPath,
+                $"2DA V2.0\n\nLABEL STRREF\n0 test {TlkService.CustomTlkBase + 1}\n");
+
+            backend.RefreshReferences();
+
+            backend.IsReferenced(1).Should().BeTrue();
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Test]
     public void ProductionReloadRejectsAnExternallyTornJsonBinaryPair()
     {
         var root = Path.Combine(Path.GetTempPath(), "swlor-tlk-reload-tests", Guid.NewGuid().ToString("N"));
@@ -520,10 +604,13 @@ public class TlkEditorTests
         public bool ExternalChange { get; set; }
         public Dictionary<int, string>? ReloadEntries { get; set; }
         public IReadOnlyList<string>? ReloadWarnings { get; set; }
+        public IReadOnlyCollection<int>? ReferencesAfterRefresh { get; set; }
+        public Exception? ReferenceRefreshFailure { get; set; }
         public bool Saved { get; private set; }
         public bool Published { get; private set; }
         public int SaveCount { get; private set; }
         public int ReloadCount { get; private set; }
+        public int ReferenceRefreshCount { get; private set; }
         public Exception? ReloadFailure { get; init; }
         public ManualResetEventSlim? SaveStarted { get; init; }
         public ManualResetEventSlim? ContinueSave { get; init; }
@@ -552,6 +639,16 @@ public class TlkEditorTests
                     return id;
             }
             throw new InvalidOperationException();
+        }
+        public void RefreshReferences()
+        {
+            ReferenceRefreshCount++;
+            if (ReferenceRefreshFailure != null)
+                throw ReferenceRefreshFailure;
+            if (ReferencesAfterRefresh == null)
+                return;
+            _referenced.Clear();
+            _referenced.UnionWith(ReferencesAfterRefresh);
         }
         public bool HasExternalChange() => ExternalChange;
         public void Reload()

--- a/SWLOR.Toolset.Tests/TlkEditorTests.cs
+++ b/SWLOR.Toolset.Tests/TlkEditorTests.cs
@@ -713,6 +713,57 @@ public class TlkEditorTests
     }
 
     [Test]
+    public void APreviouslyCapturedTlkRowOpenerRechecksTheModuleLockWhenInvoked()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "swlor-tlk-opener-lock-tests", Guid.NewGuid().ToString("N"));
+        var twoDaDirectory = Path.Combine(root, "sw_2da");
+        var jsonPath = Path.Combine(root, "sw_tlk.tlk.json");
+        Directory.CreateDirectory(twoDaDirectory);
+        File.WriteAllText(jsonPath, "{\"language\":0,\"entries\":[]}");
+
+        try
+        {
+            var log = new OutputLogService();
+            var workspace = new WorkspaceContext(
+                path => new SWLOR.Toolset.Domain.Workspace.ModuleWorkspace(path),
+                log);
+            var mutationLock = new ModuleMutationLock();
+            var backendCreations = 0;
+            var service = new EditorService(
+                workspace,
+                new LookupOptionProvider(workspace),
+                log,
+                new ToolsetDockFactory(null!, null!, null!, null!, null!, null!, null!, null!, null!),
+                new StubPrompts(),
+                mutationLock: mutationLock,
+                tlkEditorSource: new TlkEditorSource(
+                    jsonPath,
+                    Path.Combine(root, "sw_tlk.tlk"),
+                    twoDaDirectory),
+                tlkEditorBackendFactory: (_, _, _) =>
+                {
+                    Interlocked.Increment(ref backendCreations);
+                    return new MemoryBackend(new Dictionary<int, string>());
+                });
+            var opener = (Action<uint>)typeof(EditorService)
+                .GetProperty("TlkRowOpener", System.Reflection.BindingFlags.Instance |
+                    System.Reflection.BindingFlags.NonPublic)!
+                .GetValue(service)!;
+
+            using (mutationLock.BeginResourceDeletion())
+                opener(TlkService.CustomTlkBase);
+
+            backendCreations.Should().Be(0);
+            log.Lines.Should().Contain(line => line.Contains(
+                "module resource deletion is in progress", StringComparison.Ordinal));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Test]
     public async Task OpeningTheEditorPublishesTheCurrentRepositoryGeneration()
     {
         var root = Path.Combine(Path.GetTempPath(), "swlor-tlk-open-publish-tests", Guid.NewGuid().ToString("N"));

--- a/SWLOR.Toolset.Tests/TlkEditorTests.cs
+++ b/SWLOR.Toolset.Tests/TlkEditorTests.cs
@@ -176,6 +176,32 @@ public class TlkEditorTests
     }
 
     [Test]
+    public async Task SaveRevalidatesAppendedRowsAfterAnEarlierReferenceIsRemoved()
+    {
+        var backend = new MemoryBackend(
+            new Dictionary<int, string>
+            {
+                [0] = "zero",
+                [2] = "two"
+            },
+            referenced: new[] { 1 })
+        {
+            ReferencesAfterRefresh = Array.Empty<int>()
+        };
+        var editor = CreateEditor(backend);
+        editor.SelectId(3);
+
+        editor.SelectedText = "three";
+        backend.GetText(3).Should().Be("three",
+            "the cached reference initially makes the earlier blank unavailable");
+
+        (await editor.TrySaveAsync()).Should().BeFalse();
+
+        backend.Saved.Should().BeFalse();
+        editor.NavigationStatus.Should().Contain("Blank row 1");
+    }
+
+    [Test]
     public async Task PasteCanAppendWhenItFillsEveryEarlierBlankRow()
     {
         var backend = new MemoryBackend(new Dictionary<int, string>
@@ -576,6 +602,49 @@ public class TlkEditorTests
     }
 
     [Test]
+    public async Task OpeningTheEditorPublishesTheCurrentRepositoryGeneration()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "swlor-tlk-open-publish-tests", Guid.NewGuid().ToString("N"));
+        var tlkDirectory = Path.Combine(root, "sw_tlk");
+        var twoDaDirectory = Path.Combine(root, "sw_2da");
+        Directory.CreateDirectory(tlkDirectory);
+        Directory.CreateDirectory(twoDaDirectory);
+        var jsonPath = Path.Combine(tlkDirectory, "sw_tlk.tlk.json");
+        var binaryPath = Path.Combine(tlkDirectory, "sw_tlk.tlk");
+        var oldPath = Path.Combine(tlkDirectory, "old.tlk");
+        WritePair(jsonPath, binaryPath, "new repository generation");
+        File.WriteAllBytes(oldPath,
+            TlkWriter.Write(0, new Dictionary<int, string> { [0] = "old published generation" }));
+
+        try
+        {
+            var tlk = new TlkService(TlkJsonFile.Parse(
+                "{\"language\":0,\"entries\":[{\"id\":0,\"text\":\"startup\"}]}"));
+            tlk.PublishCustomTlk(TlkReader.Read(oldPath));
+            var log = new OutputLogService();
+            var workspace = new WorkspaceContext(
+                path => new SWLOR.Toolset.Domain.Workspace.ModuleWorkspace(path),
+                log);
+            var service = new EditorService(
+                workspace,
+                new LookupOptionProvider(workspace),
+                log,
+                new ToolsetDockFactory(null!, null!, null!, null!, null!, null!, null!, null!, null!),
+                new StubPrompts(),
+                tlkService: tlk,
+                tlkEditorSource: new TlkEditorSource(jsonPath, binaryPath, twoDaDirectory));
+
+            await service.OpenTlkEditorAsync();
+
+            tlk.GetCustomText(0).Should().Be("new repository generation");
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Test]
     public void ProductionBackendWritesAndVerifiesTheRepositoryJsonBinaryPair()
     {
         var root = Path.Combine(Path.GetTempPath(), "swlor-tlk-editor-tests", Guid.NewGuid().ToString("N"));
@@ -700,6 +769,42 @@ public class TlkEditorTests
             backend.GetText(0).Should().Be("accepted A");
             service.GetCustomText(0).Should().Be("accepted A",
                 "publication must use the verified snapshot rather than rereading the changed path");
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Test]
+    public void ReopenedProductionBackendCanReplaceAnOlderPublishedRepositoryGeneration()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "swlor-tlk-reopen-publish-tests", Guid.NewGuid().ToString("N"));
+        var tlkDirectory = Path.Combine(root, "sw_tlk");
+        var twoDaDirectory = Path.Combine(root, "sw_2da");
+        Directory.CreateDirectory(tlkDirectory);
+        Directory.CreateDirectory(twoDaDirectory);
+        var jsonPath = Path.Combine(tlkDirectory, "sw_tlk.tlk.json");
+        var binaryPath = Path.Combine(tlkDirectory, "sw_tlk.tlk");
+        var service = new TlkService(TlkJsonFile.Parse(
+            "{\"language\":0,\"entries\":[{\"id\":0,\"text\":\"startup\"}]}"));
+
+        try
+        {
+            WritePair(jsonPath, binaryPath, "old repository generation");
+            var first = new TlkEditorBackend(
+                new TlkEditorSource(jsonPath, binaryPath, twoDaDirectory),
+                service);
+            first.Publish();
+            service.GetCustomText(0).Should().Be("old repository generation");
+
+            WritePair(jsonPath, binaryPath, "new repository generation");
+            var reopened = new TlkEditorBackend(
+                new TlkEditorSource(jsonPath, binaryPath, twoDaDirectory),
+                service);
+            reopened.Publish();
+
+            service.GetCustomText(0).Should().Be("new repository generation");
         }
         finally
         {

--- a/SWLOR.Toolset.Tests/TlkEditorTests.cs
+++ b/SWLOR.Toolset.Tests/TlkEditorTests.cs
@@ -638,6 +638,81 @@ public class TlkEditorTests
     }
 
     [Test]
+    public void ReferenceRowsPutStructuredTwoDaUsagesBeforeRepositoryText()
+    {
+        var strRef = TlkService.CustomTlkBase;
+        var backend = new MemoryBackend(
+            new Dictionary<int, string> { [0] = "used" },
+            referenced: new[] { 0 },
+            usages:
+            [
+                new TlkEditorUsage(
+                    "Module/sample.json", 12, "12", TlkReferenceIndex.RepositoryTextColumnName, strRef),
+                new TlkEditorUsage("spells.2da", 4, "spell_label", "SpellDesc", strRef)
+            ]);
+
+        var editor = CreateEditor(backend);
+
+        editor.Usages.Select(usage => usage.Source).Should().Equal("2DA", "Repository");
+        editor.Usages.Select(usage => usage.File).Should().Equal("spells.2da", "Module/sample.json");
+    }
+
+    [Test]
+    public async Task OpeningShowsALoadingDocumentBeforeReferenceIndexingFinishes()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "swlor-tlk-loading-tests", Guid.NewGuid().ToString("N"));
+        var twoDaDirectory = Path.Combine(root, "sw_2da");
+        var jsonPath = Path.Combine(root, "sw_tlk.tlk.json");
+        var binaryPath = Path.Combine(root, "sw_tlk.tlk");
+        Directory.CreateDirectory(twoDaDirectory);
+        File.WriteAllText(jsonPath, "{\"language\":0,\"entries\":[]}");
+        var indexingStarted = new ManualResetEventSlim();
+        var continueIndexing = new ManualResetEventSlim();
+        var backend = new MemoryBackend(new Dictionary<int, string>());
+
+        try
+        {
+            var log = new OutputLogService();
+            var workspace = new WorkspaceContext(
+                path => new SWLOR.Toolset.Domain.Workspace.ModuleWorkspace(path),
+                log);
+            var service = new EditorService(
+                workspace,
+                new LookupOptionProvider(workspace),
+                log,
+                new ToolsetDockFactory(null!, null!, null!, null!, null!, null!, null!, null!, null!),
+                new StubPrompts(),
+                tlkEditorSource: new TlkEditorSource(jsonPath, binaryPath, twoDaDirectory),
+                tlkEditorBackendFactory: (_, _, cancellationToken) =>
+                {
+                    indexingStarted.Set();
+                    continueIndexing.Wait(cancellationToken);
+                    return backend;
+                });
+
+            var opening = service.OpenTlkEditorAsync();
+            indexingStarted.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+
+            var flags = System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic;
+            typeof(EditorService).GetField("_tlkEditorLoading", flags)!.GetValue(service)
+                .Should().BeOfType<TlkEditorLoadingDocumentViewModel>();
+            typeof(EditorService).GetField("_tlkEditor", flags)!.GetValue(service).Should().BeNull();
+
+            continueIndexing.Set();
+            await opening;
+
+            typeof(EditorService).GetField("_tlkEditorLoading", flags)!.GetValue(service).Should().BeNull();
+            typeof(EditorService).GetField("_tlkEditor", flags)!.GetValue(service)
+                .Should().BeOfType<TlkEditorDocumentViewModel>();
+        }
+        finally
+        {
+            continueIndexing.Set();
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Test]
     public async Task OpeningTheEditorPublishesTheCurrentRepositoryGeneration()
     {
         var root = Path.Combine(Path.GetTempPath(), "swlor-tlk-open-publish-tests", Guid.NewGuid().ToString("N"));
@@ -945,6 +1020,13 @@ public class TlkEditorTests
             editor.Rows.CreatedRowCount.Should().BeLessThan(100,
                 "the item source itself must not be eagerly copied into a collection view");
             view.GetVisualDescendants().OfType<TextBox>().Should().NotBeEmpty();
+            view.GetVisualDescendants().OfType<TextBlock>()
+                .Select(text => text.Text)
+                .Should().NotContain(text =>
+                    text != null && text.Contains("Paste here preserves", StringComparison.Ordinal));
+            view.FindControl<DataGrid>("ReferenceGrid")!.Columns
+                .Select(column => column.Header?.ToString())
+                .Should().ContainInOrder("Source", "File", "Row / line", "Label", "Column");
 
             window.Close();
             editor.OnClose().Should().BeTrue();
@@ -955,6 +1037,26 @@ public class TlkEditorTests
         }
 
         sink.Errors.Should().BeEmpty();
+    }
+
+    [AvaloniaTest]
+    public void TlkLoadingDocumentShowsProgressAndCancelsWhenClosed()
+    {
+        var loading = new TlkEditorLoadingDocumentViewModel("memory/sw_tlk.tlk.json");
+        var view = new TlkEditorLoadingDocumentView { DataContext = loading };
+        var window = new Window { Width = 900, Height = 600, Content = view };
+        window.Show();
+        window.UpdateLayout();
+
+        view.GetVisualDescendants().OfType<TextBlock>()
+            .Should().Contain(text => text.Text == "Loading TLK Editor");
+        view.GetVisualDescendants().OfType<ProgressBar>()
+            .Should().ContainSingle(progress => progress.IsIndeterminate);
+        loading.CancellationRequested.Should().BeFalse();
+
+        window.Close();
+        loading.OnClose().Should().BeTrue();
+        loading.CancellationRequested.Should().BeTrue();
     }
 
     [AvaloniaTest]
@@ -980,11 +1082,13 @@ public class TlkEditorTests
         public MemoryBackend(
             Dictionary<int, string> entries,
             IEnumerable<int>? referenced = null,
-            IReadOnlyList<string>? warnings = null)
+            IReadOnlyList<string>? warnings = null,
+            IReadOnlyList<TlkEditorUsage>? usages = null)
         {
             _entries = new Dictionary<int, string>(entries);
             _referenced = referenced?.ToHashSet() ?? new HashSet<int>();
             ReferenceWarnings = warnings ?? Array.Empty<string>();
+            UsageRows = usages;
         }
 
         public string JsonPath => "memory/sw_tlk.tlk.json";
@@ -1011,6 +1115,7 @@ public class TlkEditorTests
         public ManualResetEventSlim? ContinueSave { get; init; }
         public ManualResetEventSlim? ReferenceRefreshStarted { get; init; }
         public ManualResetEventSlim? ContinueReferenceRefresh { get; init; }
+        public IReadOnlyList<TlkEditorUsage>? UsageRows { get; }
 
         public bool ContainsEntry(int id) => _entries.ContainsKey(id);
         public string? GetText(int id) => _entries.GetValueOrDefault(id);
@@ -1023,10 +1128,23 @@ public class TlkEditorTests
         }
         public bool Clear(int id) => _entries.Remove(id);
         public bool IsReferenced(int id) => _referenced.Contains(id);
-        public int UsageCountFor(int id) => IsReferenced(id) ? 1 : 0;
-        public IReadOnlyList<TlkEditorUsage> UsagesOf(int id) => IsReferenced(id)
-            ? new[] { new TlkEditorUsage("test.2da", 7, "label", "STRREF", TlkService.CustomTlkBase + (uint)id) }
-            : Array.Empty<TlkEditorUsage>();
+        public int UsageCountFor(int id) => UsagesOf(id).Count;
+        public IReadOnlyList<TlkEditorUsage> UsagesOf(int id)
+        {
+            if (UsageRows != null)
+            {
+                var strRef = TlkService.CustomTlkBase + (uint)id;
+                return UsageRows.Where(usage => usage.StrRef == strRef).ToArray();
+            }
+
+            return IsReferenced(id)
+                ? new[]
+                {
+                    new TlkEditorUsage(
+                        "test.2da", 7, "label", "STRREF", TlkService.CustomTlkBase + (uint)id)
+                }
+                : Array.Empty<TlkEditorUsage>();
+        }
         public int FindFirstAvailableBlank() => FindNextAvailableBlank(-1);
         public int FindNextAvailableBlank(int currentId)
         {

--- a/SWLOR.Toolset.Tests/TlkEditorTests.cs
+++ b/SWLOR.Toolset.Tests/TlkEditorTests.cs
@@ -302,6 +302,27 @@ public class TlkEditorTests
     }
 
     [Test]
+    public async Task SavingAfterUndoAcrossTheSavedPositionConfirmsTheNewClear()
+    {
+        var backend = new MemoryBackend(new Dictionary<int, string> { [0] = "zero" });
+        var prompts = new StubPrompts { ConfirmDestructive = true };
+        var editor = CreateEditor(backend, prompts);
+        editor.SelectId(1);
+        editor.SelectedText = "one";
+
+        (await editor.TrySaveAsync()).Should().BeTrue();
+        editor.Undo();
+        backend.ContainsEntry(1).Should().BeFalse();
+        backend.ReferencesAfterRefresh = new[] { 1 };
+
+        (await editor.TrySaveAsync()).Should().BeTrue();
+
+        prompts.DestructiveMessages.Should().ContainSingle(message =>
+            message.Contains("cleared", StringComparison.OrdinalIgnoreCase) && message.Contains("1"));
+        backend.LastSavedEntries.Should().NotContainKey(1);
+    }
+
+    [Test]
     public void LocStringShortcutOnlyOpensCustomTlkRows()
     {
         uint? opened = null;
@@ -468,6 +489,30 @@ public class TlkEditorTests
         backend.ContinueReferenceRefresh.Set();
         await find;
         await closeRequested.Task.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task SaveWaitsForAnInProgressPasteBeforeCapturingTheDocument()
+    {
+        var backend = new MemoryBackend(new Dictionary<int, string> { [0] = "old" })
+        {
+            ReferenceRefreshStarted = new ManualResetEventSlim(),
+            ContinueReferenceRefresh = new ManualResetEventSlim(),
+            SaveStarted = new ManualResetEventSlim()
+        };
+        var editor = CreateEditor(backend, new StubPrompts { ConfirmDestructive = true });
+
+        var paste = editor.PasteRowsAsync("new");
+        backend.ReferenceRefreshStarted.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+        var save = editor.TrySaveAsync();
+
+        backend.SaveStarted.IsSet.Should().BeFalse("save must wait behind the active paste");
+        backend.ContinueReferenceRefresh.Set();
+
+        (await paste).Should().BeTrue();
+        (await save).Should().BeTrue();
+        backend.LastSavedEntries.Should().ContainKey(0).WhoseValue.Should().Be("new");
+        editor.IsDirty.Should().BeFalse();
     }
 
     [Test]
@@ -689,6 +734,7 @@ public class TlkEditorTests
         public Exception? ReferenceRefreshFailure { get; set; }
         public bool Saved { get; private set; }
         public bool Published { get; private set; }
+        public Dictionary<int, string> LastSavedEntries { get; private set; } = new();
         public int SaveCount { get; private set; }
         public int ReloadCount { get; private set; }
         public int ReferenceRefreshCount { get; private set; }
@@ -750,6 +796,7 @@ public class TlkEditorTests
         public void Save(bool overwriteExternalChanges = false)
         {
             SaveCount++;
+            LastSavedEntries = new Dictionary<int, string>(_entries);
             SaveStarted?.Set();
             ContinueSave?.Wait(TimeSpan.FromSeconds(5));
             Saved = true;

--- a/SWLOR.Toolset.Tests/TlkEditorTests.cs
+++ b/SWLOR.Toolset.Tests/TlkEditorTests.cs
@@ -10,11 +10,13 @@ using SWLOR.Toolset.Domain.Editors;
 using SWLOR.Toolset.Domain.GameData.Lookups;
 using SWLOR.Toolset.Domain.GameData.Tlk;
 using SWLOR.Toolset.Domain.Gff;
+using SWLOR.Toolset.Domain.Workspace;
 using SWLOR.Toolset.Editors;
 using SWLOR.Toolset.Editors.Tlk;
 using SWLOR.Toolset.Services;
 using SWLOR.Toolset.Settings;
 using SWLOR.Toolset.Shell;
+using SWLOR.Toolset.Shell.Panels;
 using SWLOR.Toolset.Workspace;
 
 namespace SWLOR.Toolset.Tests;
@@ -625,11 +627,12 @@ public class TlkEditorTests
             var workspace = new WorkspaceContext(
                 path => new SWLOR.Toolset.Domain.Workspace.ModuleWorkspace(path),
                 log);
+            var properties = new PropertiesViewModel(workspace, log, tlkService: tlk);
             var service = new EditorService(
                 workspace,
                 new LookupOptionProvider(workspace),
                 log,
-                new ToolsetDockFactory(null!, null!, null!, null!, null!, null!, null!, null!, null!),
+                new ToolsetDockFactory(null!, properties, null!, null!, null!, null!, null!, null!, null!),
                 new StubPrompts(),
                 tlkService: tlk,
                 tlkEditorSource: new TlkEditorSource(jsonPath, binaryPath, twoDaDirectory));
@@ -642,6 +645,72 @@ public class TlkEditorTests
         {
             Directory.Delete(root, recursive: true);
         }
+    }
+
+    [Test]
+    public async Task TlkPublicationRefreshesCatalogPropertiesAndStandardPaletteCaches()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "swlor-tlk-surface-refresh-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(root, "are"));
+        Directory.CreateDirectory(Path.Combine(root, "utc"));
+        Directory.CreateDirectory(Path.Combine(root, "uti"));
+        var itemPath = Path.Combine(root, "uti", "test_item.uti.json");
+        File.WriteAllText(itemPath,
+            $"{{\"__data_type\":\"UTI \",\"LocalizedName\":{{\"id\":{TlkService.CustomTlkBase},\"type\":\"cexolocstring\",\"value\":{{}}}}}}");
+        var tlk = new TlkService(TlkJsonFile.Parse("{\"language\":0,\"entries\":[]}"));
+        tlk.PublishCustomTlk(TlkReader.Read(
+            TlkWriter.Write(0, new Dictionary<int, string> { [0] = "Old Label" })));
+
+        try
+        {
+            var log = new OutputLogService();
+            var workspace = new WorkspaceContext(
+                path => new SWLOR.Toolset.Domain.Workspace.ModuleWorkspace(path),
+                log,
+                tlk);
+            workspace.Open(root);
+            await workspace.Catalog!.BuildTask;
+            workspace.Catalog.TryGetEntry(ResourceType.Uti, "test_item", out var entry).Should().BeTrue();
+            entry.Name.Should().Be("Old Label");
+
+            var properties = new PropertiesViewModel(workspace, log, tlkService: tlk);
+            properties.ShowEntry(entry);
+            properties.Rows.Single(row => row.Key == "LocalizedName").Value.Should().Be("Old Label");
+
+            var categories = new CategoryService(workspace, log, tlk);
+            categories.StandardSection(ResourceType.Uti);
+            GetCachedStandardPaletteCount(categories).Should().Be(1);
+            var categoryRefreshes = 0;
+            categories.Changed += () => categoryRefreshes++;
+            var catalogRefreshes = 0;
+            workspace.CatalogLabelsChanged += () => catalogRefreshes++;
+
+            tlk.PublishCustomTlk(TlkReader.Read(
+                TlkWriter.Write(0, new Dictionary<int, string> { [0] = "New Label" })));
+            workspace.RefreshTlkLabels();
+            categories.RefreshTlkLabels();
+            new ToolsetDockFactory(null!, properties, null!, null!, null!, null!, null!, null!, null!)
+                .RefreshTlkLabels();
+
+            workspace.Catalog.TryGetEntry(ResourceType.Uti, "test_item", out entry).Should().BeTrue();
+            entry.Name.Should().Be("New Label");
+            catalogRefreshes.Should().Be(1);
+            properties.Rows.Single(row => row.Key == "LocalizedName").Value.Should().Be("New Label");
+            GetCachedStandardPaletteCount(categories).Should().Be(0);
+            categoryRefreshes.Should().Be(1);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static int GetCachedStandardPaletteCount(CategoryService categories)
+    {
+        const System.Reflection.BindingFlags flags =
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic;
+        var cache = typeof(CategoryService).GetField("_standardPalettes", flags)!.GetValue(categories)!;
+        return (int)cache.GetType().GetProperty("Count")!.GetValue(cache)!;
     }
 
     [Test]

--- a/SWLOR.Toolset.Tests/TlkEditorTests.cs
+++ b/SWLOR.Toolset.Tests/TlkEditorTests.cs
@@ -31,7 +31,12 @@ public class TlkEditorTests
             referenced: new[] { 1 });
         var editor = CreateEditor(backend);
         var editRequests = 0;
-        editor.EntryEditRequested += () => editRequests++;
+        bool? wasBusyWhenEditRequested = null;
+        editor.EntryEditRequested += () =>
+        {
+            editRequests++;
+            wasBusyWhenEditRequested = editor.IsBusy;
+        };
 
         editor.Rows.Count.Should().Be(190001);
         editor.GoToValue = (TlkService.CustomTlkBase + 2).ToString();
@@ -68,6 +73,7 @@ public class TlkEditorTests
         editor.NavigationStatus.Should().Contain("ready for a new TLK entry");
         editor.RemoveRowCommand.CanExecute(null).Should().BeFalse();
         editRequests.Should().Be(1);
+        wasBusyWhenEditRequested.Should().BeFalse("the text editor must be enabled before focus is requested");
     }
 
     [Test]

--- a/SWLOR.Toolset.Tests/TlkEditorTests.cs
+++ b/SWLOR.Toolset.Tests/TlkEditorTests.cs
@@ -1101,8 +1101,11 @@ public class TlkEditorTests
 
             var grid = view.FindControl<ListBox>("RowGrid")!;
             view.FindControl<Button>("ClearFilterButton")!.Content.Should().Be("×");
+            Grid.GetColumn(view.FindControl<Button>("NextBlankButton")!).Should().Be(0);
             view.FindControl<Button>("AddRowButton")!.Content.Should().Be("Add row");
+            Grid.GetColumn(view.FindControl<Button>("AddRowButton")!).Should().Be(1);
             view.FindControl<Button>("RemoveRowButton")!.Content.Should().Be("Remove row");
+            Grid.GetColumn(view.FindControl<Button>("RemoveRowButton")!).Should().Be(2);
             view.FindControl<TextBox>("SelectedTextEditor").Should().NotBeNull();
             grid.ItemsSource.Should().BeSameAs(editor.Rows);
             grid.GetVisualDescendants().OfType<ListBoxItem>().Count().Should().BeLessThan(100,

--- a/SWLOR.Toolset.Tests/TlkEditorTests.cs
+++ b/SWLOR.Toolset.Tests/TlkEditorTests.cs
@@ -383,6 +383,33 @@ public class TlkEditorTests
     }
 
     [Test]
+    public async Task ExternalReloadKeepsTheFilterAppliedWhenThePreviousRowNoLongerMatches()
+    {
+        var backend = new MemoryBackend(new Dictionary<int, string>
+        {
+            [0] = "alpha old",
+            [1] = "beta"
+        });
+        var prompts = new StubPrompts { ExternalChoice = ExternalChangeChoice.Reload };
+        var editor = CreateEditor(backend, prompts);
+        editor.FilterText = "alpha";
+        editor.SelectedId.Should().Be(0);
+        backend.ExternalChange = true;
+        backend.ReloadEntries = new Dictionary<int, string>
+        {
+            [0] = "changed",
+            [1] = "alpha new"
+        };
+
+        (await editor.TrySaveAsync()).Should().BeTrue();
+
+        editor.FilterText.Should().Be("alpha");
+        editor.Rows.Count.Should().Be(1);
+        ((TlkEditorRowViewModel)editor.Rows[0]!).Id.Should().Be(1);
+        editor.SelectedId.Should().Be(1);
+    }
+
+    [Test]
     public async Task FailedExternalReloadKeepsTheUnsavedEditorGeneration()
     {
         var backend = new MemoryBackend(new Dictionary<int, string> { [0] = "old" })

--- a/SWLOR.Toolset.Tests/TlkEditorTests.cs
+++ b/SWLOR.Toolset.Tests/TlkEditorTests.cs
@@ -21,7 +21,7 @@ namespace SWLOR.Toolset.Tests;
 public class TlkEditorTests
 {
     [Test]
-    public void NavigationFilteringAndSafeBlankSearchUseRawIdsAndCustomStrRefs()
+    public void NavigationFilteringAndBlankSearchUseRawIdsAndCustomStrRefs()
     {
         var backend = new MemoryBackend(
             new Dictionary<int, string> { [0] = "Alpha", [2] = "Beta", [190000] = "Alpha Two" },
@@ -101,7 +101,7 @@ public class TlkEditorTests
         {
             [10] = "one\ncontinued",
             [11] = "two"
-        });
+        }, referenced: Enumerable.Range(0, 10));
         var prompts = new StubPrompts { ConfirmDestructive = true };
         var editor = CreateEditor(backend, prompts);
 
@@ -111,23 +111,69 @@ public class TlkEditorTests
         copied.Should().NotEndWith(Environment.NewLine,
             "a trailing selected blank row must not be mistaken for a clipboard terminator");
 
-        editor.SelectId(20);
+        editor.SelectId(12);
         (await editor.PasteRowsAsync(copied)).Should().BeTrue();
-        backend.GetText(20).Should().Be("one\ncontinued");
-        backend.GetText(21).Should().Be("two");
-        backend.ContainsEntry(22).Should().BeFalse();
-        editor.Rows.Count.Should().Be(23,
+        backend.GetText(12).Should().Be("one\ncontinued");
+        backend.GetText(13).Should().Be("two");
+        backend.ContainsEntry(14).Should().BeFalse();
+        editor.Rows.Count.Should().Be(15,
             "the full pasted range remains navigable even when its final row is blank");
 
-        editor.SelectId(21);
+        editor.SelectId(13);
         (await editor.PasteRowsAsync("replacement\r\nnext\r\n")).Should().BeTrue();
-        backend.GetText(21).Should().Be("replacement");
-        backend.GetText(22).Should().Be("next");
-        prompts.DestructiveMessages.Should().Contain(message => message.Contains("21: replacement"));
+        backend.GetText(13).Should().Be("replacement");
+        backend.GetText(14).Should().Be("next");
+        prompts.DestructiveMessages.Should().Contain(message => message.Contains("13: replacement"));
 
         editor.Undo();
-        backend.GetText(21).Should().Be("two");
-        backend.ContainsEntry(22).Should().BeFalse();
+        backend.GetText(13).Should().Be("two");
+        backend.ContainsEntry(14).Should().BeFalse();
+    }
+
+    [Test]
+    public async Task TypingAndPastingCannotSkipAnEarlierBlankRow()
+    {
+        var backend = new MemoryBackend(new Dictionary<int, string>
+        {
+            [0] = "zero",
+            [2] = "two"
+        });
+        var editor = CreateEditor(backend);
+
+        editor.SelectId(3);
+        editor.SelectedText = "append";
+
+        backend.ContainsEntry(3).Should().BeFalse();
+        editor.SelectedText.Should().BeEmpty();
+        editor.NavigationStatus.Should().Contain("Blank row 1");
+        (await editor.PasteRowsAsync("append")).Should().BeFalse();
+
+        editor.SelectId(1);
+        editor.SelectedText = "one";
+        editor.SelectId(3);
+        editor.SelectedText = "three";
+
+        backend.GetText(1).Should().Be("one");
+        backend.GetText(3).Should().Be("three");
+    }
+
+    [Test]
+    public async Task PasteCanAppendWhenItFillsEveryEarlierBlankRow()
+    {
+        var backend = new MemoryBackend(new Dictionary<int, string>
+        {
+            [0] = "zero",
+            [3] = "old three"
+        });
+        var editor = CreateEditor(backend, new StubPrompts { ConfirmDestructive = true });
+        editor.SelectId(1);
+
+        (await editor.PasteRowsAsync("one\ntwo\nnew three\nfour")).Should().BeTrue();
+
+        backend.GetText(1).Should().Be("one");
+        backend.GetText(2).Should().Be("two");
+        backend.GetText(3).Should().Be("new three");
+        backend.GetText(4).Should().Be("four");
     }
 
     [Test]
@@ -141,6 +187,12 @@ public class TlkEditorTests
         editor.FindFirstBlankCommand.Execute(null);
 
         editor.SelectedId.Should().Be(0);
+        editor.NavigationStatus.Should().Contain("unavailable");
+
+        editor.SelectId(1);
+        editor.SelectedText = "new row";
+
+        backend.ContainsEntry(1).Should().BeFalse();
         editor.NavigationStatus.Should().Contain("unavailable");
     }
 

--- a/SWLOR.Toolset.Tests/TlkEditorTests.cs
+++ b/SWLOR.Toolset.Tests/TlkEditorTests.cs
@@ -33,9 +33,12 @@ public class TlkEditorTests
         editor.GoToRowCommand.Execute(null);
         editor.SelectedId.Should().Be(2);
         editor.SelectedStrRef.Should().Be(TlkService.CustomTlkBase + 2);
+        var betaRow = (TlkEditorRowViewModel)editor.Rows[2]!;
 
         editor.FilterText = "alpha";
         editor.Rows.Count.Should().Be(2);
+        editor.Rows.IndexOf(betaRow).Should().Be(-1,
+            "IList.IndexOf must return -1 when a previously visible row is filtered out");
         ((TlkEditorRowViewModel)editor.Rows[0]!).Id.Should().Be(0);
         ((TlkEditorRowViewModel)editor.Rows[1]!).Id.Should().Be(190000);
 

--- a/SWLOR.Toolset.Tests/TlkEditorTests.cs
+++ b/SWLOR.Toolset.Tests/TlkEditorTests.cs
@@ -268,6 +268,40 @@ public class TlkEditorTests
     }
 
     [Test]
+    public async Task ClearKeepsTheInvokedRowWhenNavigationChangesDuringReferenceRefresh()
+    {
+        using var refreshStarted = new ManualResetEventSlim();
+        using var continueRefresh = new ManualResetEventSlim();
+        var backend = new MemoryBackend(new Dictionary<int, string>
+        {
+            [0] = "zero",
+            [1] = "one"
+        })
+        {
+            ReferenceRefreshStarted = refreshStarted,
+            ContinueReferenceRefresh = continueRefresh
+        };
+        var editor = CreateEditor(backend);
+        editor.SelectId(0);
+
+        var clear = editor.ClearRowCommand.ExecuteAsync(null);
+        try
+        {
+            refreshStarted.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+            editor.SelectId(1);
+        }
+        finally
+        {
+            continueRefresh.Set();
+        }
+        await clear;
+
+        backend.ContainsEntry(0).Should().BeFalse();
+        backend.GetText(1).Should().Be("one");
+        editor.SelectedId.Should().Be(1);
+    }
+
+    [Test]
     public void TypingCannotPopulateAKnownReferencedBlankRowWithoutConfirmation()
     {
         var backend = new MemoryBackend(

--- a/SWLOR.Toolset.Tests/TlkEditorTests.cs
+++ b/SWLOR.Toolset.Tests/TlkEditorTests.cs
@@ -1,0 +1,560 @@
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.Logging;
+using Avalonia.VisualTree;
+using FluentAssertions;
+using NUnit.Framework;
+using System.Text;
+using SWLOR.NWN.Formats.Tlk;
+using SWLOR.Toolset.Domain.Editors;
+using SWLOR.Toolset.Domain.GameData.Tlk;
+using SWLOR.Toolset.Domain.Gff;
+using SWLOR.Toolset.Editors;
+using SWLOR.Toolset.Editors.Tlk;
+using SWLOR.Toolset.Services;
+using SWLOR.Toolset.Settings;
+using SWLOR.Toolset.Shell;
+using SWLOR.Toolset.Workspace;
+
+namespace SWLOR.Toolset.Tests;
+
+public class TlkEditorTests
+{
+    [Test]
+    public void NavigationFilteringAndSafeBlankSearchUseRawIdsAndCustomStrRefs()
+    {
+        var backend = new MemoryBackend(
+            new Dictionary<int, string> { [0] = "Alpha", [2] = "Beta", [190000] = "Alpha Two" },
+            referenced: new[] { 1 });
+        var editor = CreateEditor(backend);
+
+        editor.Rows.Count.Should().Be(190001);
+        editor.GoToValue = (TlkService.CustomTlkBase + 2).ToString();
+        editor.GoToRowCommand.Execute(null);
+        editor.SelectedId.Should().Be(2);
+        editor.SelectedStrRef.Should().Be(TlkService.CustomTlkBase + 2);
+
+        editor.FilterText = "alpha";
+        editor.Rows.Count.Should().Be(2);
+        ((TlkEditorRowViewModel)editor.Rows[0]!).Id.Should().Be(0);
+        ((TlkEditorRowViewModel)editor.Rows[1]!).Id.Should().Be(190000);
+
+        editor.FindText = "Alpha Two";
+        editor.FindNextCommand.Execute(null);
+        editor.SelectedId.Should().Be(190000);
+
+        editor.SelectedText = "No longer matches";
+        editor.SelectedId.Should().Be(190000,
+            "editing must not redirect subsequent input when a filtered row stops matching");
+        editor.Rows.Count.Should().Be(2,
+            "the filtered snapshot is refreshed explicitly rather than on every keystroke");
+        editor.Rows.Count.Should().Be(2, "find navigation must not replace the filtered grid");
+
+        editor.FindFirstBlankCommand.Execute(null);
+        editor.SelectedId.Should().Be(3, "row 1 is referenced and row 2 is populated");
+        editor.FilterText.Should().BeEmpty("blank navigation must reveal its result in the grid");
+    }
+
+    [Test]
+    public async Task TextEditingClearUndoRedoAndSaveFollowOneDocumentHistory()
+    {
+        var backend = new MemoryBackend(
+            new Dictionary<int, string> { [4] = "Original" },
+            referenced: new[] { 4 });
+        var prompts = new StubPrompts { ConfirmDestructive = true };
+        var afterSaveCount = 0;
+        var editor = CreateEditor(backend, prompts, () => afterSaveCount++);
+        editor.SelectId(4);
+
+        editor.SelectedText = "Changed\nparagraph";
+        editor.IsDirty.Should().BeTrue();
+        backend.GetText(4).Should().Be("Changed\nparagraph");
+        editor.Undo();
+        backend.GetText(4).Should().Be("Original");
+        editor.Redo();
+        backend.GetText(4).Should().Be("Changed\nparagraph");
+
+        await editor.ClearRowCommand.ExecuteAsync(null);
+        backend.ContainsEntry(4).Should().BeFalse();
+        prompts.DestructiveMessages.Should().ContainSingle(message => message.Contains("REFER", StringComparison.OrdinalIgnoreCase));
+        editor.Undo();
+        backend.GetText(4).Should().Be("Changed\nparagraph");
+
+        (await editor.TrySaveAsync()).Should().BeTrue();
+        backend.Saved.Should().BeTrue();
+        backend.Published.Should().BeTrue();
+        afterSaveCount.Should().Be(1);
+        editor.IsDirty.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task GridClipboardRoundTripsMultilineRowsAndExternalTextFillsConsecutiveRows()
+    {
+        var backend = new MemoryBackend(new Dictionary<int, string>
+        {
+            [10] = "one\ncontinued",
+            [11] = "two"
+        });
+        var prompts = new StubPrompts { ConfirmDestructive = true };
+        var editor = CreateEditor(backend, prompts);
+
+        var copied = editor.CopyRows(new[] { 10, 11, 12 });
+        copied.Split(Environment.NewLine).Should().HaveCount(3,
+            "one physical clipboard line represents each selected TLK row");
+        copied.Should().NotEndWith(Environment.NewLine,
+            "a trailing selected blank row must not be mistaken for a clipboard terminator");
+
+        editor.SelectId(20);
+        (await editor.PasteRowsAsync(copied)).Should().BeTrue();
+        backend.GetText(20).Should().Be("one\ncontinued");
+        backend.GetText(21).Should().Be("two");
+        backend.ContainsEntry(22).Should().BeFalse();
+        editor.Rows.Count.Should().Be(23,
+            "the full pasted range remains navigable even when its final row is blank");
+
+        editor.SelectId(21);
+        (await editor.PasteRowsAsync("replacement\r\nnext\r\n")).Should().BeTrue();
+        backend.GetText(21).Should().Be("replacement");
+        backend.GetText(22).Should().Be("next");
+        prompts.DestructiveMessages.Should().Contain(message => message.Contains("21: replacement"));
+
+        editor.Undo();
+        backend.GetText(21).Should().Be("two");
+        backend.ContainsEntry(22).Should().BeFalse();
+    }
+
+    [Test]
+    public void IncompleteReferenceCoverageFailsClosedForBlankAllocation()
+    {
+        var backend = new MemoryBackend(
+            new Dictionary<int, string> { [0] = "used" },
+            warnings: new[] { "broken.2da" });
+        var editor = CreateEditor(backend);
+
+        editor.FindFirstBlankCommand.Execute(null);
+
+        editor.SelectedId.Should().Be(0);
+        editor.NavigationStatus.Should().Contain("unavailable");
+    }
+
+    [Test]
+    public void LocStringShortcutOnlyOpensCustomTlkRows()
+    {
+        uint? opened = null;
+        var descriptor = new FieldDescriptor
+        {
+            Label = "Name",
+            FieldName = "Name",
+            Kind = EditorKind.LocString,
+            FieldType = GffFieldType.CExoLocString
+        };
+        var customStrRef = TlkService.CustomTlkBase + 42;
+        var customDocument = JsonGffDocument.Parse(Encoding.UTF8.GetBytes(
+            $"{{\"__data_type\":\"UTI \",\"Name\":{{\"id\":{customStrRef},\"type\":\"cexolocstring\",\"value\":{{}}}}}}"));
+        var custom = new LocStringFieldViewModel(
+            descriptor,
+            new EditorFieldContext(customDocument, (_, mutation) => { mutation(); return true; },
+                openTlkRow: strRef => opened = strRef));
+
+        custom.CanOpenTlkRow.Should().BeTrue();
+        custom.OpenTlkRowCommand.Execute(null);
+        opened.Should().Be(customStrRef);
+
+        var baseDocument = JsonGffDocument.Parse(Encoding.UTF8.GetBytes(
+            "{\"__data_type\":\"UTI \",\"Name\":{\"id\":42,\"type\":\"cexolocstring\",\"value\":{}}}"));
+        var baseField = new LocStringFieldViewModel(
+            descriptor,
+            new EditorFieldContext(baseDocument, (_, mutation) => { mutation(); return true; },
+                openTlkRow: _ => { }));
+        baseField.CanOpenTlkRow.Should().BeFalse();
+        baseField.OpenTlkRowCommand.CanExecute(null).Should().BeFalse();
+
+        var unavailableCustomField = new LocStringFieldViewModel(
+            descriptor,
+            new EditorFieldContext(customDocument, (_, mutation) => { mutation(); return true; }));
+        unavailableCustomField.CanOpenTlkRow.Should().BeFalse(
+            "the shortcut must remain disabled when the TLK editor source is unavailable");
+    }
+
+    [Test]
+    public async Task ReloadChoiceDiscardsHistoryWhenTheSourceChangedExternally()
+    {
+        var backend = new MemoryBackend(new Dictionary<int, string> { [0] = "old" });
+        var prompts = new StubPrompts { ExternalChoice = ExternalChangeChoice.Reload };
+        var editor = CreateEditor(backend, prompts);
+        editor.SelectedText = "unsaved";
+        backend.ExternalChange = true;
+        backend.ReloadEntries = new Dictionary<int, string> { [0] = "external" };
+        backend.ReloadWarnings = new[] { "newly-unscannable.2da" };
+
+        (await editor.TrySaveAsync()).Should().BeTrue();
+
+        editor.SelectedText.Should().Be("external");
+        editor.IsDirty.Should().BeFalse();
+        backend.Saved.Should().BeFalse();
+        backend.ReloadCount.Should().Be(1, "the worker reload must also be the generation applied to the view");
+        editor.ReferenceStatus.Should().Contain("1 file");
+    }
+
+    [Test]
+    public async Task FailedExternalReloadKeepsTheUnsavedEditorGeneration()
+    {
+        var backend = new MemoryBackend(new Dictionary<int, string> { [0] = "old" })
+        {
+            ExternalChange = true,
+            ReloadEntries = new Dictionary<int, string> { [0] = "external" },
+            ReloadFailure = new InvalidDataException("torn pair")
+        };
+        var prompts = new StubPrompts { ExternalChoice = ExternalChangeChoice.Reload };
+        var editor = CreateEditor(backend, prompts);
+        editor.SelectedText = "unsaved";
+
+        (await editor.TrySaveAsync()).Should().BeFalse();
+
+        backend.ReloadCount.Should().Be(1);
+        editor.SelectedText.Should().Be("unsaved");
+        editor.IsDirty.Should().BeTrue();
+        backend.Published.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task CleanSaveStillRegeneratesAndPublishesTheTlkPair()
+    {
+        var backend = new MemoryBackend(new Dictionary<int, string> { [0] = "unchanged" });
+        var editor = CreateEditor(backend);
+
+        (await editor.TrySaveAsync()).Should().BeTrue();
+
+        backend.SaveCount.Should().Be(1);
+        backend.Published.Should().BeTrue();
+        editor.IsDirty.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task ConcurrentSaveRequestsShareOneBackendTransaction()
+    {
+        var backend = new MemoryBackend(new Dictionary<int, string> { [0] = "old" })
+        {
+            SaveStarted = new ManualResetEventSlim(),
+            ContinueSave = new ManualResetEventSlim()
+        };
+        var editor = CreateEditor(backend);
+        editor.SelectedText = "new";
+
+        var first = editor.TrySaveAsync();
+        backend.SaveStarted.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+        var second = editor.TrySaveAsync();
+        backend.ContinueSave.Set();
+
+        (await Task.WhenAll(first, second)).Should().OnlyContain(result => result);
+        backend.SaveCount.Should().Be(1);
+        editor.IsDirty.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task ApplicationCloseApprovalCannotBypassAnActiveTlkSave()
+    {
+        var backend = new MemoryBackend(new Dictionary<int, string> { [0] = "old" })
+        {
+            SaveStarted = new ManualResetEventSlim(),
+            ContinueSave = new ManualResetEventSlim()
+        };
+        var editor = CreateEditor(backend);
+        editor.SelectedText = "new";
+        var closeRequested = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        editor.CloseRequested += _ => closeRequested.TrySetResult();
+
+        var save = editor.TrySaveAsync();
+        backend.SaveStarted.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+        typeof(TlkEditorDocumentViewModel)
+            .GetMethod("ApproveApplicationClose", System.Reflection.BindingFlags.Instance |
+                                                   System.Reflection.BindingFlags.NonPublic)!
+            .Invoke(editor, null);
+
+        editor.OnClose().Should().BeFalse("the paired transaction is still active");
+        closeRequested.Task.IsCompleted.Should().BeFalse();
+
+        backend.ContinueSave.Set();
+        (await save).Should().BeTrue();
+        await closeRequested.Task.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public void ProductionBackendWritesAndVerifiesTheRepositoryJsonBinaryPair()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "swlor-tlk-editor-tests", Guid.NewGuid().ToString("N"));
+        var tlkDirectory = Path.Combine(root, "sw_tlk");
+        var twoDaDirectory = Path.Combine(root, "sw_2da");
+        Directory.CreateDirectory(tlkDirectory);
+        Directory.CreateDirectory(twoDaDirectory);
+        var jsonPath = Path.Combine(tlkDirectory, "sw_tlk.tlk.json");
+        var binaryPath = Path.Combine(tlkDirectory, "sw_tlk.tlk");
+        File.WriteAllText(jsonPath,
+            "{\"language\":0,\"entries\":[{\"id\":0,\"text\":\"zero\"}]}");
+        File.WriteAllText(Path.Combine(twoDaDirectory, "test.2da"),
+            "2DA V2.0\n\nLABEL STRREF\n0 test 16777216\n");
+
+        try
+        {
+            var backend = new TlkEditorBackend(new TlkEditorSource(jsonPath, binaryPath, twoDaDirectory));
+            backend.SetText(2, "two\nlines");
+            backend.Save();
+
+            TlkDocument.Load(jsonPath).GetText(2).Should().Be("two\nlines");
+            var binary = TlkReader.Read(binaryPath);
+            binary.Entries.Should().HaveCount(3);
+            binary.GetString(2).Should().Be("two\nlines");
+            backend.HasExternalChange().Should().BeFalse();
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Test]
+    public void ProductionReloadRejectsAnExternallyTornJsonBinaryPair()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "swlor-tlk-reload-tests", Guid.NewGuid().ToString("N"));
+        var tlkDirectory = Path.Combine(root, "sw_tlk");
+        var twoDaDirectory = Path.Combine(root, "sw_2da");
+        Directory.CreateDirectory(tlkDirectory);
+        Directory.CreateDirectory(twoDaDirectory);
+        var jsonPath = Path.Combine(tlkDirectory, "sw_tlk.tlk.json");
+        var binaryPath = Path.Combine(tlkDirectory, "sw_tlk.tlk");
+        File.WriteAllText(jsonPath,
+            "{\"language\":0,\"entries\":[{\"id\":0,\"text\":\"old\"}]}");
+        File.WriteAllBytes(binaryPath, TlkWriter.Write(0, new Dictionary<int, string> { [0] = "old" }));
+
+        try
+        {
+            var backend = new TlkEditorBackend(new TlkEditorSource(jsonPath, binaryPath, twoDaDirectory));
+            File.WriteAllText(jsonPath,
+                "{\"language\":0,\"entries\":[{\"id\":0,\"text\":\"external\"}]}");
+
+            var reload = () => backend.Reload();
+
+            reload.Should().Throw<InvalidDataException>();
+            backend.GetText(0).Should().Be("old", "a rejected external generation must not replace editor state");
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Test]
+    public void ProductionPublishUsesTheExactVerifiedReloadGeneration()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "swlor-tlk-publish-tests", Guid.NewGuid().ToString("N"));
+        var tlkDirectory = Path.Combine(root, "sw_tlk");
+        var twoDaDirectory = Path.Combine(root, "sw_2da");
+        Directory.CreateDirectory(tlkDirectory);
+        Directory.CreateDirectory(twoDaDirectory);
+        var jsonPath = Path.Combine(tlkDirectory, "sw_tlk.tlk.json");
+        var binaryPath = Path.Combine(tlkDirectory, "sw_tlk.tlk");
+        WritePair(jsonPath, binaryPath, "old");
+        var service = new TlkService(TlkJsonFile.Parse(
+            "{\"language\":0,\"entries\":[{\"id\":0,\"text\":\"fallback\"}]}"));
+
+        try
+        {
+            var backend = new TlkEditorBackend(
+                new TlkEditorSource(jsonPath, binaryPath, twoDaDirectory),
+                service);
+            WritePair(jsonPath, binaryPath, "accepted A");
+            backend.Reload();
+
+            WritePair(jsonPath, binaryPath, "later B");
+            backend.Publish();
+
+            backend.GetText(0).Should().Be("accepted A");
+            service.GetCustomText(0).Should().Be("accepted A",
+                "publication must use the verified snapshot rather than rereading the changed path");
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static void WritePair(string jsonPath, string binaryPath, string text)
+    {
+        File.WriteAllText(jsonPath,
+            $"{{\"language\":0,\"entries\":[{{\"id\":0,\"text\":\"{text}\"}}]}}");
+        File.WriteAllBytes(binaryPath, TlkWriter.Write(0, new Dictionary<int, string> { [0] = text }));
+    }
+
+    [AvaloniaTest]
+    public void EditorViewRendersAVirtualizedGridWithoutBindingErrors()
+    {
+        var previousSink = Logger.Sink;
+        var sink = new CountingSink();
+        Logger.Sink = sink;
+        try
+        {
+            var backend = new MemoryBackend(new Dictionary<int, string> { [199999] = "last" });
+            var editor = CreateEditor(backend);
+            var view = new TlkEditorDocumentView { DataContext = editor };
+            var window = new Window { Width = 1280, Height = 820, Content = view };
+            window.Show();
+            window.UpdateLayout();
+
+            var grid = view.FindControl<ListBox>("RowGrid")!;
+            grid.ItemsSource.Should().BeSameAs(editor.Rows);
+            grid.GetVisualDescendants().OfType<ListBoxItem>().Count().Should().BeLessThan(100,
+                "only visible rows should be realized from the 200,000-row virtual range");
+            editor.Rows.CreatedRowCount.Should().BeLessThan(100,
+                "the item source itself must not be eagerly copied into a collection view");
+            view.GetVisualDescendants().OfType<TextBox>().Should().NotBeEmpty();
+
+            window.Close();
+            editor.OnClose().Should().BeTrue();
+        }
+        finally
+        {
+            Logger.Sink = previousSink;
+        }
+
+        sink.Errors.Should().BeEmpty();
+    }
+
+    [AvaloniaTest]
+    public void ToolsMenuContainsTheTlkEditorEntryPoint()
+    {
+        var settingsPath = Path.Combine(Path.GetTempPath(), $"swlor-toolset-tlk-{Guid.NewGuid():N}.json");
+        var window = new MainWindow(ToolsetSettings.Load(settingsPath));
+
+        window.FindControl<MenuItem>("TlkEditorMenuItem")!.Header.Should().Be("_TLK Editor...");
+    }
+
+    private static TlkEditorDocumentViewModel CreateEditor(
+        MemoryBackend backend,
+        StubPrompts? prompts = null,
+        Action? afterSave = null) =>
+        new(backend, new OutputLogService(), prompts ?? new StubPrompts(), afterSave);
+
+    private sealed class MemoryBackend : ITlkEditorBackend
+    {
+        private Dictionary<int, string> _entries;
+        private readonly HashSet<int> _referenced;
+
+        public MemoryBackend(
+            Dictionary<int, string> entries,
+            IEnumerable<int>? referenced = null,
+            IReadOnlyList<string>? warnings = null)
+        {
+            _entries = new Dictionary<int, string>(entries);
+            _referenced = referenced?.ToHashSet() ?? new HashSet<int>();
+            ReferenceWarnings = warnings ?? Array.Empty<string>();
+        }
+
+        public string JsonPath => "memory/sw_tlk.tlk.json";
+        public string BinaryPath => "memory/sw_tlk.tlk";
+        public int Language => 0;
+        public int Count => _entries.Count;
+        public int MaxEntryId => _entries.Count == 0 ? -1 : _entries.Keys.Max();
+        public IReadOnlyList<TlkEditorEntry> Entries => _entries.OrderBy(pair => pair.Key)
+            .Select(pair => new TlkEditorEntry(pair.Key, pair.Value)).ToArray();
+        public IReadOnlyList<string> ReferenceWarnings { get; private set; }
+        public bool ExternalChange { get; set; }
+        public Dictionary<int, string>? ReloadEntries { get; set; }
+        public IReadOnlyList<string>? ReloadWarnings { get; set; }
+        public bool Saved { get; private set; }
+        public bool Published { get; private set; }
+        public int SaveCount { get; private set; }
+        public int ReloadCount { get; private set; }
+        public Exception? ReloadFailure { get; init; }
+        public ManualResetEventSlim? SaveStarted { get; init; }
+        public ManualResetEventSlim? ContinueSave { get; init; }
+
+        public bool ContainsEntry(int id) => _entries.ContainsKey(id);
+        public string? GetText(int id) => _entries.GetValueOrDefault(id);
+        public void SetText(int id, string text)
+        {
+            if (text.Length == 0)
+                _entries.Remove(id);
+            else
+                _entries[id] = text;
+        }
+        public bool Clear(int id) => _entries.Remove(id);
+        public bool IsReferenced(int id) => _referenced.Contains(id);
+        public int UsageCountFor(int id) => IsReferenced(id) ? 1 : 0;
+        public IReadOnlyList<TlkEditorUsage> UsagesOf(int id) => IsReferenced(id)
+            ? new[] { new TlkEditorUsage("test.2da", 7, "label", "STRREF", TlkService.CustomTlkBase + (uint)id) }
+            : Array.Empty<TlkEditorUsage>();
+        public int FindFirstAvailableBlank() => FindNextAvailableBlank(-1);
+        public int FindNextAvailableBlank(int currentId)
+        {
+            for (var id = currentId + 1; id <= Math.Max(MaxEntryId + 1, currentId + 1); id++)
+            {
+                if (!ContainsEntry(id) && !IsReferenced(id))
+                    return id;
+            }
+            throw new InvalidOperationException();
+        }
+        public bool HasExternalChange() => ExternalChange;
+        public void Reload()
+        {
+            ReloadCount++;
+            if (ReloadFailure != null)
+                throw ReloadFailure;
+            if (ReloadEntries != null)
+                _entries = new Dictionary<int, string>(ReloadEntries);
+            if (ReloadWarnings != null)
+                ReferenceWarnings = ReloadWarnings;
+            ExternalChange = false;
+        }
+        public void Save(bool overwriteExternalChanges = false)
+        {
+            SaveCount++;
+            SaveStarted?.Set();
+            ContinueSave?.Wait(TimeSpan.FromSeconds(5));
+            Saved = true;
+            ExternalChange = false;
+        }
+        public void Publish() => Published = true;
+    }
+
+    private sealed class StubPrompts : IEditorPromptService
+    {
+        public ExternalChangeChoice ExternalChoice { get; set; } = ExternalChangeChoice.Cancel;
+        public bool ConfirmDestructive { get; set; }
+        public List<string> DestructiveMessages { get; } = new();
+
+        public Task<ExternalChangeChoice> ConfirmExternalChangeAsync(string filePath) =>
+            Task.FromResult(ExternalChoice);
+        public Task<UnsavedChangesChoice> ConfirmCloseAsync(string documentTitle) =>
+            Task.FromResult(UnsavedChangesChoice.Cancel);
+        public Task<bool> ConfirmDestructiveAsync(string headline, string message, string confirmLabel)
+        {
+            DestructiveMessages.Add(headline + "\n" + message);
+            return Task.FromResult(ConfirmDestructive);
+        }
+        public Task<string?> PromptForTextAsync(
+            string headline, string message, string initialValue, string confirmLabel) =>
+            Task.FromResult<string?>(null);
+    }
+
+    private sealed class CountingSink : ILogSink
+    {
+        public List<string> Errors { get; } = new();
+        public bool IsEnabled(LogEventLevel level, string area) =>
+            level >= LogEventLevel.Warning && area == LogArea.Binding;
+        public void Log(LogEventLevel level, string area, object? source, string messageTemplate)
+        {
+            if (IsEnabled(level, area))
+                Errors.Add(messageTemplate);
+        }
+        public void Log(
+            LogEventLevel level,
+            string area,
+            object? source,
+            string messageTemplate,
+            params object?[] values)
+        {
+            if (IsEnabled(level, area))
+                Errors.Add(messageTemplate + " | " + string.Join(", ", values));
+        }
+    }
+}

--- a/SWLOR.Toolset.Tests/TlkEditorTests.cs
+++ b/SWLOR.Toolset.Tests/TlkEditorTests.cs
@@ -30,6 +30,8 @@ public class TlkEditorTests
             new Dictionary<int, string> { [0] = "Alpha", [2] = "Beta", [190000] = "Alpha Two" },
             referenced: new[] { 1 });
         var editor = CreateEditor(backend);
+        var editRequests = 0;
+        editor.EntryEditRequested += () => editRequests++;
 
         editor.Rows.Count.Should().Be(190001);
         editor.GoToValue = (TlkService.CustomTlkBase + 2).ToString();
@@ -60,13 +62,16 @@ public class TlkEditorTests
             "the filtered snapshot is refreshed explicitly rather than on every keystroke");
         editor.Rows.Count.Should().Be(2);
 
-        await editor.FindFirstBlankCommand.ExecuteAsync(null);
+        await editor.AddRowCommand.ExecuteAsync(null);
         editor.SelectedId.Should().Be(3, "row 1 is referenced and row 2 is populated");
         editor.FilterText.Should().BeEmpty("blank navigation must reveal its result in the grid");
+        editor.NavigationStatus.Should().Contain("ready for a new TLK entry");
+        editor.RemoveRowCommand.CanExecute(null).Should().BeFalse();
+        editRequests.Should().Be(1);
     }
 
     [Test]
-    public async Task TextEditingClearUndoRedoAndSaveFollowOneDocumentHistory()
+    public async Task TextEditingRemoveUndoRedoAndSaveFollowOneDocumentHistory()
     {
         var backend = new MemoryBackend(
             new Dictionary<int, string> { [4] = "Original" },
@@ -84,7 +89,7 @@ public class TlkEditorTests
         editor.Redo();
         backend.GetText(4).Should().Be("Changed\nparagraph");
 
-        await editor.ClearRowCommand.ExecuteAsync(null);
+        await editor.RemoveRowCommand.ExecuteAsync(null);
         backend.ContainsEntry(4).Should().BeFalse();
         prompts.DestructiveMessages.Should().ContainSingle(message => message.Contains("REFER", StringComparison.OrdinalIgnoreCase));
         editor.Undo();
@@ -95,6 +100,31 @@ public class TlkEditorTests
         backend.Published.Should().BeTrue();
         afterSaveCount.Should().Be(1);
         editor.IsDirty.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task RemoveRowLeavesLaterRowIdsUnchangedAndIsUndoable()
+    {
+        var backend = new MemoryBackend(new Dictionary<int, string>
+        {
+            [0] = "zero",
+            [2] = "two"
+        });
+        var editor = CreateEditor(backend);
+        editor.SelectId(0);
+
+        editor.RemoveRowCommand.CanExecute(null).Should().BeTrue();
+        await editor.RemoveRowCommand.ExecuteAsync(null);
+
+        backend.ContainsEntry(0).Should().BeFalse();
+        backend.GetText(2).Should().Be("two");
+        editor.SelectedId.Should().Be(0);
+        editor.RemoveRowCommand.CanExecute(null).Should().BeFalse();
+
+        editor.Undo();
+        backend.GetText(0).Should().Be("zero");
+        backend.GetText(2).Should().Be("two");
+        editor.RemoveRowCommand.CanExecute(null).Should().BeTrue();
     }
 
     [Test]
@@ -230,7 +260,7 @@ public class TlkEditorTests
             warnings: new[] { "broken.2da" });
         var editor = CreateEditor(backend);
 
-        await editor.FindFirstBlankCommand.ExecuteAsync(null);
+        await editor.AddRowCommand.ExecuteAsync(null);
 
         editor.SelectedId.Should().Be(0);
         editor.NavigationStatus.Should().Contain("unavailable");
@@ -256,11 +286,11 @@ public class TlkEditorTests
         var prompts = new StubPrompts { ConfirmDestructive = false };
         var editor = CreateEditor(backend, prompts);
 
-        await editor.FindFirstBlankCommand.ExecuteAsync(null);
+        await editor.AddRowCommand.ExecuteAsync(null);
 
         editor.SelectedId.Should().Be(3, "row 1 became referenced after the editor opened");
         editor.SelectId(2);
-        await editor.ClearRowCommand.ExecuteAsync(null);
+        await editor.RemoveRowCommand.ExecuteAsync(null);
 
         backend.ContainsEntry(2).Should().BeTrue();
         prompts.DestructiveMessages.Should().ContainSingle(message => message.Contains("row 2"));
@@ -284,7 +314,7 @@ public class TlkEditorTests
         var editor = CreateEditor(backend);
         editor.SelectId(0);
 
-        var clear = editor.ClearRowCommand.ExecuteAsync(null);
+        var clear = editor.RemoveRowCommand.ExecuteAsync(null);
         try
         {
             refreshStarted.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
@@ -349,10 +379,10 @@ public class TlkEditorTests
         editor.SelectedText = string.Empty;
 
         backend.ContainsEntry(4).Should().BeTrue();
-        editor.NavigationStatus.Should().Contain("Clear row");
+        editor.NavigationStatus.Should().Contain("Remove row");
         prompts.DestructiveMessages.Should().BeEmpty();
 
-        await editor.ClearRowCommand.ExecuteAsync(null);
+        await editor.RemoveRowCommand.ExecuteAsync(null);
         backend.ContainsEntry(4).Should().BeFalse();
         prompts.DestructiveMessages.Should().BeEmpty("the row was unreferenced when it was cleared");
 
@@ -570,7 +600,7 @@ public class TlkEditorTests
         var closeRequested = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         editor.CloseRequested += _ => closeRequested.TrySetResult();
 
-        var find = editor.FindFirstBlankCommand.ExecuteAsync(null);
+        var find = editor.AddRowCommand.ExecuteAsync(null);
         backend.ReferenceRefreshStarted.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
 
         editor.OnClose().Should().BeFalse("the reference refresh is still active");
@@ -1065,6 +1095,9 @@ public class TlkEditorTests
 
             var grid = view.FindControl<ListBox>("RowGrid")!;
             view.FindControl<Button>("ClearFilterButton")!.Content.Should().Be("×");
+            view.FindControl<Button>("AddRowButton")!.Content.Should().Be("Add row");
+            view.FindControl<Button>("RemoveRowButton")!.Content.Should().Be("Remove row");
+            view.FindControl<TextBox>("SelectedTextEditor").Should().NotBeNull();
             grid.ItemsSource.Should().BeSameAs(editor.Rows);
             grid.GetVisualDescendants().OfType<ListBoxItem>().Count().Should().BeLessThan(100,
                 "only visible rows should be realized from the 200,000-row virtual range");

--- a/SWLOR.Toolset.Tests/TlkEditorTests.cs
+++ b/SWLOR.Toolset.Tests/TlkEditorTests.cs
@@ -39,8 +39,12 @@ public class TlkEditorTests
         ((TlkEditorRowViewModel)editor.Rows[0]!).Id.Should().Be(0);
         ((TlkEditorRowViewModel)editor.Rows[1]!).Id.Should().Be(190000);
 
-        editor.FindText = "Alpha Two";
-        editor.FindNextCommand.Execute(null);
+        editor.ClearFilterCommand.Execute(null);
+        editor.FilterText.Should().BeEmpty();
+        editor.Rows.Count.Should().Be(190001);
+
+        editor.FilterText = "alpha";
+        editor.SelectId(190000, clearFilter: false);
         editor.SelectedId.Should().Be(190000);
 
         editor.SelectedText = "No longer matches";
@@ -48,7 +52,7 @@ public class TlkEditorTests
             "editing must not redirect subsequent input when a filtered row stops matching");
         editor.Rows.Count.Should().Be(2,
             "the filtered snapshot is refreshed explicitly rather than on every keystroke");
-        editor.Rows.Count.Should().Be(2, "find navigation must not replace the filtered grid");
+        editor.Rows.Count.Should().Be(2);
 
         editor.FindFirstBlankCommand.Execute(null);
         editor.SelectedId.Should().Be(3, "row 1 is referenced and row 2 is populated");
@@ -401,6 +405,7 @@ public class TlkEditorTests
             window.UpdateLayout();
 
             var grid = view.FindControl<ListBox>("RowGrid")!;
+            view.FindControl<Button>("ClearFilterButton")!.Content.Should().Be("×");
             grid.ItemsSource.Should().BeSameAs(editor.Rows);
             grid.GetVisualDescendants().OfType<ListBoxItem>().Count().Should().BeLessThan(100,
                 "only visible rows should be realized from the 200,000-row virtual range");

--- a/SWLOR.Toolset.Tests/TlkEditorTests.cs
+++ b/SWLOR.Toolset.Tests/TlkEditorTests.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 using System.Text;
 using SWLOR.NWN.Formats.Tlk;
 using SWLOR.Toolset.Domain.Editors;
+using SWLOR.Toolset.Domain.GameData.Lookups;
 using SWLOR.Toolset.Domain.GameData.Tlk;
 using SWLOR.Toolset.Domain.Gff;
 using SWLOR.Toolset.Editors;
@@ -513,6 +514,38 @@ public class TlkEditorTests
         (await save).Should().BeTrue();
         backend.LastSavedEntries.Should().ContainKey(0).WhoseValue.Should().Be("new");
         editor.IsDirty.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task NavigatingAnAlreadyOpenTlkEditorClearsAnyPendingRequest()
+    {
+        var log = new OutputLogService();
+        var workspace = new WorkspaceContext(
+            root => new SWLOR.Toolset.Domain.Workspace.ModuleWorkspace(root),
+            log);
+        var prompts = new StubPrompts();
+        var factory = new ToolsetDockFactory(
+            null!, null!, null!, null!, null!, null!, null!, null!, null!);
+        var service = new EditorService(
+            workspace,
+            new LookupOptionProvider(workspace),
+            log,
+            factory,
+            prompts);
+        var openEditor = CreateEditor(new MemoryBackend(new Dictionary<int, string>
+        {
+            [0] = "zero",
+            [2] = "two"
+        }));
+        var flags = System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic;
+        typeof(EditorService).GetField("_tlkEditor", flags)!.SetValue(service, openEditor);
+        typeof(EditorService).GetField("_pendingTlkStrRef", flags)!
+            .SetValue(service, TlkService.CustomTlkBase + 1);
+
+        await service.OpenTlkEditorAsync(TlkService.CustomTlkBase + 2);
+
+        openEditor.SelectedId.Should().Be(2);
+        typeof(EditorService).GetField("_pendingTlkStrRef", flags)!.GetValue(service).Should().BeNull();
     }
 
     [Test]

--- a/SWLOR.Toolset.Tests/TlkEditorTests.cs
+++ b/SWLOR.Toolset.Tests/TlkEditorTests.cs
@@ -131,6 +131,23 @@ public class TlkEditorTests
     }
 
     [Test]
+    public async Task GridPasteTreatsOneTrailingCarriageReturnAsAClipboardSeparator()
+    {
+        var backend = new MemoryBackend(new Dictionary<int, string>
+        {
+            [5] = "five",
+            [6] = "six"
+        });
+        var editor = CreateEditor(backend, new StubPrompts { ConfirmDestructive = true });
+        editor.SelectId(5);
+
+        (await editor.PasteRowsAsync("replacement\r")).Should().BeTrue();
+
+        backend.GetText(5).Should().Be("replacement");
+        backend.GetText(6).Should().Be("six", "the clipboard terminator is not another pasted row");
+    }
+
+    [Test]
     public async Task TypingAndPastingCannotSkipAnEarlierBlankRow()
     {
         var backend = new MemoryBackend(new Dictionary<int, string>
@@ -219,6 +236,43 @@ public class TlkEditorTests
         backend.ContainsEntry(2).Should().BeTrue();
         prompts.DestructiveMessages.Should().ContainSingle(message => message.Contains("row 2"));
         backend.ReferenceRefreshCount.Should().Be(2);
+    }
+
+    [Test]
+    public void TypingCannotPopulateAKnownReferencedBlankRowWithoutConfirmation()
+    {
+        var backend = new MemoryBackend(
+            new Dictionary<int, string> { [0] = "zero", [2] = "two" },
+            referenced: new[] { 1 });
+        var editor = CreateEditor(backend);
+        editor.SelectId(1);
+
+        editor.SelectedText = "one";
+
+        backend.ContainsEntry(1).Should().BeFalse();
+        editor.SelectedText.Should().BeEmpty();
+        editor.NavigationStatus.Should().Contain("grid paste");
+    }
+
+    [Test]
+    public async Task SaveConfirmsWhenAJustPopulatedBlankBecomesReferenced()
+    {
+        var backend = new MemoryBackend(new Dictionary<int, string>
+        {
+            [0] = "zero",
+            [2] = "two"
+        });
+        var prompts = new StubPrompts { ConfirmDestructive = true };
+        var editor = CreateEditor(backend, prompts);
+        editor.SelectId(1);
+        editor.SelectedText = "one";
+        backend.ReferencesAfterRefresh = new[] { 1 };
+
+        (await editor.TrySaveAsync()).Should().BeTrue();
+
+        prompts.DestructiveMessages.Should().ContainSingle(message =>
+            message.Contains("newly populated", StringComparison.OrdinalIgnoreCase));
+        backend.Saved.Should().BeTrue();
     }
 
     [Test]
@@ -386,6 +440,33 @@ public class TlkEditorTests
 
         backend.ContinueSave.Set();
         (await save).Should().BeTrue();
+        await closeRequested.Task.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task ClosingWaitsForANonSaveReferenceRefresh()
+    {
+        var backend = new MemoryBackend(new Dictionary<int, string>
+        {
+            [0] = "zero",
+            [2] = "two"
+        })
+        {
+            ReferenceRefreshStarted = new ManualResetEventSlim(),
+            ContinueReferenceRefresh = new ManualResetEventSlim()
+        };
+        var editor = CreateEditor(backend);
+        var closeRequested = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        editor.CloseRequested += _ => closeRequested.TrySetResult();
+
+        var find = editor.FindFirstBlankCommand.ExecuteAsync(null);
+        backend.ReferenceRefreshStarted.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+
+        editor.OnClose().Should().BeFalse("the reference refresh is still active");
+        closeRequested.Task.IsCompleted.Should().BeFalse();
+
+        backend.ContinueReferenceRefresh.Set();
+        await find;
         await closeRequested.Task.WaitAsync(TimeSpan.FromSeconds(5));
     }
 
@@ -614,6 +695,8 @@ public class TlkEditorTests
         public Exception? ReloadFailure { get; init; }
         public ManualResetEventSlim? SaveStarted { get; init; }
         public ManualResetEventSlim? ContinueSave { get; init; }
+        public ManualResetEventSlim? ReferenceRefreshStarted { get; init; }
+        public ManualResetEventSlim? ContinueReferenceRefresh { get; init; }
 
         public bool ContainsEntry(int id) => _entries.ContainsKey(id);
         public string? GetText(int id) => _entries.GetValueOrDefault(id);
@@ -643,6 +726,8 @@ public class TlkEditorTests
         public void RefreshReferences()
         {
             ReferenceRefreshCount++;
+            ReferenceRefreshStarted?.Set();
+            ContinueReferenceRefresh?.Wait(TimeSpan.FromSeconds(5));
             if (ReferenceRefreshFailure != null)
                 throw ReferenceRefreshFailure;
             if (ReferencesAfterRefresh == null)

--- a/SWLOR.Toolset.Tests/TlkReferenceIndexTests.cs
+++ b/SWLOR.Toolset.Tests/TlkReferenceIndexTests.cs
@@ -66,7 +66,7 @@ namespace SWLOR.Toolset.Tests
         {
             var haks = Path.Combine(CorpusLocator.RepositoryRoot, "SWLOR_Haks");
             var document = TlkDocument.Load(Path.Combine(haks, "sw_tlk", "sw_tlk.tlk.json"));
-            var index = TlkReferenceIndex.Build(Path.Combine(haks, "sw_2da"));
+            var index = TlkReferenceIndex.Build(Path.Combine(haks, "sw_2da"), CorpusLocator.RepositoryRoot);
 
             document.ContainsEntry(80831).Should().BeFalse("the biography slot is intentionally blank");
             index.IsReferenced(80831).Should().BeTrue();
@@ -84,6 +84,36 @@ namespace SWLOR.Toolset.Tests
             TestContext.Out.WriteLine($"First corpus-safe custom TLK gap: {firstSafeGap}");
             firstSafeGap.Should().Be(expectedFirstSafeGap);
             firstSafeGap.Should().Be(6181, "the current corpus's first unpopulated and unreferenced row is stable");
+        }
+
+        [Test]
+        public void Build_IndexesCustomStrRefsOutsideTwoDaFiles()
+        {
+            var root = CreateTempDirectory();
+            try
+            {
+                var twoDaDirectory = Path.Combine(root, "SWLOR_Haks", "sw_2da");
+                var moduleDirectory = Path.Combine(root, "Module", "itp");
+                Directory.CreateDirectory(twoDaDirectory);
+                Directory.CreateDirectory(moduleDirectory);
+                File.WriteAllText(Path.Combine(moduleDirectory, "palette.itp.json"),
+                    "{\n  \"value\": 16777261,\n  \"notAStrRef\": 0.16777262\n}\n");
+
+                var index = TlkReferenceIndex.Build(twoDaDirectory, root);
+
+                index.IsReferenced(45).Should().BeTrue();
+                index.UsagesOf(45).Should().ContainSingle(usage =>
+                    usage.FileName == "Module/itp/palette.itp.json" &&
+                    usage.RowIndex == 2 &&
+                    usage.ColumnName == TlkReferenceIndex.RepositoryTextColumnName);
+                index.IsReferenced(46).Should().BeFalse(
+                    "digits after a decimal point are not standalone StrRef tokens");
+                index.UnscannableFiles.Should().BeEmpty();
+            }
+            finally
+            {
+                Directory.Delete(root, recursive: true);
+            }
         }
 
         private static string CreateTempDirectory()

--- a/SWLOR.Toolset.Tests/TlkReferenceIndexTests.cs
+++ b/SWLOR.Toolset.Tests/TlkReferenceIndexTests.cs
@@ -98,6 +98,14 @@ namespace SWLOR.Toolset.Tests
                 Directory.CreateDirectory(moduleDirectory);
                 File.WriteAllText(Path.Combine(moduleDirectory, "palette.itp.json"),
                     "{\n  \"value\": 16777261,\n  \"notAStrRef\": 0.16777262\n}\n");
+                foreach (var ignoredDirectory in new[] { ".agents", ".claude", ".codex" })
+                {
+                    var path = Path.Combine(root, ignoredDirectory, "worktrees");
+                    Directory.CreateDirectory(path);
+                    File.WriteAllText(
+                        Path.Combine(path, "agent-metadata.json"),
+                        $"{{\"notRuntimeContent\":{TlkService.CustomTlkBase + 90}}}\n");
+                }
 
                 var index = TlkReferenceIndex.Build(twoDaDirectory, root);
 
@@ -108,6 +116,8 @@ namespace SWLOR.Toolset.Tests
                     usage.ColumnName == TlkReferenceIndex.RepositoryTextColumnName);
                 index.IsReferenced(46).Should().BeFalse(
                     "digits after a decimal point are not standalone StrRef tokens");
+                index.IsReferenced(90).Should().BeFalse(
+                    "agent metadata and nested agent worktrees are not runtime reference sources");
                 index.UnscannableFiles.Should().BeEmpty();
             }
             finally

--- a/SWLOR.Toolset.Tests/TlkReferenceIndexTests.cs
+++ b/SWLOR.Toolset.Tests/TlkReferenceIndexTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using FluentAssertions;
 using NUnit.Framework;
 using SWLOR.NWN.Formats.Tlk;
@@ -157,6 +158,39 @@ namespace SWLOR.Toolset.Tests
                 changed.IsReferenced(1).Should().BeTrue("the unchanged 2DA result was retained");
                 changed.IsReferenced(2).Should().BeFalse("the changed file's old result was replaced");
                 changed.IsReferenced(30).Should().BeTrue();
+            }
+            finally
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+
+        [Test]
+        public void Refresh_RescansSameLengthReplacementWithPreservedTimestamp()
+        {
+            var root = CreateTempDirectory();
+            try
+            {
+                var twoDaPath = Path.Combine(root, "sample.2da");
+                var oldStrRef = TlkService.CustomTlkBase + 1;
+                var newStrRef = TlkService.CustomTlkBase + 9;
+                var original = $"2DA V2.0\n\nLABEL STRREF\n0 test {oldStrRef}\n";
+                var replacement = $"2DA V2.0\n\nLABEL STRREF\n0 test {newStrRef}\n";
+                Encoding.UTF8.GetByteCount(replacement).Should().Be(Encoding.UTF8.GetByteCount(original));
+                File.WriteAllText(twoDaPath, original);
+                var originalWriteTime = File.GetLastWriteTimeUtc(twoDaPath);
+                var initial = TlkReferenceIndex.Build(root);
+
+                File.WriteAllText(twoDaPath, replacement);
+                File.SetLastWriteTimeUtc(twoDaPath, originalWriteTime);
+                new FileInfo(twoDaPath).Length.Should().Be(Encoding.UTF8.GetByteCount(original));
+                File.GetLastWriteTimeUtc(twoDaPath).Should().Be(originalWriteTime);
+
+                var refreshed = initial.Refresh(root);
+
+                refreshed.LastRefreshScannedSourceCount.Should().Be(1);
+                refreshed.IsReferenced(1).Should().BeFalse();
+                refreshed.IsReferenced(9).Should().BeTrue();
             }
             finally
             {

--- a/SWLOR.Toolset.Tests/TlkReferenceIndexTests.cs
+++ b/SWLOR.Toolset.Tests/TlkReferenceIndexTests.cs
@@ -116,6 +116,44 @@ namespace SWLOR.Toolset.Tests
             }
         }
 
+        [Test]
+        public void Refresh_ReusesUnchangedSourcesAndRescansOnlyChangedFiles()
+        {
+            var root = CreateTempDirectory();
+            try
+            {
+                var twoDaDirectory = Path.Combine(root, "SWLOR_Haks", "sw_2da");
+                var moduleDirectory = Path.Combine(root, "Module");
+                Directory.CreateDirectory(twoDaDirectory);
+                Directory.CreateDirectory(moduleDirectory);
+                var twoDaPath = Path.Combine(twoDaDirectory, "sample.2da");
+                var jsonPath = Path.Combine(moduleDirectory, "sample.json");
+                File.WriteAllText(twoDaPath,
+                    $"2DA V2.0\n\nLABEL STRREF\n0 test {TlkService.CustomTlkBase + 1}\n");
+                File.WriteAllText(jsonPath, $"{{\"strRef\":{TlkService.CustomTlkBase + 2}}}\n");
+
+                var initial = TlkReferenceIndex.Build(twoDaDirectory, root);
+                initial.LastRefreshScannedSourceCount.Should().Be(2);
+
+                var unchanged = initial.Refresh(twoDaDirectory, root);
+                unchanged.LastRefreshScannedSourceCount.Should().Be(0,
+                    "an editor action with no repository changes must not reread source contents");
+
+                File.WriteAllText(jsonPath,
+                    $"{{\"strRef\":{TlkService.CustomTlkBase + 30},\"changed\":true}}\n");
+                var changed = unchanged.Refresh(twoDaDirectory, root);
+
+                changed.LastRefreshScannedSourceCount.Should().Be(1);
+                changed.IsReferenced(1).Should().BeTrue("the unchanged 2DA result was retained");
+                changed.IsReferenced(2).Should().BeFalse("the changed file's old result was replaced");
+                changed.IsReferenced(30).Should().BeTrue();
+            }
+            finally
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+
         private static string CreateTempDirectory()
         {
             var path = Path.Combine(Path.GetTempPath(), "SWLOR.Toolset.Tests", Guid.NewGuid().ToString("N"));

--- a/SWLOR.Toolset.Tests/TlkReferenceIndexTests.cs
+++ b/SWLOR.Toolset.Tests/TlkReferenceIndexTests.cs
@@ -1,0 +1,96 @@
+using FluentAssertions;
+using NUnit.Framework;
+using SWLOR.NWN.Formats.Tlk;
+using SWLOR.Toolset.Domain.GameData.Tlk;
+
+namespace SWLOR.Toolset.Tests
+{
+    public class TlkReferenceIndexTests
+    {
+        [Test]
+        public void Build_UsesStructuredParserAndConservativeRawTextFallback()
+        {
+            var root = CreateTempDirectory();
+            try
+            {
+                var maxValidStrRef = TlkService.CustomTlkBase + (uint)TlkFormatLimits.MaximumEntryId;
+                var firstInvalidStrRef = maxValidStrRef + 1;
+                File.WriteAllText(Path.Combine(root, "sample.2da"),
+                    $"""
+                    2DA V2.0
+
+                        DisplayName       Description       OrdinaryNumber
+                    alpha "Quoted value" 16777221          42
+                    beta  Plain           16777222          16777215
+                    gamma Plain           {maxValidStrRef}          42
+                    delta Plain           {firstInvalidStrRef}          42
+                    """);
+                File.WriteAllText(Path.Combine(root, "scratch.2da"),
+                    """
+                    not a 2DA
+                    orphan "quoted 16777223," and16777224suffix
+                    ignored 24777216
+                    """);
+
+                var index = TlkReferenceIndex.Build(root);
+
+                index.ReferencedEntryIds.Should().Equal(5, 6, 7, 8, TlkFormatLimits.MaximumEntryId);
+                index.UsagesOf(5).Should().ContainSingle().Which.Should().Be(
+                    new TlkReferenceUsage("sample.2da", 0, "alpha", "Description", 16777221, 5));
+                index.UsageCountFor(6).Should().Be(1);
+                index.IsReferenced(4).Should().BeFalse();
+                index.IsReferenced(TlkFormatLimits.MaximumEntryId).Should().BeTrue();
+                index.IsReferenced(TlkFormatLimits.MaximumEntryId + 1).Should().BeFalse(
+                    "a number outside the writable TLK range is not a valid custom TLK reference");
+                index.UsagesOf(7).Should().ContainSingle().Which.Should().Be(
+                    new TlkReferenceUsage(
+                        "scratch.2da",
+                        1,
+                        "orphan",
+                        TlkReferenceIndex.FallbackColumnName,
+                        16777223,
+                        7));
+                index.UsagesOf(8).Should().ContainSingle(usage =>
+                    usage.ColumnName == TlkReferenceIndex.FallbackColumnName && usage.RowLabel == "orphan");
+                index.UnscannableFiles.Should().BeEmpty(
+                    "a readable malformed file is conservatively covered by raw-text fallback");
+            }
+            finally
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+
+        [Test]
+        public void Corpus_RecognizesIntentionallyBlankBiographyRow80831()
+        {
+            var haks = Path.Combine(CorpusLocator.RepositoryRoot, "SWLOR_Haks");
+            var document = TlkDocument.Load(Path.Combine(haks, "sw_tlk", "sw_tlk.tlk.json"));
+            var index = TlkReferenceIndex.Build(Path.Combine(haks, "sw_2da"));
+
+            document.ContainsEntry(80831).Should().BeFalse("the biography slot is intentionally blank");
+            index.IsReferenced(80831).Should().BeTrue();
+            index.UsagesOf(80831).Should().Contain(usage =>
+                usage.FileName.Equals("racialtypes.2da", StringComparison.OrdinalIgnoreCase) &&
+                usage.RowLabel == "6" &&
+                usage.ColumnName.Equals("Biography", StringComparison.OrdinalIgnoreCase) &&
+                usage.StrRef == 16858047);
+            index.UnscannableFiles.Should().BeEmpty(
+                "the malformed legacy 2DA is still fully covered by raw-text fallback");
+
+            var expectedFirstSafeGap = Enumerable.Range(0, document.MaxEntryId + 2)
+                .First(id => !document.ContainsEntry(id) && !index.IsReferenced(id));
+            var firstSafeGap = document.FindFirstAvailableBlank(index);
+            TestContext.Out.WriteLine($"First corpus-safe custom TLK gap: {firstSafeGap}");
+            firstSafeGap.Should().Be(expectedFirstSafeGap);
+            firstSafeGap.Should().Be(6181, "the current corpus's first unpopulated and unreferenced row is stable");
+        }
+
+        private static string CreateTempDirectory()
+        {
+            var path = Path.Combine(Path.GetTempPath(), "SWLOR.Toolset.Tests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(path);
+            return path;
+        }
+    }
+}

--- a/SWLOR.Toolset.Tests/TlkReloadTests.cs
+++ b/SWLOR.Toolset.Tests/TlkReloadTests.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using FluentAssertions;
 using NUnit.Framework;
+using SWLOR.NWN.Formats.Tlk;
 using SWLOR.Toolset.Domain.GameData.Tlk;
 
 namespace SWLOR.Toolset.Tests
@@ -28,6 +29,34 @@ namespace SWLOR.Toolset.Tests
                 service.ReloadCustomTlk(null);
                 service.GetString(TlkService.CustomTlkBase).Should().Be("repository fallback");
                 reloads.Should().Be(2);
+            }
+            finally
+            {
+                Directory.Delete(tempRoot, recursive: true);
+            }
+        }
+
+        [Test]
+        public void PublishedRepositoryGenerationRemainsAuthoritativeAcrossModuleContentReloads()
+        {
+            var tempRoot = Path.Combine(Path.GetTempPath(), "SWLOR.Toolset.Tests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempRoot);
+            var selectedPath = Path.Combine(tempRoot, "selected.tlk");
+            var publishedPath = Path.Combine(tempRoot, "published.tlk");
+
+            try
+            {
+                WriteSingleEntryTlk(selectedPath, "selected from nwn.ini TLK folder");
+                WriteSingleEntryTlk(publishedPath, "edited repository generation");
+                var service = new TlkService(TlkJsonFile.Parse(
+                    "{ \"language\": 0, \"entries\": [ { \"id\": 0, \"text\": \"repository fallback\" } ] }"));
+
+                service.ReloadCustomTlk(selectedPath);
+                service.PublishCustomTlk(TlkReader.Read(publishedPath));
+                service.ReloadCustomTlk(null);
+
+                service.GetString(TlkService.CustomTlkBase).Should().Be("edited repository generation",
+                    "module assignment reloads must not replace a generation accepted by the repository editor");
             }
             finally
             {

--- a/SWLOR.Toolset.Tests/WorkspaceTests.cs
+++ b/SWLOR.Toolset.Tests/WorkspaceTests.cs
@@ -378,6 +378,53 @@ namespace SWLOR.Toolset.Tests
         }
 
         [Test]
+        public void BlueprintCatalog_RemoveEntryWinsOverAnInFlightRefresh()
+        {
+            using var synthetic = SyntheticModule.CreateFromRealFiles(ModuleDirectory);
+            var workspace = new ModuleWorkspace(synthetic.Path);
+            var placeable = UtpDocument.Load(
+                workspace.GetResourcePath(ResourceType.Utp, "zep_shrine"));
+            var targetStrRef = placeable.LocName.StrRef;
+            targetStrRef.Should().NotBeNull();
+            using var refreshResolutionEntered = new ManualResetEventSlim();
+            using var releaseRefreshResolution = new ManualResetEventSlim();
+            var blockNextResolution = 0;
+
+            string? Resolve(uint strRef)
+            {
+                if (strRef != targetStrRef)
+                    return null;
+
+                if (Interlocked.Exchange(ref blockNextResolution, 0) == 1)
+                {
+                    refreshResolutionEntered.Set();
+                    releaseRefreshResolution.Wait();
+                }
+
+                return "Zepher Shrine";
+            }
+
+            var catalog = new BlueprintCatalog(workspace, resolveStrRef: Resolve);
+            catalog.BuildTask.GetAwaiter().GetResult();
+            Volatile.Write(ref blockNextResolution, 1);
+            var refresh = Task.Run(() => catalog.RefreshEntry(ResourceType.Utp, "zep_shrine"));
+            try
+            {
+                refreshResolutionEntered.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+                catalog.RemoveEntry(ResourceType.Utp, "zep_shrine").Should().BeTrue();
+            }
+            finally
+            {
+                releaseRefreshResolution.Set();
+            }
+
+            refresh.GetAwaiter().GetResult().Should().BeNull();
+            catalog.TryGetEntry(ResourceType.Utp, "zep_shrine", out _).Should().BeFalse();
+            catalog.Entries.Should().NotContain(entry =>
+                entry.ResourceType == ResourceType.Utp && entry.ResRef == "zep_shrine");
+        }
+
+        [Test]
         public void BlueprintCatalog_Progress_ReachesTotalCountOnCompletion()
         {
             using var synthetic = SyntheticModule.CreateFromRealFiles(ModuleDirectory);

--- a/SWLOR.Toolset.Tests/WorkspaceTests.cs
+++ b/SWLOR.Toolset.Tests/WorkspaceTests.cs
@@ -319,6 +319,65 @@ namespace SWLOR.Toolset.Tests
         }
 
         [Test]
+        public void BlueprintCatalog_RefreshEntryKeepsItsNameSourceWhenInitialBuildFinishesLater()
+        {
+            using var synthetic = SyntheticModule.CreateFromRealFiles(ModuleDirectory);
+            var workspace = new ModuleWorkspace(synthetic.Path);
+            var path = workspace.GetResourcePath(ResourceType.Utp, "zep_shrine");
+            var original = UtpDocument.Load(path);
+            var oldStrRef = original.LocName.StrRef;
+            oldStrRef.Should().NotBeNull();
+            var newStrRef = oldStrRef!.Value + 1;
+            using var initialResolutionEntered = new ManualResetEventSlim();
+            using var releaseInitialResolution = new ManualResetEventSlim();
+            var oldLabel = "Old Label";
+            var newLabel = "New Label";
+            var blockOldOnce = 1;
+
+            string? Resolve(uint strRef)
+            {
+                if (strRef == oldStrRef)
+                {
+                    var captured = Volatile.Read(ref oldLabel);
+                    if (Interlocked.Exchange(ref blockOldOnce, 0) == 1)
+                    {
+                        initialResolutionEntered.Set();
+                        releaseInitialResolution.Wait();
+                    }
+
+                    return captured;
+                }
+
+                return strRef == newStrRef ? Volatile.Read(ref newLabel) : null;
+            }
+
+            var catalog = new BlueprintCatalog(workspace, resolveStrRef: Resolve);
+            try
+            {
+                initialResolutionEntered.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+                var refreshed = UtpDocument.Load(path);
+                refreshed.Fields.Get("LocName").RawLocStringId =
+                    System.Text.Encoding.ASCII.GetBytes(
+                        newStrRef.ToString(System.Globalization.CultureInfo.InvariantCulture));
+                File.WriteAllBytes(path, refreshed.ToBytes());
+
+                catalog.RefreshEntry(ResourceType.Utp, "zep_shrine")!.Name.Should().Be("New Label");
+            }
+            finally
+            {
+                releaseInitialResolution.Set();
+            }
+            catalog.BuildTask.GetAwaiter().GetResult();
+
+            Volatile.Write(ref oldLabel, "Stale Old Label");
+            Volatile.Write(ref newLabel, "Latest New Label");
+            catalog.RefreshTlkLabels().Should().BeTrue();
+            catalog.TryGetEntry(ResourceType.Utp, "zep_shrine", out var entry).Should().BeTrue();
+            entry.Name.Should().Be("Latest New Label",
+                "the entry and its LocString source must be published as one generation");
+        }
+
+        [Test]
         public void BlueprintCatalog_Progress_ReachesTotalCountOnCompletion()
         {
             using var synthetic = SyntheticModule.CreateFromRealFiles(ModuleDirectory);

--- a/SWLOR.Toolset.Tests/WorkspaceTests.cs
+++ b/SWLOR.Toolset.Tests/WorkspaceTests.cs
@@ -272,6 +272,53 @@ namespace SWLOR.Toolset.Tests
         }
 
         [Test]
+        public void BlueprintCatalog_TlkRefreshRacingInitialInsertionUsesTheNewLabel()
+        {
+            using var synthetic = SyntheticModule.CreateFromRealFiles(ModuleDirectory);
+            var workspace = new ModuleWorkspace(synthetic.Path);
+            var placeable = UtpDocument.Load(
+                workspace.GetResourcePath(ResourceType.Utp, "zep_shrine"));
+            var targetStrRef = placeable.LocName.StrRef;
+            targetStrRef.Should().NotBeNull();
+            using var firstResolutionEntered = new ManualResetEventSlim();
+            using var releaseFirstResolution = new ManualResetEventSlim();
+            var label = "Old Label";
+            var blockTargetOnce = 1;
+
+            string? Resolve(uint strRef)
+            {
+                if (strRef != targetStrRef)
+                    return null;
+
+                var captured = Volatile.Read(ref label);
+                if (Interlocked.Exchange(ref blockTargetOnce, 0) == 1)
+                {
+                    firstResolutionEntered.Set();
+                    releaseFirstResolution.Wait();
+                }
+
+                return captured;
+            }
+
+            var catalog = new BlueprintCatalog(workspace, resolveStrRef: Resolve);
+            try
+            {
+                firstResolutionEntered.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+                Volatile.Write(ref label, "New Label");
+                catalog.RefreshTlkLabels().Should().BeFalse(
+                    "the blocked entry has resolved but has not published its name source or entry yet");
+            }
+            finally
+            {
+                releaseFirstResolution.Set();
+            }
+            catalog.BuildTask.GetAwaiter().GetResult();
+
+            catalog.TryGetEntry(ResourceType.Utp, "zep_shrine", out var entry).Should().BeTrue();
+            entry.Name.Should().Be("New Label");
+        }
+
+        [Test]
         public void BlueprintCatalog_Progress_ReachesTotalCountOnCompletion()
         {
             using var synthetic = SyntheticModule.CreateFromRealFiles(ModuleDirectory);

--- a/SWLOR.Toolset/App.axaml
+++ b/SWLOR.Toolset/App.axaml
@@ -22,14 +22,25 @@
         <TextBlock Text="{Binding Label}" VerticalAlignment="Top" Margin="0,5,0,0"
                    Classes="dim" TextWrapping="Wrap" />
         <Panel>
-          <TextBox Text="{Binding Text, Mode=TwoWay}" IsReadOnly="{Binding IsReadOnly}"
-                   Watermark="{Binding StrRefDisplay}" IsVisible="{Binding IsSingleLine}" />
-          <TextBox Text="{Binding Text, Mode=TwoWay}" IsReadOnly="{Binding IsReadOnly}"
-                   Watermark="{Binding StrRefDisplay}"
-                   IsVisible="{Binding IsMultiline}" AcceptsReturn="True" TextWrapping="Wrap"
-                   MinHeight="140" VerticalContentAlignment="Top"
-                   ScrollViewer.VerticalScrollBarVisibility="Auto"
-                   ScrollViewer.HorizontalScrollBarVisibility="Disabled" />
+          <Grid ColumnDefinitions="*,Auto" IsVisible="{Binding IsSingleLine}">
+            <TextBox Grid.Column="0" Text="{Binding Text, Mode=TwoWay}" IsReadOnly="{Binding IsReadOnly}"
+                     Watermark="{Binding StrRefDisplay}" />
+            <Button Grid.Column="1" Content="Open TLK row" Margin="5,0,0,0" Padding="8,4"
+                    Command="{Binding OpenTlkRowCommand}" IsVisible="{Binding CanOpenTlkRow}"
+                    ToolTip.Tip="Open this custom StrRef in the TLK Editor" />
+          </Grid>
+          <Grid ColumnDefinitions="*,Auto" IsVisible="{Binding IsMultiline}">
+            <TextBox Grid.Column="0" Text="{Binding Text, Mode=TwoWay}" IsReadOnly="{Binding IsReadOnly}"
+                     Watermark="{Binding StrRefDisplay}"
+                     AcceptsReturn="True" TextWrapping="Wrap"
+                     MinHeight="140" VerticalContentAlignment="Top"
+                     ScrollViewer.VerticalScrollBarVisibility="Auto"
+                     ScrollViewer.HorizontalScrollBarVisibility="Disabled" />
+            <Button Grid.Column="1" Content="Open TLK row" Margin="5,0,0,0" Padding="8,4"
+                    VerticalAlignment="Top"
+                    Command="{Binding OpenTlkRowCommand}" IsVisible="{Binding CanOpenTlkRow}"
+                    ToolTip.Tip="Open this custom StrRef in the TLK Editor" />
+          </Grid>
         </Panel>
       </behaviors:LabeledFieldPanel>
     </DataTemplate>

--- a/SWLOR.Toolset/App.axaml.cs
+++ b/SWLOR.Toolset/App.axaml.cs
@@ -284,7 +284,8 @@ namespace SWLOR.Toolset
                 sp.GetRequiredService<Services.ModuleMutationLock>(),
                 sp.GetService<CategoryService>(),
                 moduleCustomContent: sp.GetRequiredService<Workspace.ModuleCustomContentService>(),
-                externalLinks: sp.GetRequiredService<Services.IExternalLinkService>()));
+                externalLinks: sp.GetRequiredService<Services.IExternalLinkService>(),
+                tlkEditorSource: sp.GetService<Editors.Tlk.TlkEditorSource>()));
 
             // One parsed engine header shared by every script tab, built lazily on first use: the
             // header is 13,870 lines, so parsing it per tab would be wasteful and parsing it at
@@ -405,11 +406,19 @@ namespace SWLOR.Toolset
 
             var sw2DaDirectory = Path.Combine(repoRoot, "SWLOR_Haks", "sw_2da");
             var swTlkJsonPath = Path.Combine(repoRoot, "SWLOR_Haks", "sw_tlk", "sw_tlk.tlk.json");
+            var swTlkBinaryPath = Path.Combine(repoRoot, "SWLOR_Haks", "sw_tlk", "sw_tlk.tlk");
             var hakBuilderConfigPath = Path.Combine(repoRoot, "Build", "hakbuilder.json");
             var swlorHaksRoot = Path.Combine(repoRoot, "SWLOR_Haks");
 
             var hasTwoDa = Directory.Exists(sw2DaDirectory);
             var hasTlk = File.Exists(swTlkJsonPath);
+
+            // Registered even when one path is missing so the Tools menu can explain why the
+            // repository-only editor is disabled instead of silently disappearing.
+            services.AddSingleton(new Editors.Tlk.TlkEditorSource(
+                swTlkJsonPath,
+                swTlkBinaryPath,
+                sw2DaDirectory));
 
             // Located once and reused: both the resource index and the base TLK below need it.
             string? nwnInstallPath = null;

--- a/SWLOR.Toolset/App.axaml.cs
+++ b/SWLOR.Toolset/App.axaml.cs
@@ -418,7 +418,8 @@ namespace SWLOR.Toolset
             services.AddSingleton(new Editors.Tlk.TlkEditorSource(
                 swTlkJsonPath,
                 swTlkBinaryPath,
-                sw2DaDirectory));
+                sw2DaDirectory,
+                repoRoot));
 
             // Located once and reused: both the resource index and the base TLK below need it.
             string? nwnInstallPath = null;

--- a/SWLOR.Toolset/Editors/AreaEditorViewModel.cs
+++ b/SWLOR.Toolset/Editors/AreaEditorViewModel.cs
@@ -1711,7 +1711,8 @@ namespace SWLOR.Toolset.Editors
             AreaEditorDocumentLoad? loadedDocuments = null,
             Func<ResourceType, string, string?>? editCopyBlueprint = null,
             ModuleMutationLock? mutationLock = null,
-            AreaInstanceClipboard? instanceClipboard = null)
+            AreaInstanceClipboard? instanceClipboard = null,
+            Action<uint>? openTlkRow = null)
         {
             _scriptSlotHost = scriptSlotHost;
             _resolveBlueprintModel = resolveBlueprintModel;
@@ -1755,7 +1756,10 @@ namespace SWLOR.Toolset.Editors
             _savedGicBytes = _gicSession.ToBytes();
 
             var areContext = new EditorFieldContext(
-                _areSession.Document, (description, mutation) => RunAreEdit(description, mutation));
+                _areSession.Document,
+                (description, mutation) => RunAreEdit(description, mutation),
+                resolveStrRef,
+                openTlkRow);
             foreach (var group in AreSchema.Build().Groups)
             {
                 var fields = group.Fields.Select(descriptor => CreateFieldViewModel(descriptor, areContext, lookups, scriptSlotHost)).ToList();
@@ -2880,6 +2884,17 @@ namespace SWLOR.Toolset.Editors
             foreach (var group in AreaPropertyGroups)
             foreach (var field in group.Fields)
                 field.RefreshFromDocument();
+        }
+
+        /// <summary>Re-resolves custom-TLK watermarks after the shared table is regenerated.</summary>
+        public void RefreshTlkLabels()
+        {
+            foreach (var field in AreaPropertyGroups
+                         .SelectMany(group => group.Fields)
+                         .OfType<LocStringFieldViewModel>())
+            {
+                field.RefreshFromDocument();
+            }
         }
 
         private void RefreshInstanceSections()

--- a/SWLOR.Toolset/Editors/AreaEditorViewModel.cs
+++ b/SWLOR.Toolset/Editors/AreaEditorViewModel.cs
@@ -59,6 +59,7 @@ namespace SWLOR.Toolset.Editors
         private byte[] _savedGicBytes = Array.Empty<byte>();
         private bool _gicDirty;
         private readonly OutputLogService _log;
+        private readonly LookupOptionProvider _lookups;
         private readonly ModuleWorkspace _workspace;
         private readonly string _areResRef;
         private readonly TilesetCatalog? _tilesetCatalog;
@@ -1726,6 +1727,7 @@ namespace SWLOR.Toolset.Editors
             if (_mutationLock != null)
                 _mutationLock.Changed += OnMutationLockChanged;
             _log = log;
+            _lookups = lookups;
             _workspace = workspace;
             _areResRef = areResRef;
             _tilesetCatalog = tilesetCatalog;
@@ -2889,12 +2891,11 @@ namespace SWLOR.Toolset.Editors
         /// <summary>Re-resolves custom-TLK watermarks after the shared table is regenerated.</summary>
         public void RefreshTlkLabels()
         {
-            foreach (var field in AreaPropertyGroups
-                         .SelectMany(group => group.Fields)
-                         .OfType<LocStringFieldViewModel>())
-            {
+            var fields = AreaPropertyGroups.SelectMany(group => group.Fields).ToArray();
+            foreach (var field in fields.OfType<LocStringFieldViewModel>())
                 field.RefreshFromDocument();
-            }
+            foreach (var field in fields.OfType<DropdownFieldViewModel>())
+                field.RefreshOptions(_lookups.GetOptions(field.Descriptor.LookupKey));
         }
 
         private void RefreshInstanceSections()

--- a/SWLOR.Toolset/Editors/AreaEditorViewModel.cs
+++ b/SWLOR.Toolset/Editors/AreaEditorViewModel.cs
@@ -2896,6 +2896,8 @@ namespace SWLOR.Toolset.Editors
                 field.RefreshFromDocument();
             foreach (var field in fields.OfType<DropdownFieldViewModel>())
                 field.RefreshOptions(_lookups.GetOptions(field.Descriptor.LookupKey));
+            foreach (var section in Sections)
+                section.RefreshTlkLabels();
         }
 
         private void RefreshInstanceSections()

--- a/SWLOR.Toolset/Editors/BlueprintEditorViewModel.cs
+++ b/SWLOR.Toolset/Editors/BlueprintEditorViewModel.cs
@@ -139,7 +139,8 @@ namespace SWLOR.Toolset.Editors
             Func<EditorFieldContext, Func<string, Action, bool>,
                 Appearance.AppearanceGallerySectionViewModel?>? appearanceGallery = null,
             BlueprintSaveCoordinator? saveCoordinator = null,
-            Sources.ObjectSourceSectionViewModel? source = null)
+            Sources.ObjectSourceSectionViewModel? source = null,
+            Action<uint>? openTlkRow = null)
         {
             _scriptSlotHost = scriptSlotHost;
             _resourceLister = resourceLister;
@@ -152,7 +153,7 @@ namespace SWLOR.Toolset.Editors
             BlueprintType = type;
             Id = $"editor:{filePath}";
             _session = DocumentSession.Open(filePath);
-            _context = new EditorFieldContext(_session.Document, RunEdit, resolveStrRef);
+            _context = new EditorFieldContext(_session.Document, RunEdit, resolveStrRef, openTlkRow);
 
             var tabbedGroups = new List<(string Tab, EditorGroup Group)>();
             foreach (var group in schema.Groups)
@@ -590,6 +591,13 @@ namespace SWLOR.Toolset.Editors
             PlaceableSections.Behavior.RefreshFromDocument(reclassifyAmbiguousBehavior);
             PlaceableSections.Appearance.RefreshFromDocument();
             RebuildVariablesTab();
+        }
+
+        /// <summary>Re-resolves custom-TLK watermarks after the shared table is regenerated.</summary>
+        public void RefreshTlkLabels()
+        {
+            foreach (var field in Groups.SelectMany(group => group.Fields).OfType<LocStringFieldViewModel>())
+                field.RefreshFromDocument();
         }
 
         private void AfterHistoryChange()

--- a/SWLOR.Toolset/Editors/BlueprintEditorViewModel.cs
+++ b/SWLOR.Toolset/Editors/BlueprintEditorViewModel.cs
@@ -27,6 +27,7 @@ namespace SWLOR.Toolset.Editors
         private readonly EditorFieldContext _context;
         private readonly OutputLogService _log;
         private readonly IEditorPromptService _prompts;
+        private readonly LookupOptionProvider _lookups;
         private readonly IGameCodeIndex? _gameCodeIndex;
         private readonly IScriptSlotHost? _scriptSlotHost;
         private readonly BlueprintSaveCoordinator? _saveCoordinator;
@@ -146,6 +147,7 @@ namespace SWLOR.Toolset.Editors
             _resourceLister = resourceLister;
             _log = log;
             _prompts = prompts;
+            _lookups = lookups;
             _gameCodeIndex = gameCodeIndex;
             _saveCoordinator = saveCoordinator;
             Source = source;
@@ -598,6 +600,8 @@ namespace SWLOR.Toolset.Editors
         {
             foreach (var field in Groups.SelectMany(group => group.Fields).OfType<LocStringFieldViewModel>())
                 field.RefreshFromDocument();
+            foreach (var field in Groups.SelectMany(group => group.Fields).OfType<DropdownFieldViewModel>())
+                field.RefreshOptions(_lookups.GetOptions(field.Descriptor.LookupKey));
         }
 
         private void AfterHistoryChange()

--- a/SWLOR.Toolset/Editors/Creatures/CreatureEditorViewModel.cs
+++ b/SWLOR.Toolset/Editors/Creatures/CreatureEditorViewModel.cs
@@ -279,6 +279,45 @@ namespace SWLOR.Toolset.Editors.Creatures
             BasicRows[index] = CreateRow(definition);
         }
 
+        /// <summary>Rebuilds every materialized choice row after TLK-backed labels change.</summary>
+        public void RefreshTlkLabels()
+        {
+            lock (_choiceLoadSync)
+                _choiceLoads.Clear();
+
+            RebuildChoiceRows(BasicRows);
+            RebuildChoiceRows(
+                AppearanceRows,
+                deferSearchableChoices: true,
+                loadDeferredChoicesInBackground: true);
+            RebuildChoiceRows(AiRows);
+
+            foreach (var row in _roleRowCache.Values.SelectMany(rows => rows))
+                row.Dispose();
+            _roleRowCache.Clear();
+            RoleRows.Clear();
+            SelectRole(SelectedRole);
+        }
+
+        private void RebuildChoiceRows(
+            ObservableCollection<BehaviorRowViewModel> rows,
+            bool deferSearchableChoices = false,
+            bool loadDeferredChoicesInBackground = false)
+        {
+            for (var index = 0; index < rows.Count; index++)
+            {
+                if (rows[index].Definition.ChoicesKey == null)
+                    continue;
+
+                var definition = rows[index].Definition;
+                rows[index].Dispose();
+                rows[index] = CreateRow(
+                    definition,
+                    deferSearchableChoices,
+                    loadDeferredChoicesInBackground);
+            }
+        }
+
         public void NormalizeForSave() => Loot.Normalize();
 
         public void SetDirty(bool value) => IsDirty = value;

--- a/SWLOR.Toolset/Editors/Doors/DoorEditorViewModel.cs
+++ b/SWLOR.Toolset/Editors/Doors/DoorEditorViewModel.cs
@@ -291,6 +291,27 @@ namespace SWLOR.Toolset.Editors.Doors
             RefreshCompleteness();
         }
 
+        /// <summary>Rebuilds every materialized choice row after TLK-backed labels change.</summary>
+        public void RefreshTlkLabels()
+        {
+            RebuildChoiceRows(BasicRows);
+            RebuildChoiceRows(BehaviorRows);
+            RefreshCompleteness();
+        }
+
+        private void RebuildChoiceRows(ObservableCollection<DoorRowViewModel> rows)
+        {
+            for (var index = 0; index < rows.Count; index++)
+            {
+                if (rows[index].Definition.ChoicesKey == null)
+                    continue;
+
+                var definition = rows[index].Definition;
+                rows[index].Dispose();
+                rows[index] = CreateRow(definition);
+            }
+        }
+
         public void SetDirty(bool value) => IsDirty = value;
 
         private bool RunEdit(string description, Action mutation)

--- a/SWLOR.Toolset/Editors/EditorService.cs
+++ b/SWLOR.Toolset/Editors/EditorService.cs
@@ -676,8 +676,12 @@ namespace SWLOR.Toolset.Editors
         }
 
         private Action<uint>? TlkRowOpener =>
-            _tlkEditorSource?.IsAvailable == true && !IsResourceOpeningBlocked("TLK Editor")
-                ? strRef => _ = OpenTlkEditorAsync(strRef)
+            _tlkEditorSource?.IsAvailable == true
+                ? strRef =>
+                {
+                    if (!IsResourceOpeningBlocked("TLK Editor"))
+                        _ = OpenTlkEditorAsync(strRef);
+                }
                 : null;
 
         /// <summary>Refreshes open resource-backed content after the module HAK stack changes.</summary>

--- a/SWLOR.Toolset/Editors/EditorService.cs
+++ b/SWLOR.Toolset/Editors/EditorService.cs
@@ -539,11 +539,9 @@ namespace SWLOR.Toolset.Editors
         /// </summary>
         public async Task OpenTlkEditorAsync(uint? strRef = null)
         {
-            if (strRef.HasValue)
-                _pendingTlkStrRef = strRef;
-
             if (_tlkEditor != null)
             {
+                _pendingTlkStrRef = null;
                 if (strRef.HasValue)
                     _tlkEditor.SelectStrRef(strRef.Value);
                 _factory.ActivateDocument(_tlkEditor);
@@ -551,7 +549,11 @@ namespace SWLOR.Toolset.Editors
             }
 
             if (_tlkEditorOpening)
+            {
+                if (strRef.HasValue)
+                    _pendingTlkStrRef = strRef;
                 return;
+            }
             if (_tlkEditorSource == null || !_tlkEditorSource.IsAvailable)
             {
                 _log.AppendLine(_tlkEditorSource?.UnavailableReason ??
@@ -559,6 +561,7 @@ namespace SWLOR.Toolset.Editors
                 return;
             }
 
+            _pendingTlkStrRef = strRef;
             _tlkEditorOpening = true;
             try
             {

--- a/SWLOR.Toolset/Editors/EditorService.cs
+++ b/SWLOR.Toolset/Editors/EditorService.cs
@@ -622,6 +622,12 @@ namespace SWLOR.Toolset.Editors
                 editor.RefreshTlkLabels();
             foreach (var editor in _openAreaEditors.Values)
                 editor.RefreshTlkLabels();
+            foreach (var editor in _openTriggerEditors.Values)
+                editor.Editor.RefreshTlkLabels();
+            foreach (var editor in _openWaypointEditors.Values)
+                editor.Editor.RefreshTlkLabels();
+            foreach (var editor in _openSoundEditors.Values)
+                editor.Editor.RefreshTlkLabels();
         }
 
         private Action<uint>? TlkRowOpener =>

--- a/SWLOR.Toolset/Editors/EditorService.cs
+++ b/SWLOR.Toolset/Editors/EditorService.cs
@@ -369,6 +369,7 @@ namespace SWLOR.Toolset.Editors
             _workspaceContext.TagIndexInvalidated += OnTagIndexInvalidated;
             _workspaceContext.PlacementIndexInvalidated += ReloadPlacementSources;
             _workspaceContext.CatalogBuildCompleted += RefreshObjectSourceAreaNames;
+            _workspaceContext.CatalogLabelsChanged += RefreshObjectSourceAreaNames;
 
             // Opening another module invalidates every module-derived picker; saving a blueprint
             // invalidates only the ones built out of the module's own content.
@@ -614,6 +615,9 @@ namespace SWLOR.Toolset.Editors
         private void RefreshOpenTlkLabels()
         {
             ReloadOpenGameResources();
+            _workspaceContext.RefreshTlkLabels();
+            _categories?.RefreshTlkLabels();
+            _factory.RefreshTlkLabels();
             foreach (var editor in _openEditors.Values)
                 editor.RefreshTlkLabels();
             foreach (var editor in _openAreaEditors.Values)

--- a/SWLOR.Toolset/Editors/EditorService.cs
+++ b/SWLOR.Toolset/Editors/EditorService.cs
@@ -605,7 +605,7 @@ namespace SWLOR.Toolset.Editors
         }
 
         private Action<uint>? TlkRowOpener =>
-            _tlkEditorSource?.IsAvailable == true
+            _tlkEditorSource?.IsAvailable == true && !IsResourceOpeningBlocked("TLK Editor")
                 ? strRef => _ = OpenTlkEditorAsync(strRef)
                 : null;
 

--- a/SWLOR.Toolset/Editors/EditorService.cs
+++ b/SWLOR.Toolset/Editors/EditorService.cs
@@ -30,6 +30,8 @@ namespace SWLOR.Toolset.Editors
         private readonly LookupOptionProvider _lookups;
         private readonly Domain.GameData.Tlk.TlkService? _tlkService;
         private readonly Tlk.TlkEditorSource? _tlkEditorSource;
+        private readonly Func<Tlk.TlkEditorSource, Domain.GameData.Tlk.TlkService?, CancellationToken,
+            Tlk.ITlkEditorBackend> _tlkEditorBackendFactory;
         private readonly IGameCodeIndex? _gameCodeIndex;
         private readonly OutputLogService _log;
         private readonly ToolsetDockFactory _factory;
@@ -180,6 +182,7 @@ namespace SWLOR.Toolset.Editors
         private readonly Workspace.ModuleCustomContentService? _moduleCustomContent;
         private Module.ModulePropertiesDocumentViewModel? _moduleProperties;
         private Tlk.TlkEditorDocumentViewModel? _tlkEditor;
+        private Tlk.TlkEditorLoadingDocumentViewModel? _tlkEditorLoading;
         private bool _tlkEditorOpening;
         private uint? _pendingTlkStrRef;
 
@@ -298,9 +301,14 @@ namespace SWLOR.Toolset.Editors
                 string,
                 Task<IReadOnlyList<ObjectPlacement>>>? objectPlacementsFinder = null,
             Func<string, string, string, AreaEditorDocumentLoad>? areaDocumentsLoader = null,
-            Tlk.TlkEditorSource? tlkEditorSource = null)
+            Tlk.TlkEditorSource? tlkEditorSource = null,
+            Func<Tlk.TlkEditorSource, Domain.GameData.Tlk.TlkService?, CancellationToken,
+                Tlk.ITlkEditorBackend>? tlkEditorBackendFactory = null)
         {
             _tlkEditorSource = tlkEditorSource;
+            _tlkEditorBackendFactory = tlkEditorBackendFactory ??
+                ((source, tlk, cancellationToken) =>
+                    new Tlk.TlkEditorBackend(source, tlk, cancellationToken));
             _moduleCustomContent = moduleCustomContent;
             _externalLinks = externalLinks;
             _categories = categories;
@@ -535,7 +543,7 @@ namespace SWLOR.Toolset.Editors
 
         /// <summary>
         /// Opens the repository's SWLOR custom TLK as one docked document. Loading and the complete
-        /// structured 2DA reference scan stay off the UI thread; repeat requests activate the
+        /// reference scan stay off the UI thread; repeat requests activate the
         /// singleton and may navigate it to a custom StrRef.
         /// </summary>
         public async Task OpenTlkEditorAsync(uint? strRef = null)
@@ -553,6 +561,8 @@ namespace SWLOR.Toolset.Editors
             {
                 if (strRef.HasValue)
                     _pendingTlkStrRef = strRef;
+                if (_tlkEditorLoading != null)
+                    _factory.ActivateDocument(_tlkEditorLoading);
                 return;
             }
             if (_tlkEditorSource == null || !_tlkEditorSource.IsAvailable)
@@ -564,12 +574,24 @@ namespace SWLOR.Toolset.Editors
 
             _pendingTlkStrRef = strRef;
             _tlkEditorOpening = true;
+            var loading = new Tlk.TlkEditorLoadingDocumentViewModel(_tlkEditorSource.JsonPath);
+            loading.Closed += closed =>
+            {
+                if (ReferenceEquals(_tlkEditorLoading, closed))
+                    _tlkEditorLoading = null;
+            };
+            _tlkEditorLoading = loading;
+            _factory.OpenDocument(loading);
             try
             {
-                _log.AppendLine("Loading the SWLOR custom TLK and indexing 2DA references...");
+                _log.AppendLine("Loading the SWLOR custom TLK and indexing references...");
                 var backend = await Task.Run(() =>
-                    (Tlk.ITlkEditorBackend)new Tlk.TlkEditorBackend(_tlkEditorSource, _tlkService))
+                    _tlkEditorBackendFactory(
+                        _tlkEditorSource,
+                        _tlkService,
+                        loading.CancellationToken))
                     .ConfigureAwait(true);
+                loading.CancellationToken.ThrowIfCancellationRequested();
 
                 try
                 {
@@ -594,12 +616,17 @@ namespace SWLOR.Toolset.Editors
                         _tlkEditor = null;
                 };
                 editor.CloseRequested += _ => _factory.CloseDocument(editor);
+                CloseTlkLoadingDocument(loading);
                 _tlkEditor = editor;
                 _factory.OpenDocument(editor);
                 if (_pendingTlkStrRef.HasValue)
                     editor.SelectStrRef(_pendingTlkStrRef.Value);
                 _pendingTlkStrRef = null;
                 _log.AppendLine("TLK Editor ready.");
+            }
+            catch (OperationCanceledException) when (loading.CancellationRequested)
+            {
+                _pendingTlkStrRef = null;
             }
             catch (Exception ex)
             {
@@ -608,8 +635,18 @@ namespace SWLOR.Toolset.Editors
             }
             finally
             {
+                if (ReferenceEquals(_tlkEditorLoading, loading))
+                    CloseTlkLoadingDocument(loading);
                 _tlkEditorOpening = false;
             }
+        }
+
+        private void CloseTlkLoadingDocument(Tlk.TlkEditorLoadingDocumentViewModel loading)
+        {
+            loading.Complete();
+            if (ReferenceEquals(_tlkEditorLoading, loading))
+                _tlkEditorLoading = null;
+            _factory.CloseDocument(loading);
         }
 
         private void RefreshOpenTlkLabels()

--- a/SWLOR.Toolset/Editors/EditorService.cs
+++ b/SWLOR.Toolset/Editors/EditorService.cs
@@ -598,6 +598,7 @@ namespace SWLOR.Toolset.Editors
 
         private void RefreshOpenTlkLabels()
         {
+            ReloadOpenGameResources();
             foreach (var editor in _openEditors.Values)
                 editor.RefreshTlkLabels();
             foreach (var editor in _openAreaEditors.Values)

--- a/SWLOR.Toolset/Editors/EditorService.cs
+++ b/SWLOR.Toolset/Editors/EditorService.cs
@@ -29,6 +29,7 @@ namespace SWLOR.Toolset.Editors
         private readonly WorkspaceContext _workspaceContext;
         private readonly LookupOptionProvider _lookups;
         private readonly Domain.GameData.Tlk.TlkService? _tlkService;
+        private readonly Tlk.TlkEditorSource? _tlkEditorSource;
         private readonly IGameCodeIndex? _gameCodeIndex;
         private readonly OutputLogService _log;
         private readonly ToolsetDockFactory _factory;
@@ -178,6 +179,9 @@ namespace SWLOR.Toolset.Editors
         private Services.SoundPreviewService? _soundPreviews;
         private readonly Workspace.ModuleCustomContentService? _moduleCustomContent;
         private Module.ModulePropertiesDocumentViewModel? _moduleProperties;
+        private Tlk.TlkEditorDocumentViewModel? _tlkEditor;
+        private bool _tlkEditorOpening;
+        private uint? _pendingTlkStrRef;
 
         /// <summary>
         /// Whether module.ifo.json is currently owned by the Module Properties editor. Area deletion
@@ -293,8 +297,10 @@ namespace SWLOR.Toolset.Editors
                 ResourceType,
                 string,
                 Task<IReadOnlyList<ObjectPlacement>>>? objectPlacementsFinder = null,
-            Func<string, string, string, AreaEditorDocumentLoad>? areaDocumentsLoader = null)
+            Func<string, string, string, AreaEditorDocumentLoad>? areaDocumentsLoader = null,
+            Tlk.TlkEditorSource? tlkEditorSource = null)
         {
+            _tlkEditorSource = tlkEditorSource;
             _moduleCustomContent = moduleCustomContent;
             _externalLinks = externalLinks;
             _categories = categories;
@@ -525,6 +531,83 @@ namespace SWLOR.Toolset.Editors
                 _log.AppendLine($"Failed to open Module Properties: {ex.Message}");
             }
         }
+
+        /// <summary>
+        /// Opens the repository's SWLOR custom TLK as one docked document. Loading and the complete
+        /// structured 2DA reference scan stay off the UI thread; repeat requests activate the
+        /// singleton and may navigate it to a custom StrRef.
+        /// </summary>
+        public async Task OpenTlkEditorAsync(uint? strRef = null)
+        {
+            if (strRef.HasValue)
+                _pendingTlkStrRef = strRef;
+
+            if (_tlkEditor != null)
+            {
+                if (strRef.HasValue)
+                    _tlkEditor.SelectStrRef(strRef.Value);
+                _factory.ActivateDocument(_tlkEditor);
+                return;
+            }
+
+            if (_tlkEditorOpening)
+                return;
+            if (_tlkEditorSource == null || !_tlkEditorSource.IsAvailable)
+            {
+                _log.AppendLine(_tlkEditorSource?.UnavailableReason ??
+                    "TLK Editor is unavailable because the SWLOR repository root could not be resolved.");
+                return;
+            }
+
+            _tlkEditorOpening = true;
+            try
+            {
+                _log.AppendLine("Loading the SWLOR custom TLK and indexing 2DA references...");
+                var backend = await Task.Run(() =>
+                    (Tlk.ITlkEditorBackend)new Tlk.TlkEditorBackend(_tlkEditorSource, _tlkService))
+                    .ConfigureAwait(true);
+
+                var editor = new Tlk.TlkEditorDocumentViewModel(
+                    backend,
+                    _log,
+                    _prompts,
+                    RefreshOpenTlkLabels);
+                editor.Closed += closed =>
+                {
+                    if (ReferenceEquals(_tlkEditor, closed))
+                        _tlkEditor = null;
+                };
+                editor.CloseRequested += _ => _factory.CloseDocument(editor);
+                _tlkEditor = editor;
+                _factory.OpenDocument(editor);
+                if (_pendingTlkStrRef.HasValue)
+                    editor.SelectStrRef(_pendingTlkStrRef.Value);
+                _pendingTlkStrRef = null;
+                _log.AppendLine("TLK Editor ready.");
+            }
+            catch (Exception ex)
+            {
+                _pendingTlkStrRef = null;
+                _log.AppendLine($"Failed to open TLK Editor: {ex.GetBaseException().Message}");
+            }
+            finally
+            {
+                _tlkEditorOpening = false;
+            }
+        }
+
+        private void RefreshOpenTlkLabels()
+        {
+            foreach (var editor in _openEditors.Values)
+                editor.RefreshTlkLabels();
+            foreach (var editor in _openAreaEditors.Values)
+                editor.RefreshTlkLabels();
+        }
+
+        private Action<uint>? TlkRowOpener =>
+            _tlkEditorSource?.IsAvailable == true
+                ? strRef => _ = OpenTlkEditorAsync(strRef)
+                : null;
 
         /// <summary>Refreshes open resource-backed content after the module HAK stack changes.</summary>
         public void ReloadOpenGameResources()
@@ -984,7 +1067,8 @@ namespace SWLOR.Toolset.Editors
                     () => _workspaceContext.Workspace,
                     type == ResourceType.Utc ? CreateCreatureAppearanceGallery : null,
                     _blueprintSaves,
-                    CreateObjectSource(type, resRef));
+                    CreateObjectSource(type, resRef),
+                    TlkRowOpener);
                 editor.Closed += closed => _openEditors.Remove(closed.FilePath);
                 editor.CloseRequested += _ => _factory.CloseDocument(editor);
                 editor.CatalogEntryChanged += () =>
@@ -1500,6 +1584,12 @@ namespace SWLOR.Toolset.Editors
         /// </summary>
         public async Task<bool> SaveAllAsync()
         {
+            if (_tlkEditor != null &&
+                !await _tlkEditor.TrySaveAsync().ConfigureAwait(true))
+            {
+                return false;
+            }
+
             if (_moduleProperties != null &&
                 !await _moduleProperties.TrySaveAsync().ConfigureAwait(true))
             {
@@ -1597,7 +1687,20 @@ namespace SWLOR.Toolset.Editors
         /// </summary>
         public async Task<bool> TryPrepareApplicationCloseAsync()
         {
-            if (_moduleProperties?.IsDirty != true &&
+            if (_tlkEditorOpening)
+            {
+                _log.AppendLine("Wait for the TLK Editor reference index to finish loading before closing.");
+                return false;
+            }
+
+            // A clean explicit TLK save still regenerates and verifies the JSON/binary pair. Wait
+            // for that transaction before deciding whether shutdown needs a prompt or approving a
+            // discard, so process exit can never interrupt the paired commit.
+            if (_tlkEditor != null)
+                await _tlkEditor.WaitForActiveOperationAsync().ConfigureAwait(true);
+
+            if (_tlkEditor?.IsDirty != true &&
+                _moduleProperties?.IsDirty != true &&
                 !_openEditors.Values.Any(editor => editor.IsDirty) &&
                 !_openTriggerEditors.Values.Any(editor => editor.IsDirty) &&
                 !_openWaypointEditors.Values.Any(editor => editor.IsDirty) &&
@@ -1619,6 +1722,7 @@ namespace SWLOR.Toolset.Editors
             if (choice != UnsavedChangesChoice.Discard)
                 return false;
 
+            _tlkEditor?.ApproveApplicationClose();
             _moduleProperties?.ApproveApplicationClose();
 
             foreach (var editor in _openEditors.Values)
@@ -3581,7 +3685,8 @@ namespace SWLOR.Toolset.Editors
                         loadedDocuments,
                         TryEditCopyAndOpenBlueprint,
                         _mutationLock,
-                        _areaInstanceClipboard);
+                        _areaInstanceClipboard,
+                        TlkRowOpener);
                     editor.Closed += _ => _openAreaEditors.Remove(resRef);
                     editor.TilesetChanged += () => _factory.NotifyActiveAreaChanged();
                     editor.CloseRequested += _ => _factory.CloseDocument(editor);

--- a/SWLOR.Toolset/Editors/EditorService.cs
+++ b/SWLOR.Toolset/Editors/EditorService.cs
@@ -570,6 +570,18 @@ namespace SWLOR.Toolset.Editors
                     (Tlk.ITlkEditorBackend)new Tlk.TlkEditorBackend(_tlkEditorSource, _tlkService))
                     .ConfigureAwait(true);
 
+                try
+                {
+                    backend.Publish();
+                    RefreshOpenTlkLabels();
+                }
+                catch (Exception ex)
+                {
+                    _log.AppendLine(
+                        "TLK Editor opened, but publishing its repository generation failed: " +
+                        ex.GetBaseException().Message);
+                }
+
                 var editor = new Tlk.TlkEditorDocumentViewModel(
                     backend,
                     _log,

--- a/SWLOR.Toolset/Editors/EditorService.cs
+++ b/SWLOR.Toolset/Editors/EditorService.cs
@@ -628,6 +628,14 @@ namespace SWLOR.Toolset.Editors
                 editor.Editor.RefreshTlkLabels();
             foreach (var editor in _openSoundEditors.Values)
                 editor.Editor.RefreshTlkLabels();
+            foreach (var editor in _openDoorEditors.Values)
+                editor.Editor.RefreshTlkLabels();
+            foreach (var editor in _openCreatureEditors.Values)
+                editor.Editor.RefreshTlkLabels();
+            foreach (var editor in _openItemEditors.Values)
+                editor.Editor.RefreshTlkLabels();
+            foreach (var editor in _openMerchantEditors.Values)
+                editor.Editor.RefreshTlkLabels();
         }
 
         private Action<uint>? TlkRowOpener =>

--- a/SWLOR.Toolset/Editors/FieldViewModels.cs
+++ b/SWLOR.Toolset/Editors/FieldViewModels.cs
@@ -26,14 +26,19 @@ namespace SWLOR.Toolset.Editors
         /// </summary>
         public Func<uint, string?>? ResolveStrRef { get; }
 
+        /// <summary>Opens the SWLOR custom TLK editor at a full custom StrRef.</summary>
+        public Action<uint>? OpenTlkRow { get; }
+
         public EditorFieldContext(
             JsonGffDocument document,
             Func<string, Action, bool> runEdit,
-            Func<uint, string?>? resolveStrRef = null)
+            Func<uint, string?>? resolveStrRef = null,
+            Action<uint>? openTlkRow = null)
         {
             _document = document;
             _runEdit = runEdit;
             ResolveStrRef = resolveStrRef;
+            OpenTlkRow = openTlkRow;
         }
 
         public bool RunEdit(string description, Action mutation)
@@ -203,6 +208,13 @@ namespace SWLOR.Toolset.Editors
         private string _text = string.Empty;
 
         public string? StrRefDisplay { get; private set; }
+        public uint? StrRef { get; private set; }
+        public bool CanOpenTlkRow =>
+            StrRef is { } strRef &&
+            strRef >= Domain.GameData.Tlk.TlkService.CustomTlkBase &&
+            strRef - Domain.GameData.Tlk.TlkService.CustomTlkBase <=
+                SWLOR.NWN.Formats.Tlk.TlkFormatLimits.MaximumEntryId &&
+            Context.OpenTlkRow != null;
 
         public LocStringFieldViewModel(FieldDescriptor descriptor, EditorFieldContext context)
             : base(descriptor, context)
@@ -224,6 +236,7 @@ namespace SWLOR.Toolset.Editors
             var field = Context.Document.Root.GetOrNull(Descriptor.FieldName);
             if (field?.GetLocStringId() is { } id)
             {
+                StrRef = id;
                 var resolved = Context.ResolveStrRef?.Invoke(id);
                 StrRefDisplay = string.IsNullOrWhiteSpace(resolved)
                     ? $"strref {id}"
@@ -231,11 +244,22 @@ namespace SWLOR.Toolset.Editors
             }
             else
             {
+                StrRef = null;
                 StrRefDisplay = null;
             }
 
             OnPropertyChanged(nameof(StrRefDisplay));
+            OnPropertyChanged(nameof(StrRef));
+            OnPropertyChanged(nameof(CanOpenTlkRow));
+            OpenTlkRowCommand.NotifyCanExecuteChanged();
             Context.IsRefreshing = false;
+        }
+
+        [RelayCommand(CanExecute = nameof(CanOpenTlkRow))]
+        private void OpenTlkRow()
+        {
+            if (StrRef.HasValue)
+                Context.OpenTlkRow?.Invoke(StrRef.Value);
         }
 
         partial void OnTextChanged(string value)

--- a/SWLOR.Toolset/Editors/FieldViewModels.cs
+++ b/SWLOR.Toolset/Editors/FieldViewModels.cs
@@ -279,7 +279,7 @@ namespace SWLOR.Toolset.Editors
     /// </summary>
     public partial class DropdownFieldViewModel : FieldViewModel
     {
-        public IReadOnlyList<LookupOption> Options { get; }
+        public IReadOnlyList<LookupOption> Options { get; private set; }
         public bool HasOptions => Options.Count > 0;
         public string LookupUnavailableMessage =>
             "2DA metadata unavailable. The stored value is shown read-only.";
@@ -294,10 +294,16 @@ namespace SWLOR.Toolset.Editors
             FieldDescriptor descriptor, EditorFieldContext context, IReadOnlyList<LookupOption> options)
             : base(descriptor, context)
         {
-            var unset = DropdownValueValidator.GetUnsetSentinel(descriptor.FieldType);
-            Options = options.Count == 0 || descriptor.IsRequired || options.Any(option => option.Id == unset)
-                ? options
-                : new[] { new LookupOption(unset, "(None)") }.Concat(options).ToList();
+            Options = WithUnsetOption(options);
+            RefreshFromDocument();
+        }
+
+        /// <summary>Rebuilds a live dropdown after its 2DA/TLK-backed labels change.</summary>
+        public void RefreshOptions(IReadOnlyList<LookupOption> options)
+        {
+            Options = WithUnsetOption(options);
+            OnPropertyChanged(nameof(Options));
+            OnPropertyChanged(nameof(HasOptions));
             RefreshFromDocument();
         }
 
@@ -317,6 +323,14 @@ namespace SWLOR.Toolset.Editors
             if (!Context.RunEdit($"Change {Label}",
                     () => SchemaFieldAccessor.SetInteger(Context.Document, Descriptor, value.Id)))
                 RefreshFromDocument();
+        }
+
+        private IReadOnlyList<LookupOption> WithUnsetOption(IReadOnlyList<LookupOption> options)
+        {
+            var unset = DropdownValueValidator.GetUnsetSentinel(Descriptor.FieldType);
+            return options.Count == 0 || Descriptor.IsRequired || options.Any(option => option.Id == unset)
+                ? options
+                : new[] { new LookupOption(unset, "(None)") }.Concat(options).ToList();
         }
 
     }

--- a/SWLOR.Toolset/Editors/InstanceListSectionViewModel.cs
+++ b/SWLOR.Toolset/Editors/InstanceListSectionViewModel.cs
@@ -255,6 +255,7 @@ namespace SWLOR.Toolset.Editors
         /// <summary>Refreshes TLK-backed choices in the selected specialized placement editor.</summary>
         public void RefreshTlkLabels()
         {
+            DoorEditor?.RefreshTlkLabels();
             WaypointEditor?.RefreshTlkLabels();
             SoundEditor?.RefreshTlkLabels();
         }

--- a/SWLOR.Toolset/Editors/InstanceListSectionViewModel.cs
+++ b/SWLOR.Toolset/Editors/InstanceListSectionViewModel.cs
@@ -252,6 +252,13 @@ namespace SWLOR.Toolset.Editors
             SoundEditor?.RefreshPaletteChoices();
         }
 
+        /// <summary>Refreshes TLK-backed choices in the selected specialized placement editor.</summary>
+        public void RefreshTlkLabels()
+        {
+            WaypointEditor?.RefreshTlkLabels();
+            SoundEditor?.RefreshTlkLabels();
+        }
+
         /// <summary>
         /// Rebinds both the currently selected waypoint and future selections to the latest
         /// module transition-destination catalog.

--- a/SWLOR.Toolset/Editors/Items/ItemEditorViewModel.cs
+++ b/SWLOR.Toolset/Editors/Items/ItemEditorViewModel.cs
@@ -390,6 +390,23 @@ namespace SWLOR.Toolset.Editors.Items
             RefreshCompleteness();
         }
 
+        /// <summary>Rebuilds every materialized choice row after TLK-backed labels change.</summary>
+        public void RefreshTlkLabels()
+        {
+            for (var index = 0; index < BasicRows.Count; index++)
+            {
+                if (BasicRows[index].Definition.ChoicesKey == null)
+                    continue;
+
+                var definition = BasicRows[index].Definition;
+                BasicRows[index].Dispose();
+                BasicRows[index] = CreateRow(definition);
+            }
+
+            Roles.Rebuild(Family, Role, FamilyDisplay);
+            RefreshCompleteness();
+        }
+
         private bool RunEdit(string description, Action mutation)
         {
             var identifiedBefore = _store.GetLocalizedText("DescIdentified");

--- a/SWLOR.Toolset/Editors/Merchants/MerchantEditorViewModel.cs
+++ b/SWLOR.Toolset/Editors/Merchants/MerchantEditorViewModel.cs
@@ -325,6 +325,26 @@ namespace SWLOR.Toolset.Editors.Merchants
             DetailRows[index] = CreateRow(definition);
         }
 
+        /// <summary>Rebuilds every materialized choice row after TLK-backed labels change.</summary>
+        public void RefreshTlkLabels()
+        {
+            RebuildChoiceRows(DetailRows);
+            RebuildChoiceRows(PricingRows);
+        }
+
+        private void RebuildChoiceRows(ObservableCollection<BehaviorRowViewModel> rows)
+        {
+            for (var index = 0; index < rows.Count; index++)
+            {
+                if (rows[index].Definition.ChoicesKey == null)
+                    continue;
+
+                var definition = rows[index].Definition;
+                rows[index].Dispose();
+                rows[index] = CreateRow(definition);
+            }
+        }
+
         /// <summary>Refreshes inventory names/prices and the add-item picker after a UTI save.</summary>
         public void RefreshItemCatalog()
         {

--- a/SWLOR.Toolset/Editors/Sounds/SoundEditorViewModel.cs
+++ b/SWLOR.Toolset/Editors/Sounds/SoundEditorViewModel.cs
@@ -259,6 +259,27 @@ namespace SWLOR.Toolset.Editors.Sounds
             RefreshCompleteness();
         }
 
+        /// <summary>Rebuilds every materialized choice row after TLK-backed labels change.</summary>
+        public void RefreshTlkLabels()
+        {
+            RebuildChoiceRows(BasicRows);
+            RebuildChoiceRows(BehaviorRows);
+            RefreshCompleteness();
+        }
+
+        private void RebuildChoiceRows(ObservableCollection<SoundRowViewModel> rows)
+        {
+            for (var index = 0; index < rows.Count; index++)
+            {
+                if (rows[index].Definition.ChoicesKey == null)
+                    continue;
+
+                var definition = rows[index].Definition;
+                rows[index].Dispose();
+                rows[index] = CreateRow(definition);
+            }
+        }
+
         private bool RunEdit(string description, Action mutation)
         {
             var applied = _runEdit(description, mutation);

--- a/SWLOR.Toolset/Editors/Tlk/TlkEditorBackend.cs
+++ b/SWLOR.Toolset/Editors/Tlk/TlkEditorBackend.cs
@@ -8,7 +8,11 @@ using SWLOR.Toolset.Services;
 namespace SWLOR.Toolset.Editors.Tlk;
 
 /// <summary>The repository files which make the SWLOR-only TLK editor available.</summary>
-public sealed record TlkEditorSource(string JsonPath, string BinaryPath, string TwoDaDirectory)
+public sealed record TlkEditorSource(
+    string JsonPath,
+    string BinaryPath,
+    string TwoDaDirectory,
+    string? RepositoryRoot = null)
 {
     public bool IsAvailable => File.Exists(JsonPath) && Directory.Exists(TwoDaDirectory);
 
@@ -70,6 +74,7 @@ public sealed class TlkEditorBackend : ITlkEditorBackend
     private FileFingerprint _jsonFingerprint;
     private FileFingerprint _binaryFingerprint;
     private TlkFile? _acceptedBinary;
+    private TlkEditorEntry[]? _entrySnapshot;
 
     public TlkEditorBackend(TlkEditorSource source, TlkService? tlkService = null)
     {
@@ -85,7 +90,7 @@ public sealed class TlkEditorBackend : ITlkEditorBackend
         _document = snapshot.Document;
         _jsonFingerprint = snapshot.JsonFingerprint;
         _binaryFingerprint = snapshot.BinaryFingerprint;
-        _references = TlkReferenceIndex.Build(source.TwoDaDirectory);
+        _references = TlkReferenceIndex.Build(source.TwoDaDirectory, source.RepositoryRoot);
     }
 
     public string JsonPath => _source.JsonPath;
@@ -93,14 +98,24 @@ public sealed class TlkEditorBackend : ITlkEditorBackend
     public int Language => _document.Language;
     public int Count => _document.Count;
     public int MaxEntryId => _document.MaxEntryId;
-    public IReadOnlyList<TlkEditorEntry> Entries =>
+    public IReadOnlyList<TlkEditorEntry> Entries => _entrySnapshot ??=
         _document.Entries.Select(entry => new TlkEditorEntry(entry.Id, entry.Text)).ToArray();
     public IReadOnlyList<string> ReferenceWarnings => _references.UnscannableFiles;
 
     public bool ContainsEntry(int id) => _document.ContainsEntry(id);
     public string? GetText(int id) => _document.GetText(id);
-    public void SetText(int id, string text) => _document.SetText(id, text);
-    public bool Clear(int id) => _document.Clear(id);
+    public void SetText(int id, string text)
+    {
+        _document.SetText(id, text);
+        _entrySnapshot = null;
+    }
+    public bool Clear(int id)
+    {
+        var removed = _document.Clear(id);
+        if (removed)
+            _entrySnapshot = null;
+        return removed;
+    }
     public bool IsReferenced(int id) => _references.IsReferenced(id);
     public int UsageCountFor(int id) => _references.UsageCountFor(id);
     public IReadOnlyList<TlkEditorUsage> UsagesOf(int id) =>
@@ -126,12 +141,13 @@ public sealed class TlkEditorBackend : ITlkEditorBackend
         // Unlike initial open, reload must reject a torn external JSON/binary generation before it
         // can replace the editor state or be published to open toolset fields.
         var snapshot = CaptureSnapshot(verifyBinaryPair: true);
-        var references = TlkReferenceIndex.Build(_source.TwoDaDirectory);
+        var references = TlkReferenceIndex.Build(_source.TwoDaDirectory, _source.RepositoryRoot);
         _document = snapshot.Document;
         _references = references;
         _jsonFingerprint = snapshot.JsonFingerprint;
         _binaryFingerprint = snapshot.BinaryFingerprint;
         _acceptedBinary = snapshot.VerifiedBinary;
+        _entrySnapshot = null;
     }
 
     public void Save(bool overwriteExternalChanges = false)

--- a/SWLOR.Toolset/Editors/Tlk/TlkEditorBackend.cs
+++ b/SWLOR.Toolset/Editors/Tlk/TlkEditorBackend.cs
@@ -144,8 +144,11 @@ public sealed class TlkEditorBackend : ITlkEditorBackend
         _references = _references.Refresh(_source.TwoDaDirectory, _source.RepositoryRoot);
     }
 
-    public bool HasExternalChange() =>
-        !_jsonFingerprint.Matches(JsonPath) || !_binaryFingerprint.Matches(BinaryPath);
+    public bool HasExternalChange()
+    {
+        var current = FileFingerprintPair.CaptureStable(JsonPath, BinaryPath);
+        return current == null || !current.Matches(_jsonFingerprint, _binaryFingerprint);
+    }
 
     public void Reload()
     {
@@ -168,8 +171,10 @@ public sealed class TlkEditorBackend : ITlkEditorBackend
         if (overwriteExternalChanges)
         {
             using var acceptedGeneration = ModuleWriteLock.AcquireForResourcePath(JsonPath);
-            _jsonFingerprint = FileFingerprint.Capture(JsonPath);
-            _binaryFingerprint = FileFingerprint.Capture(BinaryPath);
+            var current = FileFingerprintPair.CaptureStable(JsonPath, BinaryPath) ??
+                throw new TlkExternalChangeException(JsonPath);
+            _jsonFingerprint = current.Json;
+            _binaryFingerprint = current.Binary;
         }
         else if (HasExternalChange())
         {
@@ -201,8 +206,10 @@ public sealed class TlkEditorBackend : ITlkEditorBackend
                 if (HasExternalChange())
                     throw new TlkExternalChangeException(JsonPath);
                 SaveService.CommitAll(new[] { jsonStage, binaryStage });
-                _jsonFingerprint = FileFingerprint.Capture(JsonPath);
-                _binaryFingerprint = FileFingerprint.Capture(BinaryPath);
+                // Retain the exact generation we wrote rather than accepting a path reread that a
+                // non-cooperating writer could replace immediately after the grouped commit.
+                _jsonFingerprint = FileFingerprint.FromContent(JsonPath, jsonBytes);
+                _binaryFingerprint = FileFingerprint.FromContent(BinaryPath, binaryBytes);
             }
             _acceptedBinary = verifiedBinary;
             jsonStaged = false;
@@ -323,7 +330,7 @@ public sealed class TlkEditorBackend : ITlkEditorBackend
         }
     }
 
-    private sealed record FileFingerprint(bool Exists, DateTime LastWriteUtc, byte[] Hash)
+    internal sealed record FileFingerprint(bool Exists, DateTime LastWriteUtc, byte[] Hash)
     {
         public static FileFingerprint Missing { get; } =
             new(false, default, Array.Empty<byte>());
@@ -336,14 +343,37 @@ public sealed class TlkEditorBackend : ITlkEditorBackend
             return CapturedFile.Capture(path).Fingerprint;
         }
 
-        public bool Matches(string path)
+        public bool Matches(FileFingerprint other) =>
+            Exists == other.Exists &&
+            LastWriteUtc == other.LastWriteUtc &&
+            Hash.AsSpan().SequenceEqual(other.Hash);
+    }
+
+    internal sealed record FileFingerprintPair(FileFingerprint Json, FileFingerprint Binary)
+    {
+        /// <summary>
+        /// Captures both files, then rechecks them in reverse order. A writer that changes the JSON
+        /// after its first capture or the binary while the pair is being read makes the two passes
+        /// disagree, so callers fail closed instead of accepting a torn generation.
+        /// </summary>
+        public static FileFingerprintPair? CaptureStable(
+            string jsonPath,
+            string binaryPath,
+            Func<string, FileFingerprint>? capture = null)
         {
-            if (!File.Exists(path))
-                return !Exists;
-            if (!Exists || File.GetLastWriteTimeUtc(path) != LastWriteUtc)
-                return false;
-            return SHA256.HashData(File.ReadAllBytes(path)).AsSpan().SequenceEqual(Hash);
+            capture ??= FileFingerprint.Capture;
+            var firstJson = capture(jsonPath);
+            var firstBinary = capture(binaryPath);
+            var secondBinary = capture(binaryPath);
+            var secondJson = capture(jsonPath);
+
+            return firstJson.Matches(secondJson) && firstBinary.Matches(secondBinary)
+                ? new FileFingerprintPair(secondJson, secondBinary)
+                : null;
         }
+
+        public bool Matches(FileFingerprint json, FileFingerprint binary) =>
+            Json.Matches(json) && Binary.Matches(binary);
     }
 }
 

--- a/SWLOR.Toolset/Editors/Tlk/TlkEditorBackend.cs
+++ b/SWLOR.Toolset/Editors/Tlk/TlkEditorBackend.cs
@@ -133,8 +133,7 @@ public sealed class TlkEditorBackend : ITlkEditorBackend
         _document.FindNextAvailableBlank(currentId, _references);
     public void RefreshReferences()
     {
-        var references = TlkReferenceIndex.Build(_source.TwoDaDirectory, _source.RepositoryRoot);
-        _references = references;
+        _references = _references.Refresh(_source.TwoDaDirectory, _source.RepositoryRoot);
     }
 
     public bool HasExternalChange() =>
@@ -147,7 +146,7 @@ public sealed class TlkEditorBackend : ITlkEditorBackend
         // Unlike initial open, reload must reject a torn external JSON/binary generation before it
         // can replace the editor state or be published to open toolset fields.
         var snapshot = CaptureSnapshot(verifyBinaryPair: true);
-        var references = TlkReferenceIndex.Build(_source.TwoDaDirectory, _source.RepositoryRoot);
+        var references = _references.Refresh(_source.TwoDaDirectory, _source.RepositoryRoot);
         _document = snapshot.Document;
         _references = references;
         _jsonFingerprint = snapshot.JsonFingerprint;

--- a/SWLOR.Toolset/Editors/Tlk/TlkEditorBackend.cs
+++ b/SWLOR.Toolset/Editors/Tlk/TlkEditorBackend.cs
@@ -1,0 +1,279 @@
+using System.Security.Cryptography;
+using System.Text;
+using SWLOR.NWN.Formats.Common;
+using SWLOR.NWN.Formats.Tlk;
+using SWLOR.Toolset.Domain.GameData.Tlk;
+using SWLOR.Toolset.Services;
+
+namespace SWLOR.Toolset.Editors.Tlk;
+
+/// <summary>The repository files which make the SWLOR-only TLK editor available.</summary>
+public sealed record TlkEditorSource(string JsonPath, string BinaryPath, string TwoDaDirectory)
+{
+    public bool IsAvailable => File.Exists(JsonPath) && Directory.Exists(TwoDaDirectory);
+
+    public string UnavailableReason => !File.Exists(JsonPath)
+        ? $"SWLOR custom TLK source was not found at '{JsonPath}'."
+        : !Directory.Exists(TwoDaDirectory)
+            ? $"SWLOR 2DA source directory was not found at '{TwoDaDirectory}'."
+            : string.Empty;
+}
+
+public sealed record TlkEditorEntry(int Id, string Text);
+
+public sealed record TlkEditorUsage(
+    string FileName,
+    int RowIndex,
+    string? RowLabel,
+    string ColumnName,
+    uint StrRef);
+
+/// <summary>
+/// The editor-facing boundary around TLK parsing, reference discovery, and the two-file save.
+/// Kept narrow so navigation/edit history can be tested with an in-memory implementation.
+/// </summary>
+public interface ITlkEditorBackend
+{
+    string JsonPath { get; }
+    string BinaryPath { get; }
+    int Language { get; }
+    int Count { get; }
+    int MaxEntryId { get; }
+    IReadOnlyList<TlkEditorEntry> Entries { get; }
+    IReadOnlyList<string> ReferenceWarnings { get; }
+
+    bool ContainsEntry(int id);
+    string? GetText(int id);
+    void SetText(int id, string text);
+    bool Clear(int id);
+    bool IsReferenced(int id);
+    int UsageCountFor(int id);
+    IReadOnlyList<TlkEditorUsage> UsagesOf(int id);
+    int FindFirstAvailableBlank();
+    int FindNextAvailableBlank(int currentId);
+    bool HasExternalChange();
+    void Reload();
+    void Save(bool overwriteExternalChanges = false);
+    void Publish();
+}
+
+/// <summary>
+/// Production adapter for the sparse JSON document. Save stages JSON and generated binary output,
+/// verifies the staged binary by reading it back, then commits the pair with rollback protection.
+/// </summary>
+public sealed class TlkEditorBackend : ITlkEditorBackend
+{
+    private readonly TlkEditorSource _source;
+    private readonly TlkService? _tlkService;
+    private TlkDocument _document;
+    private TlkReferenceIndex _references;
+    private FileFingerprint _jsonFingerprint;
+    private FileFingerprint _binaryFingerprint;
+    private TlkFile? _acceptedBinary;
+
+    public TlkEditorBackend(TlkEditorSource source, TlkService? tlkService = null)
+    {
+        _source = source ?? throw new ArgumentNullException(nameof(source));
+        if (!source.IsAvailable)
+            throw new FileNotFoundException(source.UnavailableReason, source.JsonPath);
+
+        _tlkService = tlkService;
+        // CommitAll protects ordinary failures immediately; this closes the remaining process-kill
+        // case before either half of a previously interrupted JSON/binary pair is read.
+        SaveService.RecoverInterruptedSaves(Path.GetDirectoryName(source.JsonPath)!);
+        var snapshot = CaptureSnapshot();
+        _document = snapshot.Document;
+        _jsonFingerprint = snapshot.JsonFingerprint;
+        _binaryFingerprint = snapshot.BinaryFingerprint;
+        _references = TlkReferenceIndex.Build(source.TwoDaDirectory);
+    }
+
+    public string JsonPath => _source.JsonPath;
+    public string BinaryPath => _source.BinaryPath;
+    public int Language => _document.Language;
+    public int Count => _document.Count;
+    public int MaxEntryId => _document.MaxEntryId;
+    public IReadOnlyList<TlkEditorEntry> Entries =>
+        _document.Entries.Select(entry => new TlkEditorEntry(entry.Id, entry.Text)).ToArray();
+    public IReadOnlyList<string> ReferenceWarnings => _references.UnscannableFiles;
+
+    public bool ContainsEntry(int id) => _document.ContainsEntry(id);
+    public string? GetText(int id) => _document.GetText(id);
+    public void SetText(int id, string text) => _document.SetText(id, text);
+    public bool Clear(int id) => _document.Clear(id);
+    public bool IsReferenced(int id) => _references.IsReferenced(id);
+    public int UsageCountFor(int id) => _references.UsageCountFor(id);
+    public IReadOnlyList<TlkEditorUsage> UsagesOf(int id) =>
+        _references.UsagesOf(id)
+            .Select(usage => new TlkEditorUsage(
+                usage.FileName,
+                usage.RowIndex,
+                usage.RowLabel,
+                usage.ColumnName,
+                usage.StrRef))
+            .ToArray();
+    public int FindFirstAvailableBlank() => _document.FindFirstAvailableBlank(_references);
+    public int FindNextAvailableBlank(int currentId) =>
+        _document.FindNextAvailableBlank(currentId, _references);
+
+    public bool HasExternalChange() =>
+        !_jsonFingerprint.Matches(JsonPath) || !_binaryFingerprint.Matches(BinaryPath);
+
+    public void Reload()
+    {
+        // Capture content and its accepted baseline in one generation. Reference indexing may be
+        // lengthy, so it follows outside the lease; a write during that scan remains detectable.
+        // Unlike initial open, reload must reject a torn external JSON/binary generation before it
+        // can replace the editor state or be published to open toolset fields.
+        var snapshot = CaptureSnapshot(verifyBinaryPair: true);
+        var references = TlkReferenceIndex.Build(_source.TwoDaDirectory);
+        _document = snapshot.Document;
+        _references = references;
+        _jsonFingerprint = snapshot.JsonFingerprint;
+        _binaryFingerprint = snapshot.BinaryFingerprint;
+        _acceptedBinary = snapshot.VerifiedBinary;
+    }
+
+    public void Save(bool overwriteExternalChanges = false)
+    {
+        if (overwriteExternalChanges)
+        {
+            using var acceptedGeneration = ModuleWriteLock.AcquireForResourcePath(JsonPath);
+            _jsonFingerprint = FileFingerprint.Capture(JsonPath);
+            _binaryFingerprint = FileFingerprint.Capture(BinaryPath);
+        }
+        else if (HasExternalChange())
+        {
+            throw new TlkExternalChangeException(JsonPath);
+        }
+
+        var jsonBytes = Encoding.UTF8.GetBytes(_document.ToJson());
+        var entries = _document.Entries.ToDictionary(entry => entry.Id, entry => entry.Text);
+        var binaryBytes = TlkWriter.Write((uint)_document.Language, entries);
+
+        SaveService.StagedWrite jsonStage = default;
+        SaveService.StagedWrite binaryStage = default;
+        var jsonStaged = false;
+        var binaryStaged = false;
+        try
+        {
+            jsonStage = SaveService.Stage(JsonPath, jsonBytes);
+            jsonStaged = true;
+            binaryStage = SaveService.Stage(BinaryPath, binaryBytes);
+            binaryStaged = true;
+
+            var verifiedBinary = VerifyStagedPair(jsonStage.TemporaryPath, binaryStage.TemporaryPath);
+
+            // Serialization/verification can take long enough for another process to write. The
+            // final fingerprint check and pair commit share one cross-process lease, closing the
+            // check/replace race. CommitAll's nested acquisition is deliberately re-entrant.
+            using (ModuleWriteLock.AcquireForResourcePath(JsonPath))
+            {
+                if (HasExternalChange())
+                    throw new TlkExternalChangeException(JsonPath);
+                SaveService.CommitAll(new[] { jsonStage, binaryStage });
+                _jsonFingerprint = FileFingerprint.Capture(JsonPath);
+                _binaryFingerprint = FileFingerprint.Capture(BinaryPath);
+            }
+            _acceptedBinary = verifiedBinary;
+            jsonStaged = false;
+            binaryStaged = false;
+        }
+        finally
+        {
+            if (jsonStaged)
+                SaveService.Discard(jsonStage);
+            if (binaryStaged)
+                SaveService.Discard(binaryStage);
+        }
+
+    }
+
+    public void Publish()
+    {
+        if (_tlkService == null)
+            return;
+        _tlkService.PublishCustomTlk(_acceptedBinary ??
+            throw new InvalidOperationException("No verified TLK binary generation is available to publish."));
+    }
+
+    private Snapshot CaptureSnapshot(bool verifyBinaryPair = false)
+    {
+        using var sourceLease = ModuleWriteLock.AcquireForResourcePath(JsonPath);
+        var document = TlkDocument.Load(JsonPath);
+        var verifiedBinary = verifyBinaryPair
+            ? VerifyDocumentBinaryPair(document, BinaryPath)
+            : null;
+        return new Snapshot(
+            document,
+            FileFingerprint.Capture(JsonPath),
+            FileFingerprint.Capture(BinaryPath),
+            verifiedBinary);
+    }
+
+    private TlkFile VerifyStagedPair(string stagedJsonPath, string stagedBinaryPath)
+    {
+        var stagedDocument = TlkDocument.Load(stagedJsonPath);
+        if (stagedDocument.Language != _document.Language ||
+            !stagedDocument.Entries.SequenceEqual(_document.Entries))
+        {
+            throw new InvalidDataException("Generated TLK JSON failed round-trip verification.");
+        }
+
+        return VerifyDocumentBinaryPair(stagedDocument, stagedBinaryPath);
+    }
+
+    private static TlkFile VerifyDocumentBinaryPair(TlkDocument document, string binaryPath)
+    {
+        var binary = TlkReader.Read(binaryPath);
+        if (binary.LanguageId != (uint)document.Language)
+            throw new InvalidDataException("Generated TLK language does not match the JSON source.");
+
+        var requiredCount = document.MaxEntryId < 0 ? 0 : document.MaxEntryId + 1;
+        if (binary.Entries.Count != requiredCount)
+            throw new InvalidDataException(
+                $"Generated TLK has {binary.Entries.Count} rows; expected {requiredCount}.");
+
+        for (var id = 0; id < requiredCount; id++)
+        {
+            if (!string.Equals(binary.GetString((uint)id), document.GetText(id), StringComparison.Ordinal))
+                throw new InvalidDataException($"Generated TLK row {id} failed round-trip verification.");
+        }
+
+        return binary;
+    }
+
+    private sealed record Snapshot(
+        TlkDocument Document,
+        FileFingerprint JsonFingerprint,
+        FileFingerprint BinaryFingerprint,
+        TlkFile? VerifiedBinary);
+
+    private sealed record FileFingerprint(bool Exists, DateTime LastWriteUtc, byte[] Hash)
+    {
+        public static FileFingerprint Capture(string path)
+        {
+            if (!File.Exists(path))
+                return new FileFingerprint(false, default, Array.Empty<byte>());
+            return new FileFingerprint(
+                true,
+                File.GetLastWriteTimeUtc(path),
+                SHA256.HashData(File.ReadAllBytes(path)));
+        }
+
+        public bool Matches(string path)
+        {
+            if (!File.Exists(path))
+                return !Exists;
+            if (!Exists || File.GetLastWriteTimeUtc(path) != LastWriteUtc)
+                return false;
+            return SHA256.HashData(File.ReadAllBytes(path)).AsSpan().SequenceEqual(Hash);
+        }
+    }
+}
+
+public sealed class TlkExternalChangeException(string path)
+    : IOException($"TLK source changed outside SWLOR Toolset: {path}")
+{
+    public string FilePath { get; } = path;
+}

--- a/SWLOR.Toolset/Editors/Tlk/TlkEditorBackend.cs
+++ b/SWLOR.Toolset/Editors/Tlk/TlkEditorBackend.cs
@@ -91,6 +91,7 @@ public sealed class TlkEditorBackend : ITlkEditorBackend
         _document = snapshot.Document;
         _jsonFingerprint = snapshot.JsonFingerprint;
         _binaryFingerprint = snapshot.BinaryFingerprint;
+        _acceptedBinary = LoadAcceptedBinary(_document, BinaryPath);
         _references = TlkReferenceIndex.Build(source.TwoDaDirectory, source.RepositoryRoot);
     }
 
@@ -246,7 +247,34 @@ public sealed class TlkEditorBackend : ITlkEditorBackend
 
     private static TlkFile VerifyDocumentBinaryPair(TlkDocument document, string binaryPath)
     {
-        var binary = TlkReader.Read(binaryPath);
+        return VerifyDocumentBinary(document, TlkReader.Read(binaryPath));
+    }
+
+    private static TlkFile CreateVerifiedBinary(TlkDocument document)
+    {
+        var entries = document.Entries.ToDictionary(entry => entry.Id, entry => entry.Text);
+        return VerifyDocumentBinary(document, TlkReader.Read(TlkWriter.Write((uint)document.Language, entries)));
+    }
+
+    private static TlkFile LoadAcceptedBinary(TlkDocument document, string binaryPath)
+    {
+        try
+        {
+            if (File.Exists(binaryPath))
+                return VerifyDocumentBinaryPair(document, binaryPath);
+        }
+        catch (Exception ex) when (
+            ex is IOException or UnauthorizedAccessException or InvalidDataException or FormatException)
+        {
+            // JSON is the editable source of truth. A missing, stale, or malformed generated file
+            // is repaired on save, while the in-memory generation below keeps open labels current.
+        }
+
+        return CreateVerifiedBinary(document);
+    }
+
+    private static TlkFile VerifyDocumentBinary(TlkDocument document, TlkFile binary)
+    {
         if (binary.LanguageId != (uint)document.Language)
             throw new InvalidDataException("Generated TLK language does not match the JSON source.");
 

--- a/SWLOR.Toolset/Editors/Tlk/TlkEditorBackend.cs
+++ b/SWLOR.Toolset/Editors/Tlk/TlkEditorBackend.cs
@@ -77,7 +77,10 @@ public sealed class TlkEditorBackend : ITlkEditorBackend
     private TlkFile? _acceptedBinary;
     private TlkEditorEntry[]? _entrySnapshot;
 
-    public TlkEditorBackend(TlkEditorSource source, TlkService? tlkService = null)
+    public TlkEditorBackend(
+        TlkEditorSource source,
+        TlkService? tlkService = null,
+        CancellationToken cancellationToken = default)
     {
         _source = source ?? throw new ArgumentNullException(nameof(source));
         if (!source.IsAvailable)
@@ -92,7 +95,11 @@ public sealed class TlkEditorBackend : ITlkEditorBackend
         _jsonFingerprint = snapshot.JsonFingerprint;
         _binaryFingerprint = snapshot.BinaryFingerprint;
         _acceptedBinary = snapshot.VerifiedBinary;
-        _references = TlkReferenceIndex.Build(source.TwoDaDirectory, source.RepositoryRoot);
+        cancellationToken.ThrowIfCancellationRequested();
+        _references = TlkReferenceIndex.Build(
+            source.TwoDaDirectory,
+            source.RepositoryRoot,
+            cancellationToken);
     }
 
     public string JsonPath => _source.JsonPath;

--- a/SWLOR.Toolset/Editors/Tlk/TlkEditorBackend.cs
+++ b/SWLOR.Toolset/Editors/Tlk/TlkEditorBackend.cs
@@ -55,6 +55,7 @@ public interface ITlkEditorBackend
     IReadOnlyList<TlkEditorUsage> UsagesOf(int id);
     int FindFirstAvailableBlank();
     int FindNextAvailableBlank(int currentId);
+    void RefreshReferences();
     bool HasExternalChange();
     void Reload();
     void Save(bool overwriteExternalChanges = false);
@@ -130,6 +131,11 @@ public sealed class TlkEditorBackend : ITlkEditorBackend
     public int FindFirstAvailableBlank() => _document.FindFirstAvailableBlank(_references);
     public int FindNextAvailableBlank(int currentId) =>
         _document.FindNextAvailableBlank(currentId, _references);
+    public void RefreshReferences()
+    {
+        var references = TlkReferenceIndex.Build(_source.TwoDaDirectory, _source.RepositoryRoot);
+        _references = references;
+    }
 
     public bool HasExternalChange() =>
         !_jsonFingerprint.Matches(JsonPath) || !_binaryFingerprint.Matches(BinaryPath);

--- a/SWLOR.Toolset/Editors/Tlk/TlkEditorBackend.cs
+++ b/SWLOR.Toolset/Editors/Tlk/TlkEditorBackend.cs
@@ -91,7 +91,7 @@ public sealed class TlkEditorBackend : ITlkEditorBackend
         _document = snapshot.Document;
         _jsonFingerprint = snapshot.JsonFingerprint;
         _binaryFingerprint = snapshot.BinaryFingerprint;
-        _acceptedBinary = LoadAcceptedBinary(_document, BinaryPath);
+        _acceptedBinary = snapshot.VerifiedBinary;
         _references = TlkReferenceIndex.Build(source.TwoDaDirectory, source.RepositoryRoot);
     }
 
@@ -222,14 +222,21 @@ public sealed class TlkEditorBackend : ITlkEditorBackend
     private Snapshot CaptureSnapshot(bool verifyBinaryPair = false)
     {
         using var sourceLease = ModuleWriteLock.AcquireForResourcePath(JsonPath);
-        var document = TlkDocument.Load(JsonPath);
+        var json = CapturedFile.Capture(JsonPath);
+        if (!json.Exists)
+            throw new FileNotFoundException("SWLOR custom TLK source was not found.", JsonPath);
+        var binary = CapturedFile.Capture(BinaryPath);
+        using var jsonStream = new MemoryStream(json.Content, writable: false);
+        var document = TlkDocument.Parse(jsonStream);
         var verifiedBinary = verifyBinaryPair
-            ? VerifyDocumentBinaryPair(document, BinaryPath)
-            : null;
+            ? binary.Exists
+                ? VerifyDocumentBinary(document, TlkReader.Read(binary.Content))
+                : throw new FileNotFoundException("Generated TLK binary was not found.", BinaryPath)
+            : LoadAcceptedBinary(document, binary);
         return new Snapshot(
             document,
-            FileFingerprint.Capture(JsonPath),
-            FileFingerprint.Capture(BinaryPath),
+            json.Fingerprint,
+            binary.Fingerprint,
             verifiedBinary);
     }
 
@@ -256,15 +263,14 @@ public sealed class TlkEditorBackend : ITlkEditorBackend
         return VerifyDocumentBinary(document, TlkReader.Read(TlkWriter.Write((uint)document.Language, entries)));
     }
 
-    private static TlkFile LoadAcceptedBinary(TlkDocument document, string binaryPath)
+    private static TlkFile LoadAcceptedBinary(TlkDocument document, CapturedFile binary)
     {
         try
         {
-            if (File.Exists(binaryPath))
-                return VerifyDocumentBinaryPair(document, binaryPath);
+            if (binary.Exists)
+                return VerifyDocumentBinary(document, TlkReader.Read(binary.Content));
         }
-        catch (Exception ex) when (
-            ex is IOException or UnauthorizedAccessException or InvalidDataException or FormatException)
+        catch (Exception ex) when (ex is InvalidDataException or FormatException)
         {
             // JSON is the editable source of truth. A missing, stale, or malformed generated file
             // is repaired on save, while the in-memory generation below keeps open labels current.
@@ -296,18 +302,31 @@ public sealed class TlkEditorBackend : ITlkEditorBackend
         TlkDocument Document,
         FileFingerprint JsonFingerprint,
         FileFingerprint BinaryFingerprint,
-        TlkFile? VerifiedBinary);
+        TlkFile VerifiedBinary);
+
+    private sealed record CapturedFile(bool Exists, byte[] Content, FileFingerprint Fingerprint)
+    {
+        public static CapturedFile Capture(string path)
+        {
+            if (!File.Exists(path))
+                return new CapturedFile(false, Array.Empty<byte>(), FileFingerprint.Missing);
+
+            var content = File.ReadAllBytes(path);
+            return new CapturedFile(true, content, FileFingerprint.FromContent(path, content));
+        }
+    }
 
     private sealed record FileFingerprint(bool Exists, DateTime LastWriteUtc, byte[] Hash)
     {
+        public static FileFingerprint Missing { get; } =
+            new(false, default, Array.Empty<byte>());
+
+        public static FileFingerprint FromContent(string path, byte[] content) =>
+            new(true, File.GetLastWriteTimeUtc(path), SHA256.HashData(content));
+
         public static FileFingerprint Capture(string path)
         {
-            if (!File.Exists(path))
-                return new FileFingerprint(false, default, Array.Empty<byte>());
-            return new FileFingerprint(
-                true,
-                File.GetLastWriteTimeUtc(path),
-                SHA256.HashData(File.ReadAllBytes(path)));
+            return CapturedFile.Capture(path).Fingerprint;
         }
 
         public bool Matches(string path)

--- a/SWLOR.Toolset/Editors/Tlk/TlkEditorDocumentViewModel.cs
+++ b/SWLOR.Toolset/Editors/Tlk/TlkEditorDocumentViewModel.cs
@@ -221,6 +221,7 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
     public string SelectedIdDisplay => SelectedId.ToString();
     public string SelectedStrRefDisplay => SelectedStrRef.ToString();
     public bool HasSelectedRow => SelectedRow != null;
+    public bool CanRemoveRow => SelectedRow != null && _backend.ContainsEntry(SelectedRow.Id);
     public bool HasUsages => Usages.Count > 0;
     public bool IsDirty => _historyPosition != _savedPosition;
     public bool CanUndo => _historyPosition > 0;
@@ -231,6 +232,7 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
     public event Action<TlkEditorDocumentViewModel>? Closed;
     public event Action<TlkEditorDocumentViewModel>? CloseRequested;
     public event Action<int>? SelectionNavigationRequested;
+    public event Action? EntryEditRequested;
 
     public TlkEditorDocumentViewModel(
         ITlkEditorBackend backend,
@@ -302,7 +304,7 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
             _refreshingSelection = true;
             SelectedText = _backend.GetText(id) ?? string.Empty;
             _refreshingSelection = false;
-            NavigationStatus = $"Use Clear row to blank TLK row {id}.";
+            NavigationStatus = $"Use Remove row to blank TLK row {id} without renumbering later rows.";
             return;
         }
         if (!_backend.ContainsEntry(id) && value.Length > 0 && _backend.IsReferenced(id))
@@ -345,15 +347,18 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
     }
 
     [RelayCommand]
-    private Task FindFirstBlank() => RunBusyOperationAsync(FindFirstBlankCoreAsync);
+    private Task AddRow() => RunBusyOperationAsync(AddRowCoreAsync);
 
-    private async Task FindFirstBlankCoreAsync()
+    private async Task AddRowCoreAsync()
     {
         if (!await TryRefreshReferencesAsync().ConfigureAwait(true))
             return;
         if (!CanAllocateBlank())
             return;
-        SelectId(_backend.FindFirstAvailableBlank(), clearFilter: true);
+        var id = _backend.FindFirstAvailableBlank();
+        SelectId(id, clearFilter: true);
+        NavigationStatus = $"Row {id} is ready for a new TLK entry.";
+        EntryEditRequested?.Invoke();
     }
 
     [RelayCommand]
@@ -369,10 +374,10 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
         SelectId(_backend.FindNextAvailableBlank(start), clearFilter: true);
     }
 
-    [RelayCommand(CanExecute = nameof(HasSelectedRow))]
-    private Task ClearRow() => RunBusyOperationAsync(ClearRowCoreAsync);
+    [RelayCommand(CanExecute = nameof(CanRemoveRow))]
+    private Task RemoveRow() => RunBusyOperationAsync(RemoveRowCoreAsync);
 
-    private async Task ClearRowCoreAsync()
+    private async Task RemoveRowCoreAsync()
     {
         var id = SelectedRow?.Id;
         if (!id.HasValue || !_backend.ContainsEntry(id.Value))
@@ -389,18 +394,18 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
                 : $"\n\nWarning: {_backend.ReferenceWarnings.Count} reference file(s) could not be scanned, " +
                   "so additional references may exist.";
             var approved = await _prompts.ConfirmDestructiveAsync(
-                $"Clear possibly referenced TLK row {id}?",
-                $"This leaves row {id} blank." +
+                $"Remove possibly referenced TLK row {id}?",
+                $"This removes the text and leaves row {id} blank; later row IDs will not change." +
                 (usages.Length == 0 ? string.Empty : $" Known references:\n\n{usages}") +
                 incomplete,
-                "Clear row anyway").ConfigureAwait(true);
+                "Remove row anyway").ConfigureAwait(true);
             if (!approved)
                 return;
             clearConfirmed = true;
         }
 
         ApplyChanges(
-            $"Clear TLK row {id}",
+            $"Remove TLK row {id}",
             new[] { TlkValueChange.Clear(id.Value, _backend.GetText(id.Value)) });
         if (clearConfirmed)
             _confirmedClears.Add(id.Value);
@@ -1082,8 +1087,9 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
         OnPropertyChanged(nameof(SelectedIdDisplay));
         OnPropertyChanged(nameof(SelectedStrRefDisplay));
         OnPropertyChanged(nameof(HasSelectedRow));
+        OnPropertyChanged(nameof(CanRemoveRow));
         OnPropertyChanged(nameof(HasUsages));
-        ClearRowCommand.NotifyCanExecuteChanged();
+        RemoveRowCommand.NotifyCanExecuteChanged();
     }
 
     private void UpdateTitleAndState()

--- a/SWLOR.Toolset/Editors/Tlk/TlkEditorDocumentViewModel.cs
+++ b/SWLOR.Toolset/Editors/Tlk/TlkEditorDocumentViewModel.cs
@@ -51,10 +51,12 @@ public sealed class TlkEditorRowViewModel : ObservableObject
 /// </summary>
 public sealed class TlkVirtualRowCollection : IList, INotifyCollectionChanged, INotifyPropertyChanged
 {
+    private const int RowCachePruneThreshold = 512;
     private readonly TlkEditorDocumentViewModel _owner;
     private readonly Dictionary<int, WeakReference<TlkEditorRowViewModel>> _rows = new();
     private int[]? _filteredIds;
     private int _rangeMaximum;
+    private int _rowRequests;
 
     internal TlkVirtualRowCollection(TlkEditorDocumentViewModel owner)
     {
@@ -83,22 +85,42 @@ public sealed class TlkVirtualRowCollection : IList, INotifyCollectionChanged, I
     public event NotifyCollectionChangedEventHandler? CollectionChanged;
     public event PropertyChangedEventHandler? PropertyChanged;
 
-    /// <summary>Number of row view models ever requested by the item presenter.</summary>
+    /// <summary>Number of row view models currently retained by the weak cache.</summary>
     public int CreatedRowCount => _rows.Count;
 
     internal TlkEditorRowViewModel RowForId(int id)
     {
-        if (_rows.TryGetValue(id, out var weak) && weak.TryGetTarget(out var row))
-            return row;
-        row = new TlkEditorRowViewModel(_owner, id);
+        if (_rows.TryGetValue(id, out var weak))
+        {
+            if (weak.TryGetTarget(out var cachedRow))
+                return cachedRow;
+            _rows.Remove(id);
+        }
+
+        if (_rows.Count >= RowCachePruneThreshold && ++_rowRequests % 64 == 0)
+            PruneCollectedRows();
+
+        var row = new TlkEditorRowViewModel(_owner, id);
         _rows[id] = new WeakReference<TlkEditorRowViewModel>(row);
         return row;
+    }
+
+    private void PruneCollectedRows()
+    {
+        foreach (var id in _rows.Where(pair => !pair.Value.TryGetTarget(out _)).Select(pair => pair.Key).ToArray())
+            _rows.Remove(id);
     }
 
     internal bool ContainsId(int id) =>
         _filteredIds == null ? id >= 0 && id <= _rangeMaximum : Array.BinarySearch(_filteredIds, id) >= 0;
 
-    internal int IndexOfId(int id) => _filteredIds == null ? id : Array.BinarySearch(_filteredIds, id);
+    internal int IndexOfId(int id)
+    {
+        if (_filteredIds == null)
+            return id >= 0 && id <= _rangeMaximum ? id : -1;
+        var index = Array.BinarySearch(_filteredIds, id);
+        return index < 0 ? -1 : index;
+    }
 
     internal void ResetRange(int maximum, int[]? filteredIds)
     {
@@ -213,6 +235,9 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
     internal bool ContainsEntry(int id) => _backend.ContainsEntry(id);
     internal string? GetText(int id) => _backend.GetText(id);
     internal int UsageCountFor(int id) => _backend.UsageCountFor(id);
+
+    internal void ReportClipboardFailure(string operation, Exception exception) =>
+        _log.AppendLine($"Could not {operation}: {exception.GetBaseException().Message}");
 
     partial void OnSelectedRowChanged(TlkEditorRowViewModel? value)
     {
@@ -730,7 +755,7 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
         if (_backend.ReferenceWarnings.Count == 0)
             return true;
         NavigationStatus =
-            $"Safe blank search is unavailable because {_backend.ReferenceWarnings.Count} 2DA file(s) could not be indexed.";
+            $"Blank search is unavailable because {_backend.ReferenceWarnings.Count} reference file(s) could not be indexed.";
         return false;
     }
 

--- a/SWLOR.Toolset/Editors/Tlk/TlkEditorDocumentViewModel.cs
+++ b/SWLOR.Toolset/Editors/Tlk/TlkEditorDocumentViewModel.cs
@@ -590,6 +590,8 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
         {
             if (!await TryRefreshReferencesAsync().ConfigureAwait(true))
                 return false;
+            if (!RevalidateAppendedEntries())
+                return false;
             if (!await ConfirmNewlyReferencedClearsAsync().ConfigureAwait(true))
                 return false;
             if (!await ConfirmNewlyReferencedWritesAsync().ConfigureAwait(true))
@@ -1023,9 +1025,28 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
         _confirmedReferencedWrites.Clear();
     }
 
-    private bool CanCreateThrough(int highestNewId, IReadOnlyDictionary<int, string> plannedText)
+    private bool RevalidateAppendedEntries()
     {
-        if (highestNewId <= _backend.MaxEntryId)
+        var savedMaximum = _savedEntryIds.Count == 0 ? -1 : _savedEntryIds.Max();
+        var highestNewId = _backend.Entries
+            .Where(entry => entry.Id > savedMaximum && !_savedEntryIds.Contains(entry.Id))
+            .Select(entry => (int?)entry.Id)
+            .Max();
+        if (!highestNewId.HasValue)
+            return true;
+
+        return CanCreateThrough(
+            highestNewId.Value,
+            new Dictionary<int, string>(),
+            savedMaximum);
+    }
+
+    private bool CanCreateThrough(
+        int highestNewId,
+        IReadOnlyDictionary<int, string> plannedText,
+        int? existingMaximum = null)
+    {
+        if (highestNewId <= (existingMaximum ?? _backend.MaxEntryId))
             return true;
         if (!CanAllocateBlank())
             return false;

--- a/SWLOR.Toolset/Editors/Tlk/TlkEditorDocumentViewModel.cs
+++ b/SWLOR.Toolset/Editors/Tlk/TlkEditorDocumentViewModel.cs
@@ -171,6 +171,7 @@ public sealed class TlkVirtualRowCollection : IList, INotifyCollectionChanged, I
 
 /// <summary>A single referenced location displayed below the selected TLK row.</summary>
 public sealed record TlkUsageRowViewModel(
+    string Source,
     string File,
     int Row,
     string RowLabel,
@@ -265,9 +266,15 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
             Usages.Clear();
             if (value != null)
             {
-                foreach (var usage in _backend.UsagesOf(value.Id))
+                foreach (var usage in _backend.UsagesOf(value.Id)
+                             .OrderBy(usage => usage.ColumnName == TlkReferenceIndex.RepositoryTextColumnName ? 1 : 0)
+                             .ThenBy(usage => usage.FileName, StringComparer.OrdinalIgnoreCase)
+                             .ThenBy(usage => usage.RowIndex))
                 {
                     Usages.Add(new TlkUsageRowViewModel(
+                        usage.ColumnName == TlkReferenceIndex.RepositoryTextColumnName
+                            ? "Repository"
+                            : "2DA",
                         usage.FileName,
                         usage.RowIndex,
                         usage.RowLabel ?? string.Empty,

--- a/SWLOR.Toolset/Editors/Tlk/TlkEditorDocumentViewModel.cs
+++ b/SWLOR.Toolset/Editors/Tlk/TlkEditorDocumentViewModel.cs
@@ -784,14 +784,17 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
 
     private void ApplyReloadedState()
     {
-        var id = SelectedId;
+        var requestedId = Math.Min(SelectedId, Math.Max(0, _backend.MaxEntryId));
         _history.Clear();
         _historyPosition = 0;
         _savedPosition = 0;
         CaptureSavedEntryIds();
         RefreshReferenceStatus();
         RefreshFilter(keepSelection: false);
-        SelectId(Math.Min(id, Math.Max(0, _backend.MaxEntryId)), clearFilter: false);
+        if (Rows.ContainsId(requestedId))
+            SelectId(requestedId, clearFilter: false);
+        else if (SelectedRow != null)
+            SelectId(SelectedRow.Id, clearFilter: false);
         UpdateTitleAndState();
     }
 

--- a/SWLOR.Toolset/Editors/Tlk/TlkEditorDocumentViewModel.cs
+++ b/SWLOR.Toolset/Editors/Tlk/TlkEditorDocumentViewModel.cs
@@ -169,8 +169,6 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
     [ObservableProperty] private TlkEditorRowViewModel? _selectedRow;
     [ObservableProperty] private string _selectedText = string.Empty;
     [ObservableProperty] private string _filterText = string.Empty;
-    [ObservableProperty] private string _findText = string.Empty;
-    [ObservableProperty] private bool _exactMatch;
     [ObservableProperty] private string _goToValue = string.Empty;
     [ObservableProperty] private string _navigationStatus = string.Empty;
     [ObservableProperty] private string _referenceStatus = string.Empty;
@@ -256,7 +254,9 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
     }
 
     partial void OnFilterTextChanged(string value) => RefreshFilter();
-    partial void OnExactMatchChanged(bool value) => RefreshFilter();
+
+    [RelayCommand]
+    private void ClearFilter() => FilterText = string.Empty;
 
     [RelayCommand]
     private void GoToRow()
@@ -267,40 +267,6 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
             return;
         }
         SelectId(id, clearFilter: true);
-    }
-
-    [RelayCommand]
-    private void FindNext()
-    {
-        var matches = MatchingEntryIds(FindText).Where(Rows.ContainsId).ToArray();
-        if (matches.Length == 0)
-        {
-            NavigationStatus = string.IsNullOrWhiteSpace(FindText)
-                ? "Enter text or an ID to find."
-                : "No matching TLK rows.";
-            return;
-        }
-
-        var current = SelectedId;
-        var id = matches.FirstOrDefault(candidate => candidate > current, matches[0]);
-        SelectId(id, clearFilter: false);
-    }
-
-    [RelayCommand]
-    private void FindPrevious()
-    {
-        var matches = MatchingEntryIds(FindText).Where(Rows.ContainsId).ToArray();
-        if (matches.Length == 0)
-        {
-            NavigationStatus = string.IsNullOrWhiteSpace(FindText)
-                ? "Enter text or an ID to find."
-                : "No matching TLK rows.";
-            return;
-        }
-
-        var current = SelectedId;
-        var id = matches.LastOrDefault(candidate => candidate < current, matches[^1]);
-        SelectId(id, clearFilter: false);
     }
 
     [RelayCommand]
@@ -732,11 +698,8 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
         if (TryParseRow(query, out var id))
             return new[] { id };
 
-        var comparison = StringComparison.OrdinalIgnoreCase;
         return _backend.Entries
-            .Where(entry => ExactMatch
-                ? string.Equals(entry.Text, query, comparison)
-                : entry.Text.Contains(query, comparison))
+            .Where(entry => entry.Text.Contains(query, StringComparison.OrdinalIgnoreCase))
             .Select(entry => entry.Id)
             .Order()
             .ToArray();

--- a/SWLOR.Toolset/Editors/Tlk/TlkEditorDocumentViewModel.cs
+++ b/SWLOR.Toolset/Editors/Tlk/TlkEditorDocumentViewModel.cs
@@ -1,0 +1,870 @@
+using System.Collections;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Text;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Dock.Model.Mvvm.Controls;
+using SWLOR.NWN.Formats.Tlk;
+using SWLOR.Toolset.Domain.GameData.Tlk;
+using SWLOR.Toolset.Services;
+using SWLOR.Toolset.Workspace;
+
+namespace SWLOR.Toolset.Editors.Tlk;
+
+/// <summary>One lazily-created row in the virtual range displayed by the TLK grid.</summary>
+public sealed class TlkEditorRowViewModel : ObservableObject
+{
+    private readonly TlkEditorDocumentViewModel _owner;
+
+    internal TlkEditorRowViewModel(TlkEditorDocumentViewModel owner, int id)
+    {
+        _owner = owner;
+        Id = id;
+    }
+
+    public int Id { get; }
+    public uint StrRef => checked(TlkService.CustomTlkBase + (uint)Id);
+    public string Text => _owner.GetText(Id) ?? string.Empty;
+    public string Preview => Text.Replace('\r', ' ').Replace('\n', ' ');
+    public int Length => Text.Length;
+    public int UsageCount => _owner.UsageCountFor(Id);
+    public bool IsBlank => !_owner.ContainsEntry(Id);
+    public string State => IsBlank ? (UsageCount > 0 ? "Reserved blank" : "Blank") : "Text";
+
+    internal void Refresh()
+    {
+        OnPropertyChanged(nameof(Text));
+        OnPropertyChanged(nameof(Preview));
+        OnPropertyChanged(nameof(Length));
+        OnPropertyChanged(nameof(UsageCount));
+        OnPropertyChanged(nameof(IsBlank));
+        OnPropertyChanged(nameof(State));
+    }
+}
+
+/// <summary>
+/// Read-only indexed collection whose row objects are allocated only as the virtualizing grid asks
+/// for them. A weak cache keeps visible rows stable without turning a 193,000-row range into
+/// 193,000 persistent view models.
+/// </summary>
+public sealed class TlkVirtualRowCollection : IList, INotifyCollectionChanged, INotifyPropertyChanged
+{
+    private readonly TlkEditorDocumentViewModel _owner;
+    private readonly Dictionary<int, WeakReference<TlkEditorRowViewModel>> _rows = new();
+    private int[]? _filteredIds;
+    private int _rangeMaximum;
+
+    internal TlkVirtualRowCollection(TlkEditorDocumentViewModel owner)
+    {
+        _owner = owner;
+        _rangeMaximum = Math.Max(0, owner.MaxEntryId);
+    }
+
+    public int Count => _filteredIds?.Length ?? checked(_rangeMaximum + 1);
+    public bool IsReadOnly => true;
+    public bool IsFixedSize => true;
+    public bool IsSynchronized => false;
+    public object SyncRoot => this;
+
+    public object? this[int index]
+    {
+        get
+        {
+            if ((uint)index >= (uint)Count)
+                throw new ArgumentOutOfRangeException(nameof(index));
+            var id = _filteredIds?[index] ?? index;
+            return RowForId(id);
+        }
+        set => throw new NotSupportedException();
+    }
+
+    public event NotifyCollectionChangedEventHandler? CollectionChanged;
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    /// <summary>Number of row view models ever requested by the item presenter.</summary>
+    public int CreatedRowCount => _rows.Count;
+
+    internal TlkEditorRowViewModel RowForId(int id)
+    {
+        if (_rows.TryGetValue(id, out var weak) && weak.TryGetTarget(out var row))
+            return row;
+        row = new TlkEditorRowViewModel(_owner, id);
+        _rows[id] = new WeakReference<TlkEditorRowViewModel>(row);
+        return row;
+    }
+
+    internal bool ContainsId(int id) =>
+        _filteredIds == null ? id >= 0 && id <= _rangeMaximum : Array.BinarySearch(_filteredIds, id) >= 0;
+
+    internal int IndexOfId(int id) => _filteredIds == null ? id : Array.BinarySearch(_filteredIds, id);
+
+    internal void ResetRange(int maximum, int[]? filteredIds)
+    {
+        _rangeMaximum = Math.Max(0, maximum);
+        _filteredIds = filteredIds;
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Count)));
+        CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+    }
+
+    internal void RefreshRows(IEnumerable<int> ids)
+    {
+        foreach (var id in ids.Distinct())
+        {
+            if (_rows.TryGetValue(id, out var weak) && weak.TryGetTarget(out var row))
+                row.Refresh();
+        }
+    }
+
+    public IEnumerator GetEnumerator()
+    {
+        for (var index = 0; index < Count; index++)
+            yield return this[index];
+    }
+
+    public int IndexOf(object? value) => value is TlkEditorRowViewModel row ? IndexOfId(row.Id) : -1;
+    public bool Contains(object? value) => IndexOf(value) >= 0;
+    public void CopyTo(Array array, int index)
+    {
+        for (var source = 0; source < Count; source++)
+            array.SetValue(this[source], index + source);
+    }
+
+    public int Add(object? value) => throw new NotSupportedException();
+    public void Clear() => throw new NotSupportedException();
+    public void Insert(int index, object? value) => throw new NotSupportedException();
+    public void Remove(object? value) => throw new NotSupportedException();
+    public void RemoveAt(int index) => throw new NotSupportedException();
+}
+
+/// <summary>A single referenced location displayed below the selected TLK row.</summary>
+public sealed record TlkUsageRowViewModel(
+    string File,
+    int Row,
+    string RowLabel,
+    string Column,
+    uint StrRef);
+
+/// <summary>Undoable, singleton SWLOR custom TLK document.</summary>
+public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
+{
+    private const string ClipboardRowPrefix = "SWLOR-TLK-V1:";
+    private readonly ITlkEditorBackend _backend;
+    private readonly OutputLogService _log;
+    private readonly IEditorPromptService _prompts;
+    private readonly Action? _afterSave;
+    private readonly List<TlkHistoryEntry> _history = new();
+    private int _historyPosition;
+    private int _savedPosition;
+    private bool _refreshingSelection;
+    private bool _closeApproved;
+    private bool _closePromptOpen;
+    private bool _disposed;
+    private Task<bool>? _activeSave;
+
+    public TlkVirtualRowCollection Rows { get; }
+    public ObservableCollection<TlkUsageRowViewModel> Usages { get; } = new();
+
+    [ObservableProperty] private TlkEditorRowViewModel? _selectedRow;
+    [ObservableProperty] private string _selectedText = string.Empty;
+    [ObservableProperty] private string _filterText = string.Empty;
+    [ObservableProperty] private string _findText = string.Empty;
+    [ObservableProperty] private bool _exactMatch;
+    [ObservableProperty] private string _goToValue = string.Empty;
+    [ObservableProperty] private string _navigationStatus = string.Empty;
+    [ObservableProperty] private string _referenceStatus = string.Empty;
+    [ObservableProperty] private bool _isBusy;
+
+    public int EntryCount => _backend.Count;
+    public int MaxEntryId => _backend.MaxEntryId;
+    public int VisibleRowCount => Rows.Count;
+    public int SelectedId => SelectedRow?.Id ?? 0;
+    public uint SelectedStrRef => checked(TlkService.CustomTlkBase + (uint)SelectedId);
+    public string SelectedIdDisplay => SelectedId.ToString();
+    public string SelectedStrRefDisplay => SelectedStrRef.ToString();
+    public bool HasSelectedRow => SelectedRow != null;
+    public bool HasUsages => Usages.Count > 0;
+    public bool IsDirty => _historyPosition != _savedPosition;
+    public bool CanUndo => _historyPosition > 0;
+    public bool CanRedo => _historyPosition < _history.Count;
+    public string JsonPath => _backend.JsonPath;
+    public string BinaryPath => _backend.BinaryPath;
+
+    public event Action<TlkEditorDocumentViewModel>? Closed;
+    public event Action<TlkEditorDocumentViewModel>? CloseRequested;
+    public event Action<int>? SelectionNavigationRequested;
+
+    public TlkEditorDocumentViewModel(
+        ITlkEditorBackend backend,
+        OutputLogService log,
+        IEditorPromptService prompts,
+        Action? afterSave = null)
+    {
+        _backend = backend ?? throw new ArgumentNullException(nameof(backend));
+        _log = log ?? throw new ArgumentNullException(nameof(log));
+        _prompts = prompts ?? throw new ArgumentNullException(nameof(prompts));
+        _afterSave = afterSave;
+        Id = $"tlk-editor:{backend.JsonPath}";
+        Rows = new TlkVirtualRowCollection(this);
+        RefreshReferenceStatus();
+        UpdateTitleAndState();
+        SelectId(0, clearFilter: false);
+    }
+
+    internal bool ContainsEntry(int id) => _backend.ContainsEntry(id);
+    internal string? GetText(int id) => _backend.GetText(id);
+    internal int UsageCountFor(int id) => _backend.UsageCountFor(id);
+
+    partial void OnSelectedRowChanged(TlkEditorRowViewModel? value)
+    {
+        _refreshingSelection = true;
+        try
+        {
+            SelectedText = value == null ? string.Empty : _backend.GetText(value.Id) ?? string.Empty;
+            Usages.Clear();
+            if (value != null)
+            {
+                foreach (var usage in _backend.UsagesOf(value.Id))
+                {
+                    Usages.Add(new TlkUsageRowViewModel(
+                        usage.FileName,
+                        usage.RowIndex,
+                        usage.RowLabel ?? string.Empty,
+                        usage.ColumnName,
+                        usage.StrRef));
+                }
+            }
+        }
+        finally
+        {
+            _refreshingSelection = false;
+        }
+
+        NotifySelectionState();
+    }
+
+    partial void OnSelectedTextChanged(string value)
+    {
+        if (_refreshingSelection || SelectedRow == null)
+            return;
+
+        var id = SelectedRow.Id;
+        ApplyChanges(
+            $"Edit TLK row {id}",
+            new[] { TlkValueChange.Set(id, _backend.ContainsEntry(id), _backend.GetText(id), value) });
+    }
+
+    partial void OnFilterTextChanged(string value) => RefreshFilter();
+    partial void OnExactMatchChanged(bool value) => RefreshFilter();
+
+    [RelayCommand]
+    private void GoToRow()
+    {
+        if (!TryParseRow(GoToValue, out var id))
+        {
+            NavigationStatus = "Enter a raw row ID or a full custom StrRef.";
+            return;
+        }
+        SelectId(id, clearFilter: true);
+    }
+
+    [RelayCommand]
+    private void FindNext()
+    {
+        var matches = MatchingEntryIds(FindText).Where(Rows.ContainsId).ToArray();
+        if (matches.Length == 0)
+        {
+            NavigationStatus = string.IsNullOrWhiteSpace(FindText)
+                ? "Enter text or an ID to find."
+                : "No matching TLK rows.";
+            return;
+        }
+
+        var current = SelectedId;
+        var id = matches.FirstOrDefault(candidate => candidate > current, matches[0]);
+        SelectId(id, clearFilter: false);
+    }
+
+    [RelayCommand]
+    private void FindPrevious()
+    {
+        var matches = MatchingEntryIds(FindText).Where(Rows.ContainsId).ToArray();
+        if (matches.Length == 0)
+        {
+            NavigationStatus = string.IsNullOrWhiteSpace(FindText)
+                ? "Enter text or an ID to find."
+                : "No matching TLK rows.";
+            return;
+        }
+
+        var current = SelectedId;
+        var id = matches.LastOrDefault(candidate => candidate < current, matches[^1]);
+        SelectId(id, clearFilter: false);
+    }
+
+    [RelayCommand]
+    private void FindFirstBlank()
+    {
+        if (!CanAllocateBlank())
+            return;
+        SelectId(_backend.FindFirstAvailableBlank(), clearFilter: true);
+    }
+
+    [RelayCommand]
+    private void FindNextBlank()
+    {
+        if (!CanAllocateBlank())
+            return;
+        SelectId(_backend.FindNextAvailableBlank(SelectedId), clearFilter: true);
+    }
+
+    [RelayCommand(CanExecute = nameof(HasSelectedRow))]
+    private async Task ClearRow()
+    {
+        if (SelectedRow == null || !_backend.ContainsEntry(SelectedRow.Id))
+            return;
+
+        var id = SelectedRow.Id;
+        if (_backend.IsReferenced(id) || _backend.ReferenceWarnings.Count > 0)
+        {
+            var usages = FormatUsages(_backend.UsagesOf(id));
+            var incomplete = _backend.ReferenceWarnings.Count == 0
+                ? string.Empty
+                : $"\n\nWarning: {_backend.ReferenceWarnings.Count} 2DA file(s) could not be scanned, " +
+                  "so additional references may exist.";
+            var confirmed = await _prompts.ConfirmDestructiveAsync(
+                $"Clear possibly referenced TLK row {id}?",
+                $"This leaves row {id} blank." +
+                (usages.Length == 0 ? string.Empty : $" Known 2DA references:\n\n{usages}") +
+                incomplete,
+                "Clear row anyway").ConfigureAwait(true);
+            if (!confirmed)
+                return;
+        }
+
+        ApplyChanges(
+            $"Clear TLK row {id}",
+            new[] { TlkValueChange.Clear(id, _backend.GetText(id)) });
+    }
+
+    /// <summary>Returns one text line per selected grid row, in row order.</summary>
+    public string CopyRows(IEnumerable<int> rowIds) => string.Join(
+        Environment.NewLine,
+        rowIds.Distinct().Order().Select(id => EncodeClipboardRow(_backend.GetText(id) ?? string.Empty)));
+
+    /// <summary>
+    /// Applies a grid paste as one undo step. Newlines divide consecutive rows; the selected-row
+    /// text box uses the platform's normal paste instead and therefore preserves those newlines.
+    /// </summary>
+    public async Task<bool> PasteRowsAsync(string clipboardText)
+    {
+        if (SelectedRow == null || clipboardText == null)
+            return false;
+
+        var lines = clipboardText.Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Replace('\r', '\n')
+            .Split('\n')
+            .ToList();
+        if (lines.Count > 1 && lines[^1].Length == 0 && clipboardText.EndsWith('\n'))
+            lines.RemoveAt(lines.Count - 1);
+        if (lines.Count == 0)
+            return false;
+
+        // Grid-to-grid copy encodes only rows that need escaping, so an entry which itself contains
+        // newlines round-trips without becoming several rows while ordinary copied rows remain
+        // ordinary readable clipboard text.
+        if (lines.Any(line => line.StartsWith(ClipboardRowPrefix, StringComparison.Ordinal)))
+        {
+            try
+            {
+                lines = lines.Select(line => line.StartsWith(ClipboardRowPrefix, StringComparison.Ordinal)
+                    ? Encoding.UTF8.GetString(Convert.FromBase64String(line[ClipboardRowPrefix.Length..]))
+                    : line).ToList();
+            }
+            catch (FormatException)
+            {
+                NavigationStatus = "Copied TLK row data is malformed and was not pasted.";
+                return false;
+            }
+        }
+
+        var start = SelectedRow.Id;
+        if ((long)start + lines.Count - 1 > TlkFormatLimits.MaximumEntryId)
+        {
+            NavigationStatus = "Paste would exceed the valid custom TLK row range.";
+            return false;
+        }
+
+        var changes = new List<TlkValueChange>(lines.Count);
+        var overwrites = new List<int>();
+        var referenced = new List<int>();
+        for (var offset = 0; offset < lines.Count; offset++)
+        {
+            var id = start + offset;
+            if (_backend.ContainsEntry(id))
+                overwrites.Add(id);
+            if (_backend.IsReferenced(id))
+                referenced.Add(id);
+            changes.Add(TlkValueChange.Set(
+                id, _backend.ContainsEntry(id), _backend.GetText(id), lines[offset]));
+        }
+
+        if (overwrites.Count > 0 || referenced.Count > 0 || _backend.ReferenceWarnings.Count > 0)
+        {
+            var preview = BuildPastePreview(start, lines, overwrites, referenced) +
+                          (_backend.ReferenceWarnings.Count == 0
+                              ? string.Empty
+                              : $"\n\nReference coverage is incomplete: {_backend.ReferenceWarnings.Count} 2DA file(s) could not be scanned.");
+            var confirmed = await _prompts.ConfirmDestructiveAsync(
+                $"Paste {lines.Count} TLK rows?",
+                preview,
+                "Paste rows").ConfigureAwait(true);
+            if (!confirmed)
+                return false;
+        }
+
+        ApplyChanges($"Paste {lines.Count} TLK rows at {start}", changes);
+        EnsureRangeIncludes(start + lines.Count - 1);
+        SelectId(start, clearFilter: true);
+        NavigationStatus = $"Pasted {lines.Count} row(s), {start}-{start + lines.Count - 1}.";
+        return true;
+    }
+
+    public void SelectStrRef(uint strRef)
+    {
+        if (strRef < TlkService.CustomTlkBase)
+        {
+            NavigationStatus = $"StrRef {strRef} belongs to the base-game TLK and cannot be edited here.";
+            return;
+        }
+        var rawId = strRef - TlkService.CustomTlkBase;
+        if (rawId > TlkFormatLimits.MaximumEntryId)
+        {
+            NavigationStatus = $"StrRef {strRef} is outside the supported SWLOR TLK range.";
+            return;
+        }
+        SelectId((int)rawId, clearFilter: true);
+    }
+
+    public void SelectId(int id, bool clearFilter = true)
+    {
+        if (id < 0 || id > TlkFormatLimits.MaximumEntryId)
+        {
+            NavigationStatus = $"TLK row {id} is outside the valid custom StrRef range.";
+            return;
+        }
+
+        if (clearFilter && !string.IsNullOrEmpty(FilterText))
+            FilterText = string.Empty;
+        EnsureRangeIncludes(id);
+        var row = Rows.RowForId(id);
+        if (ReferenceEquals(SelectedRow, row))
+            OnSelectedRowChanged(row);
+        else
+            SelectedRow = row;
+        GoToValue = id.ToString();
+        NavigationStatus = $"Row {id} · StrRef {TlkService.CustomTlkBase + (uint)id}";
+        SelectionNavigationRequested?.Invoke(id);
+    }
+
+    [RelayCommand(CanExecute = nameof(CanUndo))]
+    public void Undo()
+    {
+        if (!CanUndo)
+            return;
+        var entry = _history[--_historyPosition];
+        ApplyHistory(entry.Changes, useNewValue: false);
+    }
+
+    [RelayCommand(CanExecute = nameof(CanRedo))]
+    public void Redo()
+    {
+        if (!CanRedo)
+            return;
+        var entry = _history[_historyPosition++];
+        ApplyHistory(entry.Changes, useNewValue: true);
+    }
+
+    public async Task<bool> TrySaveAsync()
+    {
+        if (_activeSave != null)
+            return await _activeSave.ConfigureAwait(true);
+
+        var operation = TrySaveCoreAsync();
+        _activeSave = operation;
+        try
+        {
+            return await operation.ConfigureAwait(true);
+        }
+        finally
+        {
+            if (ReferenceEquals(_activeSave, operation))
+                _activeSave = null;
+        }
+    }
+
+    private async Task<bool> TrySaveCoreAsync()
+    {
+        IsBusy = true;
+        try
+        {
+            var overwrite = false;
+            if (await Task.Run(_backend.HasExternalChange).ConfigureAwait(true))
+            {
+                var choice = await _prompts.ConfirmExternalChangeAsync(_backend.JsonPath).ConfigureAwait(true);
+                if (choice == ExternalChangeChoice.Cancel)
+                    return false;
+                if (choice == ExternalChangeChoice.Reload)
+                {
+                    await Task.Run(_backend.Reload).ConfigureAwait(true);
+                    ApplyReloadedState();
+                    PublishAndRefreshLabels("reload");
+                    _log.AppendLine($"Reloaded externally changed TLK {_backend.JsonPath}.");
+                    return true;
+                }
+                overwrite = true;
+            }
+
+            await Task.Run(() => _backend.Save(overwrite)).ConfigureAwait(true);
+            _savedPosition = _historyPosition;
+            UpdateTitleAndState();
+            PublishAndRefreshLabels("save");
+            _log.AppendLine($"Saved {_backend.JsonPath} and generated {_backend.BinaryPath}.");
+            return true;
+        }
+        catch (TlkExternalChangeException)
+        {
+            _log.AppendLine("TLK save stopped because the source changed while saving.");
+            return false;
+        }
+        catch (Exception ex)
+        {
+            _log.AppendLine($"TLK save failed: {ex.GetBaseException().Message}");
+            return false;
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    internal void ApproveApplicationClose() => _closeApproved = true;
+
+    internal async Task WaitForActiveOperationAsync()
+    {
+        var activeSave = _activeSave;
+        if (activeSave != null)
+            await activeSave.ConfigureAwait(true);
+    }
+
+    public override bool OnClose()
+    {
+        if (IsBusy)
+        {
+            if (!_closePromptOpen)
+            {
+                _closePromptOpen = true;
+                _ = WaitForBusyThenCloseAsync();
+            }
+            return false;
+        }
+
+        if (!_closeApproved && IsDirty)
+        {
+            if (!_closePromptOpen)
+            {
+                _closePromptOpen = true;
+                _ = ConfirmCloseAsync();
+            }
+            return false;
+        }
+
+        if (_disposed)
+            return base.OnClose();
+        _disposed = true;
+        Closed?.Invoke(this);
+        return base.OnClose();
+    }
+
+    private async Task WaitForBusyThenCloseAsync()
+    {
+        var activeSave = _activeSave;
+        if (activeSave != null)
+            await activeSave.ConfigureAwait(true);
+
+        if (_closeApproved || !IsDirty)
+        {
+            _closeApproved = true;
+            _closePromptOpen = false;
+            CloseRequested?.Invoke(this);
+            return;
+        }
+
+        await ConfirmCloseAsync().ConfigureAwait(true);
+    }
+
+    private async Task ConfirmCloseAsync()
+    {
+        try
+        {
+            var choice = await _prompts.ConfirmCloseAsync("TLK Editor").ConfigureAwait(true);
+            var approved = choice == UnsavedChangesChoice.Discard ||
+                           choice == UnsavedChangesChoice.Save && await TrySaveAsync().ConfigureAwait(true);
+            if (!approved)
+                return;
+            _closeApproved = true;
+            CloseRequested?.Invoke(this);
+        }
+        finally
+        {
+            _closePromptOpen = false;
+        }
+    }
+
+    private void ApplyChanges(string description, IEnumerable<TlkValueChange> requested)
+    {
+        var changes = requested
+            .GroupBy(change => change.Id)
+            .Select(group => group.Last())
+            .Where(change => change.OldExists != change.NewExists ||
+                             !string.Equals(change.OldText, change.NewText, StringComparison.Ordinal))
+            .OrderBy(change => change.Id)
+            .ToArray();
+        if (changes.Length == 0)
+            return;
+
+        if (_historyPosition < _history.Count)
+        {
+            _history.RemoveRange(_historyPosition, _history.Count - _historyPosition);
+            if (_savedPosition > _historyPosition)
+                _savedPosition = -1;
+        }
+
+        ApplyHistory(changes, useNewValue: true, refreshState: false);
+        _history.Add(new TlkHistoryEntry(description, changes));
+        _historyPosition++;
+        RefreshAfterEdit(changes.Select(change => change.Id));
+    }
+
+    private void ApplyHistory(
+        IReadOnlyList<TlkValueChange> changes,
+        bool useNewValue,
+        bool refreshState = true)
+    {
+        foreach (var change in changes)
+        {
+            var exists = useNewValue ? change.NewExists : change.OldExists;
+            var text = useNewValue ? change.NewText : change.OldText;
+            if (exists)
+                _backend.SetText(change.Id, text ?? string.Empty);
+            else
+                _backend.Clear(change.Id);
+        }
+
+        if (refreshState)
+            RefreshAfterEdit(changes.Select(change => change.Id));
+    }
+
+    private void RefreshAfterEdit(IEnumerable<int> changedIds)
+    {
+        var ids = changedIds.ToArray();
+        // Keep the current filtered snapshot stable while text is being edited. Refiltering on
+        // every keystroke can evict the selected row and redirect the remaining input elsewhere.
+        // The next filter/exact change recomputes the snapshot explicitly.
+        if (string.IsNullOrWhiteSpace(FilterText) && !Rows.ContainsId(MaxEntryId))
+        {
+            Rows.ResetRange(Math.Max(0, MaxEntryId), null);
+            OnPropertyChanged(nameof(VisibleRowCount));
+        }
+        Rows.RefreshRows(ids);
+        if (SelectedRow != null && ids.Contains(SelectedRow.Id))
+        {
+            _refreshingSelection = true;
+            SelectedText = _backend.GetText(SelectedRow.Id) ?? string.Empty;
+            _refreshingSelection = false;
+        }
+        UpdateTitleAndState();
+        NotifySelectionState();
+    }
+
+    private void ApplyReloadedState()
+    {
+        var id = SelectedId;
+        _history.Clear();
+        _historyPosition = 0;
+        _savedPosition = 0;
+        RefreshReferenceStatus();
+        RefreshFilter(keepSelection: false);
+        SelectId(Math.Min(id, Math.Max(0, _backend.MaxEntryId)), clearFilter: false);
+        UpdateTitleAndState();
+    }
+
+    private void RefreshReferenceStatus()
+    {
+        ReferenceStatus = _backend.ReferenceWarnings.Count == 0
+            ? "2DA references indexed."
+            : $"Reference scan skipped {_backend.ReferenceWarnings.Count} file(s); see Output.";
+        foreach (var warning in _backend.ReferenceWarnings)
+            _log.AppendLine($"TLK reference scan: {warning}");
+    }
+
+    private void RefreshFilter(bool keepSelection = true)
+    {
+        var selectedId = SelectedId;
+        var ids = MatchingEntryIds(FilterText);
+        var filtered = string.IsNullOrWhiteSpace(FilterText) ? null : ids;
+        Rows.ResetRange(Math.Max(MaxEntryId, selectedId), filtered);
+        OnPropertyChanged(nameof(VisibleRowCount));
+        if (keepSelection && Rows.ContainsId(selectedId))
+            SelectedRow = Rows.RowForId(selectedId);
+        else if (filtered is { Length: > 0 })
+            SelectedRow = Rows.RowForId(filtered[0]);
+        else if (filtered is { Length: 0 })
+            SelectedRow = null;
+    }
+
+    private int[] MatchingEntryIds(string value)
+    {
+        var query = value.Trim();
+        if (query.Length == 0)
+            return Array.Empty<int>();
+        if (TryParseRow(query, out var id))
+            return new[] { id };
+
+        var comparison = StringComparison.OrdinalIgnoreCase;
+        return _backend.Entries
+            .Where(entry => ExactMatch
+                ? string.Equals(entry.Text, query, comparison)
+                : entry.Text.Contains(query, comparison))
+            .Select(entry => entry.Id)
+            .Order()
+            .ToArray();
+    }
+
+    private static bool TryParseRow(string? value, out int id)
+    {
+        id = -1;
+        if (!uint.TryParse(value?.Trim(), out var number))
+            return false;
+        var raw = number >= TlkService.CustomTlkBase ? number - TlkService.CustomTlkBase : number;
+        if (raw > TlkFormatLimits.MaximumEntryId)
+            return false;
+        id = (int)raw;
+        return true;
+    }
+
+    private void EnsureRangeIncludes(int id)
+    {
+        if (Rows.ContainsId(id))
+            return;
+        Rows.ResetRange(Math.Max(Math.Max(0, MaxEntryId), id), null);
+        OnPropertyChanged(nameof(VisibleRowCount));
+    }
+
+    private bool CanAllocateBlank()
+    {
+        if (_backend.ReferenceWarnings.Count == 0)
+            return true;
+        NavigationStatus =
+            $"Safe blank search is unavailable because {_backend.ReferenceWarnings.Count} 2DA file(s) could not be indexed.";
+        return false;
+    }
+
+    private void NotifySelectionState()
+    {
+        OnPropertyChanged(nameof(SelectedId));
+        OnPropertyChanged(nameof(SelectedStrRef));
+        OnPropertyChanged(nameof(SelectedIdDisplay));
+        OnPropertyChanged(nameof(SelectedStrRefDisplay));
+        OnPropertyChanged(nameof(HasSelectedRow));
+        OnPropertyChanged(nameof(HasUsages));
+        ClearRowCommand.NotifyCanExecuteChanged();
+    }
+
+    private void UpdateTitleAndState()
+    {
+        Title = IsDirty ? "TLK Editor *" : "TLK Editor";
+        OnPropertyChanged(nameof(IsDirty));
+        OnPropertyChanged(nameof(CanUndo));
+        OnPropertyChanged(nameof(CanRedo));
+        OnPropertyChanged(nameof(EntryCount));
+        OnPropertyChanged(nameof(MaxEntryId));
+        UndoCommand.NotifyCanExecuteChanged();
+        RedoCommand.NotifyCanExecuteChanged();
+    }
+
+    private static string FormatUsages(IReadOnlyList<TlkEditorUsage> usages) => string.Join(
+        Environment.NewLine,
+        usages.Take(30).Select(usage =>
+            $"{usage.FileName}: row {usage.RowIndex}" +
+            (string.IsNullOrWhiteSpace(usage.RowLabel) ? string.Empty : $" ({usage.RowLabel})") +
+            $", {usage.ColumnName}")) +
+        (usages.Count > 30 ? $"{Environment.NewLine}…and {usages.Count - 30} more." : string.Empty);
+
+    private static string BuildPastePreview(
+        int start,
+        IReadOnlyList<string> lines,
+        IReadOnlyCollection<int> overwrites,
+        IReadOnlyCollection<int> referenced)
+    {
+        var preview = lines.Take(24).Select((text, offset) =>
+        {
+            var id = start + offset;
+            var flags = new List<string>();
+            if (overwrites.Contains(id))
+                flags.Add("OVERWRITES TEXT");
+            if (referenced.Contains(id))
+                flags.Add("REFERENCED");
+            var sample = text.Replace('\r', ' ').Replace('\n', ' ');
+            if (sample.Length > 70)
+                sample = sample[..67] + "…";
+            return $"{id}: {sample}" + (flags.Count == 0 ? string.Empty : $" [{string.Join(", ", flags)}]");
+        });
+        var textPreview = string.Join(Environment.NewLine, preview);
+        if (lines.Count > 24)
+            textPreview += $"{Environment.NewLine}…and {lines.Count - 24} more row(s).";
+        return "Review the consecutive rows that will be written:\n\n" + textPreview;
+    }
+
+    private static string EncodeClipboardRow(string text) =>
+        text.Length == 0 ||
+        text.Contains('\r') ||
+        text.Contains('\n') ||
+        text.StartsWith(ClipboardRowPrefix, StringComparison.Ordinal)
+            ? ClipboardRowPrefix + Convert.ToBase64String(Encoding.UTF8.GetBytes(text))
+            : text;
+
+    private void PublishAndRefreshLabels(string operation)
+    {
+        try
+        {
+            _backend.Publish();
+            _afterSave?.Invoke();
+        }
+        catch (Exception ex)
+        {
+            // The disk transaction/reload already succeeded. Keep the document generation honest
+            // and report the non-persistent cache refresh failure separately.
+            _log.AppendLine(
+                $"TLK {operation} succeeded, but refreshing open labels failed: " +
+                ex.GetBaseException().Message);
+        }
+    }
+
+    private sealed record TlkHistoryEntry(string Description, IReadOnlyList<TlkValueChange> Changes);
+
+    private sealed record TlkValueChange(
+        int Id,
+        bool OldExists,
+        string? OldText,
+        bool NewExists,
+        string? NewText)
+    {
+        public static TlkValueChange Set(int id, bool oldExists, string? oldText, string text) =>
+            new(id, oldExists, oldText, text.Length > 0, text.Length > 0 ? text : null);
+
+        public static TlkValueChange Clear(int id, string? oldText) =>
+            new(id, true, oldText, false, null);
+    }
+}

--- a/SWLOR.Toolset/Editors/Tlk/TlkEditorDocumentViewModel.cs
+++ b/SWLOR.Toolset/Editors/Tlk/TlkEditorDocumentViewModel.cs
@@ -187,8 +187,11 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
     private readonly Action? _afterSave;
     private readonly List<TlkHistoryEntry> _history = new();
     private readonly HashSet<int> _confirmedClears = new();
+    private readonly HashSet<int> _confirmedReferencedWrites = new();
     private int _historyPosition;
     private int _savedPosition;
+    private int _busyOperationCount;
+    private TaskCompletionSource? _idleOperations;
     private bool _refreshingSelection;
     private bool _closeApproved;
     private bool _closePromptOpen;
@@ -291,6 +294,15 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
             NavigationStatus = $"Use Clear row to blank TLK row {id}.";
             return;
         }
+        if (!_backend.ContainsEntry(id) && value.Length > 0 && _backend.IsReferenced(id))
+        {
+            _refreshingSelection = true;
+            SelectedText = string.Empty;
+            _refreshingSelection = false;
+            NavigationStatus =
+                $"Blank row {id} is referenced. Use grid paste (Ctrl+V) so the change can be confirmed.";
+            return;
+        }
         if (value.Length > 0 && id > _backend.MaxEntryId &&
             !CanCreateThrough(id, new Dictionary<int, string> { [id] = value }))
         {
@@ -322,7 +334,9 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
     }
 
     [RelayCommand]
-    private async Task FindFirstBlank()
+    private Task FindFirstBlank() => RunBusyOperationAsync(FindFirstBlankCoreAsync);
+
+    private async Task FindFirstBlankCoreAsync()
     {
         if (!await TryRefreshReferencesAsync().ConfigureAwait(true))
             return;
@@ -332,7 +346,9 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
     }
 
     [RelayCommand]
-    private async Task FindNextBlank()
+    private Task FindNextBlank() => RunBusyOperationAsync(FindNextBlankCoreAsync);
+
+    private async Task FindNextBlankCoreAsync()
     {
         if (!await TryRefreshReferencesAsync().ConfigureAwait(true))
             return;
@@ -342,7 +358,9 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
     }
 
     [RelayCommand(CanExecute = nameof(HasSelectedRow))]
-    private async Task ClearRow()
+    private Task ClearRow() => RunBusyOperationAsync(ClearRowCoreAsync);
+
+    private async Task ClearRowCoreAsync()
     {
         if (SelectedRow == null || !_backend.ContainsEntry(SelectedRow.Id))
             return;
@@ -385,16 +403,20 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
     /// Applies a grid paste as one undo step. Newlines divide consecutive rows; the selected-row
     /// text box uses the platform's normal paste instead and therefore preserves those newlines.
     /// </summary>
-    public async Task<bool> PasteRowsAsync(string clipboardText)
+    public Task<bool> PasteRowsAsync(string clipboardText) =>
+        RunBusyOperationAsync(() => PasteRowsCoreAsync(clipboardText));
+
+    private async Task<bool> PasteRowsCoreAsync(string clipboardText)
     {
         if (SelectedRow == null || clipboardText == null)
             return false;
 
-        var lines = clipboardText.Replace("\r\n", "\n", StringComparison.Ordinal)
-            .Replace('\r', '\n')
+        var normalizedText = clipboardText.Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Replace('\r', '\n');
+        var lines = normalizedText
             .Split('\n')
             .ToList();
-        if (lines.Count > 1 && lines[^1].Length == 0 && clipboardText.EndsWith('\n'))
+        if (lines.Count > 1 && lines[^1].Length == 0 && normalizedText.EndsWith('\n'))
             lines.RemoveAt(lines.Count - 1);
         if (lines.Count == 0)
             return false;
@@ -440,6 +462,7 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
         var overwrites = new List<int>();
         var referenced = new List<int>();
         var cleared = new List<int>();
+        var filledBlanks = new List<int>();
         for (var offset = 0; offset < lines.Count; offset++)
         {
             var id = start + offset;
@@ -449,6 +472,8 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
                 if (lines[offset].Length == 0)
                     cleared.Add(id);
             }
+            else if (lines[offset].Length > 0)
+                filledBlanks.Add(id);
             if (_backend.IsReferenced(id))
                 referenced.Add(id);
             changes.Add(TlkValueChange.Set(
@@ -469,6 +494,8 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
                 return false;
             foreach (var id in cleared.Where(id => _backend.IsReferenced(id) || _backend.ReferenceWarnings.Count > 0))
                 _confirmedClears.Add(id);
+            foreach (var id in filledBlanks.Where(id => _backend.IsReferenced(id) || _backend.ReferenceWarnings.Count > 0))
+                _confirmedReferencedWrites.Add(id);
         }
 
         ApplyChanges($"Paste {lines.Count} TLK rows at {start}", changes);
@@ -553,12 +580,14 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
 
     private async Task<bool> TrySaveCoreAsync()
     {
-        IsBusy = true;
+        BeginBusyOperation();
         try
         {
             if (!await TryRefreshReferencesAsync().ConfigureAwait(true))
                 return false;
             if (!await ConfirmNewlyReferencedClearsAsync().ConfigureAwait(true))
+                return false;
+            if (!await ConfirmNewlyReferencedWritesAsync().ConfigureAwait(true))
                 return false;
 
             var overwrite = false;
@@ -597,7 +626,7 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
         }
         finally
         {
-            IsBusy = false;
+            EndBusyOperation();
         }
     }
 
@@ -605,9 +634,13 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
 
     internal async Task WaitForActiveOperationAsync()
     {
-        var activeSave = _activeSave;
-        if (activeSave != null)
-            await activeSave.ConfigureAwait(true);
+        while (IsBusy)
+        {
+            var idle = _idleOperations;
+            if (idle == null)
+                return;
+            await idle.Task.ConfigureAwait(true);
+        }
     }
 
     public override bool OnClose()
@@ -641,9 +674,7 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
 
     private async Task WaitForBusyThenCloseAsync()
     {
-        var activeSave = _activeSave;
-        if (activeSave != null)
-            await activeSave.ConfigureAwait(true);
+        await WaitForActiveOperationAsync().ConfigureAwait(true);
 
         if (_closeApproved || !IsDirty)
         {
@@ -723,6 +754,8 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
         var ids = changedIds.ToArray();
         foreach (var id in ids.Where(_backend.ContainsEntry))
             _confirmedClears.Remove(id);
+        foreach (var id in ids.Where(id => !_backend.ContainsEntry(id)))
+            _confirmedReferencedWrites.Remove(id);
         // Keep the current filtered snapshot stable while text is being edited. Refiltering on
         // every keystroke can evict the selected row and redirect the remaining input elsewhere.
         // The next filter/exact change recomputes the snapshot explicitly.
@@ -747,6 +780,7 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
         var id = SelectedId;
         _history.Clear();
         _confirmedClears.Clear();
+        _confirmedReferencedWrites.Clear();
         _historyPosition = 0;
         _savedPosition = 0;
         RefreshReferenceStatus();
@@ -825,8 +859,6 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
 
     private async Task<bool> TryRefreshReferencesAsync()
     {
-        var wasBusy = IsBusy;
-        IsBusy = true;
         try
         {
             await Task.Run(_backend.RefreshReferences).ConfigureAwait(true);
@@ -841,10 +873,6 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
             NavigationStatus = "TLK references could not be refreshed; the operation was cancelled.";
             _log.AppendLine($"TLK reference refresh failed: {ex.GetBaseException().Message}");
             return false;
-        }
-        finally
-        {
-            IsBusy = wasBusy;
         }
     }
 
@@ -876,6 +904,82 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
         foreach (var id in cleared)
             _confirmedClears.Add(id);
         return true;
+    }
+
+    private async Task<bool> ConfirmNewlyReferencedWritesAsync()
+    {
+        var filled = _history
+            .Take(_historyPosition)
+            .SelectMany(entry => entry.Changes)
+            .GroupBy(change => change.Id)
+            .Where(group => !group.First().OldExists)
+            .Select(group => group.Key)
+            .Where(id =>
+                _backend.ContainsEntry(id) &&
+                (_backend.IsReferenced(id) || _backend.ReferenceWarnings.Count > 0) &&
+                !_confirmedReferencedWrites.Contains(id))
+            .Order()
+            .ToArray();
+        if (filled.Length == 0)
+            return true;
+
+        var confirmed = await _prompts.ConfirmDestructiveAsync(
+            "Save newly populated TLK rows with possible references?",
+            "These newly populated rows are now referenced, or reference coverage is incomplete:\n\n" +
+            string.Join(", ", filled) +
+            "\n\nSaving will replace blank rows that may already be reserved by other content.",
+            "Save anyway").ConfigureAwait(true);
+        if (!confirmed)
+            return false;
+        foreach (var id in filled)
+            _confirmedReferencedWrites.Add(id);
+        return true;
+    }
+
+    private void BeginBusyOperation()
+    {
+        if (_busyOperationCount++ != 0)
+            return;
+
+        _idleOperations = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        IsBusy = true;
+    }
+
+    private void EndBusyOperation()
+    {
+        if (--_busyOperationCount != 0)
+            return;
+
+        IsBusy = false;
+        var idle = _idleOperations;
+        _idleOperations = null;
+        idle?.TrySetResult();
+    }
+
+    private async Task RunBusyOperationAsync(Func<Task> operation)
+    {
+        BeginBusyOperation();
+        try
+        {
+            await operation().ConfigureAwait(true);
+        }
+        finally
+        {
+            EndBusyOperation();
+        }
+    }
+
+    private async Task<T> RunBusyOperationAsync<T>(Func<Task<T>> operation)
+    {
+        BeginBusyOperation();
+        try
+        {
+            return await operation().ConfigureAwait(true);
+        }
+        finally
+        {
+            EndBusyOperation();
+        }
     }
 
     private bool CanCreateThrough(int highestNewId, IReadOnlyDictionary<int, string> plannedText)

--- a/SWLOR.Toolset/Editors/Tlk/TlkEditorDocumentViewModel.cs
+++ b/SWLOR.Toolset/Editors/Tlk/TlkEditorDocumentViewModel.cs
@@ -186,8 +186,11 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
     private readonly IEditorPromptService _prompts;
     private readonly Action? _afterSave;
     private readonly List<TlkHistoryEntry> _history = new();
+    private readonly HashSet<int> _savedEntryIds = new();
     private readonly HashSet<int> _confirmedClears = new();
     private readonly HashSet<int> _confirmedReferencedWrites = new();
+    private readonly SemaphoreSlim _operationGate = new(1, 1);
+    private readonly object _busyOperationSync = new();
     private int _historyPosition;
     private int _savedPosition;
     private int _busyOperationCount;
@@ -238,6 +241,7 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
         _log = log ?? throw new ArgumentNullException(nameof(log));
         _prompts = prompts ?? throw new ArgumentNullException(nameof(prompts));
         _afterSave = afterSave;
+        CaptureSavedEntryIds();
         Id = $"tlk-editor:{backend.JsonPath}";
         Rows = new TlkVirtualRowCollection(this);
         RefreshReferenceStatus();
@@ -578,9 +582,10 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
         }
     }
 
-    private async Task<bool> TrySaveCoreAsync()
+    private Task<bool> TrySaveCoreAsync() => RunBusyOperationAsync(SaveCoreAsync);
+
+    private async Task<bool> SaveCoreAsync()
     {
-        BeginBusyOperation();
         try
         {
             if (!await TryRefreshReferencesAsync().ConfigureAwait(true))
@@ -609,6 +614,7 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
 
             await Task.Run(() => _backend.Save(overwrite)).ConfigureAwait(true);
             _savedPosition = _historyPosition;
+            CaptureSavedEntryIds();
             UpdateTitleAndState();
             PublishAndRefreshLabels("save");
             _log.AppendLine($"Saved {_backend.JsonPath} and generated {_backend.BinaryPath}.");
@@ -624,22 +630,23 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
             _log.AppendLine($"TLK save failed: {ex.GetBaseException().Message}");
             return false;
         }
-        finally
-        {
-            EndBusyOperation();
-        }
     }
 
     internal void ApproveApplicationClose() => _closeApproved = true;
 
     internal async Task WaitForActiveOperationAsync()
     {
-        while (IsBusy)
+        while (true)
         {
-            var idle = _idleOperations;
-            if (idle == null)
-                return;
-            await idle.Task.ConfigureAwait(true);
+            Task? idle;
+            lock (_busyOperationSync)
+            {
+                if (_busyOperationCount == 0)
+                    return;
+                idle = _idleOperations?.Task;
+            }
+            if (idle != null)
+                await idle.ConfigureAwait(true);
         }
     }
 
@@ -779,10 +786,9 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
     {
         var id = SelectedId;
         _history.Clear();
-        _confirmedClears.Clear();
-        _confirmedReferencedWrites.Clear();
         _historyPosition = 0;
         _savedPosition = 0;
+        CaptureSavedEntryIds();
         RefreshReferenceStatus();
         RefreshFilter(keepSelection: false);
         SelectId(Math.Min(id, Math.Max(0, _backend.MaxEntryId)), clearFilter: false);
@@ -878,12 +884,7 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
 
     private async Task<bool> ConfirmNewlyReferencedClearsAsync()
     {
-        var cleared = _history
-            .Take(_historyPosition)
-            .SelectMany(entry => entry.Changes)
-            .GroupBy(change => change.Id)
-            .Where(group => group.First().OldExists)
-            .Select(group => group.Key)
+        var cleared = _savedEntryIds
             .Where(id =>
                 !_backend.ContainsEntry(id) &&
                 (_backend.IsReferenced(id) || _backend.ReferenceWarnings.Count > 0) &&
@@ -908,13 +909,10 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
 
     private async Task<bool> ConfirmNewlyReferencedWritesAsync()
     {
-        var filled = _history
-            .Take(_historyPosition)
-            .SelectMany(entry => entry.Changes)
-            .GroupBy(change => change.Id)
-            .Where(group => !group.First().OldExists)
-            .Select(group => group.Key)
+        var filled = _backend.Entries
+            .Select(entry => entry.Id)
             .Where(id =>
+                !_savedEntryIds.Contains(id) &&
                 _backend.ContainsEntry(id) &&
                 (_backend.IsReferenced(id) || _backend.ReferenceWarnings.Count > 0) &&
                 !_confirmedReferencedWrites.Contains(id))
@@ -938,22 +936,37 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
 
     private void BeginBusyOperation()
     {
-        if (_busyOperationCount++ != 0)
-            return;
+        var becameBusy = false;
+        lock (_busyOperationSync)
+        {
+            if (_busyOperationCount++ == 0)
+            {
+                _idleOperations = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                becameBusy = true;
+            }
+        }
 
-        _idleOperations = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        IsBusy = true;
+        if (becameBusy)
+            IsBusy = true;
     }
 
     private void EndBusyOperation()
     {
-        if (--_busyOperationCount != 0)
-            return;
+        TaskCompletionSource? idle = null;
+        lock (_busyOperationSync)
+        {
+            if (--_busyOperationCount == 0)
+            {
+                idle = _idleOperations;
+                _idleOperations = null;
+            }
+        }
 
-        IsBusy = false;
-        var idle = _idleOperations;
-        _idleOperations = null;
-        idle?.TrySetResult();
+        if (idle != null)
+        {
+            IsBusy = false;
+            idle.TrySetResult();
+        }
     }
 
     private async Task RunBusyOperationAsync(Func<Task> operation)
@@ -961,7 +974,15 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
         BeginBusyOperation();
         try
         {
-            await operation().ConfigureAwait(true);
+            await _operationGate.WaitAsync().ConfigureAwait(true);
+            try
+            {
+                await operation().ConfigureAwait(true);
+            }
+            finally
+            {
+                _operationGate.Release();
+            }
         }
         finally
         {
@@ -974,12 +995,29 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
         BeginBusyOperation();
         try
         {
-            return await operation().ConfigureAwait(true);
+            await _operationGate.WaitAsync().ConfigureAwait(true);
+            try
+            {
+                return await operation().ConfigureAwait(true);
+            }
+            finally
+            {
+                _operationGate.Release();
+            }
         }
         finally
         {
             EndBusyOperation();
         }
+    }
+
+    private void CaptureSavedEntryIds()
+    {
+        _savedEntryIds.Clear();
+        foreach (var entry in _backend.Entries)
+            _savedEntryIds.Add(entry.Id);
+        _confirmedClears.Clear();
+        _confirmedReferencedWrites.Clear();
     }
 
     private bool CanCreateThrough(int highestNewId, IReadOnlyDictionary<int, string> plannedText)

--- a/SWLOR.Toolset/Editors/Tlk/TlkEditorDocumentViewModel.cs
+++ b/SWLOR.Toolset/Editors/Tlk/TlkEditorDocumentViewModel.cs
@@ -273,6 +273,15 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
             return;
 
         var id = SelectedRow.Id;
+        if (value.Length > 0 && id > _backend.MaxEntryId &&
+            !CanCreateThrough(id, new Dictionary<int, string> { [id] = value }))
+        {
+            _refreshingSelection = true;
+            SelectedText = _backend.GetText(id) ?? string.Empty;
+            _refreshingSelection = false;
+            return;
+        }
+
         ApplyChanges(
             $"Edit TLK row {id}",
             new[] { TlkValueChange.Set(id, _backend.ContainsEntry(id), _backend.GetText(id), value) });
@@ -322,7 +331,7 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
             var usages = FormatUsages(_backend.UsagesOf(id));
             var incomplete = _backend.ReferenceWarnings.Count == 0
                 ? string.Empty
-                : $"\n\nWarning: {_backend.ReferenceWarnings.Count} 2DA file(s) could not be scanned, " +
+                : $"\n\nWarning: {_backend.ReferenceWarnings.Count} reference file(s) could not be scanned, " +
                   "so additional references may exist.";
             var confirmed = await _prompts.ConfirmDestructiveAsync(
                 $"Clear possibly referenced TLK row {id}?",
@@ -387,6 +396,16 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
             return false;
         }
 
+        var plannedText = lines
+            .Select((text, offset) => new KeyValuePair<int, string>(start + offset, text))
+            .ToDictionary(pair => pair.Key, pair => pair.Value);
+        var highestNewId = plannedText
+            .Where(pair => pair.Key > _backend.MaxEntryId && pair.Value.Length > 0)
+            .Select(pair => (int?)pair.Key)
+            .Max();
+        if (highestNewId.HasValue && !CanCreateThrough(highestNewId.Value, plannedText))
+            return false;
+
         var changes = new List<TlkValueChange>(lines.Count);
         var overwrites = new List<int>();
         var referenced = new List<int>();
@@ -406,7 +425,7 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
             var preview = BuildPastePreview(start, lines, overwrites, referenced) +
                           (_backend.ReferenceWarnings.Count == 0
                               ? string.Empty
-                              : $"\n\nReference coverage is incomplete: {_backend.ReferenceWarnings.Count} 2DA file(s) could not be scanned.");
+                              : $"\n\nReference coverage is incomplete: {_backend.ReferenceWarnings.Count} reference file(s) could not be scanned.");
             var confirmed = await _prompts.ConfirmDestructiveAsync(
                 $"Paste {lines.Count} TLK rows?",
                 preview,
@@ -694,7 +713,7 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
     private void RefreshReferenceStatus()
     {
         ReferenceStatus = _backend.ReferenceWarnings.Count == 0
-            ? "2DA references indexed."
+            ? "TLK references indexed."
             : $"Reference scan skipped {_backend.ReferenceWarnings.Count} file(s); see Output.";
         foreach (var warning in _backend.ReferenceWarnings)
             _log.AppendLine($"TLK reference scan: {warning}");
@@ -757,6 +776,29 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
         NavigationStatus =
             $"Blank search is unavailable because {_backend.ReferenceWarnings.Count} reference file(s) could not be indexed.";
         return false;
+    }
+
+    private bool CanCreateThrough(int highestNewId, IReadOnlyDictionary<int, string> plannedText)
+    {
+        if (highestNewId <= _backend.MaxEntryId)
+            return true;
+        if (!CanAllocateBlank())
+            return false;
+
+        var blankId = _backend.FindFirstAvailableBlank();
+        for (var id = blankId; id < highestNewId; id++)
+        {
+            if (_backend.ContainsEntry(id) || _backend.IsReferenced(id))
+                continue;
+            if (!plannedText.TryGetValue(id, out var text) || text.Length == 0)
+            {
+                NavigationStatus =
+                    $"Use Blank row {id} before adding row {highestNewId}.";
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private void NotifySelectionState()

--- a/SWLOR.Toolset/Editors/Tlk/TlkEditorDocumentViewModel.cs
+++ b/SWLOR.Toolset/Editors/Tlk/TlkEditorDocumentViewModel.cs
@@ -347,18 +347,22 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
     }
 
     [RelayCommand]
-    private Task AddRow() => RunBusyOperationAsync(AddRowCoreAsync);
+    private async Task AddRow()
+    {
+        if (await RunBusyOperationAsync(AddRowCoreAsync).ConfigureAwait(true))
+            EntryEditRequested?.Invoke();
+    }
 
-    private async Task AddRowCoreAsync()
+    private async Task<bool> AddRowCoreAsync()
     {
         if (!await TryRefreshReferencesAsync().ConfigureAwait(true))
-            return;
+            return false;
         if (!CanAllocateBlank())
-            return;
+            return false;
         var id = _backend.FindFirstAvailableBlank();
         SelectId(id, clearFilter: true);
         NavigationStatus = $"Row {id} is ready for a new TLK entry.";
-        EntryEditRequested?.Invoke();
+        return true;
     }
 
     [RelayCommand]

--- a/SWLOR.Toolset/Editors/Tlk/TlkEditorDocumentViewModel.cs
+++ b/SWLOR.Toolset/Editors/Tlk/TlkEditorDocumentViewModel.cs
@@ -354,11 +354,12 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
 
     private async Task FindNextBlankCoreAsync()
     {
+        var start = SelectedId;
         if (!await TryRefreshReferencesAsync().ConfigureAwait(true))
             return;
         if (!CanAllocateBlank())
             return;
-        SelectId(_backend.FindNextAvailableBlank(SelectedId), clearFilter: true);
+        SelectId(_backend.FindNextAvailableBlank(start), clearFilter: true);
     }
 
     [RelayCommand(CanExecute = nameof(HasSelectedRow))]
@@ -366,16 +367,16 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
 
     private async Task ClearRowCoreAsync()
     {
-        if (SelectedRow == null || !_backend.ContainsEntry(SelectedRow.Id))
+        var id = SelectedRow?.Id;
+        if (!id.HasValue || !_backend.ContainsEntry(id.Value))
             return;
         if (!await TryRefreshReferencesAsync().ConfigureAwait(true))
             return;
 
-        var id = SelectedRow.Id;
         var clearConfirmed = false;
-        if (_backend.IsReferenced(id) || _backend.ReferenceWarnings.Count > 0)
+        if (_backend.IsReferenced(id.Value) || _backend.ReferenceWarnings.Count > 0)
         {
-            var usages = FormatUsages(_backend.UsagesOf(id));
+            var usages = FormatUsages(_backend.UsagesOf(id.Value));
             var incomplete = _backend.ReferenceWarnings.Count == 0
                 ? string.Empty
                 : $"\n\nWarning: {_backend.ReferenceWarnings.Count} reference file(s) could not be scanned, " +
@@ -393,9 +394,9 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
 
         ApplyChanges(
             $"Clear TLK row {id}",
-            new[] { TlkValueChange.Clear(id, _backend.GetText(id)) });
+            new[] { TlkValueChange.Clear(id.Value, _backend.GetText(id.Value)) });
         if (clearConfirmed)
-            _confirmedClears.Add(id);
+            _confirmedClears.Add(id.Value);
     }
 
     /// <summary>Returns one text line per selected grid row, in row order.</summary>

--- a/SWLOR.Toolset/Editors/Tlk/TlkEditorDocumentViewModel.cs
+++ b/SWLOR.Toolset/Editors/Tlk/TlkEditorDocumentViewModel.cs
@@ -139,6 +139,15 @@ public sealed class TlkVirtualRowCollection : IList, INotifyCollectionChanged, I
         }
     }
 
+    internal void RefreshCachedRows()
+    {
+        foreach (var weak in _rows.Values)
+        {
+            if (weak.TryGetTarget(out var row))
+                row.Refresh();
+        }
+    }
+
     public IEnumerator GetEnumerator()
     {
         for (var index = 0; index < Count; index++)
@@ -177,6 +186,7 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
     private readonly IEditorPromptService _prompts;
     private readonly Action? _afterSave;
     private readonly List<TlkHistoryEntry> _history = new();
+    private readonly HashSet<int> _confirmedClears = new();
     private int _historyPosition;
     private int _savedPosition;
     private bool _refreshingSelection;
@@ -273,6 +283,14 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
             return;
 
         var id = SelectedRow.Id;
+        if (_backend.ContainsEntry(id) && value.Length == 0)
+        {
+            _refreshingSelection = true;
+            SelectedText = _backend.GetText(id) ?? string.Empty;
+            _refreshingSelection = false;
+            NavigationStatus = $"Use Clear row to blank TLK row {id}.";
+            return;
+        }
         if (value.Length > 0 && id > _backend.MaxEntryId &&
             !CanCreateThrough(id, new Dictionary<int, string> { [id] = value }))
         {
@@ -304,16 +322,20 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
     }
 
     [RelayCommand]
-    private void FindFirstBlank()
+    private async Task FindFirstBlank()
     {
+        if (!await TryRefreshReferencesAsync().ConfigureAwait(true))
+            return;
         if (!CanAllocateBlank())
             return;
         SelectId(_backend.FindFirstAvailableBlank(), clearFilter: true);
     }
 
     [RelayCommand]
-    private void FindNextBlank()
+    private async Task FindNextBlank()
     {
+        if (!await TryRefreshReferencesAsync().ConfigureAwait(true))
+            return;
         if (!CanAllocateBlank())
             return;
         SelectId(_backend.FindNextAvailableBlank(SelectedId), clearFilter: true);
@@ -324,8 +346,11 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
     {
         if (SelectedRow == null || !_backend.ContainsEntry(SelectedRow.Id))
             return;
+        if (!await TryRefreshReferencesAsync().ConfigureAwait(true))
+            return;
 
         var id = SelectedRow.Id;
+        var clearConfirmed = false;
         if (_backend.IsReferenced(id) || _backend.ReferenceWarnings.Count > 0)
         {
             var usages = FormatUsages(_backend.UsagesOf(id));
@@ -333,19 +358,22 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
                 ? string.Empty
                 : $"\n\nWarning: {_backend.ReferenceWarnings.Count} reference file(s) could not be scanned, " +
                   "so additional references may exist.";
-            var confirmed = await _prompts.ConfirmDestructiveAsync(
+            var approved = await _prompts.ConfirmDestructiveAsync(
                 $"Clear possibly referenced TLK row {id}?",
                 $"This leaves row {id} blank." +
-                (usages.Length == 0 ? string.Empty : $" Known 2DA references:\n\n{usages}") +
+                (usages.Length == 0 ? string.Empty : $" Known references:\n\n{usages}") +
                 incomplete,
                 "Clear row anyway").ConfigureAwait(true);
-            if (!confirmed)
+            if (!approved)
                 return;
+            clearConfirmed = true;
         }
 
         ApplyChanges(
             $"Clear TLK row {id}",
             new[] { TlkValueChange.Clear(id, _backend.GetText(id)) });
+        if (clearConfirmed)
+            _confirmedClears.Add(id);
     }
 
     /// <summary>Returns one text line per selected grid row, in row order.</summary>
@@ -395,6 +423,8 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
             NavigationStatus = "Paste would exceed the valid custom TLK row range.";
             return false;
         }
+        if (!await TryRefreshReferencesAsync().ConfigureAwait(true))
+            return false;
 
         var plannedText = lines
             .Select((text, offset) => new KeyValuePair<int, string>(start + offset, text))
@@ -409,11 +439,16 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
         var changes = new List<TlkValueChange>(lines.Count);
         var overwrites = new List<int>();
         var referenced = new List<int>();
+        var cleared = new List<int>();
         for (var offset = 0; offset < lines.Count; offset++)
         {
             var id = start + offset;
             if (_backend.ContainsEntry(id))
+            {
                 overwrites.Add(id);
+                if (lines[offset].Length == 0)
+                    cleared.Add(id);
+            }
             if (_backend.IsReferenced(id))
                 referenced.Add(id);
             changes.Add(TlkValueChange.Set(
@@ -432,6 +467,8 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
                 "Paste rows").ConfigureAwait(true);
             if (!confirmed)
                 return false;
+            foreach (var id in cleared.Where(id => _backend.IsReferenced(id) || _backend.ReferenceWarnings.Count > 0))
+                _confirmedClears.Add(id);
         }
 
         ApplyChanges($"Paste {lines.Count} TLK rows at {start}", changes);
@@ -519,6 +556,11 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
         IsBusy = true;
         try
         {
+            if (!await TryRefreshReferencesAsync().ConfigureAwait(true))
+                return false;
+            if (!await ConfirmNewlyReferencedClearsAsync().ConfigureAwait(true))
+                return false;
+
             var overwrite = false;
             if (await Task.Run(_backend.HasExternalChange).ConfigureAwait(true))
             {
@@ -679,6 +721,8 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
     private void RefreshAfterEdit(IEnumerable<int> changedIds)
     {
         var ids = changedIds.ToArray();
+        foreach (var id in ids.Where(_backend.ContainsEntry))
+            _confirmedClears.Remove(id);
         // Keep the current filtered snapshot stable while text is being edited. Refiltering on
         // every keystroke can evict the selected row and redirect the remaining input elsewhere.
         // The next filter/exact change recomputes the snapshot explicitly.
@@ -702,6 +746,7 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
     {
         var id = SelectedId;
         _history.Clear();
+        _confirmedClears.Clear();
         _historyPosition = 0;
         _savedPosition = 0;
         RefreshReferenceStatus();
@@ -776,6 +821,61 @@ public partial class TlkEditorDocumentViewModel : Document, IEditorDocument
         NavigationStatus =
             $"Blank search is unavailable because {_backend.ReferenceWarnings.Count} reference file(s) could not be indexed.";
         return false;
+    }
+
+    private async Task<bool> TryRefreshReferencesAsync()
+    {
+        var wasBusy = IsBusy;
+        IsBusy = true;
+        try
+        {
+            await Task.Run(_backend.RefreshReferences).ConfigureAwait(true);
+            RefreshReferenceStatus();
+            Rows.RefreshCachedRows();
+            if (SelectedRow != null)
+                OnSelectedRowChanged(SelectedRow);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            NavigationStatus = "TLK references could not be refreshed; the operation was cancelled.";
+            _log.AppendLine($"TLK reference refresh failed: {ex.GetBaseException().Message}");
+            return false;
+        }
+        finally
+        {
+            IsBusy = wasBusy;
+        }
+    }
+
+    private async Task<bool> ConfirmNewlyReferencedClearsAsync()
+    {
+        var cleared = _history
+            .Take(_historyPosition)
+            .SelectMany(entry => entry.Changes)
+            .GroupBy(change => change.Id)
+            .Where(group => group.First().OldExists)
+            .Select(group => group.Key)
+            .Where(id =>
+                !_backend.ContainsEntry(id) &&
+                (_backend.IsReferenced(id) || _backend.ReferenceWarnings.Count > 0) &&
+                !_confirmedClears.Contains(id))
+            .Order()
+            .ToArray();
+        if (cleared.Length == 0)
+            return true;
+
+        var confirmed = await _prompts.ConfirmDestructiveAsync(
+            "Save cleared TLK rows with possible references?",
+            "These cleared rows are now referenced, or reference coverage is incomplete:\n\n" +
+            string.Join(", ", cleared) +
+            "\n\nSaving will leave those references without TLK text.",
+            "Save anyway").ConfigureAwait(true);
+        if (!confirmed)
+            return false;
+        foreach (var id in cleared)
+            _confirmedClears.Add(id);
+        return true;
     }
 
     private bool CanCreateThrough(int highestNewId, IReadOnlyDictionary<int, string> plannedText)

--- a/SWLOR.Toolset/Editors/Tlk/TlkEditorLoadingDocumentViewModel.cs
+++ b/SWLOR.Toolset/Editors/Tlk/TlkEditorLoadingDocumentViewModel.cs
@@ -1,0 +1,36 @@
+using Dock.Model.Mvvm.Controls;
+
+namespace SWLOR.Toolset.Editors.Tlk;
+
+/// <summary>The immediately visible document shown while the TLK and its references are indexed.</summary>
+public sealed class TlkEditorLoadingDocumentViewModel : Document
+{
+    private readonly CancellationTokenSource _cancellation = new();
+    private bool _completed;
+    private bool _closed;
+
+    public TlkEditorLoadingDocumentViewModel(string jsonPath)
+    {
+        Id = $"tlk-editor-loading:{jsonPath}";
+        Title = "TLK Editor";
+    }
+
+    internal CancellationToken CancellationToken => _cancellation.Token;
+    public bool CancellationRequested => _cancellation.IsCancellationRequested;
+
+    public event Action<TlkEditorLoadingDocumentViewModel>? Closed;
+
+    internal void Complete() => _completed = true;
+
+    public override bool OnClose()
+    {
+        if (_closed)
+            return base.OnClose();
+
+        _closed = true;
+        if (!_completed)
+            _cancellation.Cancel();
+        Closed?.Invoke(this);
+        return base.OnClose();
+    }
+}

--- a/SWLOR.Toolset/Editors/Triggers/TriggerEditorViewModel.cs
+++ b/SWLOR.Toolset/Editors/Triggers/TriggerEditorViewModel.cs
@@ -254,6 +254,27 @@ namespace SWLOR.Toolset.Editors.Triggers
             RefreshCompleteness();
         }
 
+        /// <summary>Rebuilds every materialized choice row after TLK-backed labels change.</summary>
+        public void RefreshTlkLabels()
+        {
+            RebuildChoiceRows(BasicRows);
+            RebuildChoiceRows(BehaviorRows);
+            RefreshCompleteness();
+        }
+
+        private void RebuildChoiceRows(ObservableCollection<TriggerRowViewModel> rows)
+        {
+            for (var index = 0; index < rows.Count; index++)
+            {
+                if (rows[index].Definition.ChoicesKey == null)
+                    continue;
+
+                var definition = rows[index].Definition;
+                rows[index].Dispose();
+                rows[index] = CreateRow(definition);
+            }
+        }
+
         private void ReloadRowsFromDocument()
         {
             foreach (var row in BasicRows.Concat(BehaviorRows))

--- a/SWLOR.Toolset/Editors/Views/Tlk/TlkEditorDocumentView.axaml
+++ b/SWLOR.Toolset/Editors/Views/Tlk/TlkEditorDocumentView.axaml
@@ -106,7 +106,7 @@
 
       <Grid Grid.Column="2" RowDefinitions="Auto,*">
         <Grid Grid.Row="0" ColumnDefinitions="Auto,*,Auto" Margin="0,0,0,6">
-          <TextBlock Grid.Column="0" Text="References (2DA first)" FontWeight="SemiBold" />
+          <TextBlock Grid.Column="0" Text="References" FontWeight="SemiBold" />
           <TextBlock Grid.Column="2" Text="{Binding ReferenceStatus}" Classes="dim"
                      FontSize="11" TextTrimming="CharacterEllipsis" />
         </Grid>

--- a/SWLOR.Toolset/Editors/Views/Tlk/TlkEditorDocumentView.axaml
+++ b/SWLOR.Toolset/Editors/Views/Tlk/TlkEditorDocumentView.axaml
@@ -21,8 +21,8 @@
     </Grid>
 
     <Grid Grid.Row="1" ColumnDefinitions="Auto,Auto,18,Auto,*,Auto" ColumnSpacing="7" Margin="0,7,0,7">
-      <Button Grid.Column="0" Content="First safe blank" Command="{Binding FindFirstBlankCommand}" Padding="10,5" />
-      <Button Grid.Column="1" Content="Next safe blank" Command="{Binding FindNextBlankCommand}" Padding="10,5" />
+      <Button Grid.Column="0" Content="First Blank" Command="{Binding FindFirstBlankCommand}" Padding="10,5" />
+      <Button Grid.Column="1" Content="Next Blank" Command="{Binding FindNextBlankCommand}" Padding="10,5" />
       <Button Grid.Column="3" Content="Clear row" Command="{Binding ClearRowCommand}" Padding="10,5" />
       <TextBlock Grid.Column="4" Text="{Binding NavigationStatus}" Classes="dim"
                  VerticalAlignment="Center" TextTrimming="CharacterEllipsis" />

--- a/SWLOR.Toolset/Editors/Views/Tlk/TlkEditorDocumentView.axaml
+++ b/SWLOR.Toolset/Editors/Views/Tlk/TlkEditorDocumentView.axaml
@@ -3,7 +3,7 @@
              xmlns:tlk="using:SWLOR.Toolset.Editors.Tlk"
              x:Class="SWLOR.Toolset.Editors.Tlk.TlkEditorDocumentView"
              x:DataType="tlk:TlkEditorDocumentViewModel">
-  <Grid RowDefinitions="Auto,Auto,*,5,240,Auto" Margin="8" IsEnabled="{Binding !IsBusy}">
+  <Grid RowDefinitions="Auto,Auto,*,5,280,Auto" Margin="8" IsEnabled="{Binding !IsBusy}">
     <Grid Grid.Row="0" ColumnDefinitions="Auto,190,Auto,18,Auto,*" ColumnSpacing="7">
       <TextBlock Grid.Column="0" Text="Go to row / StrRef" VerticalAlignment="Center" />
       <TextBox Grid.Column="1" Text="{Binding GoToValue, Mode=TwoWay}"
@@ -79,18 +79,15 @@
 
     <GridSplitter Grid.Row="3" ResizeDirection="Rows" Background="{DynamicResource RuleBrush}" />
 
-    <Grid Grid.Row="4" ColumnDefinitions="3*,8,2*">
+    <Grid Grid.Row="4" ColumnDefinitions="2*,8,3*">
       <Grid Grid.Column="0" RowDefinitions="Auto,*">
-        <Grid Grid.Row="0" ColumnDefinitions="Auto,Auto,12,Auto,Auto,*" ColumnSpacing="6" Margin="0,0,0,6">
+        <Grid Grid.Row="0" ColumnDefinitions="Auto,Auto,12,Auto,Auto" ColumnSpacing="6" Margin="0,0,0,6">
           <TextBlock Grid.Column="0" Text="Row" Classes="dim" VerticalAlignment="Center" />
           <Button Grid.Column="1" Content="{Binding SelectedIdDisplay}"
                   Click="OnCopyRowId" Padding="8,3" ToolTip.Tip="Copy raw TLK row ID" />
           <TextBlock Grid.Column="3" Text="Custom StrRef" Classes="dim" VerticalAlignment="Center" />
           <Button Grid.Column="4" Content="{Binding SelectedStrRefDisplay}"
                   Click="OnCopyStrRef" Padding="8,3" ToolTip.Tip="Copy full custom StrRef" />
-          <TextBlock Grid.Column="5" Text="Paste here preserves newlines in this one entry. Paste in the grid fills consecutive rows."
-                     Classes="dim" FontSize="11" VerticalAlignment="Center"
-                     TextWrapping="Wrap" Margin="10,0,0,0" />
         </Grid>
         <TextBox Grid.Row="1" Text="{Binding SelectedText, Mode=TwoWay}"
                  AcceptsReturn="True" TextWrapping="Wrap"
@@ -105,19 +102,41 @@
 
       <Grid Grid.Column="2" RowDefinitions="Auto,*">
         <Grid Grid.Row="0" ColumnDefinitions="Auto,*,Auto" Margin="0,0,0,6">
-          <TextBlock Grid.Column="0" Text="2DA references" FontWeight="SemiBold" />
+          <TextBlock Grid.Column="0" Text="References (2DA first)" FontWeight="SemiBold" />
           <TextBlock Grid.Column="2" Text="{Binding ReferenceStatus}" Classes="dim"
                      FontSize="11" TextTrimming="CharacterEllipsis" />
         </Grid>
-        <DataGrid Grid.Row="1" ItemsSource="{Binding Usages}"
+        <DataGrid x:Name="ReferenceGrid" Grid.Row="1" ItemsSource="{Binding Usages}"
                   IsReadOnly="True" AutoGenerateColumns="False"
                   x:CompileBindings="False"
                   GridLinesVisibility="Horizontal">
           <DataGrid.Columns>
-            <DataGridTextColumn Header="File" Binding="{Binding File}" Width="*" />
-            <DataGridTextColumn Header="Row" Binding="{Binding Row}" Width="70" />
-            <DataGridTextColumn Header="Label" Binding="{Binding RowLabel}" Width="110" />
-            <DataGridTextColumn Header="Column" Binding="{Binding Column}" Width="120" />
+            <DataGridTextColumn Header="Source" Binding="{Binding Source}" Width="85" />
+            <DataGridTemplateColumn Header="File" Width="2*">
+              <DataGridTemplateColumn.CellTemplate>
+                <DataTemplate>
+                  <TextBlock Text="{Binding File}" TextTrimming="CharacterEllipsis"
+                             ToolTip.Tip="{Binding File}" />
+                </DataTemplate>
+              </DataGridTemplateColumn.CellTemplate>
+            </DataGridTemplateColumn>
+            <DataGridTextColumn Header="Row / line" Binding="{Binding Row}" Width="85" />
+            <DataGridTemplateColumn Header="Label" Width="120">
+              <DataGridTemplateColumn.CellTemplate>
+                <DataTemplate>
+                  <TextBlock Text="{Binding RowLabel}" TextTrimming="CharacterEllipsis"
+                             ToolTip.Tip="{Binding RowLabel}" />
+                </DataTemplate>
+              </DataGridTemplateColumn.CellTemplate>
+            </DataGridTemplateColumn>
+            <DataGridTemplateColumn Header="Column" Width="145">
+              <DataGridTemplateColumn.CellTemplate>
+                <DataTemplate>
+                  <TextBlock Text="{Binding Column}" TextTrimming="CharacterEllipsis"
+                             ToolTip.Tip="{Binding Column}" />
+                </DataTemplate>
+              </DataGridTemplateColumn.CellTemplate>
+            </DataGridTemplateColumn>
           </DataGrid.Columns>
         </DataGrid>
       </Grid>

--- a/SWLOR.Toolset/Editors/Views/Tlk/TlkEditorDocumentView.axaml
+++ b/SWLOR.Toolset/Editors/Views/Tlk/TlkEditorDocumentView.axaml
@@ -1,0 +1,131 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:tlk="using:SWLOR.Toolset.Editors.Tlk"
+             x:Class="SWLOR.Toolset.Editors.Tlk.TlkEditorDocumentView"
+             x:DataType="tlk:TlkEditorDocumentViewModel">
+  <Grid RowDefinitions="Auto,Auto,*,5,240,Auto" Margin="8" IsEnabled="{Binding !IsBusy}">
+    <Grid Grid.Row="0" ColumnDefinitions="Auto,190,Auto,18,Auto,*,Auto" ColumnSpacing="7">
+      <TextBlock Grid.Column="0" Text="Go to row / StrRef" VerticalAlignment="Center" />
+      <TextBox Grid.Column="1" Text="{Binding GoToValue, Mode=TwoWay}"
+               Watermark="Row ID or 16777216+" />
+      <Button Grid.Column="2" Content="Go" Command="{Binding GoToRowCommand}" Padding="14,5" />
+
+      <TextBlock Grid.Column="4" Text="Filter rows" VerticalAlignment="Center" />
+      <TextBox Grid.Column="5" Text="{Binding FilterText, Mode=TwoWay}"
+               Watermark="Text, row ID, or full StrRef" />
+      <CheckBox Grid.Column="6" Content="Exact" IsChecked="{Binding ExactMatch, Mode=TwoWay}"
+                VerticalAlignment="Center" />
+    </Grid>
+
+    <Grid Grid.Row="1" ColumnDefinitions="Auto,Auto,18,Auto,210,Auto,Auto,18,Auto,*,Auto" ColumnSpacing="7" Margin="0,7,0,7">
+      <Button Grid.Column="0" Content="First safe blank" Command="{Binding FindFirstBlankCommand}" Padding="10,5" />
+      <Button Grid.Column="1" Content="Next safe blank" Command="{Binding FindNextBlankCommand}" Padding="10,5" />
+      <TextBlock Grid.Column="3" Text="Find" VerticalAlignment="Center" />
+      <TextBox Grid.Column="4" Text="{Binding FindText, Mode=TwoWay}"
+               Watermark="Text, row ID, or full StrRef" />
+      <Button Grid.Column="5" Content="Previous" Command="{Binding FindPreviousCommand}" Padding="10,5" />
+      <Button Grid.Column="6" Content="Next" Command="{Binding FindNextCommand}" Padding="10,5" />
+      <Button Grid.Column="8" Content="Clear row" Command="{Binding ClearRowCommand}" Padding="10,5" />
+      <TextBlock Grid.Column="9" Text="{Binding NavigationStatus}" Classes="dim"
+                 VerticalAlignment="Center" TextTrimming="CharacterEllipsis" />
+      <TextBlock Grid.Column="10"
+                 Text="{Binding EntryCount, StringFormat='{}{0:N0} entries'}"
+                 Classes="count" VerticalAlignment="Center" />
+    </Grid>
+
+    <!-- DataGridCollectionView eagerly copies any ordinary IEnumerable. This indexed ListBox keeps
+         the sparse row source lazy while retaining a familiar fixed-column table layout. -->
+    <Grid Grid.Row="2" RowDefinitions="Auto,*">
+      <Border Grid.Row="0" BorderBrush="{DynamicResource RuleBrush}" BorderThickness="0,0,0,1"
+              Padding="8,5" Background="{DynamicResource ChromeBrush}">
+        <Grid ColumnDefinitions="95,135,80,65,105,*" ColumnSpacing="6">
+          <TextBlock Grid.Column="0" Text="Row" FontWeight="SemiBold" />
+          <TextBlock Grid.Column="1" Text="Custom StrRef" FontWeight="SemiBold" />
+          <TextBlock Grid.Column="2" Text="Length" FontWeight="SemiBold" />
+          <TextBlock Grid.Column="3" Text="Uses" FontWeight="SemiBold" />
+          <TextBlock Grid.Column="4" Text="State" FontWeight="SemiBold" />
+          <TextBlock Grid.Column="5" Text="Text" FontWeight="SemiBold" />
+        </Grid>
+      </Border>
+      <ListBox x:Name="RowGrid" Grid.Row="1"
+               ItemsSource="{Binding Rows}"
+               SelectedItem="{Binding SelectedRow, Mode=TwoWay}"
+               SelectionMode="Multiple"
+               KeyDown="OnRowGridKeyDown">
+        <ListBox.ItemsPanel>
+          <ItemsPanelTemplate>
+            <VirtualizingStackPanel />
+          </ItemsPanelTemplate>
+        </ListBox.ItemsPanel>
+        <ListBox.Styles>
+          <Style Selector="ListBoxItem">
+            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+            <Setter Property="Padding" Value="8,4" />
+          </Style>
+        </ListBox.Styles>
+        <ListBox.ItemTemplate>
+          <DataTemplate x:DataType="tlk:TlkEditorRowViewModel">
+            <Grid ColumnDefinitions="95,135,80,65,105,*" ColumnSpacing="6">
+              <TextBlock Grid.Column="0" Text="{Binding Id}" />
+              <TextBlock Grid.Column="1" Text="{Binding StrRef}" />
+              <TextBlock Grid.Column="2" Text="{Binding Length}" />
+              <TextBlock Grid.Column="3" Text="{Binding UsageCount}" />
+              <TextBlock Grid.Column="4" Text="{Binding State}" />
+              <TextBlock Grid.Column="5" Text="{Binding Preview}"
+                         TextTrimming="CharacterEllipsis" />
+            </Grid>
+          </DataTemplate>
+        </ListBox.ItemTemplate>
+      </ListBox>
+    </Grid>
+
+    <GridSplitter Grid.Row="3" ResizeDirection="Rows" Background="{DynamicResource RuleBrush}" />
+
+    <Grid Grid.Row="4" ColumnDefinitions="3*,8,2*">
+      <Grid Grid.Column="0" RowDefinitions="Auto,*">
+        <Grid Grid.Row="0" ColumnDefinitions="Auto,Auto,12,Auto,Auto,*" ColumnSpacing="6" Margin="0,0,0,6">
+          <TextBlock Grid.Column="0" Text="Row" Classes="dim" VerticalAlignment="Center" />
+          <Button Grid.Column="1" Content="{Binding SelectedIdDisplay}"
+                  Click="OnCopyRowId" Padding="8,3" ToolTip.Tip="Copy raw TLK row ID" />
+          <TextBlock Grid.Column="3" Text="Custom StrRef" Classes="dim" VerticalAlignment="Center" />
+          <Button Grid.Column="4" Content="{Binding SelectedStrRefDisplay}"
+                  Click="OnCopyStrRef" Padding="8,3" ToolTip.Tip="Copy full custom StrRef" />
+          <TextBlock Grid.Column="5" Text="Paste here preserves newlines in this one entry. Paste in the grid fills consecutive rows."
+                     Classes="dim" FontSize="11" VerticalAlignment="Center"
+                     TextWrapping="Wrap" Margin="10,0,0,0" />
+        </Grid>
+        <TextBox Grid.Row="1" Text="{Binding SelectedText, Mode=TwoWay}"
+                 AcceptsReturn="True" TextWrapping="Wrap"
+                 VerticalContentAlignment="Top"
+                 ScrollViewer.VerticalScrollBarVisibility="Auto"
+                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                 IsEnabled="{Binding HasSelectedRow}" />
+      </Grid>
+
+      <GridSplitter Grid.Column="1" ResizeDirection="Columns" Margin="3,0"
+                    Background="{DynamicResource RuleBrush}" />
+
+      <Grid Grid.Column="2" RowDefinitions="Auto,*">
+        <Grid Grid.Row="0" ColumnDefinitions="Auto,*,Auto" Margin="0,0,0,6">
+          <TextBlock Grid.Column="0" Text="2DA references" FontWeight="SemiBold" />
+          <TextBlock Grid.Column="2" Text="{Binding ReferenceStatus}" Classes="dim"
+                     FontSize="11" TextTrimming="CharacterEllipsis" />
+        </Grid>
+        <DataGrid Grid.Row="1" ItemsSource="{Binding Usages}"
+                  IsReadOnly="True" AutoGenerateColumns="False"
+                  x:CompileBindings="False"
+                  GridLinesVisibility="Horizontal">
+          <DataGrid.Columns>
+            <DataGridTextColumn Header="File" Binding="{Binding File}" Width="*" />
+            <DataGridTextColumn Header="Row" Binding="{Binding Row}" Width="70" />
+            <DataGridTextColumn Header="Label" Binding="{Binding RowLabel}" Width="110" />
+            <DataGridTextColumn Header="Column" Binding="{Binding Column}" Width="120" />
+          </DataGrid.Columns>
+        </DataGrid>
+      </Grid>
+    </Grid>
+
+    <TextBlock Grid.Row="5" Margin="0,7,0,0" Classes="dim" FontSize="11"
+               Text="{Binding JsonPath}" TextTrimming="CharacterEllipsis" />
+  </Grid>
+</UserControl>

--- a/SWLOR.Toolset/Editors/Views/Tlk/TlkEditorDocumentView.axaml
+++ b/SWLOR.Toolset/Editors/Views/Tlk/TlkEditorDocumentView.axaml
@@ -20,17 +20,18 @@
       </Grid>
     </Grid>
 
-    <Grid Grid.Row="1" ColumnDefinitions="Auto,Auto,18,Auto,*,Auto" ColumnSpacing="7" Margin="0,7,0,7">
-      <Button x:Name="AddRowButton" Grid.Column="0" Content="Add row"
+    <Grid Grid.Row="1" ColumnDefinitions="Auto,Auto,Auto,*,Auto" ColumnSpacing="7" Margin="0,7,0,7">
+      <Button x:Name="NextBlankButton" Grid.Column="0" Content="Next Blank"
+              Command="{Binding FindNextBlankCommand}" Padding="10,5" />
+      <Button x:Name="AddRowButton" Grid.Column="1" Content="Add row"
               Command="{Binding AddRowCommand}" Padding="10,5"
               ToolTip.Tip="Use the first unreferenced blank row without changing existing StrRefs" />
-      <Button Grid.Column="1" Content="Next Blank" Command="{Binding FindNextBlankCommand}" Padding="10,5" />
-      <Button x:Name="RemoveRowButton" Grid.Column="3" Content="Remove row"
+      <Button x:Name="RemoveRowButton" Grid.Column="2" Content="Remove row"
               Command="{Binding RemoveRowCommand}" Padding="10,5"
               ToolTip.Tip="Remove this row's text without renumbering later rows" />
-      <TextBlock Grid.Column="4" Text="{Binding NavigationStatus}" Classes="dim"
+      <TextBlock Grid.Column="3" Text="{Binding NavigationStatus}" Classes="dim"
                  VerticalAlignment="Center" TextTrimming="CharacterEllipsis" />
-      <TextBlock Grid.Column="5"
+      <TextBlock Grid.Column="4"
                  Text="{Binding EntryCount, StringFormat='{}{0:N0} entries'}"
                  Classes="count" VerticalAlignment="Center" />
     </Grid>

--- a/SWLOR.Toolset/Editors/Views/Tlk/TlkEditorDocumentView.axaml
+++ b/SWLOR.Toolset/Editors/Views/Tlk/TlkEditorDocumentView.axaml
@@ -4,31 +4,29 @@
              x:Class="SWLOR.Toolset.Editors.Tlk.TlkEditorDocumentView"
              x:DataType="tlk:TlkEditorDocumentViewModel">
   <Grid RowDefinitions="Auto,Auto,*,5,240,Auto" Margin="8" IsEnabled="{Binding !IsBusy}">
-    <Grid Grid.Row="0" ColumnDefinitions="Auto,190,Auto,18,Auto,*,Auto" ColumnSpacing="7">
+    <Grid Grid.Row="0" ColumnDefinitions="Auto,190,Auto,18,Auto,*" ColumnSpacing="7">
       <TextBlock Grid.Column="0" Text="Go to row / StrRef" VerticalAlignment="Center" />
       <TextBox Grid.Column="1" Text="{Binding GoToValue, Mode=TwoWay}"
                Watermark="Row ID or 16777216+" />
       <Button Grid.Column="2" Content="Go" Command="{Binding GoToRowCommand}" Padding="14,5" />
 
       <TextBlock Grid.Column="4" Text="Filter rows" VerticalAlignment="Center" />
-      <TextBox Grid.Column="5" Text="{Binding FilterText, Mode=TwoWay}"
-               Watermark="Text, row ID, or full StrRef" />
-      <CheckBox Grid.Column="6" Content="Exact" IsChecked="{Binding ExactMatch, Mode=TwoWay}"
-                VerticalAlignment="Center" />
+      <Grid Grid.Column="5" ColumnDefinitions="*,Auto" ColumnSpacing="4">
+        <TextBox Grid.Column="0" Text="{Binding FilterText, Mode=TwoWay}"
+                 Watermark="Text, row ID, or full StrRef" />
+        <Button x:Name="ClearFilterButton" Grid.Column="1" Content="×"
+                Command="{Binding ClearFilterCommand}" Padding="8,4"
+                ToolTip.Tip="Clear filter" />
+      </Grid>
     </Grid>
 
-    <Grid Grid.Row="1" ColumnDefinitions="Auto,Auto,18,Auto,210,Auto,Auto,18,Auto,*,Auto" ColumnSpacing="7" Margin="0,7,0,7">
+    <Grid Grid.Row="1" ColumnDefinitions="Auto,Auto,18,Auto,*,Auto" ColumnSpacing="7" Margin="0,7,0,7">
       <Button Grid.Column="0" Content="First safe blank" Command="{Binding FindFirstBlankCommand}" Padding="10,5" />
       <Button Grid.Column="1" Content="Next safe blank" Command="{Binding FindNextBlankCommand}" Padding="10,5" />
-      <TextBlock Grid.Column="3" Text="Find" VerticalAlignment="Center" />
-      <TextBox Grid.Column="4" Text="{Binding FindText, Mode=TwoWay}"
-               Watermark="Text, row ID, or full StrRef" />
-      <Button Grid.Column="5" Content="Previous" Command="{Binding FindPreviousCommand}" Padding="10,5" />
-      <Button Grid.Column="6" Content="Next" Command="{Binding FindNextCommand}" Padding="10,5" />
-      <Button Grid.Column="8" Content="Clear row" Command="{Binding ClearRowCommand}" Padding="10,5" />
-      <TextBlock Grid.Column="9" Text="{Binding NavigationStatus}" Classes="dim"
+      <Button Grid.Column="3" Content="Clear row" Command="{Binding ClearRowCommand}" Padding="10,5" />
+      <TextBlock Grid.Column="4" Text="{Binding NavigationStatus}" Classes="dim"
                  VerticalAlignment="Center" TextTrimming="CharacterEllipsis" />
-      <TextBlock Grid.Column="10"
+      <TextBlock Grid.Column="5"
                  Text="{Binding EntryCount, StringFormat='{}{0:N0} entries'}"
                  Classes="count" VerticalAlignment="Center" />
     </Grid>

--- a/SWLOR.Toolset/Editors/Views/Tlk/TlkEditorDocumentView.axaml
+++ b/SWLOR.Toolset/Editors/Views/Tlk/TlkEditorDocumentView.axaml
@@ -21,9 +21,13 @@
     </Grid>
 
     <Grid Grid.Row="1" ColumnDefinitions="Auto,Auto,18,Auto,*,Auto" ColumnSpacing="7" Margin="0,7,0,7">
-      <Button Grid.Column="0" Content="First Blank" Command="{Binding FindFirstBlankCommand}" Padding="10,5" />
+      <Button x:Name="AddRowButton" Grid.Column="0" Content="Add row"
+              Command="{Binding AddRowCommand}" Padding="10,5"
+              ToolTip.Tip="Use the first unreferenced blank row without changing existing StrRefs" />
       <Button Grid.Column="1" Content="Next Blank" Command="{Binding FindNextBlankCommand}" Padding="10,5" />
-      <Button Grid.Column="3" Content="Clear row" Command="{Binding ClearRowCommand}" Padding="10,5" />
+      <Button x:Name="RemoveRowButton" Grid.Column="3" Content="Remove row"
+              Command="{Binding RemoveRowCommand}" Padding="10,5"
+              ToolTip.Tip="Remove this row's text without renumbering later rows" />
       <TextBlock Grid.Column="4" Text="{Binding NavigationStatus}" Classes="dim"
                  VerticalAlignment="Center" TextTrimming="CharacterEllipsis" />
       <TextBlock Grid.Column="5"
@@ -89,7 +93,7 @@
           <Button Grid.Column="4" Content="{Binding SelectedStrRefDisplay}"
                   Click="OnCopyStrRef" Padding="8,3" ToolTip.Tip="Copy full custom StrRef" />
         </Grid>
-        <TextBox Grid.Row="1" Text="{Binding SelectedText, Mode=TwoWay}"
+        <TextBox x:Name="SelectedTextEditor" Grid.Row="1" Text="{Binding SelectedText, Mode=TwoWay}"
                  AcceptsReturn="True" TextWrapping="Wrap"
                  VerticalContentAlignment="Top"
                  ScrollViewer.VerticalScrollBarVisibility="Auto"

--- a/SWLOR.Toolset/Editors/Views/Tlk/TlkEditorDocumentView.axaml.cs
+++ b/SWLOR.Toolset/Editors/Views/Tlk/TlkEditorDocumentView.axaml.cs
@@ -1,0 +1,91 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Input.Platform;
+using Avalonia.Interactivity;
+
+namespace SWLOR.Toolset.Editors.Tlk;
+
+public partial class TlkEditorDocumentView : UserControl
+{
+    private TlkEditorDocumentViewModel? _subscribed;
+
+    public TlkEditorDocumentView()
+    {
+        InitializeComponent();
+        DataContextChanged += (_, _) => SubscribeToNavigation();
+        AttachedToVisualTree += (_, _) => SubscribeToNavigation();
+        DetachedFromVisualTree += (_, _) => UnsubscribeFromNavigation();
+    }
+
+    private void SubscribeToNavigation()
+    {
+        UnsubscribeFromNavigation();
+        if (DataContext is not TlkEditorDocumentViewModel viewModel)
+            return;
+        _subscribed = viewModel;
+        viewModel.SelectionNavigationRequested += OnSelectionNavigationRequested;
+    }
+
+    private void UnsubscribeFromNavigation()
+    {
+        if (_subscribed != null)
+            _subscribed.SelectionNavigationRequested -= OnSelectionNavigationRequested;
+        _subscribed = null;
+    }
+
+    private void OnSelectionNavigationRequested(int id)
+    {
+        if (DataContext is TlkEditorDocumentViewModel viewModel && viewModel.SelectedRow != null)
+            RowGrid.ScrollIntoView(viewModel.SelectedRow);
+    }
+
+    private async void OnCopyRowId(object? sender, RoutedEventArgs args)
+    {
+        if (DataContext is TlkEditorDocumentViewModel viewModel)
+            await SetClipboardTextAsync(viewModel.SelectedIdDisplay);
+    }
+
+    private async void OnCopyStrRef(object? sender, RoutedEventArgs args)
+    {
+        if (DataContext is TlkEditorDocumentViewModel viewModel)
+            await SetClipboardTextAsync(viewModel.SelectedStrRefDisplay);
+    }
+
+    private async void OnRowGridKeyDown(object? sender, KeyEventArgs args)
+    {
+        if (DataContext is not TlkEditorDocumentViewModel viewModel ||
+            (args.KeyModifiers & KeyModifiers.Control) == 0)
+        {
+            return;
+        }
+
+        var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
+        if (clipboard == null)
+            return;
+
+        if (args.Key == Key.C)
+        {
+            var ids = (RowGrid.SelectedItems?.OfType<TlkEditorRowViewModel>() ??
+                       Enumerable.Empty<TlkEditorRowViewModel>())
+                .Select(row => row.Id)
+                .ToArray();
+            if (ids.Length > 0)
+            {
+                await clipboard.SetTextAsync(viewModel.CopyRows(ids));
+                args.Handled = true;
+            }
+        }
+        else if (args.Key == Key.V)
+        {
+            var text = await clipboard.TryGetTextAsync();
+            if (text != null)
+            {
+                await viewModel.PasteRowsAsync(text);
+                args.Handled = true;
+            }
+        }
+    }
+
+    private Task SetClipboardTextAsync(string text) =>
+        TopLevel.GetTopLevel(this)?.Clipboard?.SetTextAsync(text) ?? Task.CompletedTask;
+}

--- a/SWLOR.Toolset/Editors/Views/Tlk/TlkEditorDocumentView.axaml.cs
+++ b/SWLOR.Toolset/Editors/Views/Tlk/TlkEditorDocumentView.axaml.cs
@@ -42,13 +42,33 @@ public partial class TlkEditorDocumentView : UserControl
     private async void OnCopyRowId(object? sender, RoutedEventArgs args)
     {
         if (DataContext is TlkEditorDocumentViewModel viewModel)
-            await SetClipboardTextAsync(viewModel.SelectedIdDisplay);
+        {
+            args.Handled = true;
+            try
+            {
+                await SetClipboardTextAsync(viewModel.SelectedIdDisplay);
+            }
+            catch (Exception ex)
+            {
+                viewModel.ReportClipboardFailure("copy the TLK row ID", ex);
+            }
+        }
     }
 
     private async void OnCopyStrRef(object? sender, RoutedEventArgs args)
     {
         if (DataContext is TlkEditorDocumentViewModel viewModel)
-            await SetClipboardTextAsync(viewModel.SelectedStrRefDisplay);
+        {
+            args.Handled = true;
+            try
+            {
+                await SetClipboardTextAsync(viewModel.SelectedStrRefDisplay);
+            }
+            catch (Exception ex)
+            {
+                viewModel.ReportClipboardFailure("copy the custom StrRef", ex);
+            }
+        }
     }
 
     private async void OnRowGridKeyDown(object? sender, KeyEventArgs args)
@@ -71,17 +91,29 @@ public partial class TlkEditorDocumentView : UserControl
                 .ToArray();
             if (ids.Length > 0)
             {
-                await clipboard.SetTextAsync(viewModel.CopyRows(ids));
                 args.Handled = true;
+                try
+                {
+                    await clipboard.SetTextAsync(viewModel.CopyRows(ids));
+                }
+                catch (Exception ex)
+                {
+                    viewModel.ReportClipboardFailure("copy TLK rows", ex);
+                }
             }
         }
         else if (args.Key == Key.V)
         {
-            var text = await clipboard.TryGetTextAsync();
-            if (text != null)
+            args.Handled = true;
+            try
             {
-                await viewModel.PasteRowsAsync(text);
-                args.Handled = true;
+                var text = await clipboard.TryGetTextAsync();
+                if (text != null)
+                    await viewModel.PasteRowsAsync(text);
+            }
+            catch (Exception ex)
+            {
+                viewModel.ReportClipboardFailure("paste TLK rows", ex);
             }
         }
     }

--- a/SWLOR.Toolset/Editors/Views/Tlk/TlkEditorDocumentView.axaml.cs
+++ b/SWLOR.Toolset/Editors/Views/Tlk/TlkEditorDocumentView.axaml.cs
@@ -24,12 +24,16 @@ public partial class TlkEditorDocumentView : UserControl
             return;
         _subscribed = viewModel;
         viewModel.SelectionNavigationRequested += OnSelectionNavigationRequested;
+        viewModel.EntryEditRequested += OnEntryEditRequested;
     }
 
     private void UnsubscribeFromNavigation()
     {
         if (_subscribed != null)
+        {
             _subscribed.SelectionNavigationRequested -= OnSelectionNavigationRequested;
+            _subscribed.EntryEditRequested -= OnEntryEditRequested;
+        }
         _subscribed = null;
     }
 
@@ -38,6 +42,8 @@ public partial class TlkEditorDocumentView : UserControl
         if (DataContext is TlkEditorDocumentViewModel viewModel && viewModel.SelectedRow != null)
             RowGrid.ScrollIntoView(viewModel.SelectedRow);
     }
+
+    private void OnEntryEditRequested() => SelectedTextEditor.Focus();
 
     private async void OnCopyRowId(object? sender, RoutedEventArgs args)
     {

--- a/SWLOR.Toolset/Editors/Views/Tlk/TlkEditorLoadingDocumentView.axaml
+++ b/SWLOR.Toolset/Editors/Views/Tlk/TlkEditorLoadingDocumentView.axaml
@@ -1,0 +1,16 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:tlk="using:SWLOR.Toolset.Editors.Tlk"
+             x:Class="SWLOR.Toolset.Editors.Tlk.TlkEditorLoadingDocumentView"
+             x:DataType="tlk:TlkEditorLoadingDocumentViewModel">
+  <Grid Margin="24">
+    <StackPanel Width="420" Spacing="14"
+                HorizontalAlignment="Center" VerticalAlignment="Center">
+      <TextBlock Text="Loading TLK Editor" FontSize="20" FontWeight="SemiBold"
+                 HorizontalAlignment="Center" />
+      <ProgressBar IsIndeterminate="True" Height="4" />
+      <TextBlock Text="Reading the SWLOR custom TLK and indexing references…"
+                 Classes="dim" TextAlignment="Center" TextWrapping="Wrap" />
+    </StackPanel>
+  </Grid>
+</UserControl>

--- a/SWLOR.Toolset/Editors/Views/Tlk/TlkEditorLoadingDocumentView.axaml.cs
+++ b/SWLOR.Toolset/Editors/Views/Tlk/TlkEditorLoadingDocumentView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace SWLOR.Toolset.Editors.Tlk;
+
+public partial class TlkEditorLoadingDocumentView : UserControl
+{
+    public TlkEditorLoadingDocumentView()
+    {
+        InitializeComponent();
+    }
+}

--- a/SWLOR.Toolset/Editors/Waypoints/WaypointEditorViewModel.cs
+++ b/SWLOR.Toolset/Editors/Waypoints/WaypointEditorViewModel.cs
@@ -229,6 +229,27 @@ namespace SWLOR.Toolset.Editors.Waypoints
             RefreshCompleteness();
         }
 
+        /// <summary>Rebuilds every materialized choice row after TLK-backed labels change.</summary>
+        public void RefreshTlkLabels()
+        {
+            RebuildChoiceRows(BasicRows);
+            RebuildChoiceRows(BehaviorRows);
+            RefreshCompleteness();
+        }
+
+        private void RebuildChoiceRows(ObservableCollection<WaypointRowViewModel> rows)
+        {
+            for (var index = 0; index < rows.Count; index++)
+            {
+                if (rows[index].Definition.ChoicesKey == null)
+                    continue;
+
+                var definition = rows[index].Definition;
+                rows[index].Dispose();
+                rows[index] = CreateRow(definition);
+            }
+        }
+
         public bool PrepareForSave()
         {
             RefreshCompleteness();

--- a/SWLOR.Toolset/SWLOR.Toolset.csproj
+++ b/SWLOR.Toolset/SWLOR.Toolset.csproj
@@ -55,4 +55,8 @@
     <ProjectReference Include="..\SWLOR.Toolset.Domain\SWLOR.Toolset.Domain.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="SWLOR.Toolset.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/SWLOR.Toolset/Shell/MainWindow.axaml
+++ b/SWLOR.Toolset/Shell/MainWindow.axaml
@@ -47,6 +47,9 @@
                   Command="{Binding AreaGeneratorCommand}" />
         <MenuItem x:Name="FactionEditorMenuItem" Header="_Faction Editor..."
                   Command="{Binding FactionEditorCommand}" />
+        <MenuItem x:Name="TlkEditorMenuItem" Header="_TLK Editor..."
+                  Command="{Binding TlkEditorCommand}"
+                  ToolTip.Tip="{Binding TlkEditorAvailabilityMessage}" />
         <Separator />
         <MenuItem Header="Run Validation" Command="{Binding FocusValidationCommand}" />
         <Separator />

--- a/SWLOR.Toolset/Shell/Panels/ModuleExplorerViewModel.cs
+++ b/SWLOR.Toolset/Shell/Panels/ModuleExplorerViewModel.cs
@@ -145,6 +145,11 @@ namespace SWLOR.Toolset.Shell.Panels
                 if (_workspaceContext.Catalog is { } catalog)
                     RefreshFromCatalog(catalog);
             };
+            _workspaceContext.CatalogLabelsChanged += () =>
+            {
+                if (_workspaceContext.Catalog is { } catalog)
+                    RefreshFromCatalog(catalog);
+            };
         }
 
         /// <summary>

--- a/SWLOR.Toolset/Shell/Panels/PropertiesViewModel.cs
+++ b/SWLOR.Toolset/Shell/Panels/PropertiesViewModel.cs
@@ -27,6 +27,7 @@ namespace SWLOR.Toolset.Shell.Panels
         private readonly PortraitService? _portraitService;
         private readonly TlkService? _tlkService;
         private readonly OutputLogService _log;
+        private CatalogEntry? _selectedEntry;
 
         [ObservableProperty]
         private string _selectionTitle = "(nothing selected)";
@@ -55,6 +56,8 @@ namespace SWLOR.Toolset.Shell.Panels
             var workspace = _workspaceContext.Workspace;
             if (workspace == null)
                 return;
+
+            _selectedEntry = entry;
 
             SelectionTitle = $"{entry.ResourceTypeDisplayName} — {entry.ResRef}";
             Rows.Clear();
@@ -89,6 +92,13 @@ namespace SWLOR.Toolset.Shell.Panels
                 Rows.Add(new PropertyRow("Error", ex.Message));
                 _log.AppendLine($"Failed to load '{entry.ResRef}' ({entry.ResourceTypeDisplayName}): {ex.Message}");
             }
+        }
+
+        /// <summary>Rebuilds the current materialized rows after the active TLK generation changes.</summary>
+        public void RefreshTlkLabels()
+        {
+            if (_selectedEntry != null)
+                ShowEntry(_selectedEntry);
         }
 
         private void ShowConversationSummary(ModuleWorkspace workspace, string resRef)

--- a/SWLOR.Toolset/Shell/Panels/SearchViewModel.cs
+++ b/SWLOR.Toolset/Shell/Panels/SearchViewModel.cs
@@ -42,6 +42,7 @@ namespace SWLOR.Toolset.Shell.Panels
             Id = "Search";
             Title = "Search";
             _workspaceContext.CatalogEntriesChanged += (_, _) => Refresh();
+            _workspaceContext.CatalogLabelsChanged += Refresh;
         }
 
         /// <summary>

--- a/SWLOR.Toolset/Shell/ShellViewModel.cs
+++ b/SWLOR.Toolset/Shell/ShellViewModel.cs
@@ -111,6 +111,7 @@ namespace SWLOR.Toolset.Shell
         private readonly ModuleCustomContentService? _moduleCustomContent;
         private readonly TilesetCatalog? _tilesetCatalog;
         private readonly ResourceIndex? _resourceIndex;
+        private readonly Editors.Tlk.TlkEditorSource? _tlkEditorSource;
 
         /// <summary>Guards against a second rescan starting while one is already reopening the catalog.</summary>
         private bool _isRescanningAfterWatcherOverflow;
@@ -141,8 +142,10 @@ namespace SWLOR.Toolset.Shell
             ErfArchiveService? erfArchiveService = null,
             ModuleCustomContentService? moduleCustomContent = null,
             TilesetCatalog? tilesetCatalog = null,
-            ResourceIndex? resourceIndex = null)
+            ResourceIndex? resourceIndex = null,
+            Editors.Tlk.TlkEditorSource? tlkEditorSource = null)
         {
+            _tlkEditorSource = tlkEditorSource;
             _resourceIndex = resourceIndex;
             _tilesetCatalog = tilesetCatalog;
             _moduleCustomContent = moduleCustomContent;
@@ -449,6 +452,18 @@ namespace SWLOR.Toolset.Shell
                 RunPackFromModulePropertiesAsync,
                 OpenBuildConfiguration));
         }
+
+        public string TlkEditorAvailabilityMessage => _tlkEditorSource?.IsAvailable == true
+            ? "Edit SWLOR's custom sw_tlk source and generated binary."
+            : _tlkEditorSource?.UnavailableReason ??
+              "TLK Editor is unavailable because the SWLOR repository root could not be resolved.";
+
+        [RelayCommand(CanExecute = nameof(CanOpenTlkEditor))]
+        private async Task TlkEditor() =>
+            await _editorService.Value.OpenTlkEditorAsync().ConfigureAwait(true);
+
+        private bool CanOpenTlkEditor() =>
+            !IsInteractionBlocked && _tlkEditorSource?.IsAvailable == true;
 
         private async Task RunValidationFromModulePropertiesAsync()
         {
@@ -900,6 +915,7 @@ namespace SWLOR.Toolset.Shell
             PackModuleCommand.NotifyCanExecuteChanged();
             BuildAllScriptsCommand.NotifyCanExecuteChanged();
             ModulePropertiesCommand.NotifyCanExecuteChanged();
+            TlkEditorCommand.NotifyCanExecuteChanged();
             NotifyActiveEditorCommandsChanged();
         }
 

--- a/SWLOR.Toolset/Shell/ToolsetDockFactory.cs
+++ b/SWLOR.Toolset/Shell/ToolsetDockFactory.cs
@@ -212,6 +212,9 @@ namespace SWLOR.Toolset.Shell
         /// <summary>Re-reads the front area in the tile-facing panels, after its tileset changed.</summary>
         public void NotifyActiveAreaChanged() => _palette.OnActiveAreaChanged();
 
+        /// <summary>Rebuilds materialized tool-panel values that resolve through the TLK.</summary>
+        public void RefreshTlkLabels() => _properties.RefreshTlkLabels();
+
         /// <summary>Docks an editor document into the Documents area and activates it.</summary>
         public void OpenDocument(Document document)
         {

--- a/SWLOR.Toolset/Workspace/CategoryService.cs
+++ b/SWLOR.Toolset/Workspace/CategoryService.cs
@@ -473,6 +473,13 @@ namespace SWLOR.Toolset.Workspace
         /// <summary>Re-reads the tree in open views without writing anything.</summary>
         public void NotifyChanged() => Changed?.Invoke();
 
+        /// <summary>Drops TLK-resolved standard palette names and refreshes open category views.</summary>
+        public void RefreshTlkLabels()
+        {
+            _standardPalettes.Clear();
+            Changed?.Invoke();
+        }
+
         private StandardPalette StandardPaletteFor(ResourceType type)
         {
             if (_standardPalettes.TryGetValue(type, out var cached))

--- a/SWLOR.Toolset/Workspace/WorkspaceContext.cs
+++ b/SWLOR.Toolset/Workspace/WorkspaceContext.cs
@@ -22,6 +22,8 @@ namespace SWLOR.Toolset.Workspace
 
         public event Action? WorkspaceOpened;
         public event Action? CatalogBuildCompleted;
+        /// <summary>Raised once after materialized catalog names are re-resolved from a new TLK.</summary>
+        public event Action? CatalogLabelsChanged;
         /// <summary>
         /// Raised for every saved, reloaded, created, or removed resource so content-dependent
         /// caches can invalidate even when its catalog Name/Tag did not change.
@@ -246,6 +248,16 @@ namespace SWLOR.Toolset.Workspace
             CatalogEntryRefreshed?.Invoke(type, resRef);
             if (catalogChanged)
                 CatalogEntriesChanged?.Invoke(type, resRef);
+        }
+
+        /// <summary>
+        /// Re-resolves catalog display names from cached LocString metadata after a TLK publication.
+        /// This does not reopen the module's blueprint files.
+        /// </summary>
+        public void RefreshTlkLabels()
+        {
+            if (Catalog?.RefreshTlkLabels() == true)
+                CatalogLabelsChanged?.Invoke();
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

- add a singleton docked TLK Editor for `SWLOR_Haks/sw_tlk/sw_tlk.tlk.json`
- support raw row/custom StrRef navigation, filtering, previous/next find, exact matching, and safe first/next blank allocation
- index custom TLK references across SWLOR 2DAs and protect referenced blank rows
- support multiline row editing plus lossless multi-row copy/paste
- add Open TLK Row shortcuts to supported custom-StrRef LocString fields
- save JSON and generated TLK binary as a verified paired transaction, then publish the exact accepted binary generation to open toolset labels
- add a managed text-only TLK V3.0 writer with shared reader/writer safety limits

## Validation

- `dotnet build SWLOR.Toolset.Tests\SWLOR.Toolset.Tests.csproj -p:RunPostBuildEvent=Never --no-restore`
- `dotnet test SWLOR.Toolset.Tests\SWLOR.Toolset.Tests.csproj --no-build --filter "FullyQualifiedName~Tlk|FullyQualifiedName~ViewLocator" -p:RunPostBuildEvent=Never` — 66 passed
- `dotnet test SWLOR.NWN.Formats.Tests\SWLOR.NWN.Formats.Tests.csproj --no-build -p:RunPostBuildEvent=Never` — 75 passed
- broad Toolset run: 2,963 passed, 1 skipped; four pre-existing unrelated corpus/serializer assertions reproduced in isolation
- repeated independent writer/save and UI/lifecycle reviews completed with no actionable findings

The SWLOR_Haks submodule pointer is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated TLK editor accessible from the Tools menu.
  * Edit, filter, navigate, copy, paste, undo, and redo localized text entries.
  * Add or remove sparse rows and open custom TLK rows from localized-string fields.
  * View repository-wide references and usage details.
  * Save and publish validated TLK updates, with loading progress and cancellation.
  * Refresh localized labels and dropdown options after TLK changes.

* **Bug Fixes**
  * Improved validation for encoding, references, file changes, and allocation limits.

* **Tests**
  * Expanded coverage for editing, persistence, navigation, references, encoding, and boundary conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->