### PR TITLE
Fix Final Line missing-health scaling and add engine regression coverage

### DIFF
--- a/SWLOR.Game.Server.EngineTests/Definitions/AbilityBehaviors/MimicryTechniqueAbilityBehaviors.cs
+++ b/SWLOR.Game.Server.EngineTests/Definitions/AbilityBehaviors/MimicryTechniqueAbilityBehaviors.cs
@@ -199,7 +199,7 @@ namespace SWLOR.Game.Server.EngineTests.Definitions.AbilityBehaviors
                     ExpectsTargetDamage = true,
                     ExpectsSTMCost = true,
                     ExpectsRecast = true,
-                    Notes = "damagePercentAdjustment (MissingHpRamp) is a conditional bonus on top of the unconditional base hit; not asserted.",
+                    Notes = "Per-target missing-HP damage scaling is verified by FinalLineEngineTests against identical rolls with the bonus disabled.",
                 },
 
                 // FinalSuppressionTechniqueAbilityDefinition - line AoE, 0 base damage, unconditional Stunned.

--- a/SWLOR.Game.Server.EngineTests/Definitions/FinalLineEngineTests.cs
+++ b/SWLOR.Game.Server.EngineTests/Definitions/FinalLineEngineTests.cs
@@ -1,0 +1,95 @@
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using SWLOR.Game.Server.EngineTests.Framework;
+using SWLOR.Game.Server.Feature.AbilityDefinition.Mimicry;
+using SWLOR.NWN.API.NWNX;
+using SWLOR.NWN.API.NWScript.Enum;
+
+namespace SWLOR.Game.Server.EngineTests.Definitions
+{
+    public static class FinalLineEngineTests
+    {
+        [EngineTest("Final Line scales each line target and refreshes health on later casts", Category = "FinalLine", TimeoutSeconds = 60f)]
+        public static async Task DamageScalesPerTarget(EngineTestContext ctx)
+        {
+            var caster = ctx.SpawnCreature("nw_bandit001");
+            var targets = new[] { ctx.SpawnCreature("nw_rat001", 2f), ctx.SpawnCreature("nw_rat001", 4f) };
+            await ctx.WaitFrameAsync();
+            ObjectPlugin.SetPosition(caster, GetPositionFromLocation(ctx.GetArenaLocation(-4f)));
+            for (var i = 0; i < targets.Length; i++)
+            {
+                ObjectPlugin.SetPosition(targets[i], GetPositionFromLocation(ctx.GetArenaLocation(-2f + 2f * i)));
+                ctx.MakeHostile(targets[i]);
+                ctx.SuppressNPCNaturalRegen(targets[i]);
+                Stat.SetNPCMaxHitPoints(targets[i], 30000);
+                ctx.AssertEqual(30000, GetMaxHitPoints(targets[i]), "target HP budget");
+            }
+            foreach (var creature in targets.Append(caster))
+                ApplyEffectToObject(DurationType.Temporary, EffectCutsceneParalyze(), creature, 120f);
+
+            var ability = new FinalLineTechniqueAbilityDefinition().BuildAbilities()[FeatType.FinalLineTechnique];
+            // Compare the actual technique against itself with only its bonus disabled. Identical
+            // RNG seeds preserve the ordinary damage/critical rolls in both executions.
+            var closure = ability.ImpactAction.Target;
+            var field = closure.GetType().GetField("damagePercentAdjustment", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            ctx.Assert(field != null, "Final Line must forward its per-target bonus to the area impact");
+            var ramp = (Func<uint, int>)field.GetValue(closure);
+            ctx.Assert(ramp != null, "Final Line must have a damage bonus");
+            ctx.AssertEqual(0, ramp(OBJECT_INVALID), "invalid target bonus");
+            Combat.SetAbilityHitResolutionOverride(true);
+            Combat.SetAutoAttackHitResolutionOverride(false);
+            try
+            {
+                foreach (var percent in new[] { 100, 80, 75, 60, 50, 40, 25, 20, 10, 1, 100 })
+                {
+                    var startingHp = new[] { 300 * percent, 300 * (101 - percent) };
+                    var baseline = new int[2];
+                    for (var pass = 0; pass < 2; pass++)
+                    {
+                        for (var i = 0; i < targets.Length; i++)
+                        {
+                            StatusEffect.RemoveStatusEffect<ExposedStatusEffect>(targets[i]);
+                            ObjectPlugin.SetCurrentHitPoints(targets[i], startingHp[i]);
+                            ctx.AssertEqual(35 * (30000 - startingHp[i]) / 30000, ramp(targets[i]), "live HP bonus");
+                        }
+                        field.SetValue(closure, pass == 0 ? null : ramp);
+                        ctx.SeedRandom(49123);
+                        Ability.BeginAbilityImpact(caster, ability);
+                        try
+                        {
+                            await ctx.ExecuteInCreatureContextAsync(caster, () =>
+                                ability.ImpactAction(caster, targets[0], 1, GetLocation(targets[1])));
+                        }
+                        finally
+                        {
+                            ctx.AssertEqual(2, Ability.EndAbilityImpact(caster).ImpactedTargetCount, "both line targets hit");
+                        }
+                        await ctx.WaitFrameAsync();
+                        for (var i = 0; i < targets.Length; i++)
+                        {
+                            var damage = startingHp[i] - GetCurrentHitPoints(targets[i]);
+                            ctx.Assert(damage > 0, "Final Line must deal damage");
+                            ctx.Assert(StatusEffect.HasStatusEffect<ExposedStatusEffect>(targets[i]), "Final Line must apply Exposed");
+                            if (pass == 0)
+                                baseline[i] = damage;
+                            else
+                            {
+                                var bonus = 35 * (30000 - startingHp[i]) / 30000;
+                                var expected = baseline[i] + (int)Math.Ceiling(baseline[i] * (bonus / 100f));
+                                ctx.AssertEqual(expected, damage, $"target {i}, HP {startingHp[i]}/30000, bonus {bonus}%");
+                                ctx.Log($"HP {startingHp[i]}/30000: baseline {baseline[i]}, bonus {bonus}%, damage {damage}");
+                            }
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                field.SetValue(closure, ramp);
+                Combat.SetAbilityHitResolutionOverride(null);
+                Combat.SetAutoAttackHitResolutionOverride(null);
+            }
+        }
+    }
+}

--- a/SWLOR.Game.Server.Tests/Perks/FinalLineTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/FinalLineTests.cs
@@ -1,0 +1,99 @@
+using System.Reflection;
+using FluentAssertions;
+using NUnit.Framework;
+using SWLOR.Game.Server.Feature.AbilityDefinition.Mimicry;
+using SWLOR.Game.Server.Service;
+
+namespace SWLOR.Game.Server.Tests.Perks;
+
+public class FinalLineTests
+{
+    private static readonly Func<int, int, int, int> Bonus = typeof(FinalLineTechniqueAbilityDefinition).Assembly
+        .GetType("SWLOR.Game.Server.Feature.AbilityDefinition.NPC.InnateAbility")!
+        .GetMethod("CalculateMissingHpBonus", BindingFlags.NonPublic | BindingFlags.Static)!
+        .CreateDelegate<Func<int, int, int, int>>();
+    private static readonly Func<uint, int, Func<uint, int>, int> Apply = typeof(Ability)
+        .GetMethod("ApplyDamagePercentAdjustment", BindingFlags.NonPublic | BindingFlags.Static)!
+        .CreateDelegate<Func<uint, int, Func<uint, int>, int>>();
+
+    [TestCase(100, 0)]
+    [TestCase(99, 0)]
+    [TestCase(98, 0)]
+    [TestCase(97, 1)]
+    [TestCase(80, 7)]
+    [TestCase(75, 8)]
+    [TestCase(60, 14)]
+    [TestCase(50, 17)]
+    [TestCase(40, 21)]
+    [TestCase(25, 26)]
+    [TestCase(20, 28)]
+    [TestCase(10, 31)]
+    [TestCase(1, 34)]
+    [TestCase(0, 35)]
+    [TestCase(-10, 35)]
+    [TestCase(110, 0)]
+    public void TargetHealthDeterminesBonus(int hp, int expected) =>
+        Bonus(hp, 100, 35).Should().Be(expected);
+
+    [TestCase(0)]
+    [TestCase(-100)]
+    public void InvalidMaximumHealthGrantsNoBonus(int maxHp) =>
+        Bonus(1, maxHp, 35).Should().Be(0);
+
+    [Test]
+    public void EveryHealthValueRespectsLinearRampAndCap()
+    {
+        foreach (var maximum in new[] { 1, 7, 100, 350, 1000, 32767 })
+        {
+            var previous = 35;
+            for (var hp = 0; hp <= maximum; hp++)
+            {
+                var actual = Bonus(hp, maximum, 35);
+                actual.Should().Be((int)decimal.Floor(35m * (maximum - hp) / maximum));
+                actual.Should().BeInRange(0, previous);
+                previous = actual;
+            }
+        }
+        Bonus(0, int.MaxValue, 35).Should().Be(35, "intermediate multiplication must not overflow");
+        Bonus(int.MinValue, int.MaxValue, 35).Should().Be(35);
+    }
+
+    [TestCase(100, 100, 100)]
+    [TestCase(80, 100, 107)]
+    [TestCase(50, 100, 117)]
+    [TestCase(25, 100, 126)]
+    [TestCase(1, 100, 134)]
+    [TestCase(50, 40, 47)]
+    [TestCase(50, 200, 234)]
+    [TestCase(50, 1, 2)]
+    public void BonusMultipliesResolvedDamageAndRoundsExtraDamageUp(int hp, int rolledDamage, int expected) =>
+        Apply(1, rolledDamage, _ => Bonus(hp, 100, 35)).Should().Be(expected);
+
+    [Test]
+    public void EachTargetAndSubsequentHitUsesFreshHealth()
+    {
+        var health = new Dictionary<uint, int> { [1] = 100, [2] = 50, [3] = 1 };
+        var calls = new List<uint>();
+        int Adjustment(uint target)
+        {
+            calls.Add(target);
+            return Bonus(health[target], 100, 35);
+        }
+        Apply(1, 100, Adjustment).Should().Be(100);
+        Apply(2, 100, Adjustment).Should().Be(117);
+        Apply(3, 100, Adjustment).Should().Be(134);
+        health[1] = 25;
+        Apply(1, 100, Adjustment).Should().Be(126);
+        health[1] = 100;
+        Apply(1, 100, Adjustment).Should().Be(100, "healing must remove the previous bonus");
+        calls.Should().Equal(1u, 2u, 3u, 1u, 1u);
+    }
+
+    [Test]
+    public void ZeroDamageDoesNotBecomeDamageOrEvaluateTheBonus()
+    {
+        Apply(1, 0, _ => throw new AssertionException("Zero damage should bypass the bonus"))
+            .Should().Be(0);
+        Apply(1, 100, null).Should().Be(100);
+    }
+}

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/NPC/InnateAbility.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/NPC/InnateAbility.cs
@@ -221,15 +221,22 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.NPC
         {
             return target =>
             {
-                if (!GetIsObjectValid(target) || GetMaxHitPoints(target) <= 0)
+                if (!GetIsObjectValid(target))
                     return 0;
 
-                var missingFraction = 1f - (float)GetCurrentHitPoints(target) / GetMaxHitPoints(target);
-                if (missingFraction <= 0f)
-                    return 0;
-
-                return (int)(maxPercentBonus * missingFraction);
+                return CalculateMissingHpBonus(GetCurrentHitPoints(target), GetMaxHitPoints(target), maxPercentBonus);
             };
+        }
+
+        private static int CalculateMissingHpBonus(int currentHp, int maxHp, int maxPercentBonus)
+        {
+            if (maxHp <= 0 || maxPercentBonus <= 0)
+                return 0;
+
+            // Integer arithmetic preserves exact percentage boundaries (e.g. 20% missing = +7%).
+            // Clamp unconscious targets so missing HP never grants more than the advertised cap.
+            var missingHp = maxHp - Math.Clamp(currentHp, 0, maxHp);
+            return (int)((long)maxPercentBonus * missingHp / maxHp);
         }
 
         /// <summary>

--- a/SWLOR.Game.Server/Readmes/MimicryBalance.md
+++ b/SWLOR.Game.Server/Readmes/MimicryBalance.md
@@ -135,6 +135,20 @@ The signature payload band contains 30 combat actives and 3 stances. Eleven comb
 | Rupturing Quake | Self-centered damage, 6-second Knockdown, and 30-second Sunder |
 | Scorching Breath | Cone damage with Burn and Weakened |
 
+Final Line calculates its bonus separately for each target when the line hits, using that
+target's HP before damage: `floor(35 * missing HP / maximum HP)`, capped at 35%.
+The extra damage is `ceil(normal rolled damage * bonus / 100)`. At 100%, 80%, 50%,
+25%, and 1% remaining HP, the bonuses are respectively 0%, 7%, 17%, 26%, and 34%.
+This bonus applies to Final Line's own hit; it is not a persistent damage boost on
+later auto-attacks. Exposed is its separate 30-second status effect.
+
+`FinalLineTests` covers health boundaries, the full integer HP range for several HP
+budgets, clamping, damage rounding, and changing health between hits.
+`FinalLineEngineTests` compares the actual technique's damage with its bonus enabled
+and disabled using identical random seeds, two targets with different health, and
+repeated casts including healing back to full. It also checks that both targets
+receive Exposed.
+
 | Non-damage technique | Distinct role |
 |---|---|
 | Crossfire Drill | Cone Suppression |


### PR DESCRIPTION
Final Line could grant +6% instead of +7% at 80% target health because of floating-point rounding, and negative target HP could exceed the advertised +35% cap. Use exact integer arithmetic and clamp the health input so each hit receives the correct bounded bonus.

Add focused tests for health boundaries, complete HP sweeps across several budgets, rounding, multiple targets, and healing between hits. An engine regression executes the actual technique with identical random seeds and the bonus enabled/disabled, checking 22 target-health comparisons and Exposed application. Document that the bonus affects Final Line's own hit, separately from Exposed.

Validation: 72 focused Final Line, Mimicry, and area-targeting tests passed; the isolated Docker engine regression passed; git diff --check passed. Build used -p:RunPostBuildEvent=Never (8 pre-existing warnings, no errors). Test containers were removed after completion. No submodule pointer changes.