### PR TITLE
Repair appearance palette refresh and include body texture fixes

### DIFF
--- a/SWLOR.Game.Server.Tests/Feature/TintMapReviewTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/TintMapReviewTests.cs
@@ -356,13 +356,16 @@ public class TintMapReviewTests
                 "selecting a preset must clear an inactive creature channel's persisted RGB tint");
     }
 
-    [Test]
-    public void CreatureSemanticColorsRemainCreatureOwnedOnEquippedMeshes()
+    [TestCase(TintMapLayerType.Skin)]
+    [TestCase(TintMapLayerType.Hair)]
+    [TestCase(TintMapLayerType.Tattoo1)]
+    [TestCase(TintMapLayerType.Tattoo2)]
+    public void CreatureSemanticColorsRemainCreatureOwnedOnEquippedMeshes(TintMapLayerType layer)
     {
         var material = new TintMapMaterialDefinition(
             "exposed_skin",
             "exposed_skin",
-            TintMapLayerType.Skin,
+            layer,
             TintMapLayerType.Cloth1);
         var selection = new TintMapMaterialSelection(
             "pmh0_chest189",
@@ -372,8 +375,8 @@ public class TintMapReviewTests
             usesItemColors: true,
             AppearanceArmor.Torso);
 
-        selection.GetPaletteSource(TintMapLayerType.Skin).Should().Be(100);
-        selection.UsesItemColor(TintMapLayerType.Skin).Should().BeFalse();
+        selection.GetPaletteSource(layer).Should().Be(100);
+        selection.UsesItemColor(layer).Should().BeFalse();
         selection.GetPaletteSource(TintMapLayerType.Cloth1).Should().Be(200);
         selection.UsesItemColor(TintMapLayerType.Cloth1).Should().BeTrue();
     }
@@ -682,6 +685,32 @@ public class TintMapReviewTests
     }
 
     [Test]
+    public void PaletteAndRgbEditsRefreshCurrentStateAfterClientModelReplacement()
+    {
+        var service = ReadSource("SWLOR.Game.Server", "Feature", "AppearanceDefinition", "TintMap", "TintMapService.cs");
+        var editor = ReadSource("SWLOR.Game.Server", "Feature", "GuiDefinition", "ViewModel", "AppearanceEditorViewModel.cs");
+        var palette = FindMethod(editor, "ApplySelectedPaletteColor").ToString();
+        palette.IndexOf("TintMapService.RefreshAfterColorChange(_target)", StringComparison.Ordinal)
+            .Should().BeGreaterThan(palette.LastIndexOf("SetColor(_target", StringComparison.Ordinal),
+                "the palette must be stored before tint state is refreshed");
+        palette.Should().NotContain("TintMapService.ApplyCurrentColors(_target)");
+
+        var refresh = FindMethod(service, nameof(TintMapService.RefreshAfterColorChange));
+        refresh.ParameterList.Parameters.Should().HaveCount(1,
+            "a delayed refresh must retain only the creature, not a stale color or material selection");
+        var delayed = refresh.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Single(call => GetInvokedMethodName(call) == "DelayCommand");
+        delayed.ToString().Should().Contain("RefreshDelaySeconds");
+        delayed.ToString().Should().Contain("GetIsObjectValid(creature)");
+        delayed.ToString().Should().Contain("ApplyCurrentColorsAndPublish(creature)");
+        refresh.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Count(call => GetInvokedMethodName(call) == "ApplyCurrentColorsAndPublish")
+            .Should().Be(2, "colors must be applied immediately and after client model replacement");
+        delayed.ToString().Should().NotContain("SetColor(",
+            "an older queued refresh must not overwrite a newer native palette selection");
+    }
+
+    [Test]
     public void SemanticRgbEditsSynchronizeInactiveAndPersistedOverrides()
     {
         var serviceSource = ReadSource(
@@ -701,10 +730,8 @@ public class TintMapReviewTests
         synchronizeCalls.Should().Contain("SetLocalInt");
         synchronizeCalls.Should().Contain("SaveDroidOverrides",
             "inactive semantic keys must remain synchronized after a droid respawns");
-        synchronizeCalls.Should().Contain("ApplyCurrentColorsAndPublish",
-            "a live RGB edit must rebuild and publish the complete composed tint state immediately");
-        synchronizeCalls.Should().Contain("DelayCommand",
-            "the latest semantic color must be reapplied after an in-flight body-part refresh");
+        synchronizeCalls.Should().Contain(nameof(TintMapService.RefreshAfterColorChange),
+            "RGB and palette edits must use the same immediate and delayed refresh");
         synchronizeCalls.Should().Contain(nameof(TintMapModelResolver.GetCurrentSelections),
             "an RGB edit must re-resolve body parts that changed while the editor remained open");
 
@@ -2271,7 +2298,7 @@ public class TintMapReviewTests
     }
 
     [Test]
-    public void CreatureSemanticColorsUseOneModelWidePaletteRowUpdate()
+    public void CreatureSemanticColorsPreserveWildcardAndExplicitAttachmentRows()
     {
         var serviceSource = ReadSource(
             "SWLOR.Game.Server",
@@ -2298,6 +2325,13 @@ public class TintMapReviewTests
         applyCreatureColor.ToString().Should().Contain(
             "WriteMaterialColor(creature, string.Empty, layer, color)");
         applyCreatureColor.ToString().Should().Contain("selection.Material.Resref");
+        var namedRows = applyCreatureColor.DescendantNodes().OfType<ForEachStatementSyntax>()
+            .Single(loop => loop.Expression.ToString() == "materialResrefs");
+        namedRows.ToString().Should().Contain("WriteMaterialColor(creature, materialResref, layer, color)");
+        var wildcardRow = applyCreatureColor.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Single(call => call.ToString() == "WriteMaterialColor(creature, string.Empty, layer, color)");
+        namedRows.SpanStart.Should().BeGreaterThan(wildcardRow.SpanStart,
+            "the native wildcard removes preceding named records for the same row");
         applyCreatureColor.DescendantNodes()
             .OfType<InvocationExpressionSyntax>()
             .Count(invocation => invocation.Expression.ToString() == "ResetMaterialShaderUniforms")

--- a/SWLOR.Game.Server/Feature/AppearanceDefinition/TintMap/TintMapService.cs
+++ b/SWLOR.Game.Server/Feature/AppearanceDefinition/TintMap/TintMapService.cs
@@ -907,10 +907,19 @@ namespace SWLOR.Game.Server.Feature.AppearanceDefinition.TintMap
             // Creature colors are semantic across the whole modular model: every registered
             // material whose tint mask uses this layer must receive the same value. The enabled
             // material-name-null tweak publishes one authoritative model-wide row.
+            RefreshAfterColorChange(creature);
+        }
+
+        public static void RefreshAfterColorChange(uint creature)
+        {
+            if (!GetIsObjectValid(creature))
+                return;
+
             ApplyCurrentColorsAndPublish(creature);
 
-            // Reapply once after the model refresh interval, resolving the selections again, so a
-            // body-part replacement that completes during the edit receives the latest value too.
+            // Native palette changes and RGB-driven phenotype changes can replace client meshes
+            // after the immediate update. Read current state again rather than replaying the edit's
+            // captured color or materials, so a newer edit or part change always wins.
             DelayCommand(RefreshDelaySeconds, () =>
             {
                 if (!GetIsObjectValid(creature))
@@ -1670,6 +1679,16 @@ namespace SWLOR.Game.Server.Feature.AppearanceDefinition.TintMap
             // The material-name-null tweak expands this one semantic row across every composed
             // child mesh. This is the same model-wide update used by the known-good PLT tinter.
             WriteMaterialColor(creature, string.Empty, layer, color);
+
+            // Keep explicit records for the resolved attachments as well. Equipment changes
+            // can replace a child mesh after the blanket update has been applied. Its material
+            // must have the same semantic color when the client installs that replacement.
+            // Write these after the wildcard: the native tweak removes matching named rows
+            // when it receives a wildcard. Authored exceptions are applied by the caller last.
+            foreach (var materialResref in materialResrefs)
+            {
+                WriteMaterialColor(creature, materialResref, layer, color);
+            }
         }
 
         private static void ApplyCurrentColorsAndPublish(uint creature)

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/AppearanceEditorViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/AppearanceEditorViewModel.cs
@@ -2190,7 +2190,7 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
                 }
             }
 
-            TintMapService.ApplyCurrentColors(_target);
+            TintMapService.RefreshAfterColorChange(_target);
             if (reloadEditor)
                 LoadTintMapEditor();
             return true;

--- a/SWLOR.Game.Server/Readmes/TintMapRendering.md
+++ b/SWLOR.Game.Server/Readmes/TintMapRendering.md
@@ -35,6 +35,13 @@ Both complete refreshes and individual row updates must use a write-only row
 helper. Only the complete refresh may clear old RGB/custom-mode parameters.
 Palette IDs and blueprint colors remain unchanged.
 
+Skin, hair, and tattoo updates write the blanket row first, then the same row
+for each resolved material, including exposed skin and fur on equipment.
+Named attachment records must follow the wildcard because the NWNX tweak
+removes earlier named records for that parameter. Authored material exceptions
+are applied last. This preserves explicit attachment colors during mesh
+replacement without changing the equipment's cloth, leather, or metal dyes.
+
 ## Preserve exact custom RGB
 
 RGB edits persist the requested bytes in the existing TMC/TMG/TM variables.
@@ -43,6 +50,13 @@ color in a session cache while rendering a nearest preset. Native preset
 clicks clear the corresponding RGB override; unset armor parts inherit TMG,
 and explicit part colors remain independent. These edits do not replace or
 re-equip items.
+
+Palette-menu and creature RGB edits share `RefreshAfterColorChange`: publish the
+complete tint state immediately, then reapply it after the model refresh interval.
+Native palette writes and RGB phenotype transitions can replace client head/body
+meshes after the initial publication. The delayed callback reads the current
+colors and material selections; it must not retain the earlier edit's color or
+selection, which could overwrite a newer edit or miss a replacement head/robe.
 
 `TintMapShaderColor.Encode` carries all 24 RGB bits through the existing scalar
 row parameter. Atlas coordinates occupy [0,1). Custom values occupy [1,4),


### PR DESCRIPTION
Palette-menu edits previously missed the delayed refresh used by RGB tinting, allowing replaced head/body meshes to retain default colors. Route both through the same immediate and delayed refresh, resolving current colors and materials on replay. Write explicit skin, hair, and tattoo material rows after the wildcard update while preserving authored exceptions.

Update SWLOR_Haks to the companion asset repairs: https://github.com/zunath/SWLOR_Haks/pull/401. These restore reported head textures, omitted stock body tint bindings, neck 2, and female Wookiee harness channels. Review and deploy both changes together; the asset PR should merge first.

Validation:
- Server test project builds with -p:RunPostBuildEvent=Never.
- 137 focused appearance/tint/robe tests pass, including palette/RGB refresh ordering and creature-owned colors on equipped meshes.
- Companion HAK validation: 69 tint tests, 6 audit tests, full tint catalog validation, and dependent robe pose checks pass.

Not deployed or visually verified in-game. The asset audit explicitly retains pre-existing unresolved texture references rather than claiming the entire model corpus is clean.