### PR TITLE
Validate untested combat perk readiness

### DIFF
--- a/SWLOR.Game.Server.EngineTests/Definitions/AbilityBehaviors/ForceAbilityBehaviors.cs
+++ b/SWLOR.Game.Server.EngineTests/Definitions/AbilityBehaviors/ForceAbilityBehaviors.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using SWLOR.Game.Server.EngineTests.Framework;
+using SWLOR.Game.Server.Service.PerkService;
+using SWLOR.Game.Server.Service.StatService;
 using SWLOR.NWN.API.NWScript.Enum;
 
 namespace SWLOR.Game.Server.EngineTests.Definitions.AbilityBehaviors
@@ -84,7 +86,9 @@ namespace SWLOR.Game.Server.EngineTests.Definitions.AbilityBehaviors
                 {
                     Feat = FeatType.EclipseOfResolve1,
                     Target = AbilityTargetKind.HostileCreature,
+                    ExpectedActivatorStatusEffects = new[] { typeof(CourageousResolve1StatusEffect) },
                     ExpectedTargetStatusEffects = new[] { typeof(EclipseOfResolve1StatusEffect) },
+                    SetupNPCPerkLevels = new() { [PerkType.CourageousResolve] = 1 },
                     ExpectsFPCost = true,
                     ExpectsRecast = true,
                     Notes = "Sphere targeting has OriginOnSelf, so no location target is required; impact is centered on the activator and catches the nearby hostile.",
@@ -181,7 +185,9 @@ namespace SWLOR.Game.Server.EngineTests.Definitions.AbilityBehaviors
                     Target = AbilityTargetKind.FriendlyCreature,
                     TargetDistanceMeters = 10f,
                     MaximumActivatorDistanceToTargetAfterImpact = 2f,
+                    ExpectedActivatorStatusEffects = new[] { typeof(CourageousResolve1StatusEffect) },
                     ExpectedTargetStatusEffects = new[] { typeof(ForceIntercept1StatusEffect) },
+                    SetupNPCPerkLevels = new() { [PerkType.CourageousResolve] = 1 },
                     ExpectsFPCost = true,
                     ExpectsRecast = true,
                     Notes = "ValidateFriendlyTarget with allowSelf:false - cast on a spawned same-faction ally. Impact jumps the caster to the ally and applies ForceIntercept1StatusEffect to them; 5 FP / 24s recast per the definition.",
@@ -193,7 +199,9 @@ namespace SWLOR.Game.Server.EngineTests.Definitions.AbilityBehaviors
                 {
                     Feat = FeatType.ForceJudgment1,
                     Target = AbilityTargetKind.HostileCreature,
+                    ExpectedActivatorStatusEffects = new[] { typeof(CourageousResolve1StatusEffect) },
                     ExpectedTargetStatusEffects = new[] { typeof(ForceJudgment1StatusEffect) },
+                    SetupNPCPerkLevels = new() { [PerkType.CourageousResolve] = 1 },
                     ExpectsTargetDamage = true,
                     ExpectsFPCost = true,
                     ExpectsRecast = true,
@@ -202,7 +210,9 @@ namespace SWLOR.Game.Server.EngineTests.Definitions.AbilityBehaviors
                 {
                     Feat = FeatType.ForceJudgment2,
                     Target = AbilityTargetKind.HostileCreature,
+                    ExpectedActivatorStatusEffects = new[] { typeof(CourageousResolve1StatusEffect) },
                     ExpectedTargetStatusEffects = new[] { typeof(ForceJudgment2StatusEffect) },
+                    SetupNPCPerkLevels = new() { [PerkType.CourageousResolve] = 1 },
                     ExpectsTargetDamage = true,
                     ExpectsFPCost = true,
                     ExpectsRecast = true,
@@ -211,7 +221,9 @@ namespace SWLOR.Game.Server.EngineTests.Definitions.AbilityBehaviors
                 {
                     Feat = FeatType.ForceJudgment3,
                     Target = AbilityTargetKind.HostileCreature,
+                    ExpectedActivatorStatusEffects = new[] { typeof(CourageousResolve1StatusEffect) },
                     ExpectedTargetStatusEffects = new[] { typeof(ForceJudgment3StatusEffect) },
+                    SetupNPCPerkLevels = new() { [PerkType.CourageousResolve] = 1 },
                     ExpectsTargetDamage = true,
                     ExpectsFPCost = true,
                     ExpectsRecast = true,
@@ -352,22 +364,36 @@ namespace SWLOR.Game.Server.EngineTests.Definitions.AbilityBehaviors
                     ExpectsRecast = true,
                 },
 
-                // GuardianWardAbilityDefinition - grants temporary HP (raw EffectTemporaryHitpoints,
-                // not a tracked status effect) plus conditional riders gated on stat adjustments a
-                // base NPC doesn't have; the unconditional temp HP is asserted, the riders are not.
+                // GuardianWardAbilityDefinition - grants temporary HP (raw EffectTemporaryHitpoints)
+                // and exercises the two trained Control-protection riders: Protective Presence's
+                // ranged deflection and Reflective Barrier's tracked status effect.
                 new()
                 {
                     Feat = FeatType.GuardianWard1,
                     Target = AbilityTargetKind.Self,
+                    ExpectedActivatorStatusEffects = new[] { typeof(ReflectiveBarrier1StatusEffect) },
+                    ExpectedActivatorStatAdjustments = new() { [StatType.RangedDeflection] = 4 },
+                    SetupNPCPerkLevels = new()
+                    {
+                        [PerkType.LightGuardianDeflectivePresence] = 1,
+                        [PerkType.ReflectiveBarrier] = 1
+                    },
                     ExpectsActivatorTemporaryHP = true,
                     ExpectsFPCost = true,
                     ExpectsRecast = true,
-                    Notes = "Grants raw temporary HP (asserted via the engine-effect scan); LightGuardianPowerSupport riders are gated on stat adjustments the NPC doesn't have.",
+                    Notes = "Asserts the raw temporary-HP pool plus trained Protective Presence and Reflective Barrier riders.",
                 },
                 new()
                 {
                     Feat = FeatType.GuardianWard2,
                     Target = AbilityTargetKind.Self,
+                    ExpectedActivatorStatusEffects = new[] { typeof(ReflectiveBarrier1StatusEffect) },
+                    ExpectedActivatorStatAdjustments = new() { [StatType.RangedDeflection] = 4 },
+                    SetupNPCPerkLevels = new()
+                    {
+                        [PerkType.LightGuardianDeflectivePresence] = 1,
+                        [PerkType.ReflectiveBarrier] = 1
+                    },
                     ExpectsActivatorTemporaryHP = true,
                     ExpectsFPCost = true,
                     ExpectsRecast = true,
@@ -376,6 +402,13 @@ namespace SWLOR.Game.Server.EngineTests.Definitions.AbilityBehaviors
                 {
                     Feat = FeatType.GuardianWard3,
                     Target = AbilityTargetKind.Self,
+                    ExpectedActivatorStatusEffects = new[] { typeof(ReflectiveBarrier1StatusEffect) },
+                    ExpectedActivatorStatAdjustments = new() { [StatType.RangedDeflection] = 4 },
+                    SetupNPCPerkLevels = new()
+                    {
+                        [PerkType.LightGuardianDeflectivePresence] = 1,
+                        [PerkType.ReflectiveBarrier] = 1
+                    },
                     ExpectsActivatorTemporaryHP = true,
                     ExpectsFPCost = true,
                     ExpectsRecast = true,
@@ -384,6 +417,13 @@ namespace SWLOR.Game.Server.EngineTests.Definitions.AbilityBehaviors
                 {
                     Feat = FeatType.GuardianWard4,
                     Target = AbilityTargetKind.Self,
+                    ExpectedActivatorStatusEffects = new[] { typeof(ReflectiveBarrier1StatusEffect) },
+                    ExpectedActivatorStatAdjustments = new() { [StatType.RangedDeflection] = 4 },
+                    SetupNPCPerkLevels = new()
+                    {
+                        [PerkType.LightGuardianDeflectivePresence] = 1,
+                        [PerkType.ReflectiveBarrier] = 1
+                    },
                     ExpectsActivatorTemporaryHP = true,
                     ExpectsFPCost = true,
                     ExpectsRecast = true,
@@ -416,7 +456,9 @@ namespace SWLOR.Game.Server.EngineTests.Definitions.AbilityBehaviors
                 {
                     Feat = FeatType.MindTrick1,
                     Target = AbilityTargetKind.HostileCreature,
+                    ExpectedActivatorStatusEffects = new[] { typeof(CourageousResolve1StatusEffect) },
                     ExpectedTargetStatusEffects = new[] { typeof(ConfusionStatusEffect) },
+                    SetupNPCPerkLevels = new() { [PerkType.CourageousResolve] = 1 },
                     ExpectsFPCost = true,
                     ExpectsRecast = true,
                     Notes = "Duration is a Willpower contest between caster and target; both are nw_rat001 so it resolves to the 30s base rather than being resisted to 0.",
@@ -425,7 +467,9 @@ namespace SWLOR.Game.Server.EngineTests.Definitions.AbilityBehaviors
                 {
                     Feat = FeatType.MindTrick2,
                     Target = AbilityTargetKind.HostileCreature,
+                    ExpectedActivatorStatusEffects = new[] { typeof(CourageousResolve1StatusEffect) },
                     ExpectedTargetStatusEffects = new[] { typeof(ConfusionStatusEffect) },
+                    SetupNPCPerkLevels = new() { [PerkType.CourageousResolve] = 1 },
                     ExpectsFPCost = true,
                     ExpectsRecast = true,
                 },
@@ -436,7 +480,9 @@ namespace SWLOR.Game.Server.EngineTests.Definitions.AbilityBehaviors
                 {
                     Feat = FeatType.NightmareField1,
                     Target = AbilityTargetKind.HostileCreature,
+                    ExpectedActivatorStatusEffects = new[] { typeof(CourageousResolve1StatusEffect) },
                     ExpectedTargetStatusEffects = new[] { typeof(NightmareField1StatusEffect) },
+                    SetupNPCPerkLevels = new() { [PerkType.CourageousResolve] = 1 },
                     ExpectsFPCost = true,
                     ExpectsRecast = true,
                 },
@@ -459,6 +505,8 @@ namespace SWLOR.Game.Server.EngineTests.Definitions.AbilityBehaviors
                 {
                     Feat = FeatType.RadiantLance1,
                     Target = AbilityTargetKind.HostileCreature,
+                    ExpectedActivatorStatusEffects = new[] { typeof(CourageousResolve1StatusEffect) },
+                    SetupNPCPerkLevels = new() { [PerkType.CourageousResolve] = 1 },
                     ExpectsTargetDamage = true,
                     ExpectsFPCost = true,
                     ExpectsRecast = true,
@@ -467,6 +515,8 @@ namespace SWLOR.Game.Server.EngineTests.Definitions.AbilityBehaviors
                 {
                     Feat = FeatType.RadiantLance2,
                     Target = AbilityTargetKind.HostileCreature,
+                    ExpectedActivatorStatusEffects = new[] { typeof(CourageousResolve1StatusEffect) },
+                    SetupNPCPerkLevels = new() { [PerkType.CourageousResolve] = 1 },
                     ExpectsTargetDamage = true,
                     ExpectsFPCost = true,
                     ExpectsRecast = true,
@@ -475,6 +525,8 @@ namespace SWLOR.Game.Server.EngineTests.Definitions.AbilityBehaviors
                 {
                     Feat = FeatType.RadiantLance3,
                     Target = AbilityTargetKind.HostileCreature,
+                    ExpectedActivatorStatusEffects = new[] { typeof(CourageousResolve1StatusEffect) },
+                    SetupNPCPerkLevels = new() { [PerkType.CourageousResolve] = 1 },
                     ExpectsTargetDamage = true,
                     ExpectsFPCost = true,
                     ExpectsRecast = true,
@@ -573,7 +625,9 @@ namespace SWLOR.Game.Server.EngineTests.Definitions.AbilityBehaviors
                 {
                     Feat = FeatType.WeakenResolve1,
                     Target = AbilityTargetKind.HostileCreature,
+                    ExpectedActivatorStatusEffects = new[] { typeof(CourageousResolve1StatusEffect) },
                     ExpectedTargetStatusEffects = new[] { typeof(WeakenResolve1StatusEffect) },
+                    SetupNPCPerkLevels = new() { [PerkType.CourageousResolve] = 1 },
                     ExpectsFPCost = true,
                     ExpectsRecast = true,
                 },
@@ -581,7 +635,9 @@ namespace SWLOR.Game.Server.EngineTests.Definitions.AbilityBehaviors
                 {
                     Feat = FeatType.WeakenResolve2,
                     Target = AbilityTargetKind.HostileCreature,
+                    ExpectedActivatorStatusEffects = new[] { typeof(CourageousResolve1StatusEffect) },
                     ExpectedTargetStatusEffects = new[] { typeof(WeakenResolve2StatusEffect) },
+                    SetupNPCPerkLevels = new() { [PerkType.CourageousResolve] = 1 },
                     ExpectsFPCost = true,
                     ExpectsRecast = true,
                 },

--- a/SWLOR.Game.Server.Tests/Feature/AbilityDamageQueueTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/AbilityDamageQueueTests.cs
@@ -118,26 +118,111 @@ public class AbilityDamageQueueTests
             "SWLOR.Game.Server",
             "Service",
             "Ability.cs")).Replace("\r\n", "\n");
+        var endImpactStart = source.IndexOf(
+            "public static AbilityImpactSummary EndAbilityImpact",
+            StringComparison.Ordinal);
+        var trackedImpactLookupStart = source.IndexOf(
+            "private static TrackedAbilityImpact GetTrackedAbilityImpact",
+            StringComparison.Ordinal);
+        var queueDamageStart = source.IndexOf(
+            "public void QueueDamageEffect",
+            StringComparison.Ordinal);
+        var flushDamageStart = source.IndexOf(
+            "public void FlushDamageEffects",
+            StringComparison.Ordinal);
+        var pendingDamageEffectStart = source.IndexOf(
+            "private sealed class PendingDamageEffect",
+            StringComparison.Ordinal);
+        endImpactStart.Should().BeGreaterThan(-1);
+        trackedImpactLookupStart.Should().BeGreaterThan(endImpactStart);
+        queueDamageStart.Should().BeGreaterThan(-1);
+        flushDamageStart.Should().BeGreaterThan(queueDamageStart);
+        pendingDamageEffectStart.Should().BeGreaterThan(flushDamageStart);
         var endImpactBody = source.Substring(
-            source.IndexOf("public static AbilityImpactSummary EndAbilityImpact", StringComparison.Ordinal),
-            source.IndexOf("private static TrackedAbilityImpact GetTrackedAbilityImpact", StringComparison.Ordinal) -
-            source.IndexOf("public static AbilityImpactSummary EndAbilityImpact", StringComparison.Ordinal));
+            endImpactStart,
+            trackedImpactLookupStart - endImpactStart);
         var queueBody = source.Substring(
-            source.IndexOf("public void QueueDamageEffect", StringComparison.Ordinal),
-            source.IndexOf("public void FlushDamageEffects", StringComparison.Ordinal) -
-            source.IndexOf("public void QueueDamageEffect", StringComparison.Ordinal));
+            queueDamageStart,
+            flushDamageStart - queueDamageStart);
         var flushBody = source.Substring(
-            source.IndexOf("public void FlushDamageEffects", StringComparison.Ordinal),
-            source.IndexOf("private sealed class PendingDamageEffect", StringComparison.Ordinal) -
-            source.IndexOf("public void FlushDamageEffects", StringComparison.Ordinal));
+            flushDamageStart,
+            pendingDamageEffectStart - flushDamageStart);
 
         endImpactBody.Should().Contain("impact.FlushDamageEffects(activator);");
         source.Should().Contain("trackedImpact.QueueDamageEffect(");
-        queueBody.Should().Contain("_pendingDamageEffects.Add(new PendingDamageEffect(target, damage, damageType));");
+        source.Should().Contain("trackedImpact.QueueDirectDamageEffect(");
+        queueBody.Should().Contain("public void QueueDirectDamageEffect(");
+        queueBody.Should().Contain("QueueDamageEffect(target, damage, damageType, combatDamageType);");
+        queueBody.Should().Contain("_pendingDamageEffects.Add(new PendingDamageEffect(");
         flushBody.Should().Contain("var effects = _pendingDamageEffects.ToArray();");
         flushBody.Should().Contain("AssignCommand(activator, () =>");
         flushBody.Should().Contain("foreach (var effect in effects)");
         flushBody.Should().Contain("EffectDamage(effect.Damage, effect.DamageType)");
+
+        var preDamageValidation = flushBody.IndexOf(
+            "StatusEffect.NotifyPreDamageStatusEffects(",
+            StringComparison.Ordinal);
+        var damageApplication = flushBody.IndexOf(
+            "EffectDamage(effect.Damage, effect.DamageType)",
+            StringComparison.Ordinal);
+        var reflection = flushBody.IndexOf(
+            "Combat.ApplyDamageReflectionEffects(",
+            StringComparison.Ordinal);
+        preDamageValidation.Should().BeGreaterThan(-1);
+        preDamageValidation.Should().BeLessThan(
+            reflection,
+            "each queued hit must validate source-dependent defenses before calculating reflection");
+        reflection.Should().BeLessThan(
+            damageApplication,
+            "the ward-consuming hit must reflect before its damage is applied, while the next loop iteration revalidates the consumed pool");
+    }
+
+    [Test]
+    public void MultiHitWeaponAbilities_ResolveConditionalReflectionPerQueuedHit()
+    {
+        var root = FindRepositoryRoot();
+        var weaponAbilitySource = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "SWLOR.Game.Server",
+            "Feature",
+            "AbilityDefinition",
+            "WeaponActiveAbilityDefinitionBase.cs")).Replace("\r\n", "\n");
+        var configureMultiHitStart = weaponAbilitySource.IndexOf(
+            "protected static void ConfigureMultiHit(",
+            StringComparison.Ordinal);
+        var configureInterruptStart = weaponAbilitySource.IndexOf(
+            "protected static void ConfigureInterrupt(",
+            StringComparison.Ordinal);
+        configureMultiHitStart.Should().BeGreaterThan(-1);
+        configureInterruptStart.Should().BeGreaterThan(configureMultiHitStart);
+        var configureMultiHit = weaponAbilitySource.Substring(
+            configureMultiHitStart,
+            configureInterruptStart - configureMultiHitStart);
+
+        configureMultiHit.Should().Contain("for (var i = 0; i < hits; i++)");
+        configureMultiHit.Should().Contain("Ability.ApplyCombatImpact(",
+            "every hit is queued independently against the same target");
+
+        var abilitySource = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "SWLOR.Game.Server",
+            "Service",
+            "Ability.cs")).Replace("\r\n", "\n");
+        var publicImpactStart = abilitySource.IndexOf(
+            "public static int ApplyHostileCombatImpact(",
+            StringComparison.Ordinal);
+        var privateImpactStart = abilitySource.IndexOf(
+            "private static int ApplyHostileCombatImpact(",
+            StringComparison.Ordinal);
+        publicImpactStart.Should().BeGreaterThan(-1);
+        privateImpactStart.Should().BeGreaterThan(publicImpactStart);
+        var primaryImpact = abilitySource.Substring(
+            publicImpactStart,
+            privateImpactStart - publicImpactStart);
+
+        primaryImpact.Should().Contain("trackedImpact.QueueDirectDamageEffect(");
+        primaryImpact.Should().Contain("if (trackedImpact == null)\n                    Combat.ApplyDamageReflectionEffects(",
+            "tracked hits must not reflect until each queued damage effect is applied");
     }
 
     [Test]
@@ -168,7 +253,7 @@ public class AbilityDamageQueueTests
         formulaSelectionBody.Should().Contain("return ApplyHostileCombatImpact(",
             "unscaled damage must retain the primary ability damage, rider, and enmity path");
         primaryImpactBody.Should().Contain("Combat.SendTemporaryHitPointDamageFeedback(activator, target, damage);");
-        primaryImpactBody.Should().Contain("trackedImpact.QueueDamageEffect(");
+        primaryImpactBody.Should().Contain("trackedImpact.QueueDirectDamageEffect(");
 
         unscaledDamageBody.Should().Contain("var trackedImpact = GetTrackedAbilityImpact(activator);");
         unscaledDamageBody.Should().Contain("baseDamage + (trackedImpact?.NextAbilityDamageBonus ?? 0)",

--- a/SWLOR.Game.Server.Tests/Perks/ForceLightGuardianTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/ForceLightGuardianTests.cs
@@ -130,8 +130,8 @@ public class ForceLightGuardianTests
 
         var support = File.ReadAllText((forceAbilityRoot / "LightGuardianPowerSupport.cs").FullName);
         support.Should().Contain("TemporaryHitPointEffects.IsActivePoolFromSource(");
-        support.Should().Contain("\"GUARDIAN_WARD\"");
-        support.Should().Contain("\"FATAL_DAMAGE_SAVE\"");
+        support.Should().Contain("TemporaryHitPointEffectKey.GuardianWard");
+        support.Should().Contain("TemporaryHitPointEffectKey.FatalDamageSave");
         support.Should().Contain("StatusEffect.RemoveStatusEffect(target, typeof(ReflectiveBarrier1StatusEffect), false)",
             "replacing a Guardian Ward pool must remove the prior caster's reflection rider");
         support.Should().NotContain("StatusEffect.HasStatusEffect(friendly, typeof(ReflectiveBarrier1StatusEffect), activator)",
@@ -148,13 +148,30 @@ public class ForceLightGuardianTests
         var combat = File.ReadAllText((root / "SWLOR.Game.Server" / "Service" / "Combat.cs").FullName);
         combat.Should().Contain("StatusEffect.GetStatusEffectSourceWithStat(");
         combat.Should().Contain("TemporaryHitPointEffects.ApplyFlatFromSource(");
+        combat.Should().Contain("TemporaryHitPointEffectKey.FatalDamageSave");
 
         var reflectiveBarrier = File.ReadAllText((root / "SWLOR.Game.Server" / "Feature" / "StatusEffectDefinition" / "ReflectiveBarrier1StatusEffect.cs").FullName);
-        reflectiveBarrier.Should().Contain("TemporaryHitPointEffects.IsActivePoolFromSource(creature, \"GUARDIAN_WARD\", Source)");
+        reflectiveBarrier.Should().Contain("TemporaryHitPointEffectKey.GuardianWard");
         reflectiveBarrier.Should().Contain("IPreDamageStatusEffect");
         reflectiveBarrier.Should().Contain("public void OnBeforeDamageTaken(");
         reflectiveBarrier.Should().NotContain("DelayCommand(",
             "an exhausted barrier must be gone before the shared reflection stage reads its stats");
+
+        var temporaryHPKeys = File.ReadAllText((root / "SWLOR.Game.Server" / "Feature" / "AbilityDefinition" / "TemporaryHitPointEffectKey.cs").FullName);
+        temporaryHPKeys.Should().Contain("public const string FatalDamageSave = \"FATAL_DAMAGE_SAVE\";");
+        temporaryHPKeys.Should().Contain("public const string GuardianWard = \"GUARDIAN_WARD\";");
+
+        var guardianWardDefinitionSource = File.ReadAllText((forceAbilityRoot / "GuardianWardAbilityDefinition.cs").FullName);
+        var temporaryHPKeyConsumers = string.Join(
+            Environment.NewLine,
+            support,
+            combat,
+            reflectiveBarrier,
+            guardianWardDefinitionSource);
+        temporaryHPKeyConsumers.Should().NotContain("\"FATAL_DAMAGE_SAVE\"",
+            "shared temporary-HP identifiers must be referenced through named constants");
+        temporaryHPKeyConsumers.Should().NotContain("\"GUARDIAN_WARD\"",
+            "shared temporary-HP identifiers must be referenced through named constants");
 
         var weaponDamage = File.ReadAllText((root / "SWLOR.Game.Server" / "Native" / "GetDamageRoll.cs").FullName);
         var abilityDamage = File.ReadAllText((root / "SWLOR.Game.Server" / "Service" / "Ability.cs").FullName);

--- a/SWLOR.Game.Server.Tests/Perks/ForceLightGuardianTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/ForceLightGuardianTests.cs
@@ -174,6 +174,17 @@ public class ForceLightGuardianTests
             "shared temporary-HP identifiers must be referenced through named constants");
 
         var weaponDamage = File.ReadAllText((root / "SWLOR.Game.Server" / "Native" / "GetDamageRoll.cs").FullName);
+        var weaponProcessDamageStart = weaponDamage.IndexOf(
+            "private static int ProcessDamage(",
+            StringComparison.Ordinal);
+        var weaponAddDamageStart = weaponDamage.IndexOf(
+            "private static void AddDamageToAttackData(",
+            StringComparison.Ordinal);
+        weaponProcessDamageStart.Should().BeGreaterThan(-1);
+        weaponAddDamageStart.Should().BeGreaterThan(weaponProcessDamageStart);
+        var weaponProcessDamage = weaponDamage.Substring(
+            weaponProcessDamageStart,
+            weaponAddDamageStart - weaponProcessDamageStart);
         var abilityDamage = File.ReadAllText((root / "SWLOR.Game.Server" / "Service" / "Ability.cs").FullName);
         var abilityPreDamageNotification = abilityDamage.IndexOf(
             "StatusEffect.NotifyPreDamageStatusEffects(activator, target, damage, damageType);",
@@ -196,16 +207,15 @@ public class ForceLightGuardianTests
             immediateDamageApplication,
             "ordinary damage reactions such as Guardian's Resolve healing must observe post-hit HP");
 
-        var weaponPreDamageNotification = weaponDamage.IndexOf(
+        var weaponPreDamageNotification = weaponProcessDamage.IndexOf(
             "StatusEffect.NotifyPreDamageStatusEffects(",
             StringComparison.Ordinal);
         weaponPreDamageNotification.Should().BeGreaterThan(-1);
         weaponPreDamageNotification.Should().BeLessThan(
-            weaponDamage.IndexOf("PublishDamageDealtEvent(", weaponPreDamageNotification, StringComparison.Ordinal),
-            "conditional reflection must be validated before weapon damage callbacks and reflection");
-        weaponPreDamageNotification.Should().BeLessThan(
-            weaponDamage.IndexOf("Combat.ApplyDamageReflectionEffects(", weaponPreDamageNotification, StringComparison.Ordinal),
+            weaponProcessDamage.IndexOf("Combat.ApplyDamageReflectionEffects(", weaponPreDamageNotification, StringComparison.Ordinal),
             "an exhausted conditional reflection status must be removed before weapon reflection is calculated");
+        weaponProcessDamage.Should().NotContain("PublishDamageDealtEvent(",
+            "reflection must retain its original position in weapon damage calculation rather than moving across damage-dealt callbacks");
     }
 
     [Test]

--- a/SWLOR.Game.Server.Tests/Perks/ForceLightGuardianTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/ForceLightGuardianTests.cs
@@ -151,9 +151,14 @@ public class ForceLightGuardianTests
 
         var reflectiveBarrier = File.ReadAllText((root / "SWLOR.Game.Server" / "Feature" / "StatusEffectDefinition" / "ReflectiveBarrier1StatusEffect.cs").FullName);
         reflectiveBarrier.Should().Contain("TemporaryHitPointEffects.IsActivePoolFromSource(creature, \"GUARDIAN_WARD\", Source)");
-        reflectiveBarrier.Should().Contain("RemoveWhenGuardianWardPoolEnds(defender, delayUntilAfterDamageResolution: true)");
-        reflectiveBarrier.Should().Contain("if (current?.Id == statusEffectId)",
-            "a delayed cleanup from an exhausted pool must not remove a newly recast barrier");
+        reflectiveBarrier.Should().Contain("RemoveWhenGuardianWardPoolEnds(defender)");
+        reflectiveBarrier.Should().NotContain("DelayCommand(",
+            "an exhausted barrier must be gone before the shared reflection stage reads its stats");
+
+        var weaponDamage = File.ReadAllText((root / "SWLOR.Game.Server" / "Native" / "GetDamageRoll.cs").FullName);
+        weaponDamage.IndexOf("PublishDamageDealtEvent(", StringComparison.Ordinal)
+            .Should().BeLessThan(weaponDamage.IndexOf("Combat.ApplyDamageReflectionEffects(", StringComparison.Ordinal),
+                "weapon damage-status notifications must remove exhausted conditional reflection before reflection is calculated");
     }
 
     [Test]

--- a/SWLOR.Game.Server.Tests/Perks/ForceLightGuardianTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/ForceLightGuardianTests.cs
@@ -159,6 +159,21 @@ public class ForceLightGuardianTests
         weaponDamage.IndexOf("PublishDamageDealtEvent(", StringComparison.Ordinal)
             .Should().BeLessThan(weaponDamage.IndexOf("Combat.ApplyDamageReflectionEffects(", StringComparison.Ordinal),
                 "weapon damage-status notifications must remove exhausted conditional reflection before reflection is calculated");
+
+        var abilityDamage = File.ReadAllText((root / "SWLOR.Game.Server" / "Service" / "Ability.cs").FullName);
+        var abilityNotification = abilityDamage.IndexOf(
+            "StatusEffect.NotifyDamageStatusEffects(activator, target, damage, damageType);",
+            StringComparison.Ordinal);
+        abilityNotification.Should().BeGreaterThan(-1);
+        abilityNotification.Should().BeLessThan(
+            abilityDamage.IndexOf(
+                "EffectDamage(damage, effectDamageType ?? damageType.GetNWScriptDamageType())",
+                abilityNotification,
+                StringComparison.Ordinal),
+            "an ability hit that exhausts Guardian Ward must retain reflection for that originating hit");
+        abilityNotification.Should().BeLessThan(
+            abilityDamage.IndexOf("trackedImpact.QueueDamageEffect(", abilityNotification, StringComparison.Ordinal),
+            "queued ability hits must use the same pre-damage notification ordering");
     }
 
     [Test]

--- a/SWLOR.Game.Server.Tests/Perks/ForceLightGuardianTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/ForceLightGuardianTests.cs
@@ -189,6 +189,7 @@ public class ForceLightGuardianTests
         var abilityPreDamageNotification = abilityDamage.IndexOf(
             "StatusEffect.NotifyPreDamageStatusEffects(activator, target, damage, damageType);",
             StringComparison.Ordinal);
+        abilityPreDamageNotification.Should().BeGreaterThan(-1);
         var abilityPostDamageNotification = abilityDamage.IndexOf(
             "StatusEffect.NotifyDamageStatusEffects(activator, target, damage, damageType);",
             StringComparison.Ordinal);
@@ -196,16 +197,40 @@ public class ForceLightGuardianTests
             "EffectDamage(damage, effectDamageType ?? damageType.GetNWScriptDamageType())",
             abilityPreDamageNotification,
             StringComparison.Ordinal);
-        abilityPreDamageNotification.Should().BeGreaterThan(-1);
         abilityPreDamageNotification.Should().BeLessThan(
             immediateDamageApplication,
             "conditional reflection must be validated before the originating ability hit");
-        abilityPreDamageNotification.Should().BeLessThan(
-            abilityDamage.IndexOf("trackedImpact.QueueDamageEffect(", abilityPreDamageNotification, StringComparison.Ordinal),
-            "queued ability hits must use the same pre-damage validation");
         abilityPostDamageNotification.Should().BeGreaterThan(
             immediateDamageApplication,
             "ordinary damage reactions such as Guardian's Resolve healing must observe post-hit HP");
+
+        var queuedDamageFlushStart = abilityDamage.IndexOf(
+            "public void FlushDamageEffects(uint activator)",
+            StringComparison.Ordinal);
+        var pendingDamageEffectStart = abilityDamage.IndexOf(
+            "private sealed class PendingDamageEffect",
+            StringComparison.Ordinal);
+        queuedDamageFlushStart.Should().BeGreaterThan(-1);
+        pendingDamageEffectStart.Should().BeGreaterThan(queuedDamageFlushStart);
+        var queuedDamageFlush = abilityDamage.Substring(
+            queuedDamageFlushStart,
+            pendingDamageEffectStart - queuedDamageFlushStart);
+        var queuedPreDamageNotification = queuedDamageFlush.IndexOf(
+            "StatusEffect.NotifyPreDamageStatusEffects(",
+            StringComparison.Ordinal);
+        var queuedDamageApplication = queuedDamageFlush.IndexOf(
+            "EffectDamage(effect.Damage, effect.DamageType)",
+            StringComparison.Ordinal);
+        var queuedReflection = queuedDamageFlush.IndexOf(
+            "Combat.ApplyDamageReflectionEffects(",
+            StringComparison.Ordinal);
+        queuedPreDamageNotification.Should().BeGreaterThan(-1);
+        queuedPreDamageNotification.Should().BeLessThan(
+            queuedReflection,
+            "each queued hit must validate its conditional reflection before reflection is calculated");
+        queuedReflection.Should().BeLessThan(
+            queuedDamageApplication,
+            "the queued hit that consumes the final Guardian Ward pool must reflect before its damage is applied, then the next hit revalidates the consumed pool");
 
         var weaponPreDamageNotification = weaponProcessDamage.IndexOf(
             "StatusEffect.NotifyPreDamageStatusEffects(",

--- a/SWLOR.Game.Server.Tests/Perks/ForceLightGuardianTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/ForceLightGuardianTests.cs
@@ -132,6 +132,8 @@ public class ForceLightGuardianTests
         support.Should().Contain("TemporaryHitPointEffects.IsActivePoolFromSource(");
         support.Should().Contain("\"GUARDIAN_WARD\"");
         support.Should().Contain("\"FATAL_DAMAGE_SAVE\"");
+        support.Should().Contain("StatusEffect.RemoveStatusEffect(target, typeof(ReflectiveBarrier1StatusEffect), false)",
+            "replacing a Guardian Ward pool must remove the prior caster's reflection rider");
         support.Should().NotContain("StatusEffect.HasStatusEffect(friendly, typeof(ReflectiveBarrier1StatusEffect), activator)",
             "the stronger resolve bonus depends on Force temporary HP, not ownership of Reflective Barrier");
 
@@ -150,6 +152,8 @@ public class ForceLightGuardianTests
         var reflectiveBarrier = File.ReadAllText((root / "SWLOR.Game.Server" / "Feature" / "StatusEffectDefinition" / "ReflectiveBarrier1StatusEffect.cs").FullName);
         reflectiveBarrier.Should().Contain("TemporaryHitPointEffects.IsActivePoolFromSource(creature, \"GUARDIAN_WARD\", Source)");
         reflectiveBarrier.Should().Contain("RemoveWhenGuardianWardPoolEnds(defender, delayUntilAfterDamageResolution: true)");
+        reflectiveBarrier.Should().Contain("if (current?.Id == statusEffectId)",
+            "a delayed cleanup from an exhausted pool must not remove a newly recast barrier");
     }
 
     [Test]

--- a/SWLOR.Game.Server.Tests/Perks/ForceLightGuardianTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/ForceLightGuardianTests.cs
@@ -139,6 +139,8 @@ public class ForceLightGuardianTests
 
         var temporaryHP = File.ReadAllText((root / "SWLOR.Game.Server" / "Feature" / "AbilityDefinition" / "TemporaryHitPointEffects.cs").FullName);
         temporaryHP.Should().Contain("public static void ApplyFlatFromSource(");
+        temporaryHP.Should().Contain("ApplyFlatFromSource(OBJECT_INVALID, target, effectKey, amount, durationSeconds);",
+            "sourced and unsourced temporary-HP pools must share one metadata-reset path");
         temporaryHP.Should().Contain("public static bool IsActivePoolFromSource(");
         temporaryHP.Should().Contain("GetEffectTag(effect) == effectTag");
 

--- a/SWLOR.Game.Server.Tests/Perks/ForceLightGuardianTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/ForceLightGuardianTests.cs
@@ -151,29 +151,44 @@ public class ForceLightGuardianTests
 
         var reflectiveBarrier = File.ReadAllText((root / "SWLOR.Game.Server" / "Feature" / "StatusEffectDefinition" / "ReflectiveBarrier1StatusEffect.cs").FullName);
         reflectiveBarrier.Should().Contain("TemporaryHitPointEffects.IsActivePoolFromSource(creature, \"GUARDIAN_WARD\", Source)");
-        reflectiveBarrier.Should().Contain("RemoveWhenGuardianWardPoolEnds(defender)");
+        reflectiveBarrier.Should().Contain("IPreDamageStatusEffect");
+        reflectiveBarrier.Should().Contain("public void OnBeforeDamageTaken(");
         reflectiveBarrier.Should().NotContain("DelayCommand(",
             "an exhausted barrier must be gone before the shared reflection stage reads its stats");
 
         var weaponDamage = File.ReadAllText((root / "SWLOR.Game.Server" / "Native" / "GetDamageRoll.cs").FullName);
-        weaponDamage.IndexOf("PublishDamageDealtEvent(", StringComparison.Ordinal)
-            .Should().BeLessThan(weaponDamage.IndexOf("Combat.ApplyDamageReflectionEffects(", StringComparison.Ordinal),
-                "weapon damage-status notifications must remove exhausted conditional reflection before reflection is calculated");
-
         var abilityDamage = File.ReadAllText((root / "SWLOR.Game.Server" / "Service" / "Ability.cs").FullName);
-        var abilityNotification = abilityDamage.IndexOf(
+        var abilityPreDamageNotification = abilityDamage.IndexOf(
+            "StatusEffect.NotifyPreDamageStatusEffects(activator, target, damage, damageType);",
+            StringComparison.Ordinal);
+        var abilityPostDamageNotification = abilityDamage.IndexOf(
             "StatusEffect.NotifyDamageStatusEffects(activator, target, damage, damageType);",
             StringComparison.Ordinal);
-        abilityNotification.Should().BeGreaterThan(-1);
-        abilityNotification.Should().BeLessThan(
-            abilityDamage.IndexOf(
-                "EffectDamage(damage, effectDamageType ?? damageType.GetNWScriptDamageType())",
-                abilityNotification,
-                StringComparison.Ordinal),
-            "an ability hit that exhausts Guardian Ward must retain reflection for that originating hit");
-        abilityNotification.Should().BeLessThan(
-            abilityDamage.IndexOf("trackedImpact.QueueDamageEffect(", abilityNotification, StringComparison.Ordinal),
-            "queued ability hits must use the same pre-damage notification ordering");
+        var immediateDamageApplication = abilityDamage.IndexOf(
+            "EffectDamage(damage, effectDamageType ?? damageType.GetNWScriptDamageType())",
+            abilityPreDamageNotification,
+            StringComparison.Ordinal);
+        abilityPreDamageNotification.Should().BeGreaterThan(-1);
+        abilityPreDamageNotification.Should().BeLessThan(
+            immediateDamageApplication,
+            "conditional reflection must be validated before the originating ability hit");
+        abilityPreDamageNotification.Should().BeLessThan(
+            abilityDamage.IndexOf("trackedImpact.QueueDamageEffect(", abilityPreDamageNotification, StringComparison.Ordinal),
+            "queued ability hits must use the same pre-damage validation");
+        abilityPostDamageNotification.Should().BeGreaterThan(
+            immediateDamageApplication,
+            "ordinary damage reactions such as Guardian's Resolve healing must observe post-hit HP");
+
+        var weaponPreDamageNotification = weaponDamage.IndexOf(
+            "StatusEffect.NotifyPreDamageStatusEffects(",
+            StringComparison.Ordinal);
+        weaponPreDamageNotification.Should().BeGreaterThan(-1);
+        weaponPreDamageNotification.Should().BeLessThan(
+            weaponDamage.IndexOf("PublishDamageDealtEvent(", weaponPreDamageNotification, StringComparison.Ordinal),
+            "conditional reflection must be validated before weapon damage callbacks and reflection");
+        weaponPreDamageNotification.Should().BeLessThan(
+            weaponDamage.IndexOf("Combat.ApplyDamageReflectionEffects(", weaponPreDamageNotification, StringComparison.Ordinal),
+            "an exhausted conditional reflection status must be removed before weapon reflection is calculated");
     }
 
     [Test]

--- a/SWLOR.Game.Server.Tests/Perks/ForceLightGuardianTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/ForceLightGuardianTests.cs
@@ -89,6 +89,70 @@ public class ForceLightGuardianTests
     }
 
     [Test]
+    public void ForceLightGuardianTraitHooks_MatchTheirBiblePowerCategories()
+    {
+        var root = FindRepositoryRoot();
+        var forceAbilityRoot = root / "SWLOR.Game.Server" / "Feature" / "AbilityDefinition" / "Force";
+
+        var guardianWard = File.ReadAllText((forceAbilityRoot / "GuardianWardAbilityDefinition.cs").FullName);
+        guardianWard.Should().Contain("LightGuardianPowerSupport.ApplyTemporaryHPPowerRiders(activator, friendly, 30f)");
+
+        var powersThatDoNotQualifyForProtectivePresence = new[]
+        {
+            "ForcePushAbilityDefinition.cs",
+            "ForceLeapAbilityDefinition.cs",
+            "ForceInterceptAbilityDefinition.cs",
+            "PurifyingWaveAbilityDefinition.cs",
+            "LastStandOfTheLightAbilityDefinition.cs"
+        };
+        foreach (var file in powersThatDoNotQualifyForProtectivePresence)
+        {
+            File.ReadAllText((forceAbilityRoot / file).FullName)
+                .Should().NotContain("ApplyDeflectivePresence(", $"{file} is not a Control protection power");
+        }
+
+        var sensePowerFiles = new[]
+        {
+            "WeakenResolveAbilityDefinition.cs",
+            "ForceJudgmentAbilityDefinition.cs",
+            "RadiantLanceAbilityDefinition.cs",
+            "MindTrickAbilityDefinition.cs",
+            "NightmareFieldAbilityDefinition.cs",
+            "ForceInterceptAbilityDefinition.cs",
+            "EclipseOfResolveAbilityDefinition.cs"
+        };
+        foreach (var file in sensePowerFiles)
+        {
+            File.ReadAllText((forceAbilityRoot / file).FullName)
+                .Should().Contain("LightGuardianPowerSupport.ApplyCourageousResolve(activator)",
+                    $"{file} implements a Sense power");
+        }
+
+        var support = File.ReadAllText((forceAbilityRoot / "LightGuardianPowerSupport.cs").FullName);
+        support.Should().Contain("TemporaryHitPointEffects.IsActivePoolFromSource(");
+        support.Should().Contain("\"GUARDIAN_WARD\"");
+        support.Should().Contain("\"FATAL_DAMAGE_SAVE\"");
+        support.Should().NotContain("StatusEffect.HasStatusEffect(friendly, typeof(ReflectiveBarrier1StatusEffect), activator)",
+            "the stronger resolve bonus depends on Force temporary HP, not ownership of Reflective Barrier");
+
+        var temporaryHP = File.ReadAllText((root / "SWLOR.Game.Server" / "Feature" / "AbilityDefinition" / "TemporaryHitPointEffects.cs").FullName);
+        temporaryHP.Should().Contain("public static void ApplyFlatFromSource(");
+        temporaryHP.Should().Contain("public static bool IsActivePoolFromSource(");
+        temporaryHP.Should().Contain("GetEffectTag(effect) == effectTag");
+
+        var scaling = File.ReadAllText((root / "SWLOR.Game.Server" / "Feature" / "AbilityDefinition" / "AbilityEffectScaling.cs").FullName);
+        scaling.Should().Contain("TemporaryHitPointEffects.ApplyFlatFromSource(source, target, effectKey, amount, durationSeconds)");
+
+        var combat = File.ReadAllText((root / "SWLOR.Game.Server" / "Service" / "Combat.cs").FullName);
+        combat.Should().Contain("StatusEffect.GetStatusEffectSourceWithStat(");
+        combat.Should().Contain("TemporaryHitPointEffects.ApplyFlatFromSource(");
+
+        var reflectiveBarrier = File.ReadAllText((root / "SWLOR.Game.Server" / "Feature" / "StatusEffectDefinition" / "ReflectiveBarrier1StatusEffect.cs").FullName);
+        reflectiveBarrier.Should().Contain("TemporaryHitPointEffects.IsActivePoolFromSource(creature, \"GUARDIAN_WARD\", Source)");
+        reflectiveBarrier.Should().Contain("RemoveWhenGuardianWardPoolEnds(defender, delayUntilAfterDamageResolution: true)");
+    }
+
+    [Test]
     public void LastStandOfTheLight_HasDyingFallbackBeforeForcedPlayerDeath()
     {
         var root = FindRepositoryRoot();

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/AbilityEffectScaling.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/AbilityEffectScaling.cs
@@ -118,7 +118,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition
             var amount = CalculateScaledPercentOfMaxHP(source, target, percent, scalingAbility, multiplier);
             if (GetIsObjectValid(source))
                 amount = Ability.ApplyCombatReadinessMagnitude(source, amount);
-            TemporaryHitPointEffects.ApplyFlat(target, effectKey, amount, durationSeconds);
+            TemporaryHitPointEffects.ApplyFlatFromSource(source, target, effectKey, amount, durationSeconds);
         }
 
         private static float GetScalingProgress(int stat)

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Force/EclipseOfResolveAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Force/EclipseOfResolveAbilityDefinition.cs
@@ -51,6 +51,8 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
 
         private static void EclipseOfResolve1ImpactAction(uint activator, uint target, int level, Location targetLocation)
         {
+            LightGuardianPowerSupport.ApplyCourageousResolve(activator);
+
             Ability.ApplyTelegraphedCombatImpact(
                 activator,
                 target,

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Force/ForceInterceptAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Force/ForceInterceptAbilityDefinition.cs
@@ -58,7 +58,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
             AssignCommand(activator, () => ActionJumpToObject(friendly));
             StatusEffect.ApplyStatusEffect(activator, friendly, typeof(ForceIntercept1StatusEffect), 30f);
             ApplyEffectToObject(DurationType.Instant, EffectVisualEffect(VisualEffect.Vfx_Imp_Holy_Aid), friendly);
-            LightGuardianPowerSupport.ApplyDeflectivePresence(activator, friendly);
+            LightGuardianPowerSupport.ApplyCourageousResolve(activator);
         }
 
 

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Force/ForceJudgmentAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Force/ForceJudgmentAbilityDefinition.cs
@@ -132,6 +132,8 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
             Type statusEffect,
             int maxTargets)
         {
+            LightGuardianPowerSupport.ApplyCourageousResolve(activator);
+
             if (maxTargets == 1)
             {
                 Ability.ApplyCombatImpact(

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Force/ForceLeapAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Force/ForceLeapAbilityDefinition.cs
@@ -88,7 +88,6 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 Array.Empty<Type>(),
                 damageType: CombatDamageType.Force,
                 targetVisualEffect: VisualEffect.Vfx_Imp_Pulse_Negative);
-            LightGuardianPowerSupport.ApplyDeflectivePresence(activator);
         }
 
         private static void ForceLeap2ImpactAction(uint activator, uint target, int level, Location targetLocation)
@@ -106,7 +105,6 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 Array.Empty<Type>(),
                 damageType: CombatDamageType.Force,
                 targetVisualEffect: VisualEffect.Vfx_Imp_Pulse_Negative);
-            LightGuardianPowerSupport.ApplyDeflectivePresence(activator);
         }
 
         private static void LeapAndInterrupt(uint activator, uint target)

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Force/ForcePushAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Force/ForcePushAbilityDefinition.cs
@@ -139,7 +139,6 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 afterSuccessfulHit: hitTarget => ApplyHobble(activator, hitTarget, ForcePush1HobbleDurationSeconds),
                 playImpactAnimation: false,
                 useUnscaledDamage: true);
-            LightGuardianPowerSupport.ApplyDeflectivePresence(activator);
         }
 
         private static void ForcePush2ImpactAction(uint activator, uint target, int level, Location targetLocation)
@@ -164,7 +163,6 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 afterSuccessfulHit: hitTarget => ApplyHobble(activator, hitTarget, ForcePush2HobbleDurationSeconds),
                 playImpactAnimation: false,
                 useUnscaledDamage: true);
-            LightGuardianPowerSupport.ApplyDeflectivePresence(activator);
         }
 
         private static void ForcePush3ImpactAction(uint activator, uint target, int level, Location targetLocation)
@@ -189,7 +187,6 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 afterSuccessfulHit: hitTarget => ApplyHobble(activator, hitTarget, ForcePush3HobbleDurationSeconds),
                 playImpactAnimation: false,
                 useUnscaledDamage: true);
-            LightGuardianPowerSupport.ApplyDeflectivePresence(activator);
         }
 
         private static void ApplyHobble(uint activator, uint target, int durationSeconds)

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Force/GuardianWardAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Force/GuardianWardAbilityDefinition.cs
@@ -120,7 +120,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
         {
             foreach (var friendly in SWLOR.Game.Server.Feature.AbilityDefinition.AbilityTargeting.GetFriendlyTargets(activator, target, false))
             {
-                SWLOR.Game.Server.Feature.AbilityDefinition.AbilityEffectScaling.ApplyTemporaryHPPercent(activator, friendly, "GUARDIAN_WARD", 6, 30f);
+                AbilityEffectScaling.ApplyTemporaryHPPercent(activator, friendly, TemporaryHitPointEffectKey.GuardianWard, 6, 30f);
                 LightGuardianPowerSupport.ApplyTemporaryHPPowerRiders(activator, friendly, 30f);
             }
         }
@@ -129,7 +129,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
         {
             foreach (var friendly in SWLOR.Game.Server.Feature.AbilityDefinition.AbilityTargeting.GetFriendlyTargets(activator, target, false))
             {
-                SWLOR.Game.Server.Feature.AbilityDefinition.AbilityEffectScaling.ApplyTemporaryHPPercent(activator, friendly, "GUARDIAN_WARD", 9, 30f);
+                AbilityEffectScaling.ApplyTemporaryHPPercent(activator, friendly, TemporaryHitPointEffectKey.GuardianWard, 9, 30f);
                 LightGuardianPowerSupport.ApplyTemporaryHPPowerRiders(activator, friendly, 30f);
             }
         }
@@ -138,7 +138,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
         {
             foreach (var friendly in SWLOR.Game.Server.Feature.AbilityDefinition.AbilityTargeting.GetFriendlyTargets(activator, target, false))
             {
-                SWLOR.Game.Server.Feature.AbilityDefinition.AbilityEffectScaling.ApplyTemporaryHPPercent(activator, friendly, "GUARDIAN_WARD", 12, 30f);
+                AbilityEffectScaling.ApplyTemporaryHPPercent(activator, friendly, TemporaryHitPointEffectKey.GuardianWard, 12, 30f);
                 LightGuardianPowerSupport.ApplyTemporaryHPPowerRiders(activator, friendly, 30f);
             }
         }
@@ -147,7 +147,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
         {
             foreach (var friendly in SWLOR.Game.Server.Feature.AbilityDefinition.AbilityTargeting.GetFriendlyTargets(activator, target, false))
             {
-                SWLOR.Game.Server.Feature.AbilityDefinition.AbilityEffectScaling.ApplyTemporaryHPPercent(activator, friendly, "GUARDIAN_WARD", 15, 30f);
+                AbilityEffectScaling.ApplyTemporaryHPPercent(activator, friendly, TemporaryHitPointEffectKey.GuardianWard, 15, 30f);
                 LightGuardianPowerSupport.ApplyTemporaryHPPowerRiders(activator, friendly, 30f);
             }
         }

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Force/LastStandOfTheLightAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Force/LastStandOfTheLightAbilityDefinition.cs
@@ -52,7 +52,6 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
             var friendly = AbilityTargeting.ResolveFriendlyTarget(activator, target);
             StatusEffect.ApplyStatusEffect(activator, friendly, typeof(LastStandOfTheLight1StatusEffect), CapstoneAbility.ActiveDurationSeconds);
             ApplyEffectToObject(DurationType.Instant, EffectVisualEffect(VisualEffect.Vfx_Imp_Ac_Bonus), friendly);
-            LightGuardianPowerSupport.ApplyDeflectivePresence(activator, friendly);
         }
     }
 }

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Force/LightGuardianPowerSupport.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Force/LightGuardianPowerSupport.cs
@@ -9,11 +9,6 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
 {
     public static class LightGuardianPowerSupport
     {
-        public static void ApplyDeflectivePresence(uint activator)
-        {
-            ApplyDeflectivePresence(activator, activator);
-        }
-
         public static void ApplyDeflectivePresence(uint activator, uint target)
         {
             if (!GetIsObjectValid(activator))
@@ -45,8 +40,6 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
             {
                 StatusEffect.ApplyStatusEffect(activator, target, typeof(ReflectiveBarrier1StatusEffect), durationSeconds);
             }
-
-            ApplyCourageousResolve(activator);
         }
 
         public static void ApplyCourageousResolve(uint activator)
@@ -59,7 +52,16 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
 
             foreach (var friendly in AbilityTargeting.GetFriendlyTargetsNearLocation(activator, GetLocation(activator), 5f))
             {
-                var resistance = StatusEffect.HasStatusEffect(friendly, typeof(ReflectiveBarrier1StatusEffect), activator)
+                var hasForceTemporaryHP =
+                    TemporaryHitPointEffects.IsActivePoolFromSource(
+                        friendly,
+                        "GUARDIAN_WARD",
+                        activator) ||
+                    TemporaryHitPointEffects.IsActivePoolFromSource(
+                        friendly,
+                        "FATAL_DAMAGE_SAVE",
+                        activator);
+                var resistance = hasForceTemporaryHP
                     ? 15
                     : 10;
                 StatusEffect.ApplyStatusEffect(activator, friendly, new CourageousResolve1StatusEffect(resistance), 30f);

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Force/LightGuardianPowerSupport.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Force/LightGuardianPowerSupport.cs
@@ -36,6 +36,9 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
 
             ApplyDeflectivePresence(activator, target);
 
+            // Guardian Ward pools replace one another regardless of caster. Clear any rider tied
+            // to the replaced pool before conditionally applying the new caster's version.
+            StatusEffect.RemoveStatusEffect(target, typeof(ReflectiveBarrier1StatusEffect), false);
             if (Stat.GetStatAdjustment(activator, StatType.LightGuardianTemporaryHPReflectiveBarrier) > 0)
             {
                 StatusEffect.ApplyStatusEffect(activator, target, typeof(ReflectiveBarrier1StatusEffect), durationSeconds);

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Force/LightGuardianPowerSupport.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Force/LightGuardianPowerSupport.cs
@@ -58,11 +58,11 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 var hasForceTemporaryHP =
                     TemporaryHitPointEffects.IsActivePoolFromSource(
                         friendly,
-                        "GUARDIAN_WARD",
+                        TemporaryHitPointEffectKey.GuardianWard,
                         activator) ||
                     TemporaryHitPointEffects.IsActivePoolFromSource(
                         friendly,
-                        "FATAL_DAMAGE_SAVE",
+                        TemporaryHitPointEffectKey.FatalDamageSave,
                         activator);
                 var resistance = hasForceTemporaryHP
                     ? 15

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Force/MindTrickAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Force/MindTrickAbilityDefinition.cs
@@ -81,6 +81,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
         private static void MindTrick1ImpactAction(uint activator, uint target, int level, Location targetLocation)
         {
             ApplyMindTrickImpact(activator, target, targetLocation);
+            LightGuardianPowerSupport.ApplyCourageousResolve(activator);
         }
 
         private static void MindTrick2ImpactAction(uint activator, uint target, int level, Location targetLocation)
@@ -90,6 +91,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
             {
                 ApplyMindTrickImpact(activator, hostileTarget, GetLocation(hostileTarget));
             }
+            LightGuardianPowerSupport.ApplyCourageousResolve(activator);
         }
 
         private static void ApplyMindTrickImpact(uint activator, uint target, Location targetLocation)

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Force/NightmareFieldAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Force/NightmareFieldAbilityDefinition.cs
@@ -51,6 +51,8 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
 
         private static void NightmareField1ImpactAction(uint activator, uint target, int level, Location targetLocation)
         {
+            LightGuardianPowerSupport.ApplyCourageousResolve(activator);
+
             Ability.ApplyTelegraphedCombatImpact(
                 activator,
                 target,

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Force/PurifyingWaveAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Force/PurifyingWaveAbilityDefinition.cs
@@ -74,7 +74,6 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 AbilityEffectScaling.ApplyActivatedScaledHeal(activator, friendly, 8);
                 ApplyEffectToObject(DurationType.Instant, EffectVisualEffect(VisualEffect.Vfx_Imp_Remove_Condition), friendly);
             }
-            LightGuardianPowerSupport.ApplyDeflectivePresence(activator);
         }
     }
 }

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Force/RadiantLanceAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Force/RadiantLanceAbilityDefinition.cs
@@ -108,6 +108,8 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
 
         private static void ApplyRadiantLance(uint activator, uint target, Location targetLocation, int baseDamage)
         {
+            LightGuardianPowerSupport.ApplyCourageousResolve(activator);
+
             Ability.ApplyTelegraphedCombatImpact(
                 activator,
                 target,

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Force/WeakenResolveAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Force/WeakenResolveAbilityDefinition.cs
@@ -84,6 +84,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 Array.Empty<Type>(),
                 damageType: CombatDamageType.Force,
                 afterSuccessfulHit: ApplyResolveDebuffVisual);
+            LightGuardianPowerSupport.ApplyCourageousResolve(activator);
         }
 
         private static void WeakenResolve2ImpactAction(uint activator, uint target, int level, Location targetLocation)
@@ -100,6 +101,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
                 Array.Empty<Type>(),
                 damageType: CombatDamageType.Force,
                 afterSuccessfulHit: ApplyResolveDebuffVisual);
+            LightGuardianPowerSupport.ApplyCourageousResolve(activator);
         }
 
         private static void ApplyResolveDebuffVisual(uint target)

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/TemporaryHitPointEffectKey.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/TemporaryHitPointEffectKey.cs
@@ -1,0 +1,12 @@
+namespace SWLOR.Game.Server.Feature.AbilityDefinition
+{
+    /// <summary>
+    /// Stable identifiers for temporary-HP pools shared across multiple gameplay systems.
+    /// These values become native effect tags and local-variable names, so they must not change.
+    /// </summary>
+    public static class TemporaryHitPointEffectKey
+    {
+        public const string FatalDamageSave = "FATAL_DAMAGE_SAVE";
+        public const string GuardianWard = "GUARDIAN_WARD";
+    }
+}

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/TemporaryHitPointEffects.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/TemporaryHitPointEffects.cs
@@ -10,6 +10,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition
         private const string EffectTagPrefix = "TEMPORARY_HP_";
         private const string BarrierVisualEffectTagSuffix = "_BARRIER_VFX";
         private const string OwnerVariableSuffix = "_OWNER";
+        private const string SourceVariableSuffix = "_SOURCE";
 
         public static void ApplyFlatPlusPercent(
             uint target,
@@ -29,7 +30,29 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition
         {
             ValidateEffectKey(effectKey);
             DeleteLocalString(target, GetOwnerVariable(effectKey));
+            DeleteLocalObject(target, GetSourceVariable(effectKey));
             ApplyFlatInternal(target, effectKey, amount, durationSeconds);
+        }
+
+        /// <summary>
+        /// Applies a keyed temporary-HP pool and records the creature that granted it. Source
+        /// ownership is only considered active while the matching native temporary-HP effect
+        /// still exists, so consuming the pool immediately invalidates source-dependent riders.
+        /// </summary>
+        public static void ApplyFlatFromSource(
+            uint source,
+            uint target,
+            string effectKey,
+            int amount,
+            float durationSeconds)
+        {
+            ValidateEffectKey(effectKey);
+            DeleteLocalString(target, GetOwnerVariable(effectKey));
+            DeleteLocalObject(target, GetSourceVariable(effectKey));
+            ApplyFlatInternal(target, effectKey, amount, durationSeconds);
+
+            if (amount > 0 && GetIsObjectValid(source))
+                SetLocalObject(target, GetSourceVariable(effectKey), source);
         }
 
         /// <summary>
@@ -47,6 +70,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition
             ValidateEffectKey(effectKey);
             ValidateOwnerId(ownerId);
 
+            DeleteLocalObject(target, GetSourceVariable(effectKey));
             ApplyFlatInternal(target, effectKey, amount, durationSeconds);
             if (amount > 0)
                 SetLocalString(target, GetOwnerVariable(effectKey), ownerId);
@@ -95,10 +119,27 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition
         {
             ValidateEffectKey(effectKey);
             DeleteLocalString(target, GetOwnerVariable(effectKey));
+            DeleteLocalObject(target, GetSourceVariable(effectKey));
 
             var effectTag = EffectTagPrefix + effectKey;
             RemoveEffectByTag(target, effectTag);
             RemoveEffectByTag(target, effectTag + BarrierVisualEffectTagSuffix);
+        }
+
+        public static bool IsActivePoolFromSource(uint target, string effectKey, uint source)
+        {
+            ValidateEffectKey(effectKey);
+            if (!GetIsObjectValid(source) || GetLocalObject(target, GetSourceVariable(effectKey)) != source)
+                return false;
+
+            var effectTag = EffectTagPrefix + effectKey;
+            for (var effect = GetFirstEffect(target); GetIsEffectValid(effect); effect = GetNextEffect(target))
+            {
+                if (GetEffectTag(effect) == effectTag)
+                    return true;
+            }
+
+            return false;
         }
 
         /// <summary>
@@ -117,6 +158,11 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition
         private static string GetOwnerVariable(string effectKey)
         {
             return EffectTagPrefix + effectKey + OwnerVariableSuffix;
+        }
+
+        private static string GetSourceVariable(string effectKey)
+        {
+            return EffectTagPrefix + effectKey + SourceVariableSuffix;
         }
 
         private static void ValidateEffectKey(string effectKey)

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/TemporaryHitPointEffects.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/TemporaryHitPointEffects.cs
@@ -28,10 +28,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition
         // any prior pool carrying the same key, regardless of caster.
         public static void ApplyFlat(uint target, string effectKey, int amount, float durationSeconds)
         {
-            ValidateEffectKey(effectKey);
-            DeleteLocalString(target, GetOwnerVariable(effectKey));
-            DeleteLocalObject(target, GetSourceVariable(effectKey));
-            ApplyFlatInternal(target, effectKey, amount, durationSeconds);
+            ApplyFlatFromSource(OBJECT_INVALID, target, effectKey, amount, durationSeconds);
         }
 
         /// <summary>

--- a/SWLOR.Game.Server/Feature/StatusEffectDefinition/ReflectiveBarrier1StatusEffect.cs
+++ b/SWLOR.Game.Server/Feature/StatusEffectDefinition/ReflectiveBarrier1StatusEffect.cs
@@ -1,4 +1,6 @@
 using SWLOR.Game.Server.Feature.AbilityDefinition;
+using SWLOR.Game.Server.Service;
+using SWLOR.Game.Server.Service.CombatService;
 using SWLOR.Game.Server.Service.StatService;
 using SWLOR.Game.Server.Service.StatusEffectService;
 using SWLOR.NWN.API.NWScript.Enum;
@@ -11,6 +13,7 @@ namespace SWLOR.Game.Server.Feature.StatusEffectDefinition
 
         public override string Name => "Reflective Barrier";
         public override EffectIconType Icon => EffectIconType.ReflectiveBarrier1StatusEffect;
+        public override float Frequency => 1f;
         public override bool PersistsOnLogout => false;
 
         protected override void Apply(uint creature, int durationTicks)
@@ -22,6 +25,38 @@ namespace SWLOR.Game.Server.Feature.StatusEffectDefinition
 
             StatGroup.Stats[StatType.ForceDamageReflectionPercentAdjustment] = reflection;
             StatGroup.Stats[StatType.ElementalDamageReflectionPercentAdjustment] = reflection;
+        }
+
+        protected override void Tick(uint creature)
+        {
+            RemoveWhenGuardianWardPoolEnds(creature, delayUntilAfterDamageResolution: false);
+        }
+
+        protected override void OnDamageTaken(
+            uint defender,
+            uint attacker,
+            int damage,
+            CombatDamageType damageType)
+        {
+            // Damage notifications run immediately before the shared reflection stage. Delay the
+            // removal so the hit that consumes the last temporary HP still reflects, then prevent
+            // every subsequent hit from using the expired barrier.
+            RemoveWhenGuardianWardPoolEnds(defender, delayUntilAfterDamageResolution: true);
+        }
+
+        private void RemoveWhenGuardianWardPoolEnds(uint creature, bool delayUntilAfterDamageResolution)
+        {
+            if (TemporaryHitPointEffects.IsActivePoolFromSource(creature, "GUARDIAN_WARD", Source))
+                return;
+
+            if (delayUntilAfterDamageResolution)
+            {
+                DelayCommand(0f, () => StatusEffect.RemoveStatusEffect(creature, GetType(), Source, false));
+            }
+            else
+            {
+                StatusEffect.RemoveStatusEffect(creature, GetType(), Source, false);
+            }
         }
     }
 }

--- a/SWLOR.Game.Server/Feature/StatusEffectDefinition/ReflectiveBarrier1StatusEffect.cs
+++ b/SWLOR.Game.Server/Feature/StatusEffectDefinition/ReflectiveBarrier1StatusEffect.cs
@@ -46,7 +46,10 @@ namespace SWLOR.Game.Server.Feature.StatusEffectDefinition
 
         private void RemoveWhenGuardianWardPoolEnds(uint creature)
         {
-            if (TemporaryHitPointEffects.IsActivePoolFromSource(creature, "GUARDIAN_WARD", Source))
+            if (TemporaryHitPointEffects.IsActivePoolFromSource(
+                    creature,
+                    TemporaryHitPointEffectKey.GuardianWard,
+                    Source))
                 return;
 
             StatusEffect.RemoveStatusEffect(creature, GetType(), Source, false);

--- a/SWLOR.Game.Server/Feature/StatusEffectDefinition/ReflectiveBarrier1StatusEffect.cs
+++ b/SWLOR.Game.Server/Feature/StatusEffectDefinition/ReflectiveBarrier1StatusEffect.cs
@@ -29,7 +29,7 @@ namespace SWLOR.Game.Server.Feature.StatusEffectDefinition
 
         protected override void Tick(uint creature)
         {
-            RemoveWhenGuardianWardPoolEnds(creature, delayUntilAfterDamageResolution: false);
+            RemoveWhenGuardianWardPoolEnds(creature);
         }
 
         protected override void OnDamageTaken(
@@ -38,32 +38,18 @@ namespace SWLOR.Game.Server.Feature.StatusEffectDefinition
             int damage,
             CombatDamageType damageType)
         {
-            // Damage notifications run immediately before the shared reflection stage. Delay the
-            // removal so the hit that consumes the last temporary HP still reflects, then prevent
-            // every subsequent hit from using the expired barrier.
-            RemoveWhenGuardianWardPoolEnds(defender, delayUntilAfterDamageResolution: true);
+            // Damage notifications run before the engine applies the current hit. The hit that
+            // consumes the final temporary HP therefore still sees an active pool, while the next
+            // hit removes an exhausted barrier before the shared reflection stage reads its stats.
+            RemoveWhenGuardianWardPoolEnds(defender);
         }
 
-        private void RemoveWhenGuardianWardPoolEnds(uint creature, bool delayUntilAfterDamageResolution)
+        private void RemoveWhenGuardianWardPoolEnds(uint creature)
         {
             if (TemporaryHitPointEffects.IsActivePoolFromSource(creature, "GUARDIAN_WARD", Source))
                 return;
 
-            if (delayUntilAfterDamageResolution)
-            {
-                var statusEffectId = Id;
-                var source = Source;
-                DelayCommand(0f, () =>
-                {
-                    var current = StatusEffect.GetStatusEffect(creature, GetType(), source);
-                    if (current?.Id == statusEffectId)
-                        StatusEffect.RemoveStatusEffect(creature, GetType(), source, false);
-                });
-            }
-            else
-            {
-                StatusEffect.RemoveStatusEffect(creature, GetType(), Source, false);
-            }
+            StatusEffect.RemoveStatusEffect(creature, GetType(), Source, false);
         }
     }
 }

--- a/SWLOR.Game.Server/Feature/StatusEffectDefinition/ReflectiveBarrier1StatusEffect.cs
+++ b/SWLOR.Game.Server/Feature/StatusEffectDefinition/ReflectiveBarrier1StatusEffect.cs
@@ -7,7 +7,7 @@ using SWLOR.NWN.API.NWScript.Enum;
 
 namespace SWLOR.Game.Server.Feature.StatusEffectDefinition
 {
-    public sealed class ReflectiveBarrier1StatusEffect : StatusEffectBase
+    public sealed class ReflectiveBarrier1StatusEffect : StatusEffectBase, IPreDamageStatusEffect
     {
         private const int BaseReflectionPercent = 8;
 
@@ -32,15 +32,15 @@ namespace SWLOR.Game.Server.Feature.StatusEffectDefinition
             RemoveWhenGuardianWardPoolEnds(creature);
         }
 
-        protected override void OnDamageTaken(
+        public void OnBeforeDamageTaken(
             uint defender,
             uint attacker,
             int damage,
-            CombatDamageType damageType)
+            CombatDamageType damageType,
+            CombatDamageDeliveryType deliveryType = CombatDamageDeliveryType.Direct)
         {
-            // Damage notifications run before the engine applies the current hit. The hit that
-            // consumes the final temporary HP therefore still sees an active pool, while the next
-            // hit removes an exhausted barrier before the shared reflection stage reads its stats.
+            // Validate before the originating hit so a hit that consumes the final temporary HP
+            // still reflects, while the next hit cannot read stale reflection stats.
             RemoveWhenGuardianWardPoolEnds(defender);
         }
 

--- a/SWLOR.Game.Server/Feature/StatusEffectDefinition/ReflectiveBarrier1StatusEffect.cs
+++ b/SWLOR.Game.Server/Feature/StatusEffectDefinition/ReflectiveBarrier1StatusEffect.cs
@@ -51,7 +51,14 @@ namespace SWLOR.Game.Server.Feature.StatusEffectDefinition
 
             if (delayUntilAfterDamageResolution)
             {
-                DelayCommand(0f, () => StatusEffect.RemoveStatusEffect(creature, GetType(), Source, false));
+                var statusEffectId = Id;
+                var source = Source;
+                DelayCommand(0f, () =>
+                {
+                    var current = StatusEffect.GetStatusEffect(creature, GetType(), source);
+                    if (current?.Id == statusEffectId)
+                        StatusEffect.RemoveStatusEffect(creature, GetType(), source, false);
+                });
             }
             else
             {

--- a/SWLOR.Game.Server/Native/GetDamageRoll.cs
+++ b/SWLOR.Game.Server/Native/GetDamageRoll.cs
@@ -159,17 +159,7 @@ namespace SWLOR.Game.Server.Native
                     if (totalDamage > 0 && defender.m_bPlotObject == 0)
                     {
                         var weaponId = weapon?.m_idSelf ?? OBJECT_INVALID;
-                        StatusEffect.NotifyPreDamageStatusEffects(
-                            attacker.m_idSelf,
-                            defender.m_idSelf,
-                            totalDamage,
-                            damageProfile.DamageType);
                         PublishDamageDealtEvent(attacker.m_idSelf, defender.m_idSelf, weaponId, totalDamage, weaponSkillType, damageProfile.DamageType);
-                        Combat.ApplyDamageReflectionEffects(
-                            attacker.m_idSelf,
-                            defender.m_idSelf,
-                            totalDamage,
-                            damageProfile.DamageType);
                     }
                 }
 
@@ -248,6 +238,20 @@ namespace SWLOR.Game.Server.Native
             // Ensure damage is never negative
             if (damage < 0)
                 damage = 0;
+
+            if (isLandedAttack && damage > 0 && targetObject.m_nObjectType == (int)ObjectType.Creature)
+            {
+                StatusEffect.NotifyPreDamageStatusEffects(
+                    attacker.m_idSelf,
+                    targetObject.m_idSelf,
+                    damage,
+                    damageProfile.DamageType);
+                Combat.ApplyDamageReflectionEffects(
+                    attacker.m_idSelf,
+                    targetObject.m_idSelf,
+                    damage,
+                    damageProfile.DamageType);
+            }
 
             if (damageProfile.DamageType.IsPhysicalDamageType())
             {

--- a/SWLOR.Game.Server/Native/GetDamageRoll.cs
+++ b/SWLOR.Game.Server/Native/GetDamageRoll.cs
@@ -159,6 +159,11 @@ namespace SWLOR.Game.Server.Native
                     if (totalDamage > 0 && defender.m_bPlotObject == 0)
                     {
                         var weaponId = weapon?.m_idSelf ?? OBJECT_INVALID;
+                        StatusEffect.NotifyPreDamageStatusEffects(
+                            attacker.m_idSelf,
+                            defender.m_idSelf,
+                            totalDamage,
+                            damageProfile.DamageType);
                         PublishDamageDealtEvent(attacker.m_idSelf, defender.m_idSelf, weaponId, totalDamage, weaponSkillType, damageProfile.DamageType);
                         Combat.ApplyDamageReflectionEffects(
                             attacker.m_idSelf,

--- a/SWLOR.Game.Server/Native/GetDamageRoll.cs
+++ b/SWLOR.Game.Server/Native/GetDamageRoll.cs
@@ -160,6 +160,11 @@ namespace SWLOR.Game.Server.Native
                     {
                         var weaponId = weapon?.m_idSelf ?? OBJECT_INVALID;
                         PublishDamageDealtEvent(attacker.m_idSelf, defender.m_idSelf, weaponId, totalDamage, weaponSkillType, damageProfile.DamageType);
+                        Combat.ApplyDamageReflectionEffects(
+                            attacker.m_idSelf,
+                            defender.m_idSelf,
+                            totalDamage,
+                            damageProfile.DamageType);
                     }
                 }
 
@@ -238,15 +243,6 @@ namespace SWLOR.Game.Server.Native
             // Ensure damage is never negative
             if (damage < 0)
                 damage = 0;
-
-            if (isLandedAttack && damage > 0 && targetObject.m_nObjectType == (int)ObjectType.Creature)
-            {
-                Combat.ApplyDamageReflectionEffects(
-                    attacker.m_idSelf,
-                    targetObject.m_idSelf,
-                    damage,
-                    damageProfile.DamageType);
-            }
 
             if (damageProfile.DamageType.IsPhysicalDamageType())
             {

--- a/SWLOR.Game.Server/Service/Ability.cs
+++ b/SWLOR.Game.Server/Service/Ability.cs
@@ -2087,6 +2087,12 @@ namespace SWLOR.Game.Server.Service
             {
                 trackedImpact?.ConsumeStatusAppliedNextAttackDamageBonus(activator);
                 Combat.SendTemporaryHitPointDamageFeedback(activator, target, damage);
+
+                // Damage status effects must observe the current hit while conditional defenses
+                // (such as Guardian Ward-backed reflection) are still active. This also matches
+                // weapon damage and queued ability damage, both of which notify before the engine
+                // applies the originating hit.
+                StatusEffect.NotifyDamageStatusEffects(activator, target, damage, damageType);
                 if (trackedImpact == null)
                 {
                     AssignCommand(
@@ -2113,7 +2119,6 @@ namespace SWLOR.Game.Server.Service
                     skillType,
                     damageType,
                     isAbilityDamage: true);
-                StatusEffect.NotifyDamageStatusEffects(activator, target, damage, damageType);
                 Combat.ApplyDamageReflectionEffects(activator, target, damage, damageType);
             }
 

--- a/SWLOR.Game.Server/Service/Ability.cs
+++ b/SWLOR.Game.Server/Service/Ability.cs
@@ -2086,13 +2086,8 @@ namespace SWLOR.Game.Server.Service
             if (damage > 0)
             {
                 trackedImpact?.ConsumeStatusAppliedNextAttackDamageBonus(activator);
+                StatusEffect.NotifyPreDamageStatusEffects(activator, target, damage, damageType);
                 Combat.SendTemporaryHitPointDamageFeedback(activator, target, damage);
-
-                // Damage status effects must observe the current hit while conditional defenses
-                // (such as Guardian Ward-backed reflection) are still active. This also matches
-                // weapon damage and queued ability damage, both of which notify before the engine
-                // applies the originating hit.
-                StatusEffect.NotifyDamageStatusEffects(activator, target, damage, damageType);
                 if (trackedImpact == null)
                 {
                     AssignCommand(
@@ -2119,6 +2114,7 @@ namespace SWLOR.Game.Server.Service
                     skillType,
                     damageType,
                     isAbilityDamage: true);
+                StatusEffect.NotifyDamageStatusEffects(activator, target, damage, damageType);
                 Combat.ApplyDamageReflectionEffects(activator, target, damage, damageType);
             }
 

--- a/SWLOR.Game.Server/Service/Ability.cs
+++ b/SWLOR.Game.Server/Service/Ability.cs
@@ -2086,10 +2086,10 @@ namespace SWLOR.Game.Server.Service
             if (damage > 0)
             {
                 trackedImpact?.ConsumeStatusAppliedNextAttackDamageBonus(activator);
-                StatusEffect.NotifyPreDamageStatusEffects(activator, target, damage, damageType);
-                Combat.SendTemporaryHitPointDamageFeedback(activator, target, damage);
                 if (trackedImpact == null)
                 {
+                    StatusEffect.NotifyPreDamageStatusEffects(activator, target, damage, damageType);
+                    Combat.SendTemporaryHitPointDamageFeedback(activator, target, damage);
                     AssignCommand(
                         activator,
                         () => ApplyEffectToObject(
@@ -2099,10 +2099,11 @@ namespace SWLOR.Game.Server.Service
                 }
                 else
                 {
-                    trackedImpact.QueueDamageEffect(
+                    trackedImpact.QueueDirectDamageEffect(
                         target,
                         damage,
-                        effectDamageType ?? damageType.GetNWScriptDamageType());
+                        effectDamageType ?? damageType.GetNWScriptDamageType(),
+                        damageType);
                 }
 
                 ApplyDarkForceConversion(activator, target, damage);
@@ -2115,7 +2116,8 @@ namespace SWLOR.Game.Server.Service
                     damageType,
                     isAbilityDamage: true);
                 StatusEffect.NotifyDamageStatusEffects(activator, target, damage, damageType);
-                Combat.ApplyDamageReflectionEffects(activator, target, damage, damageType);
+                if (trackedImpact == null)
+                    Combat.ApplyDamageReflectionEffects(activator, target, damage, damageType);
             }
 
             ApplyHostileAbilityEnmity(
@@ -3261,11 +3263,33 @@ namespace SWLOR.Game.Server.Service
 
             public void QueueDamageEffect(uint target, int damage, DamageType damageType)
             {
+                QueueDamageEffect(target, damage, damageType, CombatDamageType.Invalid);
+            }
+
+            public void QueueDirectDamageEffect(
+                uint target,
+                int damage,
+                DamageType damageType,
+                CombatDamageType combatDamageType)
+            {
+                QueueDamageEffect(target, damage, damageType, combatDamageType);
+            }
+
+            private void QueueDamageEffect(
+                uint target,
+                int damage,
+                DamageType damageType,
+                CombatDamageType combatDamageType)
+            {
                 if (!GetIsObjectValid(target) || damage <= 0)
                     return;
 
                 Summary.AttributedDamage += damage;
-                _pendingDamageEffects.Add(new PendingDamageEffect(target, damage, damageType));
+                _pendingDamageEffects.Add(new PendingDamageEffect(
+                    target,
+                    damage,
+                    damageType,
+                    combatDamageType));
             }
 
             public void FlushDamageEffects(uint activator)
@@ -3283,6 +3307,27 @@ namespace SWLOR.Game.Server.Service
                         if (!GetIsObjectValid(effect.Target))
                             continue;
 
+                        var isDirectAbilityDamage = effect.CombatDamageType != CombatDamageType.Invalid;
+                        if (isDirectAbilityDamage)
+                        {
+                            // Resolve the direct-hit lifecycle inside this loop so the next queued
+                            // hit observes temporary HP and status effects consumed by this one.
+                            StatusEffect.NotifyPreDamageStatusEffects(
+                                activator,
+                                effect.Target,
+                                effect.Damage,
+                                effect.CombatDamageType);
+                            Combat.SendTemporaryHitPointDamageFeedback(
+                                activator,
+                                effect.Target,
+                                effect.Damage);
+                            Combat.ApplyDamageReflectionEffects(
+                                activator,
+                                effect.Target,
+                                effect.Damage,
+                                effect.CombatDamageType);
+                        }
+
                         ApplyEffectToObject(
                             DurationType.Instant,
                             EffectDamage(effect.Damage, effect.DamageType),
@@ -3294,16 +3339,22 @@ namespace SWLOR.Game.Server.Service
 
         private sealed class PendingDamageEffect
         {
-            public PendingDamageEffect(uint target, int damage, DamageType damageType)
+            public PendingDamageEffect(
+                uint target,
+                int damage,
+                DamageType damageType,
+                CombatDamageType combatDamageType)
             {
                 Target = target;
                 Damage = damage;
                 DamageType = damageType;
+                CombatDamageType = combatDamageType;
             }
 
             public uint Target { get; }
             public int Damage { get; }
             public DamageType DamageType { get; }
+            public CombatDamageType CombatDamageType { get; }
         }
     }
 }

--- a/SWLOR.Game.Server/Service/Combat.cs
+++ b/SWLOR.Game.Server/Service/Combat.cs
@@ -978,13 +978,17 @@ namespace SWLOR.Game.Server.Service
                 TemporaryHitPointEffects.ApplyFlatFromSource(
                     temporaryHPSource,
                     defender,
-                    "FATAL_DAMAGE_SAVE",
+                    TemporaryHitPointEffectKey.FatalDamageSave,
                     tempHP,
                     duration);
             }
             else
             {
-                TemporaryHitPointEffects.ApplyFlat(defender, "FATAL_DAMAGE_SAVE", tempHP, duration);
+                TemporaryHitPointEffects.ApplyFlat(
+                    defender,
+                    TemporaryHitPointEffectKey.FatalDamageSave,
+                    tempHP,
+                    duration);
             }
             ApplyEffectToObject(DurationType.Instant, EffectVisualEffect(VisualEffect.Vfx_Imp_Ac_Bonus), defender);
 

--- a/SWLOR.Game.Server/Service/Combat.cs
+++ b/SWLOR.Game.Server/Service/Combat.cs
@@ -961,6 +961,9 @@ namespace SWLOR.Game.Server.Service
                 return false;
 
             var scalingAbilityScore = Stat.GetStatAdjustment(defender, StatType.FatalDamageTemporaryHPScalingAbilityScore);
+            var temporaryHPSource = StatusEffect.GetStatusEffectSourceWithStat(
+                defender,
+                StatType.FatalDamageTemporaryHPPercent);
             var tempHP = GameMath.PercentOf(GetMaxHitPoints(defender), temporaryHPPercent);
             if (scalingAbilityScore > 0)
                 tempHP = AbilityEffectScaling.ScaleDirectEffect(tempHP, scalingAbilityScore);
@@ -970,7 +973,19 @@ namespace SWLOR.Game.Server.Service
             if (restoreToOneHP && currentHP <= 0)
                 SetCurrentHitPoints(defender, 1);
 
-            TemporaryHitPointEffects.ApplyFlat(defender, "FATAL_DAMAGE_SAVE", tempHP, duration);
+            if (GetIsObjectValid(temporaryHPSource))
+            {
+                TemporaryHitPointEffects.ApplyFlatFromSource(
+                    temporaryHPSource,
+                    defender,
+                    "FATAL_DAMAGE_SAVE",
+                    tempHP,
+                    duration);
+            }
+            else
+            {
+                TemporaryHitPointEffects.ApplyFlat(defender, "FATAL_DAMAGE_SAVE", tempHP, duration);
+            }
             ApplyEffectToObject(DurationType.Instant, EffectVisualEffect(VisualEffect.Vfx_Imp_Ac_Bonus), defender);
 
             return true;

--- a/SWLOR.Game.Server/Service/StatusEffect.cs
+++ b/SWLOR.Game.Server/Service/StatusEffect.cs
@@ -1927,6 +1927,30 @@ namespace SWLOR.Game.Server.Service
         }
 
         /// <summary>
+        /// Notifies status effects that must validate their state before an originating hit is
+        /// applied. Ordinary damage reactions remain in NotifyDamageStatusEffects so they observe
+        /// the defender's post-hit state whenever the damage path supports it.
+        /// </summary>
+        public static void NotifyPreDamageStatusEffects(
+            uint attacker,
+            uint defender,
+            int damage,
+            CombatDamageType damageType,
+            CombatDamageDeliveryType deliveryType = CombatDamageDeliveryType.Direct)
+        {
+            if (damage <= 0 || !GetIsObjectValid(attacker) || !GetIsObjectValid(defender))
+                return;
+
+            foreach (var effect in GetCreatureStatusEffects(defender)
+                         .GetAllEffects()
+                         .OfType<IPreDamageStatusEffect>()
+                         .ToList())
+            {
+                effect.OnBeforeDamageTaken(defender, attacker, damage, damageType, deliveryType);
+            }
+        }
+
+        /// <summary>
         /// Notifies limited-attack status effects once per originating hostile attack, including
         /// misses and deflections. Effects exhausted by the attempt are removed immediately so
         /// they cannot affect another attack before the next status-effect tick.

--- a/SWLOR.Game.Server/Service/StatusEffectService/IPreDamageStatusEffect.cs
+++ b/SWLOR.Game.Server/Service/StatusEffectService/IPreDamageStatusEffect.cs
@@ -1,0 +1,18 @@
+using SWLOR.Game.Server.Service.CombatService;
+
+namespace SWLOR.Game.Server.Service.StatusEffectService
+{
+    /// <summary>
+    /// Receives a callback before an originating hit is applied. Use this only for state that must
+    /// be validated before damage resolution; ordinary damage reactions belong in IStatusEffect.
+    /// </summary>
+    public interface IPreDamageStatusEffect : IStatusEffect
+    {
+        void OnBeforeDamageTaken(
+            uint defender,
+            uint attacker,
+            int damage,
+            CombatDamageType damageType,
+            CombatDamageDeliveryType deliveryType = CombatDamageDeliveryType.Direct);
+    }
+}


### PR DESCRIPTION
## Summary

- audits all 329 implemented tracker rows that are not yet complete (327 `Not Tested`, 2 `In Progress`) against the combat-upgrade Bible implementation manifest
- fixes Protective Presence so only qualifying Control protection powers grant ranged deflection
- fixes Courageous Resolve so all Sense power ranks trigger the party Mind Resistance buff
- tracks temporary-HP grant sources so Courageous Resolve grants +15 only while that caster's Force temporary HP is active
- centralizes shared temporary-HP pool identifiers so production consumers cannot drift through duplicated magic strings
- expires Reflective Barrier when its matching Guardian Ward temporary-HP pool ends
- preserves reflection on the hit that consumes Guardian Ward, removes it before later hits, and keeps ordinary damage reactions on post-hit HP through a generic pre-damage lifecycle
- adds explicit engine-behavior expectations and regression coverage for these trait paths

## Tracker audit

All 329 scoped rows map one-to-one to implemented Bible audit entries with `PASS` verdicts and no unmatched rows or recorded findings.

Scoped tracker distribution:

- Beast Mastery: 64
- Engineering: 5
- Espionage: 20
- Force: 24
- Lightsaber: 19
- Mimicry: 94
- Saberstaff: 13
- Throwing: 36
- Twin Blade: 36
- Vibroblade: 18

## Validation

- `dotnet build SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj -p:RunPostBuildEvent=Never`
- expanded perk/ability readiness matrix: 336 passed, 0 failed
- repository suite excluding the known target-branch runtime-free stance harness class: 2,009 passed, 0 failed
- isolated `StanceStatusEffectTests`: 4 passed, 3 known target-branch harness failures because GUI refresh calls `NWN.Core.GetFirstPC` without engine initialization; this PR intentionally does not alter GUI behavior

Target: `feature/combat-upgrade`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Several Force abilities now grant Courageous Resolve to the activator.
  - Guardian Ward provides improved temporary-health protection and ranged-deflection support.
  - Temporary-health effects now track their source for more accurate support bonuses.

- **Bug Fixes**
  - Reflective Barrier now validates protection before incoming damage.
  - Damage reflection now occurs at the correct point during damage resolution.
  - Deflective Presence is no longer applied by abilities that do not qualify.

- **Tests**
  - Added coverage for Force Light Guardian interactions and combat effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->