### PR TITLE
Add Arkanian language support

### DIFF
--- a/SWLOR.Game.Server/Service/Language.cs
+++ b/SWLOR.Game.Server/Service/Language.cs
@@ -23,6 +23,7 @@ namespace SWLOR.Game.Server.Service
         {
             _translators = new Dictionary<SkillType, ITranslator>
             {
+                { SkillType.Arkanian, new TranslatorArkanian() },
                 { SkillType.Bothese, new TranslatorBothese() },
                 { SkillType.Catharese, new TranslatorCatharese() },
                 { SkillType.Cheunh, new TranslatorCheunh() },
@@ -178,6 +179,7 @@ namespace SWLOR.Game.Server.Service
             switch (language)
             {
                 case SkillType.Basic: r = 255; g = 255; b = 255; break;
+                case SkillType.Arkanian: r = 190; g = 210; b = 245; break;
                 case SkillType.Bothese: r = 132; g = 56; b = 18; break;
                 case SkillType.Catharese: r = 235; g = 235; b = 199; break;
                 case SkillType.Cheunh: r = 82; g = 143; b = 174; break;
@@ -205,6 +207,7 @@ namespace SWLOR.Game.Server.Service
         {
             switch (language)
             {
+                case SkillType.Arkanian: return "Arkanian";
                 case SkillType.Bothese: return "Bothese";
                 case SkillType.Catharese: return "Catharese";
                 case SkillType.Cheunh: return "Cheunh";
@@ -263,6 +266,7 @@ namespace SWLOR.Game.Server.Service
                     var languages = new List<LanguageCommand>
                     {
                         new LanguageCommand("Basic", SkillType.Basic, new [] { "basic" }),
+                        new LanguageCommand("Arkanian", SkillType.Arkanian, new [] { "arkanian" }),
                         new LanguageCommand("Bothese", SkillType.Bothese, new[] {"bothese"}),
                         new LanguageCommand("Catharese", SkillType.Catharese, new []{"catharese"}),
                         new LanguageCommand("Cheunh", SkillType.Cheunh, new []{"cheunh"}),

--- a/SWLOR.Game.Server/Service/LanguageService/TranslatorArkanian.cs
+++ b/SWLOR.Game.Server/Service/LanguageService/TranslatorArkanian.cs
@@ -1,0 +1,100 @@
+using System.Text;
+
+namespace SWLOR.Game.Server.Service.LanguageService
+{
+    public class TranslatorArkanian : ITranslator
+    {
+        public string Translate(string message)
+        {
+            var sb = new StringBuilder();
+
+            foreach (var ch in message)
+            {
+                switch (ch)
+                {
+                    case 'a': sb.Append("ae"); break;
+                    case 'A': sb.Append("Ae"); break;
+
+                    case 'b': sb.Append("v"); break;
+                    case 'B': sb.Append("V"); break;
+
+                    case 'c': sb.Append("k"); break;
+                    case 'C': sb.Append("K"); break;
+
+                    case 'd': sb.Append("th"); break;
+                    case 'D': sb.Append("Th"); break;
+
+                    case 'e': sb.Append("i"); break;
+                    case 'E': sb.Append("I"); break;
+
+                    case 'f': sb.Append("ph"); break;
+                    case 'F': sb.Append("Ph"); break;
+
+                    case 'g': sb.Append("d"); break;
+                    case 'G': sb.Append("D"); break;
+
+                    case 'h': sb.Append("sh"); break;
+                    case 'H': sb.Append("Sh"); break;
+
+                    case 'i': sb.Append("ei"); break;
+                    case 'I': sb.Append("Ei"); break;
+
+                    case 'j': sb.Append("zh"); break;
+                    case 'J': sb.Append("Zh"); break;
+
+                    case 'k': sb.Append("q"); break;
+                    case 'K': sb.Append("Q"); break;
+
+                    case 'l': sb.Append("r"); break;
+                    case 'L': sb.Append("R"); break;
+
+                    case 'm': sb.Append("n"); break;
+                    case 'M': sb.Append("N"); break;
+
+                    case 'n': sb.Append("l"); break;
+                    case 'N': sb.Append("L"); break;
+
+                    case 'o': sb.Append("au"); break;
+                    case 'O': sb.Append("Au"); break;
+
+                    case 'p': sb.Append("b"); break;
+                    case 'P': sb.Append("B"); break;
+
+                    case 'q': sb.Append("kh"); break;
+                    case 'Q': sb.Append("Kh"); break;
+
+                    case 'r': sb.Append("s"); break;
+                    case 'R': sb.Append("S"); break;
+
+                    case 's': sb.Append("z"); break;
+                    case 'S': sb.Append("Z"); break;
+
+                    case 't': sb.Append("t"); break;
+                    case 'T': sb.Append("T"); break;
+
+                    case 'u': sb.Append("u"); break;
+                    case 'U': sb.Append("U"); break;
+
+                    case 'v': sb.Append("f"); break;
+                    case 'V': sb.Append("F"); break;
+
+                    case 'w': sb.Append("v"); break;
+                    case 'W': sb.Append("V"); break;
+
+                    case 'x': sb.Append("ks"); break;
+                    case 'X': sb.Append("Ks"); break;
+
+                    case 'y': sb.Append("ia"); break;
+                    case 'Y': sb.Append("Ia"); break;
+
+                    case 'z': sb.Append("j"); break;
+                    case 'Z': sb.Append("J"); break;
+
+                    default: sb.Append(ch); break;
+                }
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/SWLOR.Game.Server/Service/SkillService/SkillType.cs
+++ b/SWLOR.Game.Server/Service/SkillService/SkillType.cs
@@ -486,6 +486,16 @@ namespace SWLOR.Game.Server.Service.SkillService
             CombatPointCategoryType.Utility,
             CharacterType.Standard)]
         Espionage = 49,
+
+        [Skill(SkillCategoryType.Languages,
+            "Arkanian",
+            20,
+            true,
+            "Ability to speak the Arkanian language.",
+            false,
+            false,
+            false)]
+        Arkanian = 50,
     }
 
     public class SkillAttribute : Attribute


### PR DESCRIPTION
Adds Arkanian as a rank-20 language skill following existing languages. Players can select it with `/language arkanian`; it appears in language help, uses its own speech translator and chat color, and participates in the existing comprehension and language XP system. Existing characters receive the skill through the normal missing-skill initialization.

Updates the haks submodule for the matching skill label and regenerated TLK. Companion asset PR: https://github.com/zunath/SWLOR_Haks/pull/396.

Validation: test-project build with `-p:RunPostBuildEvent=Never` succeeded (8 pre-existing warnings); all 3 `SkillMappingTests` passed with `--no-build`; translator smoke checks verified empty input, uppercase/lowercase text, punctuation, whitespace, and word boundaries; binary TLK entry verified; `git diff --check` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Arkanian as a learnable language skill.
  * Added Arkanian translation for in-game messages.
  * Added Arkanian to the available language list with its command alias.
  * Added a pale blue display color for Arkanian.
* **Updates**
  * Updated game content resources to support the new language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->