### PR TITLE
Fix impact markers when area targets move during casting

### DIFF
--- a/SWLOR.Game.Server.Tests/Feature/AbilityDamageQueueTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/AbilityDamageQueueTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using NUnit.Framework;
 using SWLOR.Game.Server.Service;
 using SWLOR.Game.Server.Service.AbilityService;
+using SWLOR.Game.Server.Service.TelegraphService;
 
 namespace SWLOR.Game.Server.Tests.Feature;
 
@@ -25,7 +26,7 @@ public class AbilityDamageQueueTests
             0,
             true,
             0,
-            false
+            Array.Empty<TelegraphGeometry>()
         });
 
         trackedImpactType.GetMethod("AddDefenseIgnorePercentAdjustment")!

--- a/SWLOR.Game.Server.Tests/Feature/AbilityDamageQueueTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/AbilityDamageQueueTests.cs
@@ -8,6 +8,9 @@ namespace SWLOR.Game.Server.Tests.Feature;
 
 public class AbilityDamageQueueTests
 {
+    /// <summary>
+    /// Verifies that an impact initialized without activation markers still accumulates defense ignore.
+    /// </summary>
     [Test]
     public void TrackedAbilityImpact_AddsDefenseIgnoreToTheCurrentImpact()
     {

--- a/SWLOR.Game.Server.Tests/Service/AreaImpactTelegraphTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/AreaImpactTelegraphTests.cs
@@ -1,0 +1,125 @@
+using System.Numerics;
+using System.Reflection;
+using FluentAssertions;
+using NUnit.Framework;
+using SWLOR.Game.Server.Service;
+using SWLOR.Game.Server.Service.AbilityService;
+using SWLOR.Game.Server.Service.TelegraphService;
+
+namespace SWLOR.Game.Server.Tests.Service;
+
+public class AreaImpactTelegraphTests
+{
+    [TestCase(TelegraphType.Cone)]
+    [TestCase(TelegraphType.Line)]
+    public void TargetMovesSidewaysDuringCast_ShowsTheNewImpactDirection(TelegraphType shape)
+    {
+        var activation = DirectionalGeometry(shape, Vector3.Zero, new Vector3(4f, 0f, 0f));
+        var impact = DirectionalGeometry(shape, Vector3.Zero, new Vector3(0f, 4f, 0f));
+
+        Telegraph.ShouldShowImpactFlash(impact, new[] { activation }).Should().BeTrue(
+            "the old warning faced east, but this cast now strikes north");
+    }
+
+    [TestCase(TelegraphType.Cone)]
+    [TestCase(TelegraphType.Line)]
+    public void TargetMovesAlongTheSameDirection_DoesNotRedrawAnUnchangedArea(TelegraphType shape)
+    {
+        var activation = DirectionalGeometry(shape, Vector3.Zero, new Vector3(4f, 0f, 0f));
+        var impact = DirectionalGeometry(shape, Vector3.Zero, new Vector3(6f, 0f, 0f));
+
+        Telegraph.ShouldShowImpactFlash(impact, new[] { activation }).Should().BeFalse();
+    }
+
+    [Test]
+    public void TargetCenteredSphereMoves_ShowsItsNewCenter()
+    {
+        var activation = new TelegraphGeometry(1, TelegraphType.Sphere, Vector3.Zero, new Vector2(5f), 0f);
+
+        Telegraph.ShouldShowImpactFlash(
+                activation with { Position = new Vector3(2f, 0f, 0f) }, new[] { activation })
+            .Should().BeTrue();
+        Telegraph.ShouldShowImpactFlash(activation with { Rotation = MathF.PI }, new[] { activation })
+            .Should().BeFalse("rotating a sphere does not change its area");
+    }
+
+    [Test]
+    public void ChangedSizeOriginShapeOrArea_RequiresAnImpactFlash()
+    {
+        var activation = DirectionalGeometry(TelegraphType.Cone, Vector3.Zero, Vector3.UnitX);
+        var changedImpacts = new[]
+        {
+            activation with { Size = new Vector2(12f, 5f) },
+            activation with { Size = new Vector2(9.5f, 7f) },
+            activation with { Position = activation.Position + Vector3.UnitX },
+            activation with { Shape = TelegraphType.Line },
+            activation with { Area = 2 }
+        };
+
+        foreach (var impact in changedImpacts)
+            Telegraph.ShouldShowImpactFlash(impact, new[] { activation }).Should().BeTrue();
+    }
+
+    [Test]
+    public void EquivalentDirectionsAcrossAngleWrap_DoNotRedraw()
+    {
+        var activation = DirectionalGeometry(TelegraphType.Cone, Vector3.Zero, -Vector3.UnitX);
+        var impact = activation with { Rotation = -MathF.PI };
+
+        Telegraph.ShouldShowImpactFlash(impact, new[] { activation }).Should().BeFalse();
+    }
+
+    [Test]
+    public void NoMatchingActivationMarker_StillFlashesInstantAndDelayedImpacts()
+    {
+        var impact = DirectionalGeometry(TelegraphType.Cone, Vector3.Zero, Vector3.UnitX);
+
+        Telegraph.ShouldShowImpactFlash(impact, null).Should().BeTrue();
+        Telegraph.ShouldShowImpactFlash(impact, Array.Empty<TelegraphGeometry>()).Should().BeTrue();
+        Telegraph.ShouldShowImpactFlash(impact, new[] { impact with { Shape = TelegraphType.Sphere }, impact })
+            .Should().BeFalse("an additional activation marker can already describe this impact");
+    }
+
+    [Test]
+    public void CapturedGeometrySurvivesMarkerRemovalWithoutFollowingMutableData()
+    {
+        var telegraphs = (Dictionary<string, ActiveTelegraph>)typeof(Telegraph)
+            .GetField("_allTelegraphs", BindingFlags.Static | BindingFlags.NonPublic)!.GetValue(null)!;
+        var id = Guid.NewGuid().ToString();
+        var original = DirectionalGeometry(TelegraphType.Cone, Vector3.Zero, Vector3.UnitX);
+        var data = new TelegraphData
+        {
+            Shape = original.Shape,
+            Position = original.Position,
+            Size = original.Size,
+            Rotation = original.Rotation
+        };
+        telegraphs.Add(id, new ActiveTelegraph(original.Area, 0, 1, data));
+        try
+        {
+            var snapshots = Telegraph.CaptureGeometry(new[] { id, "missing-marker" });
+            data.Position = Vector3.One;
+            telegraphs.Remove(id);
+
+            snapshots.Should().Equal(original);
+            Telegraph.ShouldShowImpactFlash(original, snapshots).Should().BeFalse();
+            Telegraph.ShouldShowImpactFlash(original with { Position = data.Position }, snapshots).Should().BeTrue();
+        }
+        finally
+        {
+            telegraphs.Remove(id);
+        }
+    }
+
+    private static TelegraphGeometry DirectionalGeometry(TelegraphType shape, Vector3 caster, Vector3 target)
+    {
+        var rotation = MathF.Atan2(target.Y - caster.Y, target.X - caster.X);
+        var combatShape = shape == TelegraphType.Cone ? CombatImpactAreaShape.Cone : CombatImpactAreaShape.Line;
+        return new TelegraphGeometry(
+            1,
+            shape,
+            CombatImpactShapeGeometry.ResolveOrigin(caster, rotation, combatShape, true),
+            new Vector2(CombatImpactShapeGeometry.ResolveLength(combatShape, 8f, true), 5f),
+            rotation);
+    }
+}

--- a/SWLOR.Game.Server.Tests/Service/AreaImpactTelegraphTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/AreaImpactTelegraphTests.cs
@@ -10,6 +10,9 @@ namespace SWLOR.Game.Server.Tests.Service;
 
 public class AreaImpactTelegraphTests
 {
+    /// <summary>
+    /// Reproduces a target changing the attack direction after the activation warning was displayed.
+    /// </summary>
     [TestCase(TelegraphType.Cone)]
     [TestCase(TelegraphType.Line)]
     public void TargetMovesSidewaysDuringCast_ShowsTheNewImpactDirection(TelegraphType shape)
@@ -21,6 +24,9 @@ public class AreaImpactTelegraphTests
             "the old warning faced east, but this cast now strikes north");
     }
 
+    /// <summary>
+    /// Ensures movement along the same aim direction preserves suppression for an unchanged footprint.
+    /// </summary>
     [TestCase(TelegraphType.Cone)]
     [TestCase(TelegraphType.Line)]
     public void TargetMovesAlongTheSameDirection_DoesNotRedrawAnUnchangedArea(TelegraphType shape)
@@ -31,6 +37,9 @@ public class AreaImpactTelegraphTests
         Telegraph.ShouldShowImpactFlash(impact, new[] { activation }).Should().BeFalse();
     }
 
+    /// <summary>
+    /// Distinguishes a sphere's changed center from rotation that leaves its footprint unchanged.
+    /// </summary>
     [Test]
     public void TargetCenteredSphereMoves_ShowsItsNewCenter()
     {
@@ -43,6 +52,9 @@ public class AreaImpactTelegraphTests
             .Should().BeFalse("rotating a sphere does not change its area");
     }
 
+    /// <summary>
+    /// Requires a new marker when dimensions, origin, shape, or the containing game area changes.
+    /// </summary>
     [Test]
     public void ChangedSizeOriginShapeOrArea_RequiresAnImpactFlash()
     {
@@ -60,6 +72,9 @@ public class AreaImpactTelegraphTests
             Telegraph.ShouldShowImpactFlash(impact, new[] { activation }).Should().BeTrue();
     }
 
+    /// <summary>
+    /// Treats positive and negative pi as the same direction at the angle boundary.
+    /// </summary>
     [Test]
     public void EquivalentDirectionsAcrossAngleWrap_DoNotRedraw()
     {
@@ -69,6 +84,9 @@ public class AreaImpactTelegraphTests
         Telegraph.ShouldShowImpactFlash(impact, new[] { activation }).Should().BeFalse();
     }
 
+    /// <summary>
+    /// Keeps flashes without activation snapshots and accepts a match among multiple activation markers.
+    /// </summary>
     [Test]
     public void NoMatchingActivationMarker_StillFlashesInstantAndDelayedImpacts()
     {
@@ -80,6 +98,9 @@ public class AreaImpactTelegraphTests
             .Should().BeFalse("an additional activation marker can already describe this impact");
     }
 
+    /// <summary>
+    /// Ensures captured values remain stable when live marker data changes or the marker is removed.
+    /// </summary>
     [Test]
     public void CapturedGeometrySurvivesMarkerRemovalWithoutFollowingMutableData()
     {
@@ -111,6 +132,9 @@ public class AreaImpactTelegraphTests
         }
     }
 
+    /// <summary>
+    /// Builds a directional test footprint using the production origin and length offset rules.
+    /// </summary>
     private static TelegraphGeometry DirectionalGeometry(TelegraphType shape, Vector3 caster, Vector3 target)
     {
         var rotation = MathF.Atan2(target.Y - caster.Y, target.X - caster.X);

--- a/SWLOR.Game.Server.Tests/Service/TelegraphTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/TelegraphTests.cs
@@ -130,6 +130,9 @@ public class TelegraphTests
         Ability.DefaultImpactFlashDuration.Should().BeGreaterThan(0f);
     }
 
+    /// <summary>
+    /// Guards the production wiring from the immediate damage branch to geometry-aware flash suppression.
+    /// </summary>
     [Test]
     public void ApplyTelegraphedCombatImpact_FlashesOnlyWhenActivationDidNotAlreadyShowTheShape()
     {
@@ -156,6 +159,9 @@ public class TelegraphTests
         flashBody.Should().Contain("Telegraph.ShouldShowImpactFlash(geometry, activationAreaTelegraphs)");
     }
 
+    /// <summary>
+    /// Guards snapshot capture and propagation while ensuring delayed impacts do not reuse expired warnings.
+    /// </summary>
     [Test]
     public void AbilityActivation_CapturesDisplayedGeometryBeforeTheTelegraphExpires()
     {

--- a/SWLOR.Game.Server.Tests/Service/TelegraphTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/TelegraphTests.cs
@@ -146,24 +146,28 @@ public class TelegraphTests
         // would still pass.
         var branchBody = ExtractBlockBody(source, branchStart);
 
-        branchBody.Should().Contain("HadActivationAreaTelegraph",
-            "a casted area must not tear down and immediately redraw the same telegraph at impact");
+        branchBody.Should().Contain("trackedImpact?.ActivationAreaTelegraphs",
+            "the impact must compare its current geometry with the shapes displayed during activation");
         branchBody.IndexOf("ShowAreaImpactFlash(", StringComparison.Ordinal)
             .Should().BeGreaterThan(-1, "the instant-cast path must flash the area it just struck");
+
+        var flashStart = source.IndexOf("private static void ShowAreaImpactFlash(", StringComparison.Ordinal);
+        var flashBody = ExtractBlockBody(source, flashStart);
+        flashBody.Should().Contain("Telegraph.ShouldShowImpactFlash(geometry, activationAreaTelegraphs)");
     }
 
     [Test]
-    public void AbilityActivation_TracksWhetherAnAreaTelegraphWasDisplayed()
+    public void AbilityActivation_CapturesDisplayedGeometryBeforeTheTelegraphExpires()
     {
         var source = File.ReadAllText(ResolveRepositoryPath(
             "SWLOR.Game.Server",
             "Feature",
             "UsePerkFeat.cs"));
 
-        source.Should().Contain("activationTelegraphIds.Count > 0");
-        source.Should().Contain("hadActivationAreaTelegraph: hadActivationAreaTelegraph");
+        source.Should().Contain("Telegraph.CaptureGeometry(activationTelegraphIds)");
+        source.Should().Contain("activationAreaTelegraphs: activationAreaTelegraphs");
         source.Should().Contain(
-            "ability.ImpactDelay <= 0f && activationTelegraphIds.Count > 0",
+            "ability.ImpactDelay <= 0f ? activationAreaTelegraphs : null",
             "a delayed impact occurs after its activation telegraph has been removed and still needs an impact flash");
     }
 

--- a/SWLOR.Game.Server/Feature/UsePerkFeat.cs
+++ b/SWLOR.Game.Server/Feature/UsePerkFeat.cs
@@ -423,6 +423,10 @@ namespace SWLOR.Game.Server.Feature
             AssignCommand(activator, () => PlaySound(soundResref));
         }
 
+        /// <summary>
+        /// Runs an ability's impact with its activation-marker snapshots, applies completion
+        /// effects, and releases impact tracking and stamina context even if execution fails.
+        /// </summary>
         private static void ExecuteAbilityImpact(
             uint activator,
             uint target,
@@ -601,7 +605,10 @@ namespace SWLOR.Game.Server.Feature
                 DelayCommand(0.5f, () => CheckForActivationInterruption(activationId, originalPosition, activationTelegraphIds, resumeAttackTarget));
             }
 
-            // This method is called after the delay of the ability has finished.
+            /// <summary>
+            /// Completes or cancels a finished activation, retaining its marker snapshots
+            /// for an immediate impact while separately delayed impacts receive a fresh flash.
+            /// </summary>
             void CompleteActivation(
                 string activationId,
                 float abilityRecastDelay,
@@ -673,6 +680,10 @@ namespace SWLOR.Game.Server.Feature
                 ApplyRequirementEffects(activator, ability);
                 HandleStealthBreaking(activator, ability);
 
+                /// <summary>
+                /// Executes the validated impact and resumes combat, reusing activation
+                /// geometry only when no separate impact delay elapsed.
+                /// </summary>
                 void ResolveImpact()
                 {
                     ExecuteAbilityImpact(

--- a/SWLOR.Game.Server/Feature/UsePerkFeat.cs
+++ b/SWLOR.Game.Server/Feature/UsePerkFeat.cs
@@ -429,7 +429,7 @@ namespace SWLOR.Game.Server.Feature
             FeatType feat,
             AbilityDetail ability,
             Location targetLocation,
-            bool hadActivationAreaTelegraph = false)
+            IReadOnlyList<TelegraphGeometry> activationAreaTelegraphs = null)
         {
             var impactEnded = false;
             try
@@ -438,7 +438,7 @@ namespace SWLOR.Game.Server.Feature
                 Ability.BeginAbilityImpact(
                     activator,
                     ability,
-                    hadActivationAreaTelegraph: hadActivationAreaTelegraph);
+                    activationAreaTelegraphs: activationAreaTelegraphs);
                 ability.ImpactAction?.Invoke(activator, target, ability.AbilityLevel, targetLocation);
                 var summary = Ability.EndAbilityImpact(activator);
                 impactEnded = true;
@@ -602,7 +602,12 @@ namespace SWLOR.Game.Server.Feature
             }
 
             // This method is called after the delay of the ability has finished.
-            void CompleteActivation(string activationId, float abilityRecastDelay, uint resumeAttackTarget, List<string> activationTelegraphIds)
+            void CompleteActivation(
+                string activationId,
+                float abilityRecastDelay,
+                uint resumeAttackTarget,
+                List<string> activationTelegraphIds,
+                IReadOnlyList<TelegraphGeometry> activationAreaTelegraphs)
             {
                 void CancelActivation(bool resumeAttack)
                 {
@@ -676,8 +681,8 @@ namespace SWLOR.Game.Server.Feature
                         feat,
                         ability,
                         targetLocation,
-                        hadActivationAreaTelegraph:
-                            ability.ImpactDelay <= 0f && activationTelegraphIds.Count > 0);
+                        activationAreaTelegraphs:
+                            ability.ImpactDelay <= 0f ? activationAreaTelegraphs : null);
                     ResumeAttackAfterDelay(activator, resumeAttackTarget, 0.1f);
 
                     // If this is an attack make the NPC react.
@@ -751,6 +756,7 @@ namespace SWLOR.Game.Server.Feature
             var position = GetPosition(activator);
             var resumeAttackTarget = GetResumeAttackTarget(activator, target, ability);
             var activationTelegraphIds = ProcessAnimationAndVisualEffects(activationDelay);
+            var activationAreaTelegraphs = Telegraph.CaptureGeometry(activationTelegraphIds);
             SetLocalInt(activator, activationId, (int)ActivationStatus.Started);
             _activeAbilityActivations[activator] = new ActiveAbilityActivation
             {
@@ -796,12 +802,13 @@ namespace SWLOR.Game.Server.Feature
                     feat,
                     ability,
                     targetLocation,
-                    activationTelegraphIds.Count > 0);
+                    activationAreaTelegraphs);
                 Recast.ApplyRecastDelay(activator, ability.RecastGroup, recastDelay);
             }
 
             Activity.SetBusy(activator, ActivityStatusType.AbilityActivation);
-            DelayCommand(activationDelay, () => CompleteActivation(activationId, recastDelay, resumeAttackTarget, activationTelegraphIds));
+            DelayCommand(activationDelay, () => CompleteActivation(
+                activationId, recastDelay, resumeAttackTarget, activationTelegraphIds, activationAreaTelegraphs));
         }
 
         /// <summary>

--- a/SWLOR.Game.Server/Service/Ability.cs
+++ b/SWLOR.Game.Server/Service/Ability.cs
@@ -102,7 +102,7 @@ namespace SWLOR.Game.Server.Service
             uint activator,
             AbilityDetail ability,
             bool countsAsAttackAttempt = true,
-            bool hadActivationAreaTelegraph = false)
+            IReadOnlyList<TelegraphGeometry> activationAreaTelegraphs = null)
         {
             if (!GetIsObjectValid(activator) || ability == null)
                 return;
@@ -139,7 +139,7 @@ namespace SWLOR.Game.Server.Service
                 statusAppliedNextAttackDamageBonus,
                 countsAsAttackAttempt,
                 queuedWeaponBonuses.CriticalDamagePercentAdjustment,
-                hadActivationAreaTelegraph);
+                activationAreaTelegraphs);
         }
 
         private static void BeginAbilityImpact(
@@ -152,7 +152,7 @@ namespace SWLOR.Game.Server.Service
             int statusAppliedNextAttackDamageBonus = 0,
             bool countsAsAttackAttempt = true,
             int nextAbilityCriticalDamagePercentAdjustment = 0,
-            bool hadActivationAreaTelegraph = false)
+            IReadOnlyList<TelegraphGeometry> activationAreaTelegraphs = null)
         {
             if (!GetIsObjectValid(activator) || ability == null)
                 return;
@@ -166,7 +166,7 @@ namespace SWLOR.Game.Server.Service
                 statusAppliedNextAttackDamageBonus,
                 countsAsAttackAttempt,
                 nextAbilityCriticalDamagePercentAdjustment,
-                hadActivationAreaTelegraph);
+                activationAreaTelegraphs);
         }
 
         public static AbilityImpactSummary EndAbilityImpact(uint activator)
@@ -1331,22 +1331,19 @@ namespace SWLOR.Game.Server.Service
             {
                 // Instant-cast area abilities cannot use a pre-cast telegraph without violating the
                 // Bible's "Instant" activation time, so they flash their shape at impact instead.
-                // The flash is purely visual: damage below is still applied immediately. A cast that
-                // already displayed this area through its activation must not tear that shape down
-                // and recreate it at impact, which produces a visible off/on flicker.
-                if (GetTrackedAbilityImpact(activator)?.HadActivationAreaTelegraph != true)
-                {
-                    ShowAreaImpactFlash(
-                        activator,
-                        target,
-                        targetLocation,
-                        shape,
-                        lengthOrRadius,
-                        width,
-                        centerOnActivator,
-                        impactFlashDuration,
-                        backOffsetOrigin);
-                }
+                // The flash is purely visual: damage below is still applied immediately. Compare
+                // the actual impact geometry with the activation marker before suppressing a redraw.
+                ShowAreaImpactFlash(
+                    activator,
+                    target,
+                    targetLocation,
+                    shape,
+                    lengthOrRadius,
+                    width,
+                    centerOnActivator,
+                    impactFlashDuration,
+                    backOffsetOrigin,
+                    trackedImpact?.ActivationAreaTelegraphs);
 
                 var totalDamage = ApplyCombatImpactInShape(
                     activator,
@@ -1507,7 +1504,8 @@ namespace SWLOR.Game.Server.Service
             float width,
             bool centerOnActivator,
             float flashDuration,
-            bool backOffsetOrigin)
+            bool backOffsetOrigin,
+            IReadOnlyList<TelegraphGeometry> activationAreaTelegraphs)
         {
             if (flashDuration <= 0f || lengthOrRadius <= 0f)
                 return;
@@ -1523,40 +1521,36 @@ namespace SWLOR.Game.Server.Service
                 lengthOrRadius,
                 backOffsetOrigin);
 
-            switch (shape)
+            var telegraphType = shape switch
             {
-                case CombatImpactAreaShape.Sphere:
-                    Telegraph.CreateSphereTelegraph(
-                        activator,
-                        GetAreaImpactPosition(activator, target, targetLocation, centerOnActivator),
-                        lengthOrRadius,
-                        flashDuration,
-                        true,
-                        null);
-                    break;
-                case CombatImpactAreaShape.Cone:
-                    Telegraph.CreateConeTelegraph(
-                        activator,
-                        directionalOrigin,
-                        rotation,
-                        adjustedLength,
-                        width > 0f ? width : adjustedLength,
-                        flashDuration,
-                        true,
-                        null);
-                    break;
-                case CombatImpactAreaShape.Line:
-                    Telegraph.CreateLineTelegraph(
-                        activator,
-                        directionalOrigin,
-                        rotation,
-                        adjustedLength,
-                        width > 0f ? width : 2.0f,
-                        flashDuration,
-                        true,
-                        null);
-                    break;
-            }
+                CombatImpactAreaShape.Sphere => TelegraphType.Sphere,
+                CombatImpactAreaShape.Cone => TelegraphType.Cone,
+                CombatImpactAreaShape.Line => TelegraphType.Line,
+                _ => TelegraphType.None
+            };
+            if (telegraphType == TelegraphType.None)
+                return;
+
+            var position = shape == CombatImpactAreaShape.Sphere
+                ? GetAreaImpactPosition(activator, target, targetLocation, centerOnActivator)
+                : directionalOrigin;
+            var size = shape == CombatImpactAreaShape.Sphere
+                ? new System.Numerics.Vector2(lengthOrRadius, lengthOrRadius)
+                : new System.Numerics.Vector2(adjustedLength,
+                    width > 0f ? width : shape == CombatImpactAreaShape.Cone ? adjustedLength : 2.0f);
+            var geometry = new TelegraphGeometry(GetArea(activator), telegraphType, position, size, rotation);
+            if (!Telegraph.ShouldShowImpactFlash(geometry, activationAreaTelegraphs))
+                return;
+
+            Telegraph.CreateTelegraph(
+                activator,
+                position,
+                shape == CombatImpactAreaShape.Sphere ? 0f : rotation,
+                size,
+                flashDuration,
+                true,
+                telegraphType,
+                null);
         }
 
         private static int ApplyCombatImpactInShape(
@@ -3251,7 +3245,7 @@ namespace SWLOR.Game.Server.Service
             public AbilityDetail Ability { get; }
             public AbilityImpactSummary Summary { get; }
             public bool CountsAsAttackAttempt { get; }
-            public bool HadActivationAreaTelegraph { get; }
+            public IReadOnlyList<TelegraphGeometry> ActivationAreaTelegraphs { get; }
             public int NextAbilityDamageBonus { get; private set; }
             public int NextAbilityCriticalRatePercentAdjustment { get; }
             public int NextAbilityCriticalDamagePercentAdjustment { get; }
@@ -3270,7 +3264,7 @@ namespace SWLOR.Game.Server.Service
                 int statusAppliedNextAttackDamageBonus,
                 bool countsAsAttackAttempt,
                 int nextAbilityCriticalDamagePercentAdjustment,
-                bool hadActivationAreaTelegraph)
+                IReadOnlyList<TelegraphGeometry> activationAreaTelegraphs)
             {
                 Ability = ability;
                 NextAbilityDamageBonus = nextAbilityDamageBonus;
@@ -3280,7 +3274,7 @@ namespace SWLOR.Game.Server.Service
                 NextAttackEnmityBonus = nextAttackEnmityBonus;
                 StatusAppliedNextAttackDamageBonus = statusAppliedNextAttackDamageBonus;
                 CountsAsAttackAttempt = countsAsAttackAttempt;
-                HadActivationAreaTelegraph = hadActivationAreaTelegraph;
+                ActivationAreaTelegraphs = activationAreaTelegraphs;
                 Summary = new AbilityImpactSummary
                 {
                     SkillType = ability.SkillType,

--- a/SWLOR.Game.Server/Service/Ability.cs
+++ b/SWLOR.Game.Server/Service/Ability.cs
@@ -98,6 +98,10 @@ namespace SWLOR.Game.Server.Service
             return _abilities[featType];
         }
 
+        /// <summary>
+        /// Consumes the activator's pending combat bonuses and starts impact tracking,
+        /// retaining any activation-marker snapshots for the impact flash decision.
+        /// </summary>
         public static void BeginAbilityImpact(
             uint activator,
             AbilityDetail ability,
@@ -142,6 +146,9 @@ namespace SWLOR.Game.Server.Service
                 activationAreaTelegraphs);
         }
 
+        /// <summary>
+        /// Registers an impact using already-resolved bonuses and activation-marker geometry.
+        /// </summary>
         private static void BeginAbilityImpact(
             uint activator,
             AbilityDetail ability,
@@ -3255,6 +3262,10 @@ namespace SWLOR.Game.Server.Service
             public bool DarkForceConversionApplied { get; set; }
             private bool _statusAppliedNextAttackDamageBonusConsumed;
 
+            /// <summary>
+            /// Initializes per-impact bonuses, summary classification, and the activation
+            /// geometry that can suppress redundant impact markers.
+            /// </summary>
             public TrackedAbilityImpact(
                 AbilityDetail ability,
                 int nextAbilityDamageBonus,

--- a/SWLOR.Game.Server/Service/Telegraph.cs
+++ b/SWLOR.Game.Server/Service/Telegraph.cs
@@ -91,6 +91,10 @@ namespace SWLOR.Game.Server.Service
                 : new Dictionary<string, ActiveTelegraph>();
         }
 
+        /// <summary>
+        /// Copies the geometry of existing markers so activation warnings can be compared
+        /// with later impacts after their timers expire. Missing marker IDs are ignored.
+        /// </summary>
         public static IReadOnlyList<TelegraphGeometry> CaptureGeometry(IEnumerable<string> telegraphIds)
         {
             return telegraphIds
@@ -105,6 +109,10 @@ namespace SWLOR.Game.Server.Service
                 .ToArray();
         }
 
+        /// <summary>
+        /// Requests an impact flash unless a captured activation marker already described
+        /// the same area. Null or empty snapshots preserve instant and delayed impact flashes.
+        /// </summary>
         public static bool ShouldShowImpactFlash(
             TelegraphGeometry impact,
             IReadOnlyList<TelegraphGeometry> activationTelegraphs)

--- a/SWLOR.Game.Server/Service/Telegraph.cs
+++ b/SWLOR.Game.Server/Service/Telegraph.cs
@@ -91,6 +91,27 @@ namespace SWLOR.Game.Server.Service
                 : new Dictionary<string, ActiveTelegraph>();
         }
 
+        public static IReadOnlyList<TelegraphGeometry> CaptureGeometry(IEnumerable<string> telegraphIds)
+        {
+            return telegraphIds
+                .Where(_allTelegraphs.ContainsKey)
+                .Select(id => _allTelegraphs[id])
+                .Select(telegraph => new TelegraphGeometry(
+                    telegraph.Area,
+                    telegraph.Data.Shape,
+                    telegraph.Data.Position,
+                    telegraph.Data.Size,
+                    telegraph.Data.Rotation))
+                .ToArray();
+        }
+
+        public static bool ShouldShowImpactFlash(
+            TelegraphGeometry impact,
+            IReadOnlyList<TelegraphGeometry> activationTelegraphs)
+        {
+            return activationTelegraphs == null || !activationTelegraphs.Any(impact.Matches);
+        }
+
         /// <summary>
         /// Checks if a creature is within a telegraph's area of effect.
         /// </summary>

--- a/SWLOR.Game.Server/Service/TelegraphService/README.md
+++ b/SWLOR.Game.Server/Service/TelegraphService/README.md
@@ -156,6 +156,12 @@ Two distinct paths render a shape, and they are not interchangeable:
   This is what makes Bible-"Instant" area abilities visible without changing their
   activation time. Duration comes from `Ability.DefaultImpactFlashDuration`.
 
+An immediate impact skips its flash only when its geometry matches a marker shown during
+activation. `UsePerkFeat` captures immutable marker geometry before the native timers expire;
+the impact compares area, shape, position, size, and direction. A moving target or changed
+radius therefore gets a fresh marker, while an unchanged area avoids a redundant redraw.
+Impacts with a separate choreography delay still flash after that delay.
+
 Do not set `WeaponAbilityProfile.TelegraphDuration` from a Bible casting time: the
 pre-cast telegraph already covers the activation delay, and this one applies at impact, so
 the two would stack into a double delay and a double render.

--- a/SWLOR.Game.Server/Service/TelegraphService/TelegraphGeometry.cs
+++ b/SWLOR.Game.Server/Service/TelegraphService/TelegraphGeometry.cs
@@ -14,6 +14,10 @@ namespace SWLOR.Game.Server.Service.TelegraphService
         Vector2 Size,
         float Rotation)
     {
+        /// <summary>
+        /// Compares marker footprints within 1 cm and 0.001 radians, ignoring sphere rotation
+        /// and treating directions separated by a full turn as equivalent.
+        /// </summary>
         public bool Matches(TelegraphGeometry other)
         {
             const float distanceToleranceSquared = 0.0001f;

--- a/SWLOR.Game.Server/Service/TelegraphService/TelegraphGeometry.cs
+++ b/SWLOR.Game.Server/Service/TelegraphService/TelegraphGeometry.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Numerics;
+using NumericsVector3 = System.Numerics.Vector3;
+
+namespace SWLOR.Game.Server.Service.TelegraphService
+{
+    /// <summary>
+    /// Immutable geometry of a displayed marker, retained after its native timer expires.
+    /// </summary>
+    public readonly record struct TelegraphGeometry(
+        uint Area,
+        TelegraphType Shape,
+        NumericsVector3 Position,
+        Vector2 Size,
+        float Rotation)
+    {
+        public bool Matches(TelegraphGeometry other)
+        {
+            const float distanceToleranceSquared = 0.0001f;
+            const float rotationTolerance = 0.001f;
+
+            if (Area != other.Area || Shape != other.Shape ||
+                NumericsVector3.DistanceSquared(Position, other.Position) > distanceToleranceSquared ||
+                Vector2.DistanceSquared(Size, other.Size) > distanceToleranceSquared)
+                return false;
+
+            return Shape == TelegraphType.Sphere ||
+                   Math.Abs(Math.IEEERemainder(Rotation - other.Rotation, 2 * Math.PI)) <= rotationTolerance;
+        }
+    }
+}


### PR DESCRIPTION
When a creature moves sideways during an area cast such as Piercing Quills, the attack recomputes its direction at impact, but the activation-marker flag suppressed the flash for the new damage area. Players could therefore be hit outside the only marker they saw.

Capture immutable activation-marker geometry and suppress the impact flash only when the area, shape, position, dimensions, and direction still match. Unchanged areas retain the flicker fix; moved or reshaped areas receive an impact marker. Instant casts and separately delayed impacts continue to flash without changing damage timing.

Validation:
- Build succeeded with post-build deployment disabled; one existing nullable-annotation warning remains in GuiWidget.cs.
- 54 focused tests passed, including moved-target cones/lines/spheres, unchanged geometry, angle wrapping, snapshot lifetime, damage queues, and line-of-sight behavior.
- The shader-palette asset test was excluded because this worktree has no initialized SWLOR_Haks checkout. This PR does not change submodule pointers or client assets.
- In-game rendering was not exercised.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved area-impact telegraph flashes so they update when a target moves or an impact’s shape, size, position, or direction changes.
  * Prevented redundant flashes when an impact matches the telegraph already shown during activation.
  * Ensured delayed impacts continue to display their impact telegraph correctly.
* **Documentation**
  * Added guidance describing when impact flashes are displayed or skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->