### PR TITLE
Fix Mimicry control failure reports

### DIFF
--- a/SWLOR.Game.Server.Tests/Feature/ImmobilizedStatusEffectTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/ImmobilizedStatusEffectTests.cs
@@ -20,6 +20,9 @@ public class ImmobilizedStatusEffectTests
 
         source.Should().Contain("TagNativeEffect(EffectCutsceneImmobilize())",
             "a zero movement-rate factor still permits visible creeping in the client");
+        source.Should().Contain("var durationType = durationTicks < 0");
+        source.Should().Contain("? DurationType.Permanent",
+            "a permanent tracked status must not receive a zero-second temporary native root");
         source.Should().NotContain("StatType.MovementSpeedDisabled");
     }
 

--- a/SWLOR.Game.Server.Tests/Feature/ImmobilizedStatusEffectTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/ImmobilizedStatusEffectTests.cs
@@ -1,6 +1,5 @@
 using FluentAssertions;
 using NUnit.Framework;
-using SWLOR.Game.Server.Feature.StatusEffectDefinition;
 using SWLOR.Game.Server.Service;
 using SWLOR.Game.Server.Service.StatService;
 
@@ -9,17 +8,38 @@ namespace SWLOR.Game.Server.Tests.Feature;
 public class ImmobilizedStatusEffectTests
 {
     [Test]
-    public void ImmobilizedStatusEffect_DisablesMovementThroughStats()
+    public void ImmobilizedStatusEffect_UsesTheLegOnlyNativeRoot()
     {
-        var immobilized = new ImmobilizedStatusEffect();
+        var root = FindRepositoryRoot();
+        var source = File.ReadAllText(Path.Combine(
+            root,
+            "SWLOR.Game.Server",
+            "Feature",
+            "StatusEffectDefinition",
+            "ImmobilizedStatusEffect.cs"));
 
-        immobilized.StatGroup.Stats[StatType.MovementSpeedDisabled].Should().Be(1);
-        immobilized.StatGroup.Stats[StatType.MovementSpeedPercentAdjustment].Should().Be(0);
+        source.Should().Contain("TagNativeEffect(EffectCutsceneImmobilize())",
+            "a zero movement-rate factor still permits visible creeping in the client");
+        source.Should().NotContain("StatType.MovementSpeedDisabled");
     }
 
     [Test]
     public void MovementSpeedDisabled_IsNonBeneficialStatType()
     {
         Stat.GetStatTypeCategory(StatType.MovementSpeedDisabled).Should().Be(StatTypeCategory.NonBeneficial);
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(TestContext.CurrentContext.TestDirectory);
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "SWLOR.Game.Server.sln")))
+                return directory.FullName;
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate the SWLOR_NWN repository root.");
     }
 }

--- a/SWLOR.Game.Server.Tests/Feature/ImmobilizedStatusEffectTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/ImmobilizedStatusEffectTests.cs
@@ -47,17 +47,23 @@ public class ImmobilizedStatusEffectTests
         var temporaryEffects = File.ReadAllText(Path.Combine(server, "Feature", "PlayerTemporaryEffects.cs"));
 
         holoCom.Should().Contain(
-            "var effectImmobilized = TagEffect(EffectCutsceneImmobilize(), HolocomCallImmobilize);");
-        holoCom.Should().Contain("RemoveEffectByTag(sender, HolocomCallImmobilize);");
-        holoCom.Should().Contain("RemoveEffectByTag(receiver, HolocomCallImmobilize);");
+            "PlayerActivityEffectTag.HoloComImmobilize);");
+        holoCom.Should().Contain("RemoveEffectByTag(sender, PlayerActivityEffectTag.HoloComImmobilize);");
+        holoCom.Should().Contain("RemoveEffectByTag(receiver, PlayerActivityEffectTag.HoloComImmobilize);");
         holoCom.Should().NotContain("effectType == EffectTypeScript.CutsceneImmobilize");
 
         craft.Should().Contain(
-            "var effect = TagEffect(EffectCutsceneImmobilize(), CraftingImmobilizeEffectTag);");
-        craft.Should().Contain("RemoveEffectByTag(Player, CraftingImmobilizeEffectTag);");
+            "var effect = TagEffect(EffectCutsceneImmobilize(), PlayerActivityEffectTag.CraftingImmobilize);");
+        craft.Should().Contain("RemoveEffectByTag(Player, PlayerActivityEffectTag.CraftingImmobilize);");
         craft.Should().NotContain("GetEffectType(effect) == EffectTypeScript.CutsceneImmobilize");
 
-        temporaryEffects.Should().Contain("RemoveLegacyUntaggedImmobility(player);");
+        temporaryEffects.Should().Contain("RemoveStaleActivityImmobility(player);");
+        temporaryEffects.Should().Contain(
+            "RemoveEffectByTag(player, PlayerActivityEffectTag.CraftingImmobilize);");
+        temporaryEffects.Should().Contain(
+            "RemoveEffectByTag(player, PlayerActivityEffectTag.HoloComImmobilize);");
+        temporaryEffects.Should().Contain(
+            "RemoveEffectByTag(player, PlayerActivityEffectTag.RefiningImmobilize);");
         temporaryEffects.Should().Contain("string.IsNullOrWhiteSpace(GetEffectTag(effect))",
             "login cleanup may remove legacy untagged activity roots but must preserve tagged status roots");
     }

--- a/SWLOR.Game.Server.Tests/Feature/ImmobilizedStatusEffectTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/ImmobilizedStatusEffectTests.cs
@@ -29,6 +29,36 @@ public class ImmobilizedStatusEffectTests
         Stat.GetStatTypeCategory(StatType.MovementSpeedDisabled).Should().Be(StatTypeCategory.NonBeneficial);
     }
 
+    [Test]
+    public void ActivityCleanup_DoesNotRemoveTrackedImmobilizeRoots()
+    {
+        var root = FindRepositoryRoot();
+        var server = Path.Combine(root, "SWLOR.Game.Server");
+        var holoCom = File.ReadAllText(Path.Combine(server, "Service", "HoloCom.cs"));
+        var craft = File.ReadAllText(Path.Combine(
+            server,
+            "Feature",
+            "GuiDefinition",
+            "ViewModel",
+            "CraftViewModel.cs"));
+        var temporaryEffects = File.ReadAllText(Path.Combine(server, "Feature", "PlayerTemporaryEffects.cs"));
+
+        holoCom.Should().Contain(
+            "var effectImmobilized = TagEffect(EffectCutsceneImmobilize(), HolocomCallImmobilize);");
+        holoCom.Should().Contain("RemoveEffectByTag(sender, HolocomCallImmobilize);");
+        holoCom.Should().Contain("RemoveEffectByTag(receiver, HolocomCallImmobilize);");
+        holoCom.Should().NotContain("effectType == EffectTypeScript.CutsceneImmobilize");
+
+        craft.Should().Contain(
+            "var effect = TagEffect(EffectCutsceneImmobilize(), CraftingImmobilizeEffectTag);");
+        craft.Should().Contain("RemoveEffectByTag(Player, CraftingImmobilizeEffectTag);");
+        craft.Should().NotContain("GetEffectType(effect) == EffectTypeScript.CutsceneImmobilize");
+
+        temporaryEffects.Should().Contain("RemoveLegacyUntaggedImmobility(player);");
+        temporaryEffects.Should().Contain("string.IsNullOrWhiteSpace(GetEffectTag(effect))",
+            "login cleanup may remove legacy untagged activity roots but must preserve tagged status roots");
+    }
+
     private static string FindRepositoryRoot()
     {
         var directory = new DirectoryInfo(TestContext.CurrentContext.TestDirectory);

--- a/SWLOR.Game.Server.Tests/Feature/ImmobilizedStatusEffectTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/ImmobilizedStatusEffectTests.cs
@@ -20,9 +20,8 @@ public class ImmobilizedStatusEffectTests
 
         source.Should().Contain("TagNativeEffect(EffectCutsceneImmobilize())",
             "a zero movement-rate factor still permits visible creeping in the client");
-        source.Should().Contain("var durationType = durationTicks < 0");
-        source.Should().Contain("? DurationType.Permanent",
-            "a permanent tracked status must not receive a zero-second temporary native root");
+        source.Should().Contain("ApplyEffectToObject(DurationType.Permanent, effect, creature);",
+            "the tracked status must own the native root lifetime through scheduler grace, refreshes, and removal");
         source.Should().NotContain("StatType.MovementSpeedDisabled");
     }
 

--- a/SWLOR.Game.Server.Tests/Feature/NativeControlStatusEffectTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/NativeControlStatusEffectTests.cs
@@ -26,12 +26,15 @@ public class NativeControlStatusEffectTests
 
         statusEffectBase.Should().Contain("protected Effect TagNativeEffect");
         statusEffectBase.Should().Contain("void RemoveNativeEffects");
+        statusEffectBase.Should().Contain("HideEffectIcon(effect)",
+            "native control effects provide mechanics while the tracked status supplies the one player-facing icon");
         statusEffectBase.Should().Contain(":Native:");
         statusEffectService.Should().Contain("statusEffect.RemoveNativeEffects(creature);");
     }
 
     [TestCase("BlindStatusEffect.cs", "EffectBlindness()")]
     [TestCase("DazedStatusEffect.cs", "EffectDazed()")]
+    [TestCase("ImmobilizedStatusEffect.cs", "EffectCutsceneImmobilize()")]
     [TestCase("KnockdownStatusEffect.cs", "EffectKnockdown()")]
     [TestCase("StunnedStatusEffect.cs", "EffectStunned()")]
     [TestCase("TranquilizedStatusEffect.cs", "IgnoreEffectImmunity(EffectSleep())")]

--- a/SWLOR.Game.Server.Tests/Perks/MimicryTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/MimicryTests.cs
@@ -218,8 +218,14 @@ public class MimicryTests
         stimCanister.Should().Contain(
             "StatusEffect.ApplyStatusEffect(activator, ally, new StimCanisterStatusEffect(), 30f)");
         abilityTargeting.Should().Contain("bool includeActivator = true");
-        abilityTargeting.Should().Contain("Party.IsInParty(activator, creature)",
-            "Stim Canister intentionally buffs living nearby party members as well as its caster");
+        abilityTargeting.Should().Contain(
+            "if ((creature == activator && includeActivator) || Party.IsInParty(activator, creature))");
+        abilityTargeting.Should().Contain(
+            "if (!GetIsDead(creature) && GetCurrentHitPoints(creature) > 0)",
+            "dead or unconscious party members must not receive Stim Canister");
+        abilityTargeting.Should().Contain(
+            "if (includeActivator &&\r\n                !yieldedActivator &&\r\n                IsAlive(activator) &&",
+            "the caster must be included even when the area iterator does not return them");
 
         cryoBile.Should().Contain("additionalStatusEffects: new[] { typeof(ImmobilizedStatusEffect) }");
         cryoBile.Should().Contain("enmityBonus: 100",

--- a/SWLOR.Game.Server.Tests/Perks/MimicryTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/MimicryTests.cs
@@ -223,8 +223,8 @@ public class MimicryTests
         abilityTargeting.Should().Contain(
             "if (!GetIsDead(creature) && GetCurrentHitPoints(creature) > 0)",
             "dead or unconscious party members must not receive Stim Canister");
-        abilityTargeting.Should().Contain(
-            "if (includeActivator &&\r\n                !yieldedActivator &&\r\n                IsAlive(activator) &&",
+        abilityTargeting.Should().MatchRegex(
+            @"if \(includeActivator &&\s+!yieldedActivator &&\s+IsAlive\(activator\) &&",
             "the caster must be included even when the area iterator does not return them");
 
         cryoBile.Should().Contain("additionalStatusEffects: new[] { typeof(ImmobilizedStatusEffect) }");

--- a/SWLOR.Game.Server.Tests/Perks/MimicryTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/MimicryTests.cs
@@ -191,6 +191,44 @@ public class MimicryTests
     }
 
     [Test]
+    public void ReportedMimicryUtilityAndCryoPayloadsRemainWiredToTheBibleContract()
+    {
+        var root = FindRepositoryRoot();
+        var techniqueDirectory = Path.Combine(
+            root.FullName,
+            "SWLOR.Game.Server",
+            "Feature",
+            "AbilityDefinition",
+            "Mimicry");
+        var abilityTargeting = File.ReadAllText(Path.Combine(
+            root.FullName,
+            "SWLOR.Game.Server",
+            "Feature",
+            "AbilityDefinition",
+            "AbilityTargeting.cs"));
+        var stimCanister = File.ReadAllText(Path.Combine(
+            techniqueDirectory,
+            "StimCanisterTechniqueAbilityDefinition.cs"));
+        var cryoBile = File.ReadAllText(Path.Combine(
+            techniqueDirectory,
+            "CryoBileTechniqueAbilityDefinition.cs"));
+
+        stimCanister.Should().Contain(
+            "AbilityTargeting.GetFriendlyTargetsNearLocation(activator, GetLocation(activator), 4.0f)");
+        stimCanister.Should().Contain(
+            "StatusEffect.ApplyStatusEffect(activator, ally, new StimCanisterStatusEffect(), 30f)");
+        abilityTargeting.Should().Contain("bool includeActivator = true");
+        abilityTargeting.Should().Contain("Party.IsInParty(activator, creature)",
+            "Stim Canister intentionally buffs living nearby party members as well as its caster");
+
+        cryoBile.Should().Contain("additionalStatusEffects: new[] { typeof(ImmobilizedStatusEffect) }");
+        cryoBile.Should().Contain("enmityBonus: 100",
+            "Cryo Bile promises 100 additional enmity for every target that its area impact resolves against");
+        cryoBile.Should().Contain(".CombatImpactDamageAbility(AbilityType.Perception)",
+            "Cryo Bile uses the documented Perception scaling path; Freezing tick scaling is covered separately");
+    }
+
+    [Test]
     public void ShockTechniques_DescriptionsExposeTheirActualForceSuppressionContract()
     {
         var root = FindRepositoryRoot();

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/CraftViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/CraftViewModel.cs
@@ -28,7 +28,6 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
         public const string SetUpPartialName = "SetUpPartial";
         public const string CraftPartialName = "CraftPartial";
         private const string BlankTexture = "Blank";
-        private const string CraftingImmobilizeEffectTag = "CRAFTING_IMMOBILIZE";
 
         private RecipeType _recipe;
 
@@ -1132,13 +1131,13 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
 
         private void ApplyImmobility()
         {
-            var effect = TagEffect(EffectCutsceneImmobilize(), CraftingImmobilizeEffectTag);
+            var effect = TagEffect(EffectCutsceneImmobilize(), PlayerActivityEffectTag.CraftingImmobilize);
             ApplyEffectToObject(DurationType.Permanent, effect, Player);
         }
 
         private void RemoveImmobility()
         {
-            RemoveEffectByTag(Player, CraftingImmobilizeEffectTag);
+            RemoveEffectByTag(Player, PlayerActivityEffectTag.CraftingImmobilize);
         }
 
         private void SwitchToSetUpMode()

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/CraftViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/CraftViewModel.cs
@@ -28,6 +28,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
         public const string SetUpPartialName = "SetUpPartial";
         public const string CraftPartialName = "CraftPartial";
         private const string BlankTexture = "Blank";
+        private const string CraftingImmobilizeEffectTag = "CRAFTING_IMMOBILIZE";
 
         private RecipeType _recipe;
 
@@ -1131,18 +1132,13 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
 
         private void ApplyImmobility()
         {
-            ApplyEffectToObject(DurationType.Permanent, EffectCutsceneImmobilize(), Player);
+            var effect = TagEffect(EffectCutsceneImmobilize(), CraftingImmobilizeEffectTag);
+            ApplyEffectToObject(DurationType.Permanent, effect, Player);
         }
 
         private void RemoveImmobility()
         {
-            for (var effect = GetFirstEffect(Player); GetIsEffectValid(effect); effect = GetNextEffect(Player))
-            {
-                if (GetEffectType(effect) == EffectTypeScript.CutsceneImmobilize)
-                {
-                    RemoveEffect(Player, effect);
-                }
-            }
+            RemoveEffectByTag(Player, CraftingImmobilizeEffectTag);
         }
 
         private void SwitchToSetUpMode()

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/RefineryViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/RefineryViewModel.cs
@@ -271,7 +271,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
 
             // Apply immobilization
             var effect = EffectCutsceneImmobilize();
-            effect = TagEffect(effect, "REFINING_EFFECT");
+            effect = TagEffect(effect, PlayerActivityEffectTag.RefiningImmobilize);
             ApplyEffectToObject(DurationType.Temporary, effect, Player, RefiningDelaySeconds);
 
             // Play an animation

--- a/SWLOR.Game.Server/Feature/PlayerTemporaryEffects.cs
+++ b/SWLOR.Game.Server/Feature/PlayerTemporaryEffects.cs
@@ -16,7 +16,7 @@ namespace SWLOR.Game.Server.Feature
 
             ApplyCutsceneGhostToPlayer(player);
             ApplyHeight(player);
-            RemoveLegacyUntaggedImmobility(player);
+            RemoveStaleActivityImmobility(player);
             ReapplySpeed(player);
         }
 
@@ -34,8 +34,12 @@ namespace SWLOR.Game.Server.Feature
             SetObjectVisualTransform(player, ObjectVisualTransform.Scale, dbPlayer.AppearanceScale);
         }
 
-        private static void RemoveLegacyUntaggedImmobility(uint player)
+        private static void RemoveStaleActivityImmobility(uint player)
         {
+            RemoveEffectByTag(player, PlayerActivityEffectTag.CraftingImmobilize);
+            RemoveEffectByTag(player, PlayerActivityEffectTag.HoloComImmobilize);
+            RemoveEffectByTag(player, PlayerActivityEffectTag.RefiningImmobilize);
+
             for (var effect = GetFirstEffect(player); GetIsEffectValid(effect); effect = GetNextEffect(player))
             {
                 if (GetEffectType(effect) == EffectTypeScript.CutsceneImmobilize &&

--- a/SWLOR.Game.Server/Feature/PlayerTemporaryEffects.cs
+++ b/SWLOR.Game.Server/Feature/PlayerTemporaryEffects.cs
@@ -16,7 +16,7 @@ namespace SWLOR.Game.Server.Feature
 
             ApplyCutsceneGhostToPlayer(player);
             ApplyHeight(player);
-            RemoveImmobility(player);
+            RemoveLegacyUntaggedImmobility(player);
             ReapplySpeed(player);
         }
 
@@ -34,11 +34,12 @@ namespace SWLOR.Game.Server.Feature
             SetObjectVisualTransform(player, ObjectVisualTransform.Scale, dbPlayer.AppearanceScale);
         }
 
-        private static void RemoveImmobility(uint player)
+        private static void RemoveLegacyUntaggedImmobility(uint player)
         {
             for (var effect = GetFirstEffect(player); GetIsEffectValid(effect); effect = GetNextEffect(player))
             {
-                if (GetEffectType(effect) == EffectTypeScript.CutsceneImmobilize)
+                if (GetEffectType(effect) == EffectTypeScript.CutsceneImmobilize &&
+                    string.IsNullOrWhiteSpace(GetEffectTag(effect)))
                 {
                     RemoveEffect(player, effect);
                 }

--- a/SWLOR.Game.Server/Feature/StatusEffectDefinition/ImmobilizedStatusEffect.cs
+++ b/SWLOR.Game.Server/Feature/StatusEffectDefinition/ImmobilizedStatusEffect.cs
@@ -15,12 +15,12 @@ namespace SWLOR.Game.Server.Feature.StatusEffectDefinition
 
         protected override void Apply(uint creature, int durationTicks)
         {
-            ApplyImmobilize(creature, GetDurationSeconds(durationTicks));
+            ApplyImmobilize(creature, durationTicks);
         }
 
         protected override void Reapply(uint creature)
         {
-            ApplyImmobilize(creature, GetDurationSeconds(DurationTicks));
+            ApplyImmobilize(creature, DurationTicks);
         }
 
         public override string CanApply(uint creature)
@@ -49,10 +49,14 @@ namespace SWLOR.Game.Server.Feature.StatusEffectDefinition
                 ImmunityType.Immobilized);
         }
 
-        private void ApplyImmobilize(uint creature, float duration)
+        private void ApplyImmobilize(uint creature, int durationTicks)
         {
             var effect = TagNativeEffect(EffectCutsceneImmobilize());
-            ApplyEffectToObject(DurationType.Temporary, effect, creature, duration);
+            var durationType = durationTicks < 0
+                ? DurationType.Permanent
+                : DurationType.Temporary;
+            var duration = GetDurationSeconds(durationTicks);
+            ApplyEffectToObject(durationType, effect, creature, duration);
         }
     }
 }

--- a/SWLOR.Game.Server/Feature/StatusEffectDefinition/ImmobilizedStatusEffect.cs
+++ b/SWLOR.Game.Server/Feature/StatusEffectDefinition/ImmobilizedStatusEffect.cs
@@ -15,12 +15,12 @@ namespace SWLOR.Game.Server.Feature.StatusEffectDefinition
 
         protected override void Apply(uint creature, int durationTicks)
         {
-            ApplyImmobilize(creature, durationTicks);
+            ApplyImmobilize(creature);
         }
 
         protected override void Reapply(uint creature)
         {
-            ApplyImmobilize(creature, DurationTicks);
+            ApplyImmobilize(creature);
         }
 
         public override string CanApply(uint creature)
@@ -49,14 +49,10 @@ namespace SWLOR.Game.Server.Feature.StatusEffectDefinition
                 ImmunityType.Immobilized);
         }
 
-        private void ApplyImmobilize(uint creature, int durationTicks)
+        private void ApplyImmobilize(uint creature)
         {
             var effect = TagNativeEffect(EffectCutsceneImmobilize());
-            var durationType = durationTicks < 0
-                ? DurationType.Permanent
-                : DurationType.Temporary;
-            var duration = GetDurationSeconds(durationTicks);
-            ApplyEffectToObject(durationType, effect, creature, duration);
+            ApplyEffectToObject(DurationType.Permanent, effect, creature);
         }
     }
 }

--- a/SWLOR.Game.Server/Feature/StatusEffectDefinition/ImmobilizedStatusEffect.cs
+++ b/SWLOR.Game.Server/Feature/StatusEffectDefinition/ImmobilizedStatusEffect.cs
@@ -1,6 +1,5 @@
 using SWLOR.Game.Server.Service;
 using SWLOR.Game.Server.Service.CombatService;
-using SWLOR.Game.Server.Service.StatService;
 using SWLOR.Game.Server.Service.StatusEffectService;
 using SWLOR.NWN.API.NWScript.Enum;
 
@@ -14,9 +13,14 @@ namespace SWLOR.Game.Server.Feature.StatusEffectDefinition
         public override StatusEffectCleanseType CleanseTypes => StatusEffectCleanseType.Purify | StatusEffectCleanseType.SoothePet;
         public override ResistanceType ResistanceType => ResistanceType.Mobility;
 
-        public ImmobilizedStatusEffect()
+        protected override void Apply(uint creature, int durationTicks)
         {
-            StatGroup.Stats[StatType.MovementSpeedDisabled] = 1;
+            ApplyImmobilize(creature, GetDurationSeconds(durationTicks));
+        }
+
+        protected override void Reapply(uint creature)
+        {
+            ApplyImmobilize(creature, GetDurationSeconds(DurationTicks));
         }
 
         public override string CanApply(uint creature)
@@ -43,6 +47,12 @@ namespace SWLOR.Game.Server.Feature.StatusEffectDefinition
                 creature,
                 SecondsSinceNaturalExpiration,
                 ImmunityType.Immobilized);
+        }
+
+        private void ApplyImmobilize(uint creature, float duration)
+        {
+            var effect = TagNativeEffect(EffectCutsceneImmobilize());
+            ApplyEffectToObject(DurationType.Temporary, effect, creature, duration);
         }
     }
 }

--- a/SWLOR.Game.Server/Service/HoloCom.cs
+++ b/SWLOR.Game.Server/Service/HoloCom.cs
@@ -103,8 +103,7 @@ namespace SWLOR.Game.Server.Service
                 var message = "Call Connected. (Use the HoloCom or the chat command /endcall to terminate the call)";
                 SendMessageToPC(sender, message);
                 SendMessageToPC(receiver, message);
-                var effectImmobilized = EffectCutsceneImmobilize();
-                TagEffect(effectImmobilized, HolocomCallImmobilize);
+                var effectImmobilized = TagEffect(EffectCutsceneImmobilize(), HolocomCallImmobilize);
                 ApplyEffectToObject(DurationType.Permanent, effectImmobilized, sender);
                 ApplyEffectToObject(DurationType.Permanent, effectImmobilized, receiver);
 
@@ -139,29 +138,8 @@ namespace SWLOR.Game.Server.Service
             }
             else // END CALL
             {
-                for(var effect = GetFirstEffect(sender); GetIsEffectValid(effect); effect = GetNextEffect(sender))
-                {
-                    if (GetIsEffectValid(effect))
-                    {
-                        var effectType = GetEffectType(effect);
-                        if (effectType == EffectTypeScript.CutsceneImmobilize)
-                        {
-                            RemoveEffect(sender, effect);
-                        }
-                    }
-                }
-
-                for (var effect = GetFirstEffect(receiver); GetIsEffectValid(effect); effect = GetNextEffect(receiver))
-                {
-                    if (GetIsEffectValid(effect))
-                    {
-                        var effectType = GetEffectType(effect);
-                        if (effectType == EffectTypeScript.CutsceneImmobilize)
-                        {
-                            RemoveEffect(receiver, effect);
-                        }
-                    }
-                }
+                RemoveEffectByTag(sender, HolocomCallImmobilize);
+                RemoveEffectByTag(receiver, HolocomCallImmobilize);
 
                 AssignCommand(sender, () =>
                 {

--- a/SWLOR.Game.Server/Service/HoloCom.cs
+++ b/SWLOR.Game.Server/Service/HoloCom.cs
@@ -17,8 +17,6 @@ namespace SWLOR.Game.Server.Service
         private const string HolocomCallAttempt = "HOLOCOM_CALL_ATTEMPT";
         private const string HolocomHologram = "HOLOCOM_HOLOGRAM";
         private const string HologramOwner = "HOLOGRAM_OWNER";
-        private const string HolocomCallImmobilize = "HOLOCOM_CALL_IMMOBILIZE";
-
         [NWNEventHandler(ScriptName.OnModuleDeath)]
         public static void OnModuleDeath()
         {
@@ -32,7 +30,7 @@ namespace SWLOR.Game.Server.Service
         public static void OnModuleEnter()
         {
             var player = GetEnteringObject();
-            RemoveEffectByTag(player, HolocomCallImmobilize);
+            RemoveEffectByTag(player, PlayerActivityEffectTag.HoloComImmobilize);
         }
 
         [NWNEventHandler(ScriptName.OnModuleExit)]
@@ -103,7 +101,9 @@ namespace SWLOR.Game.Server.Service
                 var message = "Call Connected. (Use the HoloCom or the chat command /endcall to terminate the call)";
                 SendMessageToPC(sender, message);
                 SendMessageToPC(receiver, message);
-                var effectImmobilized = TagEffect(EffectCutsceneImmobilize(), HolocomCallImmobilize);
+                var effectImmobilized = TagEffect(
+                    EffectCutsceneImmobilize(),
+                    PlayerActivityEffectTag.HoloComImmobilize);
                 ApplyEffectToObject(DurationType.Permanent, effectImmobilized, sender);
                 ApplyEffectToObject(DurationType.Permanent, effectImmobilized, receiver);
 
@@ -138,8 +138,8 @@ namespace SWLOR.Game.Server.Service
             }
             else // END CALL
             {
-                RemoveEffectByTag(sender, HolocomCallImmobilize);
-                RemoveEffectByTag(receiver, HolocomCallImmobilize);
+                RemoveEffectByTag(sender, PlayerActivityEffectTag.HoloComImmobilize);
+                RemoveEffectByTag(receiver, PlayerActivityEffectTag.HoloComImmobilize);
 
                 AssignCommand(sender, () =>
                 {

--- a/SWLOR.Game.Server/Service/PlayerActivityEffectTag.cs
+++ b/SWLOR.Game.Server/Service/PlayerActivityEffectTag.cs
@@ -1,0 +1,9 @@
+namespace SWLOR.Game.Server.Service
+{
+    public static class PlayerActivityEffectTag
+    {
+        public const string CraftingImmobilize = "CRAFTING_IMMOBILIZE";
+        public const string HoloComImmobilize = "HOLOCOM_CALL_IMMOBILIZE";
+        public const string RefiningImmobilize = "REFINING_EFFECT";
+    }
+}

--- a/SWLOR.Game.Server/Service/StatusEffectService/StatusEffectBase.cs
+++ b/SWLOR.Game.Server/Service/StatusEffectService/StatusEffectBase.cs
@@ -250,7 +250,7 @@ namespace SWLOR.Game.Server.Service.StatusEffectService
                 : tagSuffix;
 
             _nativeEffectTagSuffixes.Add(tagSuffix);
-            return TagEffect(effect, GetNativeEffectTag(tagSuffix));
+            return TagEffect(HideEffectIcon(effect), GetNativeEffectTag(tagSuffix));
         }
 
         private string GetNativeEffectTag(string tagSuffix)


### PR DESCRIPTION
## Summary

- hide native control-effect icons so the tracked SWLOR status supplies the single player-facing icon, resolving Concussive Challenge's duplicate Dazed presentation
- restore Immobilized to the engine's leg-only immobilize effect, which fully roots movement without otherwise penalizing the target
- add regression coverage that preserves Stim Canister's caster-plus-nearby-party targeting and Cryo Bile's Immobilized, +100 enmity, and Perception scaling wiring

## Adversarial triage

- **Concussive Challenge:** confirmed. `DazedStatusEffect` applied both the native Dazed icon and the custom tracked status icon.
- **Stim Canister:** no defect found. The implementation targets the caster and living party members within 4m; the report proposed making it self-only but did not establish broken ally targeting.
- **Cryo Bile:** confirmed the root defect. The zero movement-rate factor allowed visible creeping. The other claims were not defects: +100 enmity is applied per resolved target, and Freezing already scales with Perception, Mimicry Potency, resistance, and damage-taken modifiers.

## Verification

- `dotnet build SWLOR.Game.Server.Tests\SWLOR.Game.Server.Tests.csproj -p:RunPostBuildEvent=Never` — succeeds (8 pre-existing warnings)
- focused Native Control / Immobilized / Mimicry / DoT tests — 78 passed
- status-effect icon tests — 10 passed
- gameplay icon standards audit — 1,466 entries passed
- full server test suite — 2,038 passed; 3 pre-existing `StanceStatusEffectTests` fail because their GUI refresh path calls NWScript without initializing NWN.Core (reproduces when that class is run alone and is unrelated to this diff)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Immobilizing effects now use native leg-only immobilization for more reliable movement restriction.
  - Native control effects no longer display an unnecessary effect icon.

- **Bug Fixes**
  - Improved immobilization behavior when effects are applied or reapplied.
  - Preserved intended Stim Canister targeting and Cryo Bile effects, including immobilization, enmity, and perception-based damage scaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->