### PR TITLE
Spawn called beasts at full health

### DIFF
--- a/SWLOR.Game.Server.Tests/Perks/BeastSpawnHealthTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/BeastSpawnHealthTests.cs
@@ -1,0 +1,51 @@
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace SWLOR.Game.Server.Tests.Perks;
+
+public class BeastSpawnHealthTests
+{
+    [Test]
+    public void CallBeast_SpawnsAtFullHealthWithoutWaitingForTheDelayedCorrection()
+    {
+        var root = FindRepositoryRoot();
+        var callBeast = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "SWLOR.Game.Server",
+            "Feature",
+            "AbilityDefinition",
+            "Beastmaster",
+            "CallBeastAbilityDefinition.cs"));
+        var beastMastery = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "SWLOR.Game.Server",
+            "Service",
+            "BeastMastery.cs"));
+
+        callBeast.Should().Contain(
+            "BeastMastery.SpawnBeast(activator, dbPlayer.ActiveBeastId, 100);",
+            "Call Beast should request a full-health companion");
+
+        var immediateRestore = beastMastery.IndexOf(
+            "if (percentHeal >= 100)",
+            StringComparison.Ordinal);
+        var delayedCorrection = beastMastery.IndexOf(
+            "DelayCommand(4f",
+            StringComparison.Ordinal);
+
+        immediateRestore.Should().BeGreaterThan(-1);
+        delayedCorrection.Should().BeGreaterThan(immediateRestore,
+            "full-health spawns should be restored before the delayed HP correction runs");
+    }
+
+    private static DirectoryInfo FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(TestContext.CurrentContext.TestDirectory);
+        while (directory != null && !File.Exists(Path.Combine(directory.FullName, "SWLOR.Game.Server.sln")))
+        {
+            directory = directory.Parent;
+        }
+
+        return directory ?? throw new DirectoryNotFoundException("Could not locate the SWLOR_NWN repository root.");
+    }
+}

--- a/SWLOR.Game.Server.Tests/Perks/BeastSpawnHealthTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/BeastSpawnHealthTests.cs
@@ -32,10 +32,17 @@ public class BeastSpawnHealthTests
         var delayedCorrection = beastMastery.IndexOf(
             "DelayCommand(4f",
             StringComparison.Ordinal);
+        var immediateSetMax = beastMastery.IndexOf(
+            "SetCurrentHitPoints(beast, GetMaxHitPoints(beast));",
+            StringComparison.Ordinal);
 
         immediateRestore.Should().BeGreaterThan(-1);
+        immediateSetMax.Should().BeGreaterThan(immediateRestore,
+            "the full-health branch should restore the beast to its maximum hit points");
         delayedCorrection.Should().BeGreaterThan(immediateRestore,
             "full-health spawns should be restored before the delayed HP correction runs");
+        immediateSetMax.Should().BeLessThan(delayedCorrection,
+            "the beast should reach full health immediately rather than after the delayed correction");
     }
 
     private static DirectoryInfo FindRepositoryRoot()

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Beastmaster/CallBeastAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Beastmaster/CallBeastAbilityDefinition.cs
@@ -76,7 +76,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Beastmaster
                     var playerId = GetObjectUUID(activator);
                     var dbPlayer = DB.Get<Player>(playerId);
 
-                    BeastMastery.SpawnBeast(activator, dbPlayer.ActiveBeastId, 50);
+                    BeastMastery.SpawnBeast(activator, dbPlayer.ActiveBeastId, 100);
 
                     Enmity.ModifyEnmityOnAll(activator, 230);
                     CombatPoint.AddCombatPointToAllTagged(activator, SkillType.BeastMastery);

--- a/SWLOR.Game.Server/Service/BeastMastery.cs
+++ b/SWLOR.Game.Server/Service/BeastMastery.cs
@@ -304,6 +304,13 @@ namespace SWLOR.Game.Server.Service
             // because it doesn't exist at the time of the beast being created.
             ExecuteScript(GetEventScript(beast, EventScript.Creature_OnSpawnIn), beast);
 
+            // A normal Call Beast spawn requests 100% health. Restore it immediately so the
+            // companion does not appear near death while waiting for the delayed HP correction.
+            if (percentHeal >= 100)
+            {
+                SetCurrentHitPoints(beast, GetMaxHitPoints(beast));
+            }
+
             AssignCommand(GetModule(), () =>
             {
                 DelayCommand(4f, () =>


### PR DESCRIPTION
## Summary

- make Call Beast request a full-health companion instead of a 50% heal
- restore full health immediately so the beast does not appear near death during the delayed engine HP correction
- add regression coverage for the requested health percentage and restore ordering

## Validation

- `dotnet build SWLOR.Game.Server.Tests\\SWLOR.Game.Server.Tests.csproj -p:RunPostBuildEvent=Never`
- `dotnet test SWLOR.Game.Server.Tests\\SWLOR.Game.Server.Tests.csproj --no-build --filter "FullyQualifiedName~BeastSpawnHealthTests"` (1 passed)

## Review

- addressed the automated finding by asserting the immediate max-HP assignment in the regression test
- Codex review is clean on head `b550e3e0ae`
- CodeRabbit completed successfully with zero unresolved review threads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Beasts summoned with Call Beast now spawn at full health immediately.
  * Improved health restoration timing to prevent beasts from briefly appearing injured after being summoned.

* **Tests**
  * Added coverage to verify full-health spawning and immediate restoration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->