### PR TITLE
Prevent redundant Bolster Attack recasts

### DIFF
--- a/SWLOR.Game.Server.Tests/AI/AIModelTests.cs
+++ b/SWLOR.Game.Server.Tests/AI/AIModelTests.cs
@@ -3,10 +3,13 @@ using System.Reflection;
 using System.Text.RegularExpressions;
 using FluentAssertions;
 using NUnit.Framework;
+using SWLOR.Game.Server.Feature.AbilityDefinition.Beastmaster;
+using SWLOR.Game.Server.Feature.StatusEffectDefinition;
 using SWLOR.Game.Server.Native;
 using SWLOR.Game.Server.Service;
 using SWLOR.Game.Server.Service.AbilityService;
 using SWLOR.Game.Server.Service.AIService;
+using SWLOR.Game.Server.Service.StatusEffectService;
 using SWLOR.NWN.API.NWScript.Enum;
 using static SWLOR.NWN.API.NWScript.NWScript;
 
@@ -183,6 +186,51 @@ public class AIModelTests
         CreatureToEnemies()[target] = new List<uint> { self };
 
         score(CreateContext(self: self)).Should().Be(AIScoreBand.Defensive + 4);
+    }
+
+    [Test]
+    public void BolsterAttackAIScore_SuppressesEachActiveBuffRank()
+    {
+        const uint self = 100;
+        const uint target = 200;
+        var creatureEffects = (Dictionary<uint, CreatureStatusEffect>)typeof(StatusEffect)
+            .GetField("_creatureEffects", BindingFlags.NonPublic | BindingFlags.Static)!
+            .GetValue(null)!;
+        var tracker = new CreatureStatusEffect();
+        var abilities = new BolsterAttackAbilityDefinition().BuildAbilities();
+        var ranks = new (FeatType Feat, IStatusEffect StatusEffect, int AbilityLevel)[]
+        {
+            (FeatType.BolsterAttack1, new BolsterAttack1StatusEffect(), 1),
+            (FeatType.BolsterAttack2, new BolsterAttack2StatusEffect(), 2),
+            (FeatType.BolsterAttack3, new BolsterAttack3StatusEffect(), 3)
+        };
+
+        EnemyEnmityTables()[self] = new Dictionary<uint, int>
+        {
+            [target] = 1
+        };
+        CreatureToEnemies()[target] = new List<uint> { self };
+        creatureEffects[self] = tracker;
+
+        try
+        {
+            var context = CreateContext(self: self);
+
+            foreach (var (feat, statusEffect, abilityLevel) in ranks)
+            {
+                var score = abilities[feat].AIScore;
+                score.Should().NotBeNull();
+                score!(context).Should().Be(AIScoreBand.Defensive + abilityLevel);
+
+                tracker.Add(statusEffect);
+                score(context).Should().Be(0);
+                tracker.Remove(statusEffect);
+            }
+        }
+        finally
+        {
+            creatureEffects.Remove(self);
+        }
     }
 
     [Test]

--- a/SWLOR.Game.Server.Tests/AI/AIModelTests.cs
+++ b/SWLOR.Game.Server.Tests/AI/AIModelTests.cs
@@ -189,7 +189,7 @@ public class AIModelTests
     }
 
     [Test]
-    public void BolsterAttackAIScore_SuppressesEachActiveBuffRank()
+    public void BolsterAttackAIScore_UsesActiveRankStat()
     {
         const uint self = 100;
         const uint target = 200;
@@ -216,6 +216,9 @@ public class AIModelTests
         {
             var context = CreateContext(self: self);
 
+            // A different damage-dealt buff must not be mistaken for Bolster Attack.
+            tracker.Add(new AlphaRhythm1BeastStatusEffect());
+
             foreach (var (feat, statusEffect, abilityLevel) in ranks)
             {
                 var score = abilities[feat].AIScore;
@@ -226,6 +229,11 @@ public class AIModelTests
                 score(context).Should().Be(0);
                 tracker.Remove(statusEffect);
             }
+
+            // A stronger active rank also makes every weaker Bolster rank redundant.
+            tracker.Add(ranks[2].StatusEffect);
+            foreach (var (feat, _, _) in ranks)
+                abilities[feat].AIScore!(context).Should().Be(0);
         }
         finally
         {

--- a/SWLOR.Game.Server.Tests/Perks/BeastmasterCombatUpgradeTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/BeastmasterCombatUpgradeTests.cs
@@ -60,6 +60,9 @@ public class BeastmasterCombatUpgradeTests
     {
         new BolsterAttack1StatusEffect().StatGroup.Stats[StatType.DamageDealtPercentAdjustment].Should().Be(5);
         new BolsterAttack3StatusEffect().StatGroup.Stats[StatType.DamageDealtPercentAdjustment].Should().Be(12);
+        new BolsterAttack1StatusEffect().StatGroup.Stats[StatType.BolsterAttackRank].Should().Be(1);
+        new BolsterAttack2StatusEffect().StatGroup.Stats[StatType.BolsterAttackRank].Should().Be(2);
+        new BolsterAttack3StatusEffect().StatGroup.Stats[StatType.BolsterAttackRank].Should().Be(3);
         new Hasten1StatusEffect().StatGroup.Stats[StatType.AttackDelayReductionPercent].Should().Be(15);
         new Hasten2StatusEffect().StatGroup.Stats[StatType.AttackDelayReductionPercent].Should().Be(25);
         new PrimalOverrun1StatusEffect().StatGroup.Stats[StatType.DamageDealtPercentAdjustment].Should().Be(12);

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Beastmaster/BolsterAttackAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Beastmaster/BolsterAttackAbilityDefinition.cs
@@ -7,6 +7,7 @@ using SWLOR.Game.Server.Service.AIService;
 using SWLOR.Game.Server.Service.CombatService;
 using SWLOR.Game.Server.Service.PerkService;
 using SWLOR.Game.Server.Service.SkillService;
+using SWLOR.Game.Server.Service.StatService;
 using SWLOR.Game.Server.Service.StatusEffectService;
 using SWLOR.NWN.API.Engine;
 using SWLOR.NWN.API.NWScript.Enum;
@@ -39,7 +40,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Beastmaster
                 .HasRecastDelay(RecastGroup.BolsterAttack, 18f)
                 .SkillType(SkillType.BeastMastery)
                 .IsSingleTargetAbility()
-                .HasAIScore(AIScore.SelfStatusMissing(typeof(BolsterAttack1StatusEffect), 1))
+                .HasAIScore(AIScore.SelfStatBelow(StatType.BolsterAttackRank, 1, 1))
                 .HasImpactAction(BolsterAttack1ImpactAction)
                 .IsCastedAbility()
                 .BreaksStealth()
@@ -57,7 +58,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Beastmaster
                 .HasRecastDelay(RecastGroup.BolsterAttack, 18f)
                 .SkillType(SkillType.BeastMastery)
                 .IsSingleTargetAbility()
-                .HasAIScore(AIScore.SelfStatusMissing(typeof(BolsterAttack2StatusEffect), 2))
+                .HasAIScore(AIScore.SelfStatBelow(StatType.BolsterAttackRank, 2, 2))
                 .HasImpactAction(BolsterAttack2ImpactAction)
                 .IsCastedAbility()
                 .BreaksStealth()
@@ -75,7 +76,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Beastmaster
                 .HasRecastDelay(RecastGroup.BolsterAttack, 18f)
                 .SkillType(SkillType.BeastMastery)
                 .IsSingleTargetAbility()
-                .HasAIScore(AIScore.SelfStatusMissing(typeof(BolsterAttack3StatusEffect), 3))
+                .HasAIScore(AIScore.SelfStatBelow(StatType.BolsterAttackRank, 3, 3))
                 .HasImpactAction(BolsterAttack3ImpactAction)
                 .IsCastedAbility()
                 .BreaksStealth()

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Beastmaster/BolsterAttackAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Beastmaster/BolsterAttackAbilityDefinition.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using SWLOR.Game.Server.Feature.StatusEffectDefinition;
 using SWLOR.Game.Server.Service;
 using SWLOR.Game.Server.Service.AbilityService;
+using SWLOR.Game.Server.Service.AIService;
 using SWLOR.Game.Server.Service.CombatService;
 using SWLOR.Game.Server.Service.PerkService;
 using SWLOR.Game.Server.Service.SkillService;
@@ -38,6 +39,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Beastmaster
                 .HasRecastDelay(RecastGroup.BolsterAttack, 18f)
                 .SkillType(SkillType.BeastMastery)
                 .IsSingleTargetAbility()
+                .HasAIScore(AIScore.SelfStatusMissing(typeof(BolsterAttack1StatusEffect), 1))
                 .HasImpactAction(BolsterAttack1ImpactAction)
                 .IsCastedAbility()
                 .BreaksStealth()
@@ -55,6 +57,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Beastmaster
                 .HasRecastDelay(RecastGroup.BolsterAttack, 18f)
                 .SkillType(SkillType.BeastMastery)
                 .IsSingleTargetAbility()
+                .HasAIScore(AIScore.SelfStatusMissing(typeof(BolsterAttack2StatusEffect), 2))
                 .HasImpactAction(BolsterAttack2ImpactAction)
                 .IsCastedAbility()
                 .BreaksStealth()
@@ -72,6 +75,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Beastmaster
                 .HasRecastDelay(RecastGroup.BolsterAttack, 18f)
                 .SkillType(SkillType.BeastMastery)
                 .IsSingleTargetAbility()
+                .HasAIScore(AIScore.SelfStatusMissing(typeof(BolsterAttack3StatusEffect), 3))
                 .HasImpactAction(BolsterAttack3ImpactAction)
                 .IsCastedAbility()
                 .BreaksStealth()

--- a/SWLOR.Game.Server/Feature/StatusEffectDefinition/BolsterAttack1StatusEffect.cs
+++ b/SWLOR.Game.Server/Feature/StatusEffectDefinition/BolsterAttack1StatusEffect.cs
@@ -14,6 +14,7 @@ namespace SWLOR.Game.Server.Feature.StatusEffectDefinition
         public BolsterAttack1StatusEffect()
         {
             StatGroup.Stats[StatType.DamageDealtPercentAdjustment] = 5;
+            StatGroup.Stats[StatType.BolsterAttackRank] = 1;
         }
     }
 }

--- a/SWLOR.Game.Server/Feature/StatusEffectDefinition/BolsterAttack2StatusEffect.cs
+++ b/SWLOR.Game.Server/Feature/StatusEffectDefinition/BolsterAttack2StatusEffect.cs
@@ -14,6 +14,7 @@ namespace SWLOR.Game.Server.Feature.StatusEffectDefinition
         public BolsterAttack2StatusEffect()
         {
             StatGroup.Stats[StatType.DamageDealtPercentAdjustment] = 8;
+            StatGroup.Stats[StatType.BolsterAttackRank] = 2;
         }
     }
 }

--- a/SWLOR.Game.Server/Feature/StatusEffectDefinition/BolsterAttack3StatusEffect.cs
+++ b/SWLOR.Game.Server/Feature/StatusEffectDefinition/BolsterAttack3StatusEffect.cs
@@ -14,6 +14,7 @@ namespace SWLOR.Game.Server.Feature.StatusEffectDefinition
         public BolsterAttack3StatusEffect()
         {
             StatGroup.Stats[StatType.DamageDealtPercentAdjustment] = 12;
+            StatGroup.Stats[StatType.BolsterAttackRank] = 3;
         }
     }
 }

--- a/SWLOR.Game.Server/Service/AIService/AIScore.cs
+++ b/SWLOR.Game.Server/Service/AIService/AIScore.cs
@@ -1,5 +1,5 @@
-using System;
 using SWLOR.Game.Server.Service.AbilityService;
+using SWLOR.Game.Server.Service.StatService;
 
 namespace SWLOR.Game.Server.Service.AIService
 {
@@ -25,15 +25,13 @@ namespace SWLOR.Game.Server.Service.AIService
         }
 
         /// <summary>
-        /// Scores a defensive self-buff only while the creature is in combat and the buff is absent.
+        /// Scores a defensive self-buff only while the creature is in combat and its active rank is
+        /// below the rank supplied by the ability.
         /// </summary>
-        public static AIScoreCalculation SelfStatusMissing(Type statusEffectType, int abilityLevel)
+        public static AIScoreCalculation SelfStatBelow(StatType activeRankStat, int requiredRank, int abilityLevel)
         {
-            if (statusEffectType == null)
-                throw new ArgumentNullException(nameof(statusEffectType));
-
             return context => context.CurrentEnmityTarget != OBJECT_INVALID &&
-                              !StatusEffect.HasStatusEffect(context.Self, statusEffectType)
+                              Stat.GetStatAdjustment(context.Self, activeRankStat) < requiredRank
                 ? AIScoreBand.Defensive + abilityLevel
                 : 0;
         }

--- a/SWLOR.Game.Server/Service/AIService/AIScore.cs
+++ b/SWLOR.Game.Server/Service/AIService/AIScore.cs
@@ -1,3 +1,4 @@
+using System;
 using SWLOR.Game.Server.Service.AbilityService;
 
 namespace SWLOR.Game.Server.Service.AIService
@@ -20,6 +21,20 @@ namespace SWLOR.Game.Server.Service.AIService
         {
             return context => context.TargetHealthPercent <= thresholdPercent
                 ? score + thresholdPercent - context.TargetHealthPercent
+                : 0;
+        }
+
+        /// <summary>
+        /// Scores a defensive self-buff only while the creature is in combat and the buff is absent.
+        /// </summary>
+        public static AIScoreCalculation SelfStatusMissing(Type statusEffectType, int abilityLevel)
+        {
+            if (statusEffectType == null)
+                throw new ArgumentNullException(nameof(statusEffectType));
+
+            return context => context.CurrentEnmityTarget != OBJECT_INVALID &&
+                              !StatusEffect.HasStatusEffect(context.Self, statusEffectType)
+                ? AIScoreBand.Defensive + abilityLevel
                 : 0;
         }
 

--- a/SWLOR.Game.Server/Service/StatService/StatType.cs
+++ b/SWLOR.Game.Server/Service/StatService/StatType.cs
@@ -6071,6 +6071,10 @@ namespace SWLOR.Game.Server.Service.StatService
         [StatType(StatTypeCategory.BeneficialWhenPositive)]
         AbilityActivationIdleCriticalDamagePercentAdjustment = 1052,
 
+        /// <summary>Current active rank of Bolster Attack.</summary>
+        [StatType(StatTypeCategory.NonBeneficial, StatTypeAggregation.Maximum)]
+        BolsterAttackRank = 1053,
+
     }
 
     public class StatTypeAttribute : Attribute


### PR DESCRIPTION
## Summary

- publish the active Bolster Attack rank as a `StatType` on each buff, using maximum aggregation
- add a generic stat-driven defensive AI score that only selects a self-buff when its active rank is below the ability rank
- apply it to all three Bolster ranks so beasts do not spend stamina refreshing a 180-second buff every 18 seconds
- add regression coverage proving unrelated damage buffs do not suppress Bolster and stronger Bolster ranks suppress weaker recasts

## Failure audit

- **Bolster Attack I/II/III:** valid AI-efficiency issue; fixed in this PR without changing the player-facing 18-second cooldown
- **Coordinated Strike I/II:** valid tester observation, but already fixed on `feature/combat-upgrade` by PR #2214, which converted both ranks to queued next-hit abilities so normal natural-weapon damage and the recent-master-hit bonus are included

## Verification

- `dotnet build SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj -p:RunPostBuildEvent=Never`
- `dotnet test SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj --no-build --filter "FullyQualifiedName~AIModelTests|FullyQualifiedName~BeastmasterCombatUpgradeTests"`
- Result: 63 passed, 0 failed