### PR TITLE
Fix telegraph color selection

### DIFF
--- a/SWLOR.Game.Server.Tests/Service/TelegraphTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/TelegraphTests.cs
@@ -13,8 +13,63 @@ namespace SWLOR.Game.Server.Tests.Service;
 
 public class TelegraphTests
 {
+    private const int PackedColorShift = 3;
+    private const int PackedColorMask = 0x3;
     private const int PackedRotationShift = 21;
     private const int PackedRotationMask = 0x3ff;
+
+    [TestCase(TelegraphColorType.Hostile, 0)]
+    [TestCase(TelegraphColorType.Self, 1)]
+    [TestCase(TelegraphColorType.Beneficial, 2)]
+    [TestCase(TelegraphColorType.PartyMember, 3)]
+    public void PackTelegraphData_UsesTheShaderColorProtocol(
+        TelegraphColorType colorType,
+        int expectedPackedColor)
+    {
+        var packed = InvokePackTelegraphData(TelegraphType.Sphere, colorType, 0f);
+
+        ExtractPackedColor(packed).Should().Be(expectedPackedColor);
+    }
+
+    [Test]
+    public void ShaderPalette_MatchesTheServerColorProtocol()
+    {
+        var shader = File.ReadAllText(ResolveRepositoryPath(
+            "SWLOR_Haks",
+            "sw_shader",
+            "fsfbpostpr.shd"));
+
+        shader.Should().Contain("const int COLOR_HOSTILE = 0;");
+        shader.Should().Contain("const int COLOR_SELF = 1;");
+        shader.Should().Contain("const int COLOR_BENEFICIAL = 2;");
+        shader.Should().Contain("const int COLOR_PARTY_MEMBER = 3;");
+        shader.Should().Contain("COLOR_HOSTILE) return vec3(1.0, 0.0, 0.0); // Red");
+        shader.Should().Contain("COLOR_SELF) return vec3(0.0, 0.0, 1.0); // Blue");
+        shader.Should().Contain("COLOR_BENEFICIAL) return vec3(0.0, 1.0, 0.0); // Green");
+        shader.Should().Contain("COLOR_PARTY_MEMBER) return vec3(0.66, 0.66, 0.66); // Gray");
+    }
+
+    [TestCase(true, true, true, TelegraphColorType.Self)]
+    [TestCase(true, false, false, TelegraphColorType.Self)]
+    [TestCase(false, true, true, TelegraphColorType.PartyMember)]
+    [TestCase(false, true, false, TelegraphColorType.Beneficial)]
+    [TestCase(false, false, true, TelegraphColorType.Hostile)]
+    [TestCase(false, false, false, TelegraphColorType.Beneficial)]
+    public void SelectTelegraphColorType_KeepsPartyBeneficialEffectsGreen(
+        bool isOwnTelegraph,
+        bool isPartyMemberTelegraph,
+        bool isHostile,
+        TelegraphColorType expected)
+    {
+        var method = typeof(Telegraph)
+            .GetMethod("SelectTelegraphColorType", BindingFlags.Static | BindingFlags.NonPublic)!;
+
+        var actual = (TelegraphColorType)method.Invoke(
+            null,
+            new object[] { isOwnTelegraph, isPartyMemberTelegraph, isHostile })!;
+
+        actual.Should().Be(expected);
+    }
 
     [Test]
     public void PackTelegraphData_LineKeepsGameplayRotation()
@@ -170,6 +225,14 @@ public class TelegraphTests
 
     private static int InvokePackTelegraphData(TelegraphType type, float rotation)
     {
+        return InvokePackTelegraphData(type, TelegraphColorType.Self, rotation);
+    }
+
+    private static int InvokePackTelegraphData(
+        TelegraphType type,
+        TelegraphColorType colorType,
+        float rotation)
+    {
         var method = typeof(Telegraph)
             .GetMethod("PackTelegraphData", BindingFlags.Static | BindingFlags.NonPublic)!;
 
@@ -178,10 +241,15 @@ public class TelegraphTests
             new object[]
             {
                 type,
-                TelegraphColorType.Self,
+                colorType,
                 new Vector2(8f, 2.5f),
                 rotation
             })!;
+    }
+
+    private static int ExtractPackedColor(int packed)
+    {
+        return (packed >> PackedColorShift) & PackedColorMask;
     }
 
     private static int ExtractPackedRotation(int packed)

--- a/SWLOR.Game.Server.Tests/Service/TelegraphTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/TelegraphTests.cs
@@ -72,6 +72,33 @@ public class TelegraphTests
     }
 
     [Test]
+    public void PartyMembershipChanges_RefreshAffectedTelegraphViewers()
+    {
+        var source = File.ReadAllText(ResolveRepositoryPath(
+            "SWLOR.Game.Server",
+            "Service",
+            "Party.cs"));
+        var addPartyStart = source.IndexOf("private static void AddToParty", StringComparison.Ordinal);
+        var removePartyStart = source.IndexOf("private static void RemoveCreatureFromParty", StringComparison.Ordinal);
+
+        addPartyStart.Should().BeGreaterThan(-1);
+        removePartyStart.Should().BeGreaterThan(-1);
+
+        var addPartyBody = ExtractBlockBody(source, addPartyStart);
+        var removePartyBody = ExtractBlockBody(source, removePartyStart);
+
+        addPartyBody.Should().Contain(
+            "Telegraph.UpdateShadersForPlayers(GetAllPartyMembers(requester));",
+            "joining players and associates must see active party telegraphs change color immediately");
+        removePartyBody.Should().Contain(
+            "var affectedPartyMembers = _parties[partyId].ToList();",
+            "the former party must be captured before its membership cache changes");
+        removePartyBody.Should().Contain(
+            "Telegraph.UpdateShadersForPlayers(affectedPartyMembers);",
+            "departing and remaining players must immediately repack active telegraph colors");
+    }
+
+    [Test]
     public void PackTelegraphData_LineKeepsGameplayRotation()
     {
         var packed = InvokePackTelegraphData(TelegraphType.Line, 0f);

--- a/SWLOR.Game.Server/Service/Party.cs
+++ b/SWLOR.Game.Server/Service/Party.cs
@@ -48,6 +48,8 @@ namespace SWLOR.Game.Server.Service
                 _parties[partyId].Add(creature);
                 _creatureToParty[creature] = partyId;
             }
+
+            Telegraph.UpdateShadersForPlayers(GetAllPartyMembers(requester));
         }
 
         /// <summary>
@@ -114,6 +116,7 @@ namespace SWLOR.Game.Server.Service
             if (!_creatureToParty.ContainsKey(creature)) return;
 
             var partyId = _creatureToParty[creature];
+            var affectedPartyMembers = _parties[partyId].ToList();
             var wasLeader = _partyLeaders[partyId] == creature;
 
             // Remove this creature from the caches.
@@ -141,15 +144,15 @@ namespace SWLOR.Game.Server.Service
 
                 _parties.Remove(partyId);
                 _partyLeaders.Remove(partyId);
-                return;
             }
-
             // The party is still valid but the creature who left was its leader.
             // Swap leadership to the next person in the party list.
-            if (wasLeader)
+            else if (wasLeader)
             {
                 _partyLeaders[partyId] = _parties[partyId].First();
             }
+
+            Telegraph.UpdateShadersForPlayers(affectedPartyMembers);
         }
 
         /// <summary>

--- a/SWLOR.Game.Server/Service/Telegraph.cs
+++ b/SWLOR.Game.Server/Service/Telegraph.cs
@@ -386,6 +386,23 @@ namespace SWLOR.Game.Server.Service
         }
 
         /// <summary>
+        /// Refreshes active telegraphs for specific player viewers after relationship state changes.
+        /// Party membership affects hostile telegraph colors, so existing packed uniforms must be
+        /// rebuilt even when no telegraph was created or removed.
+        /// </summary>
+        /// <param name="players">Players whose telegraph uniforms should be refreshed.</param>
+        public static void UpdateShadersForPlayers(IEnumerable<uint> players)
+        {
+            foreach (var player in players.Distinct())
+            {
+                if (!GetIsObjectValid(player) || (!GetIsPC(player) && !GetIsDM(player)))
+                    continue;
+
+                UpdateShaderForPlayer(player);
+            }
+        }
+
+        /// <summary>
         /// Updates shader uniforms only for players standing in the given area. Telegraph shader slots
         /// are per-area, so a telegraph created or removed in one area cannot affect players elsewhere.
         /// Instant abilities now flash their shape on every use, so this runs far more often than the

--- a/SWLOR.Game.Server/Service/Telegraph.cs
+++ b/SWLOR.Game.Server/Service/Telegraph.cs
@@ -316,12 +316,30 @@ namespace SWLOR.Game.Server.Service
 
         private static TelegraphColorType DetermineTelegraphColorType(uint player, uint telegrapher, bool isHostile)
         {
-            if (player == telegrapher)
+            var isOwnTelegraph = player == telegrapher;
+            var isPartyMemberTelegraph = !isOwnTelegraph && Party.IsInParty(player, telegrapher);
+
+            return SelectTelegraphColorType(isOwnTelegraph, isPartyMemberTelegraph, isHostile);
+        }
+
+        private static TelegraphColorType SelectTelegraphColorType(
+            bool isOwnTelegraph,
+            bool isPartyMemberTelegraph,
+            bool isHostile)
+        {
+            // The player's own placement stays recognizable, while beneficial effects remain green
+            // regardless of who created them. Party gray distinguishes allied offensive placement
+            // from hostile red telegraphs created outside the party.
+            if (isOwnTelegraph)
                 return TelegraphColorType.Self;
 
-            return isHostile
-                ? GetIsReactionTypeFriendly(player, telegrapher) == 1 ? TelegraphColorType.Friendly : TelegraphColorType.Hostile
-                : GetIsReactionTypeFriendly(player, telegrapher) == 1 ? TelegraphColorType.Friendly : TelegraphColorType.EnemyBeneficial;
+            if (!isHostile)
+                return TelegraphColorType.Beneficial;
+
+            if (isPartyMemberTelegraph)
+                return TelegraphColorType.PartyMember;
+
+            return TelegraphColorType.Hostile;
         }
 
         private static int PackTelegraphData(TelegraphType shapeType, TelegraphColorType colorType, Vector2 size, float rotation)

--- a/SWLOR.Game.Server/Service/TelegraphService/README.md
+++ b/SWLOR.Game.Server/Service/TelegraphService/README.md
@@ -21,10 +21,19 @@ The main service class that manages all telegraph functionality.
 - **Line**: Rectangular area extending in a direction
 
 ### Color Types
-- **Hostile**: Red - indicates dangerous effects
-- **Friendly**: Green - indicates beneficial effects
-- **Self**: Blue - indicates effects from the player
-- **Enemy Beneficial**: Gray - indicates beneficial effects from enemies
+
+Color selection uses this precedence so beneficial effects retain a consistent meaning while
+offensive telegraphs still communicate ownership:
+
+1. **Self**: Blue - any telegraph created by the observing player
+2. **Beneficial**: Green - a beneficial telegraph from any other creator, including party members
+3. **Party Member**: Gray - a hostile telegraph created by another member of the observer's party
+4. **Hostile**: Red - a hostile telegraph from any other creator
+
+Non-party allies and neutral NPCs use red or green based on the telegraph's hostile flag.
+Hostile telegraphs from associates tracked as party members use gray; their beneficial effects
+use green. The current ability integrations do not create a neutral, informational telegraph;
+add a fifth semantic color only if that use case is introduced.
 
 ## Usage
 

--- a/SWLOR.Game.Server/Service/TelegraphService/README.md
+++ b/SWLOR.Game.Server/Service/TelegraphService/README.md
@@ -139,7 +139,9 @@ effect expires, the `telegraph_effect` handler (`ScriptName.TelegraphEffect`) fi
 shape and then clears the entry. There is no separate applied/ticked event.
 
 Shader uniforms are refreshed when a telegraph is created or removed in an area, and when a
-player enters an area. There is no periodic tick.
+player enters an area. Party membership changes also refresh the affected former/current party
+viewers so active hostile telegraphs switch between red and gray immediately. There is no
+periodic tick.
 
 ## Pre-cast telegraphs vs the impact flash
 

--- a/SWLOR.Game.Server/Service/TelegraphService/TelegraphColorType.cs
+++ b/SWLOR.Game.Server/Service/TelegraphService/TelegraphColorType.cs
@@ -2,10 +2,10 @@ namespace SWLOR.Game.Server.Service.TelegraphService
 {
     public enum TelegraphColorType
     {
-        None = 0,
-        Hostile = 1,
-        Friendly = 2,
-        Self = 3,
-        EnemyBeneficial = 4,
+        // These values are a two-bit protocol shared with sw_shader/fsfbpostpr.shd.
+        Hostile = 0,
+        Self = 1,
+        Beneficial = 2,
+        PartyMember = 3,
     }
 }


### PR DESCRIPTION
## Summary

- align the server's packed telegraph color IDs with the shader's two-bit palette
- render self telegraphs blue, beneficial effects green (including party benefits), party offensive telegraphs gray, and other hostile telegraphs red
- use actual party membership rather than generic friendly reaction state
- refresh affected viewers when player or associate party membership changes so active telegraphs repack immediately
- document the precedence and add protocol, selection, and membership-refresh regression coverage

## Validation

- `dotnet build SWLOR.Game.Server.Tests/SWLOR.Game.Server.Tests.csproj -p:RunPostBuildEvent=Never`
- `dotnet test SWLOR.Game.Server.Tests/SWLOR.Game.Server.Tests.csproj --no-build --filter "FullyQualifiedName~TelegraphTests"` (19 passed)

## Companion PR

- SWLOR_Haks: https://github.com/zunath/SWLOR_Haks/pull/392
- Merge the companion PR before this parent PR so the deployment branch contains the referenced Haks commit.