### PR TITLE
Fix Piercing Toss Bleed disappearing after timer renewal

### DIFF
--- a/SWLOR.Game.Server.EngineTests/Definitions/PiercingTossEngineTests.cs
+++ b/SWLOR.Game.Server.EngineTests/Definitions/PiercingTossEngineTests.cs
@@ -1,0 +1,116 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using SWLOR.Game.Server.EngineTests.Framework;
+using SWLOR.Game.Server.Feature.AbilityDefinition.Throwing;
+using SWLOR.Game.Server.Service.CombatService;
+using SWLOR.Game.Server.Service.SkillService;
+using SWLOR.Game.Server.Service.StatService;
+using SWLOR.NWN.API.NWScript.Enum;
+
+namespace SWLOR.Game.Server.EngineTests.Definitions
+{
+    public static class PiercingTossEngineTests
+    {
+        [EngineTest("All Piercing Toss ranks retain Bleed through hits, extensions, and expiration", Category = "StatusEffect", TimeoutSeconds = 100f)]
+        public static async Task BleedSurvivesDamageAndDurationExtensions(EngineTestContext ctx)
+        {
+            var ranks = new[]
+            {
+                (FeatType.PiercingToss1, 1, 30f),
+                (FeatType.PiercingToss2, 2, 36f),
+                (FeatType.PiercingToss3, 3, 45f),
+                (FeatType.PiercingToss4, 4, 60f)
+            };
+            var abilities = new PiercingTossAbilityDefinition().BuildAbilities();
+            var cases = new List<(uint Target, BleedStatusEffect Bleed, int Ticks, DateTime AppliedAt, string Label, int PostHitHP)>();
+
+            Combat.SetAbilityHitResolutionOverride(true);
+            Combat.SetAutoAttackHitResolutionOverride(false);
+            try
+            {
+                foreach (var extensionSeconds in new[] { 0, 6 })
+                {
+                    var source = ctx.SpawnCreature("nw_bandit001");
+                    await ctx.WaitFrameAsync();
+                    SetCommandable(false, source);
+
+                    // Flurry Bleed's stat-driven rider renews the native timer in the same
+                    // impact that applies Bleed, before NWN delivers removal callbacks.
+                    if (extensionSeconds > 0)
+                    {
+                        TemporaryStatModifier.Add(source, StatType.AbilityDamageToBleedingTargetSkillType, (int)SkillType.Throwing, 120f);
+                        TemporaryStatModifier.Add(source, StatType.BleedingTargetAbilityBleedDurationExtensionSeconds, extensionSeconds, 120f);
+                    }
+
+                    foreach (var (feat, rank, duration) in ranks)
+                    {
+                        var target = ctx.SpawnCreature("nw_rat001", 2f + rank);
+                        await ctx.WaitFrameAsync();
+                        SetCommandable(false, target);
+                        ctx.SuppressNPCNaturalRegen(target);
+                        ApplyEffectToObject(DurationType.Temporary, EffectTemporaryHitpoints(1000), target, 120f);
+                        ctx.MakeHostile(target);
+
+                        var label = $"{feat} (extension {extensionSeconds}s)";
+                        var ability = abilities[feat];
+                        var appliedAt = DateTime.UtcNow;
+                        Ability.BeginAbilityImpact(source, ability);
+                        try
+                        {
+                            ability.ImpactAction(source, target, rank, GetLocation(target));
+                        }
+                        finally
+                        {
+                            Ability.EndAbilityImpact(source);
+                        }
+
+                        var bleed = StatusEffect.GetStatusEffect(target, typeof(BleedStatusEffect)) as BleedStatusEffect;
+                        ctx.Assert(bleed != null, $"{label}: Bleed must remain after the impact.");
+                        var ticks = (int)Math.Ceiling(duration / bleed.Frequency) + extensionSeconds / 6;
+                        ctx.Assert(bleed.DurationTicks == ticks, $"{label}: Bleed must have {ticks} damage ticks.");
+                        AssignCommand(source, () => ApplyEffectToObject(DurationType.Instant, EffectDamage(1), target));
+                        cases.Add((target, bleed, ticks, appliedAt, label, GetCurrentHitPoints(target)));
+                    }
+                }
+
+                await ctx.DelaySecondsAsync(1f);
+                foreach (var test in cases)
+                {
+                    ctx.Assert(StatusEffect.GetStatusEffect(test.Target, typeof(BleedStatusEffect)) == test.Bleed,
+                        $"{test.Label}: hits and old timer callbacks must preserve Bleed.");
+                    ctx.Assert(HasEffectByTag(test.Target, test.Bleed.Id), $"{test.Label}: Bleed must retain its native timer.");
+                }
+
+                await ctx.WaitUntilAsync(() => cases.All(test => test.Bleed.DurationTicks < test.Ticks), 10f, "each rank's first Bleed tick");
+                foreach (var test in cases)
+                    ctx.Assert(GetCurrentHitPoints(test.Target) < test.PostHitHP, $"{test.Label}: Bleed must deal periodic damage.");
+
+                await ctx.WaitUntilAsync(() =>
+                {
+                    foreach (var test in cases)
+                    {
+                        if ((DateTime.UtcNow - test.AppliedAt).TotalSeconds < test.Ticks * test.Bleed.Frequency)
+                        {
+                            ctx.Assert(StatusEffect.HasStatusEffect<BleedStatusEffect>(test.Target),
+                                $"{test.Label}: Bleed must not disappear before its duration ends.");
+                        }
+                    }
+
+                    return cases.All(test => !StatusEffect.HasStatusEffect<BleedStatusEffect>(test.Target));
+                }, 75f, "all Bleeds to finish their full durations");
+
+                foreach (var test in cases)
+                {
+                    ctx.Assert(test.Bleed.WasNaturallyExpired && test.Bleed.DurationTicks == 0,
+                        $"{test.Label}: Bleed must deliver its final tick before expiring.");
+                }
+            }
+            finally
+            {
+                Combat.SetAbilityHitResolutionOverride(null);
+                Combat.SetAutoAttackHitResolutionOverride(null);
+            }
+        }
+    }
+}

--- a/SWLOR.Game.Server.EngineTests/Definitions/StatusEffectEngineTests.cs
+++ b/SWLOR.Game.Server.EngineTests/Definitions/StatusEffectEngineTests.cs
@@ -19,6 +19,38 @@ namespace SWLOR.Game.Server.EngineTests.Definitions
         /// </summary>
         private const float ExpirationWaitTimeoutSeconds = 40f;
 
+        [EngineTest("Refreshing a passive status preserves it until the renewed timer expires", Category = "StatusEffect", TimeoutSeconds = 20f)]
+        public static async Task RefreshedPassiveStatusExpiresNormally(EngineTestContext ctx)
+        {
+            var npc = ctx.SpawnCreature("nw_rat001");
+            await ctx.WaitFrameAsync();
+            StatusEffect.ApplyStatusEffect<KoltoMistHealingStatusEffect>(npc, npc, 2f);
+            var effect = StatusEffect.GetStatusEffect(npc, typeof(KoltoMistHealingStatusEffect));
+
+            ctx.Assert(StatusEffect.RefreshStatusEffectDuration(npc, typeof(KoltoMistHealingStatusEffect), npc, 5f),
+                "the passive status must accept a duration refresh");
+            await ctx.DelaySecondsAsync(3f);
+            ctx.Assert(StatusEffect.GetStatusEffect(npc, typeof(KoltoMistHealingStatusEffect)) == effect,
+                "the refreshed status must survive both the old removal callback and its original expiration");
+            await ctx.WaitUntilAsync(() => !StatusEffect.HasStatusEffect<KoltoMistHealingStatusEffect>(npc),
+                5f, "the renewed passive timer to expire");
+        }
+
+        [EngineTest("Native removal still clears a renewed status", Category = "StatusEffect", TimeoutSeconds = 15f)]
+        public static async Task NativeRemovalClearsRenewedStatus(EngineTestContext ctx)
+        {
+            var npc = ctx.SpawnCreature("nw_rat001");
+            await ctx.WaitFrameAsync();
+            StatusEffect.ApplyStatusEffect<KoltoMistHealingStatusEffect>(npc, npc, 60f);
+            StatusEffect.ExtendStatusEffectDuration(npc, typeof(KoltoMistHealingStatusEffect), npc, 6f);
+            var effect = StatusEffect.GetStatusEffect(npc, typeof(KoltoMistHealingStatusEffect));
+            ctx.Assert(effect != null, "the renewed status must be present before native removal");
+            RemoveEffectByTag(npc, effect.Id);
+
+            await ctx.WaitUntilAsync(() => !StatusEffect.HasStatusEffect<KoltoMistHealingStatusEffect>(npc),
+                5f, "native removal to clear the managed status");
+        }
+
         [EngineTest("A directly applied status effect appears and naturally expires", Category = "StatusEffect", TimeoutSeconds = 60f)]
         public static async Task StatusEffectAppliesAndExpires(EngineTestContext ctx)
         {

--- a/SWLOR.Game.Server/Service/StatusEffect.cs
+++ b/SWLOR.Game.Server/Service/StatusEffect.cs
@@ -347,7 +347,14 @@ namespace SWLOR.Game.Server.Service
             if (_suppressedStatusEffectRemovalIds.Contains(tag))
                 return;
 
-            RemoveStatusEffectById(player, tag, true, false);
+            // NWN can deliver the old timer's removal callback after a duration extension
+            // has already replaced it with another native effect carrying the same tag.
+            // Wait until native removal settles, then only clear statuses without a timer.
+            DelayCommand(0f, () =>
+            {
+                if (!HasEffectByTag(player, tag))
+                    RemoveStatusEffectById(player, tag, true, false);
+            });
         }
 
         private static string GetLastStatusEffectTag()


### PR DESCRIPTION
Piercing Toss I–IV could apply Bleed and immediately report that it wore off when Flurry Bleed extended its duration. NWN queues the old timer's removal callback until after the replacement timer is installed. The callback now waits for native removal to settle and clears the managed status only when no timer with that status ID remains.

This includes the previously verified Bleed fix and covers all four current Fail rows in the [live combat testing tracker](https://docs.google.com/spreadsheets/d/1iHMKtrnh3lbUnmrgXtxEQseAJd7WIL6RU51RVSktm4s/edit?gid=2101115203#gid=2101115203), reviewed September 3: rows 879, 883, 889, and 894. No additional rows were marked Fail.

Validation:
- Game/test project build passed with `-p:RunPostBuildEvent=Never`.
- 33 focused unit tests passed (damage-over-time definitions, status delivery, and status frequency).
- 6 NWN engine tests passed, including all four Piercing Toss ranks with and without the duration-extension rider, subsequent hits, periodic damage, full expiration, passive timer refresh, and explicit native removal.
- The regression reproduced the premature removal in the engine before the fix.
- Temporary engine-test containers were removed.

Bleed retains the existing six-second tick cadence, including rounding the 45-second rank to eight ticks. No ability balance or asset changes are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed refreshed status effects expiring prematurely when their durations are extended.
  - Ensured status effects remain active through their full renewed duration and expire only after the final expected damage or effect tick.
  - Improved cleanup when an effect is removed natively, while preserving renewed instances that are still active.

- **Tests**
  - Added coverage for Piercing Toss bleeding behavior across all ranks and duration-extension scenarios.
  - Added coverage for passive status refreshes and native removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->