### PR TITLE
Fix beast stamina regen and Coordinated Strike

### DIFF
--- a/SWLOR.Game.Server.EngineTests/Definitions/AbilityBehaviors/BeastmasterAbilityBehaviors.cs
+++ b/SWLOR.Game.Server.EngineTests/Definitions/AbilityBehaviors/BeastmasterAbilityBehaviors.cs
@@ -202,8 +202,8 @@ namespace SWLOR.Game.Server.EngineTests.Definitions.AbilityBehaviors
                     ExpectsRecast = true,
                 },
 
-                // CoordinatedStrikeAbilityDefinition - hostile direct damage, no status; the
-                // "recent master damage" bonus is a conditional percent adjustment, not asserted.
+                // CoordinatedStrikeAbilityDefinition - queued natural-weapon damage, no status;
+                // the "recent master damage" bonus is a conditional percent adjustment, not asserted.
                 new()
                 {
                     Feat = FeatType.CoordinatedStrike1,

--- a/SWLOR.Game.Server.Tests/Perks/BeastmasterCombatUpgradeTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/BeastmasterCombatUpgradeTests.cs
@@ -153,6 +153,34 @@ public class BeastmasterCombatUpgradeTests
     }
 
     [Test]
+    public void CoordinatedStrike_UsesSelfTargeted2daRows()
+    {
+        var root = FindRepositoryRoot();
+        var featRows = Test2daHelper.Read2da(new FileInfo(Path.Combine(
+            root.FullName,
+            "SWLOR_Haks",
+            "sw_2da",
+            "feat.2da")));
+        var spellRows = Test2daHelper.Read2da(new FileInfo(Path.Combine(
+            root.FullName,
+            "SWLOR_Haks",
+            "sw_2da",
+            "spells.2da")));
+
+        foreach (var feat in new[] { FeatType.CoordinatedStrike1, FeatType.CoordinatedStrike2 })
+        {
+            var featRow = featRows[(int)feat];
+            featRow["TARGETSELF"].Should().Be("1");
+            featRow["HostileFeat"].Should().Be("****");
+
+            var spellRow = spellRows[int.Parse(featRow["SPELLID"])];
+            spellRow["Range"].Should().Be("P");
+            spellRow["TargetType"].Should().Be("0x01");
+            spellRow["HostileSetting"].Should().Be("0");
+        }
+    }
+
+    [Test]
     public void TameChance_ScalesSocialByThreePercentAndCapsAtSeventyFive()
     {
         var baseline = TameAbilityDefinition.CalculateTameChance(

--- a/SWLOR.Game.Server.Tests/Perks/BeastmasterCombatUpgradeTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/BeastmasterCombatUpgradeTests.cs
@@ -100,6 +100,20 @@ public class BeastmasterCombatUpgradeTests
         var executePrey = new ExecutePreyAbilityDefinition().BuildAbilities()[FeatType.ExecutePrey1];
         AssertQueuedBeastAbility(executePrey, "Execute Prey", RecastGroup.ExecutePrey, 30f, 8);
 
+        var coordinatedStrike = new CoordinatedStrikeAbilityDefinition().BuildAbilities();
+        AssertQueuedBeastAbility(
+            coordinatedStrike[FeatType.CoordinatedStrike1],
+            "Coordinated Strike I",
+            RecastGroup.CoordinatedStrike,
+            15f,
+            5);
+        AssertQueuedBeastAbility(
+            coordinatedStrike[FeatType.CoordinatedStrike2],
+            "Coordinated Strike II",
+            RecastGroup.CoordinatedStrike,
+            15f,
+            7);
+
         var apexBite = new ApexBiteAbilityDefinition().BuildAbilities()[FeatType.ApexBite1];
         AssertQueuedBeastAbility(apexBite, "Apex Bite", RecastGroup.ApexBite, 45f, 10);
 

--- a/SWLOR.Game.Server.Tests/Service/NaturalStaminaRegenerationTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/NaturalStaminaRegenerationTests.cs
@@ -1,0 +1,62 @@
+using FluentAssertions;
+using NUnit.Framework;
+using SWLOR.Game.Server.Service;
+
+namespace SWLOR.Game.Server.Tests.Service;
+
+public class NaturalStaminaRegenerationTests
+{
+    [Test]
+    public void BeastNaturalStaminaRegeneration_WaitsSixSecondsAfterStaminaSpend()
+    {
+        var spentAt = new DateTime(2026, 8, 25, 12, 0, 0, DateTimeKind.Utc);
+        var availableAt = spentAt.AddSeconds(Stat.BeastNaturalStaminaRegenDelaySeconds);
+
+        Stat.IsNaturalStaminaRegenerationAvailable(availableAt.Ticks, spentAt.Ticks)
+            .Should().BeFalse();
+        Stat.IsNaturalStaminaRegenerationAvailable(availableAt.Ticks, availableAt.AddTicks(-1).Ticks)
+            .Should().BeFalse();
+        Stat.IsNaturalStaminaRegenerationAvailable(availableAt.Ticks, availableAt.Ticks)
+            .Should().BeTrue();
+    }
+
+    [Test]
+    public void BeastHeartbeat_UsesDelayedStaminaRegenerationWithoutCombatGating()
+    {
+        var root = FindRepositoryRoot();
+        var beastMastery = File.ReadAllText(Path.Combine(
+            root,
+            "SWLOR.Game.Server",
+            "Service",
+            "BeastMastery.cs"));
+        var stat = File.ReadAllText(Path.Combine(
+            root,
+            "SWLOR.Game.Server",
+            "Service",
+            "Stat.cs"));
+
+        beastMastery.Should().Contain("Stat.RestoreBeastStats();");
+        stat.Should().Contain("RestoreNPCStats(false, true);");
+        stat.Should().Contain("BeastMastery.IsPlayerBeast(creature)");
+
+        var restoreBeastStats = stat.Substring(
+            stat.IndexOf("public static void RestoreBeastStats()", StringComparison.Ordinal),
+            stat.IndexOf("public static bool IsNaturalStaminaRegenerationAvailable", StringComparison.Ordinal) -
+            stat.IndexOf("public static void RestoreBeastStats()", StringComparison.Ordinal));
+        restoreBeastStats.Should().NotContain("GetIsInCombat");
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(TestContext.CurrentContext.TestDirectory);
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "SWLOR.Game.Server.sln")))
+                return directory.FullName;
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate the SWLOR_NWN repository root.");
+    }
+}

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Beastmaster/CoordinatedStrikeAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Beastmaster/CoordinatedStrikeAbilityDefinition.cs
@@ -37,9 +37,8 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Beastmaster
                 .HasRecastDelay(RecastGroup.CoordinatedStrike, 15f)
                 .SkillType(SkillType.BeastMastery)
                 .IsSingleTargetAbility()
-                .RequiresTarget()
                 .HasImpactAction(CoordinatedStrike1ImpactAction)
-                .IsCastedAbility()
+                .IsWeaponAbility()
                 .IsHostileAbility()
                 .BreaksStealth()
                 .RequirementStamina(5);
@@ -56,9 +55,8 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Beastmaster
                 .HasRecastDelay(RecastGroup.CoordinatedStrike, 15f)
                 .SkillType(SkillType.BeastMastery)
                 .IsSingleTargetAbility()
-                .RequiresTarget()
                 .HasImpactAction(CoordinatedStrike2ImpactAction)
-                .IsCastedAbility()
+                .IsWeaponAbility()
                 .IsHostileAbility()
                 .BreaksStealth()
                 .RequirementStamina(7);

--- a/SWLOR.Game.Server/Service/BeastMastery.cs
+++ b/SWLOR.Game.Server/Service/BeastMastery.cs
@@ -504,7 +504,7 @@ namespace SWLOR.Game.Server.Service
         [NWNEventHandler(ScriptName.OnBeastHeartbeat)]
         public static void BeastOnHeartbeat()
         {
-            Stat.RestoreNPCStats(false);
+            Stat.RestoreBeastStats();
             CompanionControl.ProcessHeartbeat(OBJECT_SELF);
         }
 

--- a/SWLOR.Game.Server/Service/Stat.cs
+++ b/SWLOR.Game.Server/Service/Stat.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using NWN.Native.API;
 using SWLOR.Game.Server.Core;
@@ -34,6 +35,8 @@ namespace SWLOR.Game.Server.Service
         private const float DefaultNPCMovementSpeedIncrease = 0.30f;
         private const int MaximumNPCHitPoints = 30000;
         private const int MaximumNPCHitPointAlignmentPasses = 4;
+        public const float BeastNaturalStaminaRegenDelaySeconds = 6f;
+        private const string BeastNaturalStaminaRegenAvailableAtVariable = "BEAST_STAMINA_REGEN_AVAILABLE_AT";
         public const int DefaultMeleeDeflectionChanceCap = 50;
         public const int DefaultRangedDeflectionChanceCap = 50;
         public const int MaximumDeflectionChanceCap = 100;
@@ -481,12 +484,22 @@ namespace SWLOR.Game.Server.Service
             }
             else
             {
-                var stamina = GetLocalInt(creature, "STAMINA");
+                var currentStamina = GetLocalInt(creature, "STAMINA");
+                var stamina = currentStamina;
                 stamina -= reduceBy;
                 if (stamina < 0)
                     stamina = 0;
 
                 SetLocalInt(creature, "STAMINA", stamina);
+
+                if (stamina < currentStamina && BeastMastery.IsPlayerBeast(creature))
+                {
+                    var availableAt = DateTime.UtcNow.AddSeconds(BeastNaturalStaminaRegenDelaySeconds);
+                    SetLocalString(
+                        creature,
+                        BeastNaturalStaminaRegenAvailableAtVariable,
+                        availableAt.Ticks.ToString(CultureInfo.InvariantCulture));
+                }
             }
 
             ExecuteScript("pc_stm_adjusted", creature);
@@ -2526,6 +2539,25 @@ namespace SWLOR.Game.Server.Service
         /// </summary>
         public static void RestoreNPCStats(bool outOfCombatRegen)
         {
+            RestoreNPCStats(outOfCombatRegen, false);
+        }
+
+        /// <summary>
+        /// Restores a beast's FP and STM. STM regeneration remains active in and out of combat,
+        /// but cannot begin until six seconds after the beast last spent STM.
+        /// </summary>
+        public static void RestoreBeastStats()
+        {
+            RestoreNPCStats(false, true);
+        }
+
+        public static bool IsNaturalStaminaRegenerationAvailable(long availableAtTicks, long currentTicks)
+        {
+            return availableAtTicks <= 0 || currentTicks >= availableAtTicks;
+        }
+
+        private static void RestoreNPCStats(bool outOfCombatRegen, bool respectsStaminaRegenDelay)
+        {
             var self = OBJECT_SELF;
             if (GetLocalInt(self, SuppressNaturalRegenVariable) != 0)
                 return;
@@ -2533,7 +2565,10 @@ namespace SWLOR.Game.Server.Service
             var maxFP = GetMaxFP(self);
             var maxSTM = GetMaxStamina(self);
             var fp = GetLocalInt(self, "FP") + 1;
-            var stm = GetLocalInt(self, "STAMINA") + 1;
+            var stm = GetLocalInt(self, "STAMINA");
+            var canRestoreStamina = !respectsStaminaRegenDelay || CanRestoreBeastStamina(self);
+            if (canRestoreStamina)
+                stm++;
 
             if (fp > maxFP)
                 fp = maxFP;
@@ -2554,6 +2589,29 @@ namespace SWLOR.Game.Server.Service
                     ApplyEffectToObject(DurationType.Instant, EffectHeal((int)hpToHeal), self);
                 }
             }
+        }
+
+        private static bool CanRestoreBeastStamina(uint beast)
+        {
+            var availableAtValue = GetLocalString(beast, BeastNaturalStaminaRegenAvailableAtVariable);
+            if (string.IsNullOrWhiteSpace(availableAtValue))
+                return true;
+
+            if (!long.TryParse(
+                    availableAtValue,
+                    NumberStyles.Integer,
+                    CultureInfo.InvariantCulture,
+                    out var availableAtTicks))
+            {
+                DeleteLocalString(beast, BeastNaturalStaminaRegenAvailableAtVariable);
+                return true;
+            }
+
+            if (!IsNaturalStaminaRegenerationAvailable(availableAtTicks, DateTime.UtcNow.Ticks))
+                return false;
+
+            DeleteLocalString(beast, BeastNaturalStaminaRegenAvailableAtVariable);
+            return true;
         }
     }
 }


### PR DESCRIPTION
## Summary
- delay player-beast natural stamina regeneration until six seconds after the beast last spends stamina
- keep beast stamina regeneration active both in and out of combat, without changing generic NPC or droid regeneration
- make Coordinated Strike I and II queue bonus damage on the beast's next landed natural-weapon attack
- preserve the existing 25% bonus when the beast attacks a target recently damaged by its master
- align both feat and linked spell rows with self-targeted queued activation
- add regression coverage for the stamina boundary, queued ability definitions, and client targeting metadata

## Validation
- `dotnet build SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj -p:RunPostBuildEvent=Never`
- 104 focused tests passed across Beastmaster, stamina regeneration, area targeting, damage queues, perk interactions, and combat damage
- `BuildHaks.cmd` completed successfully
- `PackModule.cmd` completed successfully (16,143 module files; 126 scripts)

## Review follow-up
- addressed Codex's spell-row targeting finding by setting Coordinated Strike I/II to personal range, self target type, and non-hostile activation metadata

## Companion PR
- HAK targeting data: https://github.com/zunath/SWLOR_Haks/pull/391