### PR TITLE
Cover NPC portrait references and repair source provenance

### DIFF
--- a/SWLOR.Toolset.Tests/PortraitDdsCorpusTests.cs
+++ b/SWLOR.Toolset.Tests/PortraitDdsCorpusTests.cs
@@ -195,6 +195,8 @@ public class PortraitDdsCorpusTests
         string? Resolve(int id) => id == 1 ? "example_" : null;
         var images = "lmst".Select(size => "po_example_" + size).ToHashSet();
         Assert.That(MissingPortraitSizes(1, null, Resolve, images.Contains), Is.Empty);
+        Assert.That(MissingPortraitSizes(1, "****", Resolve, images.Contains), Is.Empty);
+        Assert.That(MissingPortraitSizes(65535, "****", Resolve, images.Contains), Is.EqualTo("lmst"));
         Assert.That(MissingPortraitSizes(0, null, Resolve, images.Contains), Is.EqualTo("lmst"));
         Assert.That(MissingPortraitSizes(65535, null, Resolve, images.Contains), Is.EqualTo("lmst"));
         Assert.That(MissingPortraitSizes(1, "po_absent_", Resolve, images.Contains), Is.EqualTo("lmst"));
@@ -211,7 +213,7 @@ public class PortraitDdsCorpusTests
     private static string MissingPortraitSizes(int id, string? explicitResref,
         Func<int, string?> resolve, Func<string, bool> hasImage)
     {
-        var baseResref = string.IsNullOrWhiteSpace(explicitResref)
+        var baseResref = string.IsNullOrWhiteSpace(explicitResref) || explicitResref == "****"
             ? resolve(id) is { Length: > 0 } value && value != "****" ? "po_" + value : null
             : explicitResref;
         // Huge is intentionally absent; NWN:EE falls back to Large.

--- a/SWLOR.Toolset.Tests/PortraitDdsCorpusTests.cs
+++ b/SWLOR.Toolset.Tests/PortraitDdsCorpusTests.cs
@@ -1,8 +1,13 @@
 using System.Globalization;
+using System.Security.Cryptography;
+using System.Text.Json;
+using System.Text.RegularExpressions;
 using Microsoft.VisualBasic.FileIO;
 using NUnit.Framework;
 using SWLOR.Toolset.Domain.GameData.Resources;
+using SWLOR.Toolset.Domain.GameData.TwoDa;
 using SWLOR.Toolset.Domain.Render;
+using SWLOR.Toolset.Domain.Workspace;
 
 namespace SWLOR.Toolset.Tests;
 
@@ -80,6 +85,162 @@ public class PortraitDdsCorpusTests
         Assert.That(count, Is.EqualTo(8109), "Every retained portrait must be exercised by the real toolset decoder.");
         Assert.That(failures, Is.Empty,
             $"{failures.Count} portrait failures. First twenty:\n{string.Join("\n", failures.Take(20))}");
+    }
+
+    [Test]
+    public void EveryNpcPortraitReference_ResolvesAllRetainedSizes()
+    {
+        var root = RepoRoot;
+        var index = ModulePortraitIndex(includeBaseGame: true);
+        var table = new TwoDaService(index).GetTable("portraits");
+        var available = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+        bool HasImage(string name)
+        {
+            if (!available.TryGetValue(name, out var valid))
+            {
+                valid = TextureLoader.Load(index, name) is { Width: > 0, Height: > 0 };
+                available.Add(name, valid);
+            }
+            return valid;
+        }
+        string? BaseResref(int id) => id >= 0 && id < table.RowCount
+            ? table.GetString(id, "BaseResRef") : null;
+        var failures = new List<string>();
+        void Check(string source, int id, string? explicitResref = null)
+        {
+            var missing = MissingPortraitSizes(id, explicitResref, BaseResref, HasImage);
+            if (missing.Length > 0)
+                failures.Add($"{source}: portrait {id}/{explicitResref} missing or unreadable sizes {missing}");
+        }
+        void CheckCreature(string source, JsonElement creature)
+        {
+            var id = creature.TryGetProperty("PortraitId", out var portrait) ? portrait.GetProperty("value").GetInt32() : -1;
+            var resref = creature.TryGetProperty("Portrait", out var custom) ? custom.GetProperty("value").GetString() : null;
+            Check(source, id, resref);
+        }
+        var blueprints = Directory.GetFiles(Path.Combine(root, "Module", "utc"), "*.utc.json");
+        Assert.That(blueprints.Length, Is.GreaterThan(900), "A partial checkout must not pass.");
+        foreach (var path in blueprints)
+        {
+            using var json = JsonDocument.Parse(NwnJsonEncoding.ReadFileAsUtf8(path));
+            CheckCreature(Path.GetFileName(path), json.RootElement);
+        }
+        var placedCount = 0;
+        foreach (var path in Directory.EnumerateFiles(Path.Combine(root, "Module", "git"), "*.git.json"))
+        {
+            using var json = JsonDocument.Parse(NwnJsonEncoding.ReadFileAsUtf8(path));
+            if (!json.RootElement.TryGetProperty("Creature List", out var list)) continue;
+            var position = 0;
+            foreach (var creature in list.GetProperty("value").EnumerateArray())
+            {
+                CheckCreature($"{Path.GetFileName(path)}[{position++}]", creature);
+                placedCount++;
+            }
+        }
+        Assert.That(placedCount, Is.GreaterThan(1000));
+        var beastCount = 0;
+        foreach (var path in Directory.EnumerateFiles(Path.Combine(root, "SWLOR.Game.Server", "Feature", "BeastDefinition"), "*.cs", System.IO.SearchOption.AllDirectories))
+        {
+            foreach (Match match in Regex.Matches(File.ReadAllText(path), @"\.PortraitId\(\s*(\d+)\s*\)"))
+            {
+                Check(Path.GetFileName(path), int.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture));
+                beastCount++;
+            }
+        }
+        Assert.That(beastCount, Is.GreaterThan(50));
+        Assert.That(failures, Is.Empty, string.Join("\n", failures));
+        TestContext.WriteLine($"Checked {blueprints.Length} blueprints, {placedCount} placements and {beastCount} beast overrides.");
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void RepairedPortraits_MatchTheirCurrentSourceDigests(bool stockSources)
+    {
+        var index = ModulePortraitIndex(includeBaseGame: stockSources);
+        using var csv = new TextFieldParser(Path.Combine(RepoRoot, "SWLOR_Haks", "portrait_size_repairs.csv"));
+        csv.SetDelimiters(",");
+        var headers = csv.ReadFields()!;
+        var sourceColumn = Array.IndexOf(headers, "source");
+        var digestColumn = Array.IndexOf(headers, "source_sha256");
+        Assert.That(sourceColumn, Is.GreaterThanOrEqualTo(0));
+        Assert.That(digestColumn, Is.GreaterThanOrEqualTo(0));
+        var checkedCount = 0;
+        while (!csv.EndOfData)
+        {
+            var row = csv.ReadFields()!;
+            var source = row[sourceColumn];
+            if (source.EndsWith(".tga", StringComparison.OrdinalIgnoreCase) != stockSources) continue;
+            var identity = new ResourceIdentity(Path.GetFileNameWithoutExtension(source),
+                ResourceIdentity.TypeFromExtension(Path.GetExtension(source)));
+            Assert.That(index.TryLookup(identity, out var handle), Is.True, $"Missing repair source {source}");
+            Assert.That(SourceDigestMatches(handle.GetBytes(), row[digestColumn]), Is.True,
+                $"{source} changed: regenerate its derived portrait sizes and update their provenance.");
+            checkedCount++;
+        }
+        Assert.That(checkedCount, Is.EqualTo(stockSources ? 4 : 6));
+    }
+
+    [Test]
+    public void SourceDigest_RejectsAChangedSourceWithoutAnUpdatedRepair()
+    {
+        byte[] original = [1, 2, 3];
+        var digest = Convert.ToHexString(SHA256.HashData(original));
+        Assert.That(SourceDigestMatches(original, digest), Is.True);
+        Assert.That(SourceDigestMatches([1, 2, 4], digest), Is.False);
+    }
+
+    [Test]
+    public void PortraitReferenceChecks_RejectMissingSizesAndHonorCustomResrefs()
+    {
+        string? Resolve(int id) => id == 1 ? "example_" : null;
+        var images = "lmst".Select(size => "po_example_" + size).ToHashSet();
+        Assert.That(MissingPortraitSizes(1, null, Resolve, images.Contains), Is.Empty);
+        Assert.That(MissingPortraitSizes(0, null, Resolve, images.Contains), Is.EqualTo("lmst"));
+        Assert.That(MissingPortraitSizes(65535, null, Resolve, images.Contains), Is.EqualTo("lmst"));
+        Assert.That(MissingPortraitSizes(1, "po_absent_", Resolve, images.Contains), Is.EqualTo("lmst"));
+        Assert.That(MissingPortraitSizes(65535, "po_example_", Resolve, images.Contains), Is.Empty);
+        images.Remove("po_example_l");
+        Assert.That(MissingPortraitSizes(1, null, Resolve, images.Contains), Is.EqualTo("l"));
+        images.Remove("po_example_t");
+        Assert.That(MissingPortraitSizes(1, null, Resolve, images.Contains), Is.EqualTo("lt"));
+    }
+
+    private static bool SourceDigestMatches(byte[] source, string expected) =>
+        Convert.ToHexString(SHA256.HashData(source)).Equals(expected, StringComparison.OrdinalIgnoreCase);
+
+    private static string MissingPortraitSizes(int id, string? explicitResref,
+        Func<int, string?> resolve, Func<string, bool> hasImage)
+    {
+        var baseResref = string.IsNullOrWhiteSpace(explicitResref)
+            ? resolve(id) is { Length: > 0 } value && value != "****" ? "po_" + value : null
+            : explicitResref;
+        // Huge is intentionally absent; NWN:EE falls back to Large.
+        return new string("lmst".Where(size => baseResref == null || !hasImage(baseResref + size)).ToArray());
+    }
+
+    private static ResourceIndex ModulePortraitIndex(bool includeBaseGame)
+    {
+        KeyBifCatalog? stock = null;
+        if (includeBaseGame)
+        {
+            var install = NwnInstallLocator.Locate(Environment.GetEnvironmentVariable("NWN_INSTALL_PATH"));
+            if (install == null || !File.Exists(Path.Combine(install, "data", "nwn_base.key")))
+                Assert.Ignore("Requires NWN:EE base-game resources; install the game or set NWN_INSTALL_PATH.");
+            stock = KeyBifCatalog.Load(Path.Combine(install!, "data"));
+        }
+        var haks = Path.Combine(RepoRoot, "SWLOR_Haks");
+        using var config = JsonDocument.Parse(File.ReadAllText(Path.Combine(haks, "hakbuilder.json")));
+        var configured = config.RootElement.GetProperty("HakList").EnumerateArray().ToDictionary(
+            hak => hak.GetProperty("Name").GetString()!,
+            hak => Path.GetFullPath(Path.Combine(haks, hak.GetProperty("Path").GetString()!)),
+            StringComparer.OrdinalIgnoreCase);
+        using var module = JsonDocument.Parse(File.ReadAllText(Path.Combine(RepoRoot, "Module", "ifo", "module.ifo.json")));
+        var layers = module.RootElement.GetProperty("Mod_HakList").GetProperty("value").EnumerateArray()
+            .Select(hak => hak.GetProperty("Mod_Hak").GetProperty("value").GetString()!)
+            .Select(name => new ResourceIndex.HakLayer(name, configured[name])).ToArray();
+        foreach (var layer in layers)
+            Assert.That(Directory.Exists(layer.DirectoryPath), Is.True, $"Missing HAK source {layer.Name}");
+        return new ResourceIndex(stock, layers);
     }
 
     private static byte[] RgbGrid(TextureImage image)


### PR DESCRIPTION
Address both findings raised after #2236 merged:

- Extend the existing PortraitDdsCorpusTests to check every UTC blueprint, embedded GIT creature and beast-definition PortraitId literal against portraits.2da and actual decoded resources. Respect custom portrait resrefs and the module's loaded HAK order. Reuse the toolset's KEY/BIF, 2DA, JSON and image readers; no audit scripts, stock inventories or new files.
- Verify each size repair against its current source image using source_sha256 in companion https://github.com/zunath/SWLOR_Haks/pull/400. This catches a changed Small/Medium source whose derived Tiny/Large image was not regenerated.

Focused regression cases cover invalid IDs, explicit overrides, missing Large/Tiny images and changed source bytes. Game-backed checks follow existing toolset integration-test conventions: install NWN:EE or set NWN_INSTALL_PATH; without game data they explicitly skip. Custom-source verification runs without an installed game.

Validation: 6 toolset portrait tests pass with no skips, checking 938 blueprints, 1,322 placements, 172 beast overrides, all ten repair sources and the original 8,109 DDS conversions. All 31 existing Python portrait tests pass. Build succeeds with one existing ScriptBinderTests nullability warning. No gameplay data or image bytes change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation to ensure NPC portrait references resolve to all required retained sizes.
  * Added checks confirming repaired portraits match their recorded source digests.
  * Added coverage for detecting changed sources and handling missing portrait sizes and custom references.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->