### PR TITLE
Integrate sixteen imported SWTOR blaster pistols

### DIFF
--- a/SWLOR.Game.Server/Feature/AppearanceDefinition/ItemAppearance/PistolAppearanceDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AppearanceDefinition/ItemAppearance/PistolAppearanceDefinition.cs
@@ -18,7 +18,7 @@ namespace SWLOR.Game.Server.Feature.AppearanceDefinition.ItemAppearance
         };
         public override int[] MiddleParts { get; } =
         {
-            101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 114, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, // Color #1
+            101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, // Color #1
             // Color #2
             301, 302, 303, 305, 307, 308, 309, 310, 311, 320, 322, 324, 325, // Color #3
             404, // Color #4: blaster_high41_a01, wbwsh_m_044

--- a/SWLOR.Game.Server/Feature/AppearanceDefinition/ItemAppearance/PistolAppearanceDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AppearanceDefinition/ItemAppearance/PistolAppearanceDefinition.cs
@@ -18,7 +18,7 @@ namespace SWLOR.Game.Server.Feature.AppearanceDefinition.ItemAppearance
         };
         public override int[] MiddleParts { get; } =
         {
-            101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, // Color #1
+            101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 114, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, // Color #1
             // Color #2
             301, 302, 303, 305, 307, 308, 309, 310, 311, 320, 322, 324, 325, // Color #3
             404, // Color #4: blaster_high41_a01, wbwsh_m_044

--- a/SWLOR.Game.Server/Feature/AppearanceDefinition/ItemAppearance/PistolAppearanceDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AppearanceDefinition/ItemAppearance/PistolAppearanceDefinition.cs
@@ -21,7 +21,7 @@ namespace SWLOR.Game.Server.Feature.AppearanceDefinition.ItemAppearance
             101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 114, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, // Color #1
             // Color #2
             301, 302, 303, 305, 307, 308, 309, 310, 311, 320, 322, 324, 325, // Color #3
-            // Color #4
+            404, // Color #4: blaster_high41_a01, wbwsh_m_044
             // Color #5
             // Color #6
             701, // Color #7

--- a/SWLOR.Game.Server/Feature/AppearanceDefinition/ItemAppearance/PistolAppearanceDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AppearanceDefinition/ItemAppearance/PistolAppearanceDefinition.cs
@@ -21,7 +21,7 @@ namespace SWLOR.Game.Server.Feature.AppearanceDefinition.ItemAppearance
             101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 114, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, // Color #1
             // Color #2
             301, 302, 303, 305, 307, 308, 309, 310, 311, 320, 322, 324, 325, // Color #3
-            404, // Color #4: blaster_high41_a01, wbwsh_m_044
+            404, // Color #4
             // Color #5
             // Color #6
             701, // Color #7


### PR DESCRIPTION
Integrate sixteen supplied SWTOR blaster pistol replacements through the companion HAK PR. Adds the missing Part 404 catalog entry; the remaining replacements use existing entries. MTX54 uses Part 112, and Part 115 is not added.

| Blaster | Native middle | Toolset | Editor part |
|---|---:|---|---:|
| High 41 | 44 | 4-4 | 404 |
| High 36 | 91 | 9-1 | 109 |
| Hole Puncher A01 | 93 | 9-3 | 309 |
| Hole Puncher A02 | 101 | 10-1 | 110 |
| Lifeday 22 | 111 | 11-1 | 111 |
| MTX19 | 141 | 14-1 | 114 |
| MTX36 | 171 | 17-1 | 117 |
| Black Nebula / MTX37 | 181 | 18-1 | 118 |
| MTX48 | 191 | 19-1 | 119 |
| MTX54 | 121 | 12-1 | 112 |
| High 43 | 13 | 1-3 | 301 |
| Koth | 23 | 2-3 | 302 |
| ARN | 33 | 3-3 | 303 |
| NAR1 | 53 | 5-3 | 305 |
| MTX21 | 73 | 7-3 | 307 |
| MTX02 v 03 | 83 | 8-3 | 308 |

Batch 2 replaces the six superseded generated originals in their existing slots. Their runtime files belong to the imported-blaster companion; the separate generated PR is scoped back to Vesper-9. No blueprint or gameplay-stat changes are needed.

The six batch-2 models pass native model-reader geometry, UV, material and texture checks; compilation preserves every visible triangle corner and UV, and referenced vertices have valid orthonormal tangent frames. DDS mipmaps, actual toolset decoding and layered icon composition pass; staged inventory icons preserve all RGBA pixels. Both hand views were reviewed. The normal local build finished with zero errors, and all 114 combined runtime resources match its packed sw_weapon.hak byte-for-byte. Superseded generated maps and duplicate TGA icons are absent. The eight retained stylized models are byte-identical. Live-client fit, lighting and first-view performance still need retesting.

Companion: https://github.com/zunath/SWLOR_Haks/pull/403
Workflow/editor/deployment: https://github.com/zunath/SWLOR_NWN/pull/2242
Vesper-9: https://github.com/zunath/SWLOR_NWN/pull/2244

Merge the process PR and companion HAK PR before the parent integration. When combining the imported and Vesper-9 parent PRs, retain a HAK commit containing both asset sets.