### PR TITLE
Fix Gambler Stance non-critical stamina surcharge

### DIFF
--- a/SWLOR.Game.Server.Tests/Perks/GeneratedWeaponPerkBehaviorTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/GeneratedWeaponPerkBehaviorTests.cs
@@ -1027,6 +1027,10 @@ public class GeneratedWeaponPerkBehaviorTests
         AssertStatusStat(suppression, StatType.RangedHitSuppressionStackDurationSeconds, 30);
         AssertStatusStat(suppression, StatType.RangedCriticalDamagePercentAdjustment, -10);
 
+        var gambler = new GamblerStanceStatusEffect();
+        AssertStatusStat(gambler, StatType.CriticalRatePercentAdjustment, 12);
+        AssertStatusStat(gambler, StatType.NonCriticalRangedAbilityStaminaCostFlatAdjustment, 2);
+
         var vigor = new VigorStanceStatusEffect();
         AssertStatusStat(vigor, StatType.HostileAbilityStaminaCostFlatAdjustment, 2);
         AssertStatusStat(vigor, StatType.DamageDealtPercentAdjustment, 10);
@@ -1261,6 +1265,8 @@ public class GeneratedWeaponPerkBehaviorTests
         Stat.GetStatTypeCategory(StatType.SameTargetHostileAbilityStaminaRestore)
             .Should().Be(StatTypeCategory.BeneficialWhenPositive);
         Stat.GetStatTypeCategory(StatType.BleedingStatusExpiredNextSkillAbilityStaminaCostAdjustment)
+            .Should().Be(StatTypeCategory.BeneficialWhenNegative);
+        Stat.GetStatTypeCategory(StatType.NonCriticalRangedAbilityStaminaCostFlatAdjustment)
             .Should().Be(StatTypeCategory.BeneficialWhenNegative);
         Stat.GetStatTypeCategory(StatType.AbilityRestoredFPHastePercentAdjustment)
             .Should().Be(StatTypeCategory.BeneficialWhenPositive);

--- a/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
@@ -205,6 +205,25 @@ public class CombatDamageTests
     }
 
     [Test]
+    public void NonCriticalRangedAbilities_ApplyStatDrivenStaminaCostOnceAtCompletion()
+    {
+        var root = FindRepositoryRoot();
+        var abilitySource = File.ReadAllText(Path.Combine(root.FullName, "SWLOR.Game.Server", "Service", "Ability.cs"));
+        var combatSource = File.ReadAllText(Path.Combine(root.FullName, "SWLOR.Game.Server", "Service", "Combat.cs"));
+        var endAbilityImpact = ExtractMethod(abilitySource, "public static AbilityImpactSummary EndAbilityImpact");
+        var applyNonCriticalEffects = ExtractMethod(combatSource, "public static void ApplyNonCriticalAbilityEffects");
+        var applyStaminaCost = ExtractMethod(combatSource, "private static void ApplyNonCriticalRangedAbilityStaminaCost");
+
+        endAbilityImpact.Should().Contain("impact.Summary.CriticalHitCount > 0");
+        endAbilityImpact.Should().Contain("Combat.ApplyNonCriticalAbilityEffects");
+        applyNonCriticalEffects.Should().Contain("ApplyNonCriticalRangedAbilityStaminaCost(activator, skillType)");
+        applyStaminaCost.Should().Contain("IsRangedWeaponSkill(skillType)");
+        applyStaminaCost.Should().Contain("StatType.NonCriticalRangedAbilityStaminaCostFlatAdjustment");
+        applyStaminaCost.Should().Contain("Stat.ReduceStamina(activator, staminaCost)");
+        applyStaminaCost.Should().NotContain("GamblerStance");
+    }
+
+    [Test]
     public void DeflectionGrantedSkillBonuses_DoNotInferEquippedWeaponSkillWhenNoSelectorIsDeclared()
     {
         var root = FindRepositoryRoot();

--- a/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
@@ -215,6 +215,7 @@ public class CombatDamageTests
         var getSurcharge = ExtractMethod(combatSource, "private static int GetNonCriticalRangedAbilityStaminaCostFlatAdjustment");
         var refundSurcharge = ExtractMethod(combatSource, "public static int RefundCriticalRangedAbilityStaminaCost");
         var trackStaminaCost = ExtractMethod(combatSource, "private static void TrackAbilityStaminaCost");
+        var resourceThreshold = ExtractMethod(combatSource, "public static bool IsCurrentFPAndStaminaAtOrAbovePercent");
 
         endAbilityImpact.Should().Contain("impact.Summary.CriticalHitCount > 0");
         endAbilityImpact.Should().Contain("Combat.RefundCriticalRangedAbilityStaminaCost");
@@ -231,6 +232,8 @@ public class CombatDamageTests
         trackStaminaCost.Should().Contain("NonCriticalRangedAbilityStaminaCost = nonCriticalRangedAbilityStaminaCost");
         refundSurcharge.Should().Contain("state.NonCriticalRangedAbilityStaminaCost = 0");
         refundSurcharge.Should().Contain("Stat.RestoreStamina(creature, amount)");
+        resourceThreshold.Should().Contain("TryGetAbilityStaminaCostState(creature, ability, out var costState)");
+        resourceThreshold.Should().Contain("currentStamina += costState.NonCriticalRangedAbilityStaminaCost");
     }
 
     [Test]

--- a/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
@@ -205,22 +205,27 @@ public class CombatDamageTests
     }
 
     [Test]
-    public void NonCriticalRangedAbilities_ApplyStatDrivenStaminaCostOnceAtCompletion()
+    public void NonCriticalRangedAbilities_ReserveStatDrivenStaminaCostAndRefundCriticalResults()
     {
         var root = FindRepositoryRoot();
         var abilitySource = File.ReadAllText(Path.Combine(root.FullName, "SWLOR.Game.Server", "Service", "Ability.cs"));
         var combatSource = File.ReadAllText(Path.Combine(root.FullName, "SWLOR.Game.Server", "Service", "Combat.cs"));
         var endAbilityImpact = ExtractMethod(abilitySource, "public static AbilityImpactSummary EndAbilityImpact");
-        var applyNonCriticalEffects = ExtractMethod(combatSource, "public static void ApplyNonCriticalAbilityEffects");
-        var applyStaminaCost = ExtractMethod(combatSource, "private static void ApplyNonCriticalRangedAbilityStaminaCost");
+        var getFlatAdjustment = ExtractMethod(combatSource, "public static int GetAbilityStaminaCostFlatAdjustment(uint creature, AbilityDetail ability)");
+        var getSurcharge = ExtractMethod(combatSource, "private static int GetNonCriticalRangedAbilityStaminaCostFlatAdjustment");
+        var refundSurcharge = ExtractMethod(combatSource, "public static int RefundCriticalRangedAbilityStaminaCost");
+        var trackStaminaCost = ExtractMethod(combatSource, "private static void TrackAbilityStaminaCost");
 
         endAbilityImpact.Should().Contain("impact.Summary.CriticalHitCount > 0");
+        endAbilityImpact.Should().Contain("Combat.RefundCriticalRangedAbilityStaminaCost");
         endAbilityImpact.Should().Contain("Combat.ApplyNonCriticalAbilityEffects");
-        applyNonCriticalEffects.Should().Contain("ApplyNonCriticalRangedAbilityStaminaCost(activator, skillType)");
-        applyStaminaCost.Should().Contain("IsRangedWeaponSkill(skillType)");
-        applyStaminaCost.Should().Contain("StatType.NonCriticalRangedAbilityStaminaCostFlatAdjustment");
-        applyStaminaCost.Should().Contain("Stat.ReduceStamina(activator, staminaCost)");
-        applyStaminaCost.Should().NotContain("GamblerStance");
+        getFlatAdjustment.Should().Contain("GetNonCriticalRangedAbilityStaminaCostFlatAdjustment(creature, ability)");
+        getSurcharge.Should().Contain("IsRangedWeaponSkill(GetAbilitySkillType(creature, ability))");
+        getSurcharge.Should().Contain("StatType.NonCriticalRangedAbilityStaminaCostFlatAdjustment");
+        getSurcharge.Should().NotContain("GamblerStance");
+        trackStaminaCost.Should().Contain("NonCriticalRangedAbilityStaminaCost = Math.Min(");
+        refundSurcharge.Should().Contain("state.NonCriticalRangedAbilityStaminaCost = 0");
+        refundSurcharge.Should().Contain("Stat.RestoreStamina(creature, amount)");
     }
 
     [Test]

--- a/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
@@ -223,7 +223,9 @@ public class CombatDamageTests
         getSurcharge.Should().Contain("IsRangedWeaponSkill(GetAbilitySkillType(creature, ability))");
         getSurcharge.Should().Contain("StatType.NonCriticalRangedAbilityStaminaCostFlatAdjustment");
         getSurcharge.Should().NotContain("GamblerStance");
-        trackStaminaCost.Should().Contain("NonCriticalRangedAbilityStaminaCost = Math.Min(");
+        trackStaminaCost.Should().Contain("var nonCriticalRangedAbilityStaminaCost = Math.Min(");
+        trackStaminaCost.Should().Contain("Cost = staminaCost - nonCriticalRangedAbilityStaminaCost");
+        trackStaminaCost.Should().Contain("NonCriticalRangedAbilityStaminaCost = nonCriticalRangedAbilityStaminaCost");
         refundSurcharge.Should().Contain("state.NonCriticalRangedAbilityStaminaCost = 0");
         refundSurcharge.Should().Contain("Stat.RestoreStamina(creature, amount)");
     }

--- a/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
@@ -219,6 +219,9 @@ public class CombatDamageTests
         endAbilityImpact.Should().Contain("impact.Summary.CriticalHitCount > 0");
         endAbilityImpact.Should().Contain("Combat.RefundCriticalRangedAbilityStaminaCost");
         endAbilityImpact.Should().Contain("Combat.ApplyNonCriticalAbilityEffects");
+        endAbilityImpact.IndexOf("Combat.RefundCriticalRangedAbilityStaminaCost", StringComparison.Ordinal)
+            .Should().BeLessThan(endAbilityImpact.IndexOf("impact.CountsAsAttackAttempt", StringComparison.Ordinal),
+                "deferred area impacts must refund a critical surcharge without sending a second attack-attempt notification");
         getFlatAdjustment.Should().Contain("GetNonCriticalRangedAbilityStaminaCostFlatAdjustment(creature, ability)");
         getSurcharge.Should().Contain("IsRangedWeaponSkill(GetAbilitySkillType(creature, ability))");
         getSurcharge.Should().Contain("StatType.NonCriticalRangedAbilityStaminaCostFlatAdjustment");

--- a/SWLOR.Game.Server/Feature/StatusEffectDefinition/GamblerStanceStatusEffect.cs
+++ b/SWLOR.Game.Server/Feature/StatusEffectDefinition/GamblerStanceStatusEffect.cs
@@ -15,6 +15,7 @@ namespace SWLOR.Game.Server.Feature.StatusEffectDefinition
         public GamblerStanceStatusEffect()
         {
             StatGroup.Stats[StatType.CriticalRatePercentAdjustment] = 12;
+            StatGroup.Stats[StatType.NonCriticalRangedAbilityStaminaCostFlatAdjustment] = 2;
         }
     }
 }

--- a/SWLOR.Game.Server/Native/GetDamageRoll.cs
+++ b/SWLOR.Game.Server/Native/GetDamageRoll.cs
@@ -570,6 +570,7 @@ namespace SWLOR.Game.Server.Native
                 false,
                 canApplyRandomFlatBonusesThisDamage,
                 isLandedAttack,
+                null,
                 out var damageBeforeTargetStatusStage);
 
             // Saber Ward / Aegis Eternal: re-type a share of the physical hit into a real Force

--- a/SWLOR.Game.Server/Service/Ability.cs
+++ b/SWLOR.Game.Server/Service/Ability.cs
@@ -172,13 +172,17 @@ namespace SWLOR.Game.Server.Service
 
             _trackedAbilityImpacts.Remove(activator);
             impact.FlushDamageEffects(activator);
+            if (impact.Ability.IsHostileAbility && impact.Summary.CriticalHitCount > 0)
+            {
+                Combat.RefundCriticalRangedAbilityStaminaCost(
+                    activator,
+                    impact.Ability);
+            }
+
             if (impact.Ability.IsHostileAbility && impact.CountsAsAttackAttempt)
             {
                 if (impact.Summary.CriticalHitCount > 0)
                 {
-                    Combat.RefundCriticalRangedAbilityStaminaCost(
-                        activator,
-                        impact.Ability);
                     Combat.ConsumePersistentNextSkillAbilityCriticalRateBonus(
                         activator,
                         impact.Summary.SkillType);

--- a/SWLOR.Game.Server/Service/Ability.cs
+++ b/SWLOR.Game.Server/Service/Ability.cs
@@ -2482,7 +2482,8 @@ namespace SWLOR.Game.Server.Service
                 damage,
                 skillType,
                 damageType,
-                isAbilityDamage: true);
+                isAbilityDamage: true,
+                ability: trackedImpact?.Ability);
             damage = ApplyCombatReadinessToActivatedAbilityMagnitude(activator, damage);
             Combat.ApplyIncomingPhysicalToForceConversion(activator, target, damageType, ref damage);
             damage = Combat.ApplyTypedLeadershipDamageTakenModifier(target, damage, damageType);
@@ -2614,7 +2615,14 @@ namespace SWLOR.Game.Server.Service
             {
                 calculatedDamage = Perk.ApplyForceAffinityMagnitude(activator, perkType, calculatedDamage);
             }
-            calculatedDamage = Combat.ApplyDamageDealtModifiers(activator, target, calculatedDamage, skillType, damageType, true);
+            calculatedDamage = Combat.ApplyDamageDealtModifiers(
+                activator,
+                target,
+                calculatedDamage,
+                skillType,
+                damageType,
+                isAbilityDamage: true,
+                ability: trackedImpact?.Ability);
             calculatedDamage = ApplyCombatReadinessToActivatedAbilityMagnitude(activator, calculatedDamage);
             // Saber Ward / Aegis Eternal: re-type a share of an incoming physical hit into a real Force
             // instance (mitigated by Force resistance, shown as Force) before physical resistance.
@@ -2847,7 +2855,14 @@ namespace SWLOR.Game.Server.Service
             {
                 calculatedDamage = Perk.ApplyForceAffinityMagnitude(activator, perkType, calculatedDamage);
             }
-            calculatedDamage = Combat.ApplyDamageDealtModifiers(activator, target, calculatedDamage, skillType, damageType, true);
+            calculatedDamage = Combat.ApplyDamageDealtModifiers(
+                activator,
+                target,
+                calculatedDamage,
+                skillType,
+                damageType,
+                isAbilityDamage: true,
+                ability: trackedImpact?.Ability);
             calculatedDamage = ApplyCombatReadinessToActivatedAbilityMagnitude(activator, calculatedDamage);
             // Saber Ward / Aegis Eternal: re-type a share of an incoming physical hit into a real Force
             // instance (mitigated by Force resistance, shown as Force) before physical resistance.

--- a/SWLOR.Game.Server/Service/Ability.cs
+++ b/SWLOR.Game.Server/Service/Ability.cs
@@ -176,6 +176,9 @@ namespace SWLOR.Game.Server.Service
             {
                 if (impact.Summary.CriticalHitCount > 0)
                 {
+                    Combat.RefundCriticalRangedAbilityStaminaCost(
+                        activator,
+                        impact.Ability);
                     Combat.ConsumePersistentNextSkillAbilityCriticalRateBonus(
                         activator,
                         impact.Summary.SkillType);

--- a/SWLOR.Game.Server/Service/Combat.cs
+++ b/SWLOR.Game.Server/Service/Combat.cs
@@ -9660,13 +9660,14 @@ namespace SWLOR.Game.Server.Service
                 return;
             }
 
+            var nonCriticalRangedAbilityStaminaCost = Math.Min(
+                staminaCost,
+                GetNonCriticalRangedAbilityStaminaCostFlatAdjustment(creature, ability));
             _abilityStaminaCosts[key] = new AbilityStaminaCostState
             {
-                Cost = staminaCost,
+                Cost = staminaCost - nonCriticalRangedAbilityStaminaCost,
                 SpentAt = DateTime.UtcNow,
-                NonCriticalRangedAbilityStaminaCost = Math.Min(
-                    staminaCost,
-                    GetNonCriticalRangedAbilityStaminaCostFlatAdjustment(creature, ability))
+                NonCriticalRangedAbilityStaminaCost = nonCriticalRangedAbilityStaminaCost
             };
         }
 

--- a/SWLOR.Game.Server/Service/Combat.cs
+++ b/SWLOR.Game.Server/Service/Combat.cs
@@ -2079,6 +2079,8 @@ namespace SWLOR.Game.Server.Service
             if (!GetIsObjectValid(activator) || skillType == SkillType.Invalid)
                 return;
 
+            ApplyNonCriticalRangedAbilityStaminaCost(activator, skillType);
+
             var requiredSkillType = GetSkillTypeFromStat(Stat.GetStatAdjustment(
                 activator,
                 StatType.NonCriticalAbilityNextSkillAbilityCriticalRateSkillType));
@@ -2143,6 +2145,18 @@ namespace SWLOR.Game.Server.Service
                     activator,
                     false);
             }
+        }
+
+        private static void ApplyNonCriticalRangedAbilityStaminaCost(uint activator, SkillType skillType)
+        {
+            if (!IsRangedWeaponSkill(skillType))
+                return;
+
+            var staminaCost = Stat.GetStatAdjustment(
+                activator,
+                StatType.NonCriticalRangedAbilityStaminaCostFlatAdjustment);
+            if (staminaCost > 0)
+                Stat.ReduceStamina(activator, staminaCost);
         }
 
         private static void ApplyCriticalBleedingStatusDurationExtension(uint attacker, uint defender)

--- a/SWLOR.Game.Server/Service/Combat.cs
+++ b/SWLOR.Game.Server/Service/Combat.cs
@@ -145,6 +145,7 @@ namespace SWLOR.Game.Server.Service
         {
             public int Cost { get; init; }
             public DateTime SpentAt { get; init; }
+            public int NonCriticalRangedAbilityStaminaCost { get; set; }
             public bool StaminaRestoreApplied { get; set; }
             public int DeferredImpactCount { get; set; }
         }
@@ -2079,8 +2080,6 @@ namespace SWLOR.Game.Server.Service
             if (!GetIsObjectValid(activator) || skillType == SkillType.Invalid)
                 return;
 
-            ApplyNonCriticalRangedAbilityStaminaCost(activator, skillType);
-
             var requiredSkillType = GetSkillTypeFromStat(Stat.GetStatAdjustment(
                 activator,
                 StatType.NonCriticalAbilityNextSkillAbilityCriticalRateSkillType));
@@ -2145,18 +2144,6 @@ namespace SWLOR.Game.Server.Service
                     activator,
                     false);
             }
-        }
-
-        private static void ApplyNonCriticalRangedAbilityStaminaCost(uint activator, SkillType skillType)
-        {
-            if (!IsRangedWeaponSkill(skillType))
-                return;
-
-            var staminaCost = Stat.GetStatAdjustment(
-                activator,
-                StatType.NonCriticalRangedAbilityStaminaCostFlatAdjustment);
-            if (staminaCost > 0)
-                Stat.ReduceStamina(activator, staminaCost);
         }
 
         private static void ApplyCriticalBleedingStatusDurationExtension(uint attacker, uint defender)
@@ -9575,13 +9562,14 @@ namespace SWLOR.Game.Server.Service
             if (ability == null)
                 return 0;
 
+            var skillType = GetAbilitySkillType(creature, ability);
             var adjustment = GetAbilityStaminaCostFlatAdjustment(creature, ability.EffectiveLevelPerkType);
             if (ability.IsHostileAbility)
             {
                 adjustment += Stat.GetStatAdjustment(creature, StatType.HostileAbilityStaminaCostFlatAdjustment);
+                adjustment += GetNonCriticalRangedAbilityStaminaCostFlatAdjustment(creature, ability);
             }
 
-            var skillType = GetAbilitySkillType(creature, ability);
             var flatSkillType = GetSkillTypeFromStat(Stat.GetStatAdjustment(
                 creature,
                 StatType.SkillAbilityStaminaCostFlatAdjustmentSkillType));
@@ -9602,6 +9590,34 @@ namespace SWLOR.Game.Server.Service
             }
 
             return adjustment;
+        }
+
+        private static int GetNonCriticalRangedAbilityStaminaCostFlatAdjustment(
+            uint creature,
+            AbilityDetail ability)
+        {
+            if (ability?.IsHostileAbility != true ||
+                !IsRangedWeaponSkill(GetAbilitySkillType(creature, ability)))
+            {
+                return 0;
+            }
+
+            return Math.Max(0, Stat.GetStatAdjustment(
+                creature,
+                StatType.NonCriticalRangedAbilityStaminaCostFlatAdjustment));
+        }
+
+        public static int RefundCriticalRangedAbilityStaminaCost(uint creature, AbilityDetail ability)
+        {
+            if (!TryGetAbilityStaminaCostState(creature, ability, out var state) ||
+                state.NonCriticalRangedAbilityStaminaCost <= 0)
+            {
+                return 0;
+            }
+
+            var amount = state.NonCriticalRangedAbilityStaminaCost;
+            state.NonCriticalRangedAbilityStaminaCost = 0;
+            return Stat.RestoreStamina(creature, amount);
         }
 
         public static void ApplyAbilityStaminaCostFPRestore(uint creature, AbilityDetail ability, int staminaCost)
@@ -9647,7 +9663,10 @@ namespace SWLOR.Game.Server.Service
             _abilityStaminaCosts[key] = new AbilityStaminaCostState
             {
                 Cost = staminaCost,
-                SpentAt = DateTime.UtcNow
+                SpentAt = DateTime.UtcNow,
+                NonCriticalRangedAbilityStaminaCost = Math.Min(
+                    staminaCost,
+                    GetNonCriticalRangedAbilityStaminaCostFlatAdjustment(creature, ability))
             };
         }
 

--- a/SWLOR.Game.Server/Service/Combat.cs
+++ b/SWLOR.Game.Server/Service/Combat.cs
@@ -1005,6 +1005,7 @@ namespace SWLOR.Game.Server.Service
             bool isAbilityDamage,
             bool canApplyRandomFlatBonuses,
             bool isLandedAttack,
+            AbilityDetail ability,
             out int damageBeforeTargetStatusStage)
         {
             damageBeforeTargetStatusStage = 0;
@@ -1032,7 +1033,8 @@ namespace SWLOR.Game.Server.Service
                 skillType,
                 damageType,
                 isAbilityDamage,
-                canApplyRandomFlatBonuses);
+                canApplyRandomFlatBonuses,
+                ability);
             // The repeated-target modifiers keep per-attacker stack state, so a swing the engine
             // later discards must not advance (or reset) their counters - the damage value itself
             // is thrown away with the swing.
@@ -1080,7 +1082,8 @@ namespace SWLOR.Game.Server.Service
             CombatDamageType damageType = CombatDamageType.Physical,
             bool isAbilityDamage = false,
             bool canApplyRandomFlatBonuses = true,
-            bool isLandedAttack = true)
+            bool isLandedAttack = true,
+            AbilityDetail ability = null)
         {
             return ApplyDamageDealtModifiers(
                 attacker,
@@ -1091,6 +1094,7 @@ namespace SWLOR.Game.Server.Service
                 isAbilityDamage,
                 canApplyRandomFlatBonuses,
                 isLandedAttack,
+                ability,
                 out _);
         }
 
@@ -4176,7 +4180,8 @@ namespace SWLOR.Game.Server.Service
             SkillType skillType,
             CombatDamageType damageType,
             bool isAbilityDamage,
-            bool canApplyRandomFlatBonuses)
+            bool canApplyRandomFlatBonuses,
+            AbilityDetail ability)
         {
             var adjustment = 0;
             adjustment += GetStatusSourceStatAdjustment(
@@ -4249,7 +4254,8 @@ namespace SWLOR.Game.Server.Service
                     attacker,
                     Stat.GetStatAdjustment(
                         attacker,
-                        StatType.HighFPAndStaminaAbilityDamagePercentAdjustmentThresholdPercent)))
+                        StatType.HighFPAndStaminaAbilityDamagePercentAdjustmentThresholdPercent),
+                    ability))
             {
                 adjustment += Stat.GetStatAdjustment(
                     attacker,
@@ -5463,7 +5469,8 @@ namespace SWLOR.Game.Server.Service
             if (ability.IsHostileAbility &&
                 IsCurrentFPAndStaminaAtOrAbovePercent(
                     activator,
-                    Stat.GetStatAdjustment(activator, StatType.HighFPAndStaminaAbilityDamageBonusThresholdPercent)))
+                    Stat.GetStatAdjustment(activator, StatType.HighFPAndStaminaAbilityDamageBonusThresholdPercent),
+                    ability))
             {
                 bonus += Stat.GetStatAdjustment(activator, StatType.HighFPAndStaminaAbilityDamageBonus);
             }
@@ -10937,7 +10944,10 @@ namespace SWLOR.Game.Server.Service
             return Stat.GetCurrentFP(creature) >= maxFP * (thresholdPercent / 100f);
         }
 
-        public static bool IsCurrentFPAndStaminaAtOrAbovePercent(uint creature, int thresholdPercent)
+        public static bool IsCurrentFPAndStaminaAtOrAbovePercent(
+            uint creature,
+            int thresholdPercent,
+            AbilityDetail ability = null)
         {
             if (thresholdPercent <= 0)
                 return false;
@@ -10947,8 +10957,14 @@ namespace SWLOR.Game.Server.Service
             if (maxFP <= 0 || maxStamina <= 0)
                 return false;
 
+            var currentStamina = Stat.GetCurrentStamina(creature);
+            if (TryGetAbilityStaminaCostState(creature, ability, out var costState))
+            {
+                currentStamina += costState.NonCriticalRangedAbilityStaminaCost;
+            }
+
             return Stat.GetCurrentFP(creature) >= maxFP * (thresholdPercent / 100f) &&
-                   Stat.GetCurrentStamina(creature) >= maxStamina * (thresholdPercent / 100f);
+                   currentStamina >= maxStamina * (thresholdPercent / 100f);
         }
 
         public static bool IsCurrentFPAndStaminaAtOrBelowPercent(uint creature, int thresholdPercent)

--- a/SWLOR.Game.Server/Service/StatService/StatType.cs
+++ b/SWLOR.Game.Server/Service/StatService/StatType.cs
@@ -6075,6 +6075,13 @@ namespace SWLOR.Game.Server.Service.StatService
         [StatType(StatTypeCategory.NonBeneficial, StatTypeAggregation.Maximum)]
         BolsterAttackRank = 1053,
 
+        /// <summary>
+        /// Flat Stamina cost charged after a hostile ranged weapon ability resolves without
+        /// any critical hits.
+        /// </summary>
+        [StatType(StatTypeCategory.BeneficialWhenNegative)]
+        NonCriticalRangedAbilityStaminaCostFlatAdjustment = 1054,
+
     }
 
     public class StatTypeAttribute : Attribute

--- a/tools/GenerateWeaponArchetypeImplementation.py
+++ b/tools/GenerateWeaponArchetypeImplementation.py
@@ -1881,6 +1881,7 @@ def exact_weapon_stance_stat_entries(row, base):
 
     if base == "Gambler Stance":
         add_stat(stats, "CriticalRatePercentAdjustment", parse_percent(r"\+(\d+)% Critical Rate", description))
+        add_stat(stats, "NonCriticalRangedAbilityStaminaCostFlatAdjustment", parse_count(r"cost (\d+) additional STM", description))
         return list(stats.items())
 
     if base == "Suppression Stance":


### PR DESCRIPTION
## Summary

- add a stat-driven 2 STM conditional surcharge for hostile ranged weapon abilities
- reserve the surcharge during activation so low-stamina users must pay it in full, then refund it exactly once when any immediate or deferred impact critically hits
- track the refundable reservation separately so it cannot inflate costly-ability thresholds or suppress provisional resource-threshold bonuses
- support Pistol, Rifle, and Throwing abilities, including queued, multi-hit, and telegraphed area abilities
- update the weapon archetype generator and focused regression coverage

## Testing

- `dotnet build SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj -p:RunPostBuildEvent=Never`
- combined Gambler/deferred-queue/cross-skill filter: 25 passed
- `CombatDamageTests`: 60 passed; 3 unrelated fixture failures because this worktree lacks the `SWLOR_Haks` 2DA files

A broader earlier run of the two initially affected test classes likewise produced only missing-`SWLOR_Haks` fixture failures.