### PR TITLE
Restore authored helmet dyes while preserving exact RGB tinting

### DIFF
--- a/SWLOR.Game.Server.EngineTests/Definitions/TintMapEngineTests.cs
+++ b/SWLOR.Game.Server.EngineTests/Definitions/TintMapEngineTests.cs
@@ -486,10 +486,15 @@ namespace SWLOR.Game.Server.EngineTests.Definitions
                 foreach (var layer in selection.Material.Layers)
                 {
                     var definition = TintMapMaterialRegistry.GetLayer(layer);
-                    var material = TintMapVariable.IsCreatureColorLayer(layer) ? string.Empty : selection.Material.Resref.ToLowerInvariant();
+                    var material = selection.Material.Resref.ToLowerInvariant();
                     var paletteId = TintMapService.GetStandardColorId(civilian, selection, layer);
-                    expected[(material, definition.UniformName.ToLowerInvariant())] =
-                        (definition.PaletteBaseRow + paletteId + 0.5f) / 2048f;
+                    var uniform = definition.UniformName.ToLowerInvariant();
+                    var coordinate = (definition.PaletteBaseRow + paletteId + 0.5f) / 2048f;
+                    expected[(material, uniform)] = coordinate;
+                    // Semantic colors also have named attachment records so replacements
+                    // receive the same dye after the client's wildcard update.
+                    if (TintMapVariable.IsCreatureColorLayer(layer))
+                        expected[(string.Empty, uniform)] = coordinate;
                 }
             }
 

--- a/SWLOR.Game.Server.EngineTests/Definitions/TintMapEngineTests.cs
+++ b/SWLOR.Game.Server.EngineTests/Definitions/TintMapEngineTests.cs
@@ -21,6 +21,22 @@ namespace SWLOR.Game.Server.EngineTests.Definitions
     {
         private readonly record struct NativeTintRow(string Material, string Parameter, int Type, float Value);
 
+        [EngineTest("Tint module declares the client material and mask packs", Category = "Tint")]
+        public static Task ModuleDeclaresTintAssets(EngineTestContext ctx)
+        {
+            var module = NWNXLib.g_pAppManager.m_pServerExoApp.GetModule();
+            ctx.Assert(module != null, "The running module must exist.");
+            var declared = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            for (var index = 0; index < module.m_pHakFiles.Count; index++)
+                declared.Add(module.m_pHakFiles[index].ToString());
+
+            // Server-side 2DA lookups still succeed when an old packed module omits these
+            // packs. The client then renders converted models without their materials.
+            foreach (var hak in new[] { "sw_tint_mtr", "sw_tint0", "sw_tint1", "sw_tint2" })
+                ctx.Assert(declared.Contains(hak), $"The loaded module must declare {hak}.hak for clients.");
+            return Task.CompletedTask;
+        }
+
         [EngineTest("Tint Shuttle Pilot refresh installs authored helmet and chest dyes", Category = "Tint", TimeoutSeconds = 30f)]
         public static async Task ShuttlePilotRefreshInstallsAuthoredRows(EngineTestContext ctx)
         {
@@ -45,23 +61,26 @@ namespace SWLOR.Game.Server.EngineTests.Definitions
             ctx.Assert(originalArmorColors.SequenceEqual(ReadArmorColors(armor)), "Untinted armor palette fields remain authored.");
 
             var selection = TintMapModelResolver.GetCurrentSelections(pilot).Single(s => s.Material.Resref == "helm_114");
-            ctx.Assert(!RobeModelRenderer.SupportsRgb(selection), "The worn helmet cannot render exact RGB scalars.");
-            var color = new TintMapColor(255, 0, 0);
+            ctx.Assert(RobeModelRenderer.SupportsRgb(selection), "Helmet RGB editing must remain available.");
+            var color = new TintMapColor(17, 83, 209);
             var layer = TintMapLayerType.Cloth1;
             var channel = (int)AppearanceArmorColor.Cloth1;
             await RunAssignedAsync(ctx, pilot, () =>
             {
-                // Retain compatibility with RGB already persisted by older editor versions.
                 TintMapService.SetColor(pilot, selection, layer, color);
-                ctx.AssertEqual(TintMapPaletteColors.GetClosestColorId(layer, color),
-                    GetItemAppearance(helmet, ItemAppearanceType.ArmorColor, channel), "Legacy RGB reaches the native helmet scheme as a preset.");
-                ctx.AssertEqual(135, TintMapService.GetStandardColorId(pilot, selection, layer), "The authored helmet baseline survives projection.");
+                AssertNativeRgb(ctx, helmet, "helm_114", layer, color);
+                AssertNativeRgb(ctx, pilot, "helm_114", layer, color);
+                ctx.AssertEqual(135,
+                    GetItemAppearance(helmet, ItemAppearanceType.ArmorColor, channel), "Exact RGB must not replace the authored palette with an approximation.");
+                ctx.AssertEqual(135, TintMapService.GetStandardColorId(pilot, selection, layer), "The authored helmet baseline survives an RGB edit.");
                 TintMapService.ApplyCurrentColors(pilot);
+                AssertNativeRgb(ctx, helmet, "helm_114", layer, color);
                 TintMapService.ResetColor(pilot, selection, layer);
                 ctx.AssertEqual(135, GetItemAppearance(helmet, ItemAppearanceType.ArmorColor, channel), "Reset restores the authored helmet dye.");
+                AssertNativeRow(ctx, ReadNativeRows(ctx, helmet), "helm_114", "rowcloth1", (704f + 135f + 0.5f) / 2048f);
                 AssertProjectionCleared(ctx, helmet, channel);
             });
-            ctx.Assert(originalArmorColors.SequenceEqual(ReadArmorColors(armor)), "Helmet projection never changes armor dyes.");
+            ctx.Assert(originalArmorColors.SequenceEqual(ReadArmorColors(armor)), "Helmet RGB never changes armor dyes.");
             ctx.SetResultDetail("Placed pilot retains authored helmet114 and chest249 dyes after a queued refresh. Server state only; client rendering is not attached.");
         }
 
@@ -547,9 +566,9 @@ namespace SWLOR.Game.Server.EngineTests.Definitions
 
         private static List<NativeTintRow> ReadNativeRows(EngineTestContext ctx, uint civilian)
         {
-            var nativeCreature = NWNXLib.g_pAppManager.m_pServerExoApp.GetCreatureByGameObjectID(civilian);
-            ctx.Assert(nativeCreature != null, "The spawned NPC must have a native creature object.");
-            var parameters = nativeCreature.m_lMaterialShaderParameters;
+            var nativeObject = NWNXLib.g_pAppManager.m_pServerExoApp.GetGameObject(civilian)?.AsNWSObject();
+            ctx.Assert(nativeObject != null, "The tint target must have a native object.");
+            var parameters = nativeObject.m_lMaterialShaderParameters;
             var rows = new List<NativeTintRow>(parameters.Count);
             for (var index = 0; index < parameters.Count; index++)
             {

--- a/SWLOR.Game.Server.EngineTests/Definitions/TintMapEngineTests.cs
+++ b/SWLOR.Game.Server.EngineTests/Definitions/TintMapEngineTests.cs
@@ -21,6 +21,50 @@ namespace SWLOR.Game.Server.EngineTests.Definitions
     {
         private readonly record struct NativeTintRow(string Material, string Parameter, int Type, float Value);
 
+        [EngineTest("Tint Shuttle Pilot refresh installs authored helmet and chest dyes", Category = "Tint", TimeoutSeconds = 30f)]
+        public static async Task ShuttlePilotRefreshInstallsAuthoredRows(EngineTestContext ctx)
+        {
+            var pilot = GetObjectByTag("novapilot");
+            ctx.Assert(GetIsObjectValid(pilot), "The starter area's placed Shuttle Pilot must exist.");
+            var helmet = GetItemInSlot(InventorySlot.Head, pilot);
+            var armor = GetItemInSlot(InventorySlot.Chest, pilot);
+            ctx.AssertEqual(114, GetItemAppearance(helmet, ItemAppearanceType.SimpleModel, 0), "Pilot helmet model");
+            ctx.AssertEqual(249, GetItemAppearance(armor, ItemAppearanceType.ArmorModel, (int)AppearanceArmor.Torso), "Pilot chest model");
+            var originalHelmetColors = ReadArmorColors(helmet);
+            var originalArmorColors = ReadArmorColors(armor);
+            await RunAssignedAsync(ctx, GetArea(pilot), () => TintMapService.QueueRefresh(pilot));
+            await ctx.WaitUntilAsync(() => ReadNativeRows(ctx, pilot).Any(row => row.Material == "helm_114"),
+                5f, "the queued pilot tint refresh");
+            var rows = ReadNativeRows(ctx, pilot);
+            AssertNoResetRecords(ctx, rows);
+            AssertNativeRow(ctx, rows, "helm_114", "rowcloth1", (704f + 135f + 0.5f) / 2048f);
+            AssertNativeRow(ctx, rows, "helm_114", "rowleath1", (880f + 23f + 0.5f) / 2048f);
+            AssertNativeRow(ctx, rows, "pfh0_chest249", "rowmetal1", (352f + 133f + 0.5f) / 2048f);
+            AssertNativeRow(ctx, rows, "pfh0_chest249", "rowcloth1", (704f + 132f + 0.5f) / 2048f);
+            ctx.Assert(originalHelmetColors.SequenceEqual(ReadArmorColors(helmet)), "Untinted helmet palette fields remain authored.");
+            ctx.Assert(originalArmorColors.SequenceEqual(ReadArmorColors(armor)), "Untinted armor palette fields remain authored.");
+
+            var selection = TintMapModelResolver.GetCurrentSelections(pilot).Single(s => s.Material.Resref == "helm_114");
+            ctx.Assert(!RobeModelRenderer.SupportsRgb(selection), "The worn helmet cannot render exact RGB scalars.");
+            var color = new TintMapColor(255, 0, 0);
+            var layer = TintMapLayerType.Cloth1;
+            var channel = (int)AppearanceArmorColor.Cloth1;
+            await RunAssignedAsync(ctx, pilot, () =>
+            {
+                // Retain compatibility with RGB already persisted by older editor versions.
+                TintMapService.SetColor(pilot, selection, layer, color);
+                ctx.AssertEqual(TintMapPaletteColors.GetClosestColorId(layer, color),
+                    GetItemAppearance(helmet, ItemAppearanceType.ArmorColor, channel), "Legacy RGB reaches the native helmet scheme as a preset.");
+                ctx.AssertEqual(135, TintMapService.GetStandardColorId(pilot, selection, layer), "The authored helmet baseline survives projection.");
+                TintMapService.ApplyCurrentColors(pilot);
+                TintMapService.ResetColor(pilot, selection, layer);
+                ctx.AssertEqual(135, GetItemAppearance(helmet, ItemAppearanceType.ArmorColor, channel), "Reset restores the authored helmet dye.");
+                AssertProjectionCleared(ctx, helmet, channel);
+            });
+            ctx.Assert(originalArmorColors.SequenceEqual(ReadArmorColors(armor)), "Helmet projection never changes armor dyes.");
+            ctx.SetResultDetail("Placed pilot retains authored helmet114 and chest249 dyes after a queued refresh. Server state only; client rendering is not attached.");
+        }
+
         [EngineTest("Tint NPC spawn installs authored hair and clothing rows", Category = "Tint", TimeoutSeconds = 30f)]
         public static async Task CreatureSpawnInstallsAuthoredRows(EngineTestContext ctx)
         {

--- a/SWLOR.Game.Server.Tests/Feature/HelmetTintTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/HelmetTintTests.cs
@@ -1,0 +1,21 @@
+using NUnit.Framework;
+using SWLOR.Game.Server.Feature.AppearanceDefinition.TintMap;
+using SWLOR.NWN.API.NWScript.Enum.Item;
+
+namespace SWLOR.Game.Server.Tests.Feature;
+
+public class HelmetTintTests
+{
+    [TestCase("helm_114", 1u, 2u, false)]
+    [TestCase("HELM_114", 1u, 2u, false)]
+    [TestCase("helm_114", 1u, 1u, true)]
+    [TestCase("pfh0_head103", 2u, 2u, true)]
+    [TestCase("pfh0_chest249", 1u, 2u, true)]
+    public void RgbAvailabilityFollowsTheRenderedAttachment(string model, uint item, uint creature, bool supported)
+    {
+        var selection = new TintMapMaterialSelection(model,
+            new TintMapMaterialDefinition(model, model, new[] { TintMapLayerType.Cloth1 }),
+            item, creature, true, AppearanceArmor.Invalid);
+        Assert.That(RobeModelRenderer.SupportsRgb(selection), Is.EqualTo(supported));
+    }
+}

--- a/SWLOR.Game.Server.Tests/Feature/HelmetTintTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/HelmetTintTests.cs
@@ -6,8 +6,8 @@ namespace SWLOR.Game.Server.Tests.Feature;
 
 public class HelmetTintTests
 {
-    [TestCase("helm_114", 1u, 2u, false)]
-    [TestCase("HELM_114", 1u, 2u, false)]
+    [TestCase("helm_114", 1u, 2u, true)]
+    [TestCase("HELM_114", 1u, 2u, true)]
     [TestCase("helm_114", 1u, 1u, true)]
     [TestCase("pfh0_head103", 2u, 2u, true)]
     [TestCase("pfh0_chest249", 1u, 2u, true)]

--- a/SWLOR.Game.Server.Tests/Feature/TintMapReviewTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/TintMapReviewTests.cs
@@ -112,7 +112,8 @@ public class TintMapReviewTests
         var definitionRoot = CSharpSyntaxTree.ParseText(definition).GetRoot();
         var definitionMethods = definitionRoot.DescendantNodes()
             .OfType<MethodDeclarationSyntax>()
-            .ToDictionary(method => method.Identifier.ValueText);
+            .GroupBy(method => method.Identifier.ValueText)
+            .ToDictionary(group => group.Key, group => string.Join("\n", group.Select(method => method.ToString())));
 
         definition.Should().Contain("row.AddColorPicker()");
         definition.Should().Contain(".BindSelectedColor(model => model.SelectedTintColor)");

--- a/SWLOR.Game.Server.Tests/Feature/TintMapReviewTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/TintMapReviewTests.cs
@@ -2359,6 +2359,7 @@ public class TintMapReviewTests
 
     [TestCase(nameof(TintMapService.ApplyCurrentColors))]
     [TestCase(nameof(TintMapService.ApplyCurrentItemColors))]
+    [TestCase("ApplyEquippedHelmetColors")]
     public void CompleteTintRefreshResetsOnceBeforeWritingAnyRows(string refreshMethodName)
     {
         var source = ReadSource(
@@ -2384,6 +2385,11 @@ public class TintMapReviewTests
                     continue;
 
                 var name = identifier.Identifier.ValueText;
+                // The creature refresh delegates the helmet item's independent row list.
+                // Its reset/write ordering is checked by its own case, not counted as a
+                // second reset of the creature. Shared row helpers remain traversed.
+                if (name == "ApplyEquippedHelmetColors" && name != refreshMethodName)
+                    continue;
                 if (name == "ResetMaterialShaderUniforms")
                     resets.Add((method, call));
                 else if (name == "SetMaterialShaderUniformVec4")
@@ -2421,12 +2427,13 @@ public class TintMapReviewTests
             .OfType<InvocationExpressionSyntax>()
             .Where(call => GetInvokedMethodName(call) == "ResetMaterialShaderUniforms")
             .ToArray();
-        resets.Should().HaveCount(2,
-            "legacy shader parameters must be cleared only by complete creature and world-item refreshes");
+        resets.Should().HaveCount(3,
+            "legacy shader parameters must be cleared only by complete creature, equipped-helmet and world-item refreshes");
         resets.Select(call => call.Ancestors().OfType<MethodDeclarationSyntax>().First().Identifier.ValueText)
             .Should().BeEquivalentTo(new[]
             {
-                nameof(TintMapService.ApplyCurrentColors), nameof(TintMapService.ApplyCurrentItemColors)
+                nameof(TintMapService.ApplyCurrentColors), nameof(TintMapService.ApplyCurrentItemColors),
+                "ApplyEquippedHelmetColors"
             });
         foreach (var reset in resets)
         {

--- a/SWLOR.Game.Server/Feature/AppearanceDefinition/TintMap/RobeModelRenderer.cs
+++ b/SWLOR.Game.Server/Feature/AppearanceDefinition/TintMap/RobeModelRenderer.cs
@@ -84,7 +84,8 @@ namespace SWLOR.Game.Server.Feature.AppearanceDefinition.TintMap
         public static int GetBasePhenotype(uint creature) => _catalog.GetBasePhenotype((int)GetPhenoType(creature));
 
         public static bool SupportsRgb(TintMapMaterialSelection selection) =>
-            selection.ArmorPart != AppearanceArmor.Robe || _catalog.Supports(selection.ModelResref);
+            !selection.IsWornHelmet &&
+            (selection.ArmorPart != AppearanceArmor.Robe || _catalog.Supports(selection.ModelResref));
 
         public static bool Apply(uint creature, IReadOnlyList<TintMapMaterialSelection> selections, bool hasRobeRgb)
         {

--- a/SWLOR.Game.Server/Feature/AppearanceDefinition/TintMap/RobeModelRenderer.cs
+++ b/SWLOR.Game.Server/Feature/AppearanceDefinition/TintMap/RobeModelRenderer.cs
@@ -84,8 +84,7 @@ namespace SWLOR.Game.Server.Feature.AppearanceDefinition.TintMap
         public static int GetBasePhenotype(uint creature) => _catalog.GetBasePhenotype((int)GetPhenoType(creature));
 
         public static bool SupportsRgb(TintMapMaterialSelection selection) =>
-            !selection.IsWornHelmet &&
-            (selection.ArmorPart != AppearanceArmor.Robe || _catalog.Supports(selection.ModelResref));
+            selection.ArmorPart != AppearanceArmor.Robe || _catalog.Supports(selection.ModelResref);
 
         public static bool Apply(uint creature, IReadOnlyList<TintMapMaterialSelection> selections, bool hasRobeRgb)
         {

--- a/SWLOR.Game.Server/Feature/AppearanceDefinition/TintMap/TintMapMaterialSelection.cs
+++ b/SWLOR.Game.Server/Feature/AppearanceDefinition/TintMap/TintMapMaterialSelection.cs
@@ -19,6 +19,11 @@ namespace SWLOR.Game.Server.Feature.AppearanceDefinition.TintMap
         /// </summary>
         public string OverrideModelResref { get; }
 
+        // A worn helmet is a separate client attachment which does not receive
+        // creature shader parameters. Its native PLT scheme still carries dyes.
+        public bool IsWornHelmet => UsesItemColors && PaletteSource != CreaturePaletteSource &&
+            ModelResref.StartsWith("helm_", System.StringComparison.OrdinalIgnoreCase);
+
         public TintMapMaterialSelection(
             string modelResref,
             TintMapMaterialDefinition material,

--- a/SWLOR.Game.Server/Feature/AppearanceDefinition/TintMap/TintMapService.cs
+++ b/SWLOR.Game.Server/Feature/AppearanceDefinition/TintMap/TintMapService.cs
@@ -145,7 +145,7 @@ namespace SWLOR.Game.Server.Feature.AppearanceDefinition.TintMap
             var hasRobeRgb = selections.Any(selection => selection.ArmorPart == AppearanceArmor.Robe &&
                 selection.Material.Layers.Any(layer => GetEffectiveColor(creature, selection, layer).CustomColor.HasValue));
             var rendersRobeRgb = RobeModelRenderer.Apply(creature, selections, hasRobeRgb);
-            ProjectNativeRobeColors(creature, selections, rendersRobeRgb);
+            ProjectNativeAttachmentColors(creature, selections, rendersRobeRgb);
             ResetMaterialShaderUniforms(creature);
             var creatureLayers = new HashSet<TintMapLayerType>();
             foreach (var selection in selections)
@@ -189,18 +189,19 @@ namespace SWLOR.Game.Server.Feature.AppearanceDefinition.TintMap
             }
         }
 
-        private static void ProjectNativeRobeColors(uint creature, IReadOnlyList<TintMapMaterialSelection> selections,
+        private static void ProjectNativeAttachmentColors(uint creature, IReadOnlyList<TintMapMaterialSelection> selections,
             bool rendersRobeRgb)
         {
-            // The client replays material uniforms on the body/head/attachments, but omits its
-            // separate robe Gob. Tiny PLT resources carry these native palette values to the shader.
+            // The client omits separate robes and worn helmets from material-uniform replay.
+            // Tiny PLT resources carry these native palette values to their shaders.
             var robes = selections.Where(selection => !rendersRobeRgb && selection.ArmorPart == AppearanceArmor.Robe).ToList();
+            var helmets = selections.Where(selection => selection.IsWornHelmet).ToList();
             var creatureStateChanged = false;
             foreach (var layer in Enum.GetValues<TintMapLayerType>().Where(TintMapVariable.IsCreatureColorLayer))
             {
                 var channel = GetCreatureColorChannel(layer);
                 var nativeColor = GetColor(creature, channel);
-                var active = robes.Any(selection => selection.Material.Layers.Contains(layer)) &&
+                var active = robes.Concat(helmets).Any(selection => selection.Material.Layers.Contains(layer)) &&
                              TintMapColor.TryFromStoredValue(
                                  GetLocalInt(creature, GetCreatureCustomColorStateVariable(layer)), out _);
                 var update = ResolveNativePaletteUpdate(creature, (int)layer, nativeColor,
@@ -232,6 +233,8 @@ namespace SWLOR.Game.Server.Feature.AppearanceDefinition.TintMap
                 }
             }
 
+            ProjectNativeHelmetColors(creature, helmets);
+
             var item = GetItemInSlot(InventorySlot.Chest, creature);
             if (!GetIsObjectValid(item))
                 return;
@@ -258,6 +261,37 @@ namespace SWLOR.Game.Server.Feature.AppearanceDefinition.TintMap
                     changes.Add((colorIndex, update.Color));
             }
 
+            ApplyNativeItemPaletteUpdates(creature, item, changes, itemStateChanged);
+        }
+
+        private static void ProjectNativeHelmetColors(uint creature, IReadOnlyList<TintMapMaterialSelection> selections)
+        {
+            var item = GetItemInSlot(InventorySlot.Head, creature);
+            if (!GetIsObjectValid(item))
+                return;
+
+            var changes = new List<(int Index, int Color)>();
+            var stateChanged = false;
+            foreach (var layer in Enum.GetValues<TintMapLayerType>())
+            {
+                if (!TryGetArmorColorChannel(layer, out var channel))
+                    continue;
+                var index = (int)channel;
+                var nativeColor = GetItemAppearance(item, ItemAppearanceType.ArmorColor, index);
+                var selection = selections.FirstOrDefault(selection => selection.PaletteSource == item &&
+                    selection.Material.Layers.Contains(layer) && GetSavedColor(selection, layer) > 0);
+                var update = ResolveNativePaletteUpdate(item, index, nativeColor,
+                    selection == null ? null : GetEffectiveColor(creature, selection, layer).PaletteColorId);
+                stateChanged |= StoreNativePaletteUpdate(item, index, update);
+                if (update.Color != nativeColor)
+                    changes.Add((index, update.Color));
+            }
+            ApplyNativeItemPaletteUpdates(creature, item, changes, stateChanged);
+        }
+
+        private static void ApplyNativeItemPaletteUpdates(uint creature, uint item,
+            IReadOnlyList<(int Index, int Color)> changes, bool itemStateChanged)
+        {
             for (var index = 0; index < changes.Count; index++)
             {
                 var change = changes[index];
@@ -1609,7 +1643,8 @@ namespace SWLOR.Game.Server.Feature.AppearanceDefinition.TintMap
                     }
 
                     return Math.Clamp(
-                        GetItemAppearance(selection.PaletteSource, ItemAppearanceType.ArmorColor, colorIndex),
+                        GetNativePaletteBaseline(selection.PaletteSource, colorIndex,
+                            GetItemAppearance(selection.PaletteSource, ItemAppearanceType.ArmorColor, colorIndex)),
                         0,
                         TintMapMaterialRegistry.PaletteColorCount - 1);
                 }

--- a/SWLOR.Game.Server/Feature/AppearanceDefinition/TintMap/TintMapService.cs
+++ b/SWLOR.Game.Server/Feature/AppearanceDefinition/TintMap/TintMapService.cs
@@ -145,7 +145,8 @@ namespace SWLOR.Game.Server.Feature.AppearanceDefinition.TintMap
             var hasRobeRgb = selections.Any(selection => selection.ArmorPart == AppearanceArmor.Robe &&
                 selection.Material.Layers.Any(layer => GetEffectiveColor(creature, selection, layer).CustomColor.HasValue));
             var rendersRobeRgb = RobeModelRenderer.Apply(creature, selections, hasRobeRgb);
-            ProjectNativeAttachmentColors(creature, selections, rendersRobeRgb);
+            ProjectNativeRobeColors(creature, selections, rendersRobeRgb);
+            ApplyEquippedHelmetColors(creature, selections);
             ResetMaterialShaderUniforms(creature);
             var creatureLayers = new HashSet<TintMapLayerType>();
             foreach (var selection in selections)
@@ -189,19 +190,18 @@ namespace SWLOR.Game.Server.Feature.AppearanceDefinition.TintMap
             }
         }
 
-        private static void ProjectNativeAttachmentColors(uint creature, IReadOnlyList<TintMapMaterialSelection> selections,
+        private static void ProjectNativeRobeColors(uint creature, IReadOnlyList<TintMapMaterialSelection> selections,
             bool rendersRobeRgb)
         {
-            // The client omits separate robes and worn helmets from material-uniform replay.
-            // Tiny PLT resources carry these native palette values to their shaders.
+            // The client replays material uniforms on the body/head/attachments, but omits its
+            // separate robe Gob. Tiny PLT resources carry these native palette values to the shader.
             var robes = selections.Where(selection => !rendersRobeRgb && selection.ArmorPart == AppearanceArmor.Robe).ToList();
-            var helmets = selections.Where(selection => selection.IsWornHelmet).ToList();
             var creatureStateChanged = false;
             foreach (var layer in Enum.GetValues<TintMapLayerType>().Where(TintMapVariable.IsCreatureColorLayer))
             {
                 var channel = GetCreatureColorChannel(layer);
                 var nativeColor = GetColor(creature, channel);
-                var active = robes.Concat(helmets).Any(selection => selection.Material.Layers.Contains(layer)) &&
+                var active = robes.Any(selection => selection.Material.Layers.Contains(layer)) &&
                              TintMapColor.TryFromStoredValue(
                                  GetLocalInt(creature, GetCreatureCustomColorStateVariable(layer)), out _);
                 var update = ResolveNativePaletteUpdate(creature, (int)layer, nativeColor,
@@ -233,8 +233,6 @@ namespace SWLOR.Game.Server.Feature.AppearanceDefinition.TintMap
                 }
             }
 
-            ProjectNativeHelmetColors(creature, helmets);
-
             var item = GetItemInSlot(InventorySlot.Chest, creature);
             if (!GetIsObjectValid(item))
                 return;
@@ -261,37 +259,6 @@ namespace SWLOR.Game.Server.Feature.AppearanceDefinition.TintMap
                     changes.Add((colorIndex, update.Color));
             }
 
-            ApplyNativeItemPaletteUpdates(creature, item, changes, itemStateChanged);
-        }
-
-        private static void ProjectNativeHelmetColors(uint creature, IReadOnlyList<TintMapMaterialSelection> selections)
-        {
-            var item = GetItemInSlot(InventorySlot.Head, creature);
-            if (!GetIsObjectValid(item))
-                return;
-
-            var changes = new List<(int Index, int Color)>();
-            var stateChanged = false;
-            foreach (var layer in Enum.GetValues<TintMapLayerType>())
-            {
-                if (!TryGetArmorColorChannel(layer, out var channel))
-                    continue;
-                var index = (int)channel;
-                var nativeColor = GetItemAppearance(item, ItemAppearanceType.ArmorColor, index);
-                var selection = selections.FirstOrDefault(selection => selection.PaletteSource == item &&
-                    selection.Material.Layers.Contains(layer) && GetSavedColor(selection, layer) > 0);
-                var update = ResolveNativePaletteUpdate(item, index, nativeColor,
-                    selection == null ? null : GetEffectiveColor(creature, selection, layer).PaletteColorId);
-                stateChanged |= StoreNativePaletteUpdate(item, index, update);
-                if (update.Color != nativeColor)
-                    changes.Add((index, update.Color));
-            }
-            ApplyNativeItemPaletteUpdates(creature, item, changes, stateChanged);
-        }
-
-        private static void ApplyNativeItemPaletteUpdates(uint creature, uint item,
-            IReadOnlyList<(int Index, int Color)> changes, bool itemStateChanged)
-        {
             for (var index = 0; index < changes.Count; index++)
             {
                 var change = changes[index];
@@ -306,6 +273,22 @@ namespace SWLOR.Game.Server.Feature.AppearanceDefinition.TintMap
             }
             if (itemStateChanged || changes.Count > 0)
                 Droid.UpdateEquippedItemSnapshot(creature, item);
+        }
+
+        private static void ApplyEquippedHelmetColors(uint creature, IReadOnlyList<TintMapMaterialSelection> selections)
+        {
+            var helmet = GetItemInSlot(InventorySlot.Head, creature);
+            if (!GetIsObjectValid(helmet))
+                return;
+            // The client does not replay creature rows onto its worn helmet attachment.
+            // Publish the exact same effective colors on the equipped item itself.
+            ResetMaterialShaderUniforms(helmet);
+            foreach (var selection in selections.Where(selection => selection.IsWornHelmet))
+            {
+                foreach (var layer in selection.Material.Layers)
+                    WriteMaterialColor(helmet, selection.Material.Resref, layer,
+                        GetEffectiveColor(creature, selection, layer));
+            }
         }
 
         private static void RestoreNativePaletteQuickbar(uint creature, uint item)
@@ -1643,8 +1626,7 @@ namespace SWLOR.Game.Server.Feature.AppearanceDefinition.TintMap
                     }
 
                     return Math.Clamp(
-                        GetNativePaletteBaseline(selection.PaletteSource, colorIndex,
-                            GetItemAppearance(selection.PaletteSource, ItemAppearanceType.ArmorColor, colorIndex)),
+                        GetItemAppearance(selection.PaletteSource, ItemAppearanceType.ArmorColor, colorIndex),
                         0,
                         TintMapMaterialRegistry.PaletteColorCount - 1);
                 }

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/AppearanceEditorViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/AppearanceEditorViewModel.cs
@@ -1021,6 +1021,8 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             IsCustomTintEditable = selections.Count > 0 &&
                                    selections.All(RobeModelRenderer.SupportsRgb);
             CustomTintTooltip = IsCustomTintEditable ? "Apply an RGB color."
+                : selections.Any(selection => selection.IsWornHelmet)
+                    ? "Worn helmets support preset colors only. Select a color from the palette above."
                 : selections.Any(selection => selection.ArmorPart == AppearanceArmor.Robe)
                     ? "This body and robe combination supports preset colors only. Select a color from the palette above."
                     : "This part has no visible material for this color.";

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/AppearanceEditorViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/AppearanceEditorViewModel.cs
@@ -1021,8 +1021,6 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             IsCustomTintEditable = selections.Count > 0 &&
                                    selections.All(RobeModelRenderer.SupportsRgb);
             CustomTintTooltip = IsCustomTintEditable ? "Apply an RGB color."
-                : selections.Any(selection => selection.IsWornHelmet)
-                    ? "Worn helmets support preset colors only. Select a color from the palette above."
                 : selections.Any(selection => selection.ArmorPart == AppearanceArmor.Robe)
                     ? "This body and robe combination supports preset colors only. Select a color from the palette above."
                     : "This part has no visible material for this color.";

--- a/SWLOR.Game.Server/Readmes/TintMapRendering.md
+++ b/SWLOR.Game.Server/Readmes/TintMapRendering.md
@@ -84,12 +84,11 @@ and custom-mode publications after an RGB edit.
 ## Preserve native palette transport on separate attachments
 
 The 89.8193.37-17 client does not replay creature material overrides onto the
-separate robe and worn helmet attachments. Its ordinary body and head receive those records;
-these attachments do not, even for an empty material-name wildcard. Repeating the
-refresh or writing the records on the equipped item cannot repair that gap.
-The civilian reproduced it with all 14 robe materials retaining defaults while
-the head had the correct rows. A successful server-side row test therefore
-does not establish that a robe received its colors.
+separate robe and worn helmet attachments. Its ordinary body and head receive
+those records. Worn helmets receive exact RGB when the effective material rows
+are also published on the equipped helmet item. Robes use the body-root path
+described below. A successful server-side creature-row test alone therefore
+does not establish that an attachment received its colors.
 
 NWN has another per-material transport: `PLTscheme[15]`. The native body-part
 loader fills it from the wearer and equipment when its selected PLT resource
@@ -114,12 +113,13 @@ but fill it from `pal_armor01` and use matching picker colors. Do not modify
 the original palette resources themselves. The GPU regression checks every
 color and shade against the original palette RGBA, including this distinction.
 
-This transport only supports native palette IDs. Worn helmets and unsupported robe/body
-combinations retain the nearest-preset compatibility projection for persisted
-RGB, with RGB editing disabled and presets available. Preserve the authored
-palette values separately from projected values so reset restores the original
-color and per-part inheritance. NPCs without overrides must retain their raw
-palette fields.
+The native scheme carries palette IDs; explicit material rows carry exact RGB.
+Worn helmets support both without changing their native dye fields. Unsupported
+robe/body combinations retain the nearest-preset compatibility projection for
+persisted RGB, with RGB editing disabled and presets available. Preserve those
+robes' authored palette values separately from projected values so reset restores
+the original color and per-part inheritance. NPCs without overrides must retain
+their raw palette fields.
 
 ### Shuttle Pilot helmet regression
 
@@ -130,28 +130,40 @@ armor Cloth1 132, Cloth2/Leather1/Leather2 20, Metal1 133, Metal2 0. The origina
 PLT sources and geometry also match; the conversion changed material bindings.
 Do not recolor the NPC to compensate for a renderer defect.
 
+The installed master HAK used for the reference screenshot predates Republic
+Armor Update (#320). Its female human chest 249 uses a 256-by-256, two-layer
+PLT, while master source and the converted material use that update's 512-by-512,
+five-layer replacement. With the same dyes, the replacement has a lighter torso.
+Retain the replacement artwork: tint parity must use its source PLT, rather than
+recoloring the NPC or reverting the texture to reproduce that older screenshot.
+
 In the 89.8193.37-17 Windows client, the `CNWCAnimBaseParts` material replay path
 visits the body, head, and three accessory objects, but omits the worn helmet.
 The server can correctly publish `helm_114` rows while the helmet still uses its
 positive row-zero MTR defaults, producing the reported tan crest. The generated
 `helm_114.plt` control restores its native scheme; negative MTR defaults select
 that scheme. The normal/specular textures and full-resolution BC5 mask remain
-unchanged. A dropped helmet still accepts explicit item material rows.
+unchanged. Explicit item material rows support exact RGB on both worn and
+dropped helmets. A complete helmet refresh resets the item's old rows once,
+then writes every effective layer, including the wearer's skin and hair colors.
 
-The generator applies this rule across the helmet catalog, proving each native
-named subtree and isolating shared materials used by ordinary heads. Persisted
-helmet RGB colors retain their stored value and project to the nearest native
-preset while worn; reset restores the authored dye. The editor offers preset
-colors for worn helmets and explains why exact RGB editing is unavailable.
+The generator applies the native fallback across the helmet catalog, proving
+each native named subtree and isolating shared materials used by ordinary heads.
+The editor keeps RGB enabled for worn helmets. Both preset and RGB edits publish
+the item's effective rows; reset clears the stored custom color and publishes
+the authored dye. The native palette fields are never replaced by an approximation.
 
 `TintMapEngineTests.ShuttlePilotRefreshInstallsAuthoredRows` checks the placed
-NPC's helmet/chest rows and legacy RGB/reset behavior in NWN. The GPU harness
+NPC's helmet/chest rows and exact equipped-item RGB/reset behavior in NWN. The GPU harness
 compares the actual helmet BC5 material with native versus scripted dyes and
 requires the old row-zero defaults to produce a different result. These checks
 do not attach a game client to the test server; verify the pilot in a fresh
 client session after deployment. Pack `sw_tint_mtr`, `sw_pt_helm`, `sw_pt_head`,
-and `sw_2da` together for this fix. The existing module HAK list already includes
-them, so no NPC or module data changes are needed.
+and `sw_2da` together for this fix, along with any changed tint masks. Confirm
+that the deployed, packed module declares all four tint HAKs (`sw_tint_mtr`,
+`sw_tint0`, `sw_tint1`, `sw_tint2`). The checked-in module list already includes
+them, but an older compiled module may omit them. `ModuleDeclaresTintAssets`
+checks the running module's native HAK list to catch that deployment failure.
 
 ## Exact RGB on robes
 

--- a/SWLOR.Game.Server/Readmes/TintMapRendering.md
+++ b/SWLOR.Game.Server/Readmes/TintMapRendering.md
@@ -81,11 +81,11 @@ one `draw_list` on each widget. The native editor tests validate the serialized
 coordinates and both drawing layers for all 120 swatches, along with the color
 and custom-mode publications after an RGB edit.
 
-## Preserve the robe's native palette transport
+## Preserve native palette transport on separate attachments
 
 The 89.8193.37-17 client does not replay creature material overrides onto the
-separate robe attachment. Its ordinary body and head receive those records;
-the robe does not, even for an empty material-name wildcard. Repeating the
+separate robe and worn helmet attachments. Its ordinary body and head receive those records;
+these attachments do not, even for an empty material-name wildcard. Repeating the
 refresh or writing the records on the equipped item cannot repair that gap.
 The civilian reproduced it with all 14 robe materials retaining defaults while
 the head had the correct rows. A successful server-side row test therefore
@@ -93,13 +93,13 @@ does not establish that a robe received its colors.
 
 NWN has another per-material transport: `PLTscheme[15]`. The native body-part
 loader fills it from the wearer and equipment when its selected PLT resource
-exists, and the renderer supplies it to custom shaders. Converted robes retain
+exists, and the renderer supplies it to custom shaders. Converted robes and helmets retain
 tiny, one-pixel PLT control resources for that lookup. Their visible shade and
 layer data still come from the full BC5 tint mask; the control is not artwork.
 Do not reconvert or remove these controls, replace stock PLTs, or treat them as
 authored diffuse textures when resolving model materials.
 
-Robe-consuming materials opt into the native fallback and use negative row
+Materials on proven native-selected attachment subtrees opt into the fallback and use negative row
 defaults. A received nonnegative scripted row still takes priority. Otherwise,
 the shader decodes the native color byte from the corresponding scheme entry
 and uses that color in the existing 2048-row tint atlas. The native scheme
@@ -114,12 +114,44 @@ but fill it from `pal_armor01` and use matching picker colors. Do not modify
 the original palette resources themselves. The GPU regression checks every
 color and shade against the original palette RGBA, including this distinction.
 
-This transport only supports native palette IDs. Unsupported robe/body
+This transport only supports native palette IDs. Worn helmets and unsupported robe/body
 combinations retain the nearest-preset compatibility projection for persisted
 RGB, with RGB editing disabled and presets available. Preserve the authored
 palette values separately from projected values so reset restores the original
 color and per-part inheritance. NPCs without overrides must retain their raw
 palette fields.
+
+### Shuttle Pilot helmet regression
+
+The placed starter-area Shuttle Pilot (`ooc_area`, tag `novapilot`) wears helmet
+114 and female human chest 249. Its embedded equipment is unchanged from master:
+helmet Cloth1/Cloth2 135, Leather1 23, Leather2 20, Metal1 135, Metal2 0;
+armor Cloth1 132, Cloth2/Leather1/Leather2 20, Metal1 133, Metal2 0. The original
+PLT sources and geometry also match; the conversion changed material bindings.
+Do not recolor the NPC to compensate for a renderer defect.
+
+In the 89.8193.37-17 Windows client, the `CNWCAnimBaseParts` material replay path
+visits the body, head, and three accessory objects, but omits the worn helmet.
+The server can correctly publish `helm_114` rows while the helmet still uses its
+positive row-zero MTR defaults, producing the reported tan crest. The generated
+`helm_114.plt` control restores its native scheme; negative MTR defaults select
+that scheme. The normal/specular textures and full-resolution BC5 mask remain
+unchanged. A dropped helmet still accepts explicit item material rows.
+
+The generator applies this rule across the helmet catalog, proving each native
+named subtree and isolating shared materials used by ordinary heads. Persisted
+helmet RGB colors retain their stored value and project to the nearest native
+preset while worn; reset restores the authored dye. The editor offers preset
+colors for worn helmets and explains why exact RGB editing is unavailable.
+
+`TintMapEngineTests.ShuttlePilotRefreshInstallsAuthoredRows` checks the placed
+NPC's helmet/chest rows and legacy RGB/reset behavior in NWN. The GPU harness
+compares the actual helmet BC5 material with native versus scripted dyes and
+requires the old row-zero defaults to produce a different result. These checks
+do not attach a game client to the test server; verify the pilot in a fresh
+client session after deployment. Pack `sw_tint_mtr`, `sw_pt_helm`, `sw_pt_head`,
+and `sw_2da` together for this fix. The existing module HAK list already includes
+them, so no NPC or module data changes are needed.
 
 ## Exact RGB on robes
 


### PR DESCRIPTION
The starter-area Shuttle Pilot’s helmet rendered tan because the client omits worn helmets from creature material-uniform replay. Publish every effective tint layer on the equipped helmet item as well as the creature, preserving exact RGB editing, persisted colors, preset reset, and unchanged native dye fields. The companion assets retain native palette transport when explicit rows are unavailable.

The NPC’s equipment and geometry remain unchanged. Its lighter torso comes from Republic Armor Update (#320): the installed master HAK in the reference screenshot uses an older chest texture. The replacement artwork is intentionally retained.

Companion assets: https://github.com/zunath/SWLOR_Haks/pull/411 (also targets feature/combat-upgrade). Keep the parent submodule pointer aligned when merging the companion. Deploy sw_tint_mtr, sw_pt_helm, sw_pt_head, and sw_2da together with the server. The packed module must declare sw_tint_mtr and all three sw_tint mask HAKs; source JSON and files on disk alone are insufficient. A new native engine test guards the loaded module’s HAK list.

Validation:
- Build passed with post-build deployment disabled; all 172 focused tint, helmet, robe catalog, and appearance editor unit tests passed.
- All 29 native Tint/AppearanceEditor tests passed against the final server build and corrected packed module, including exact equipped-helmet RGB/reset, item identity and equipment preservation, and the loaded-module HAK guard.
- The user confirmed in NWN 89.8193.37-17 that materials and helmet RGB both work after loading the complete asset set.
- Companion asset checks passed: 71 tint-generator tests, 43 robe tests, production GPU suite, complete corpus audit, dependent model validation, and byte verification of packed HAK resources. See the companion PR for detailed counts.

Native tests inspect server state; GPU tests exercise shaders independently. The connected-client check supplies the separate visual confirmation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for applying creature color selections to equipped helmet attachments.
  - Helmet tinting now preserves palette-based and custom RGB colors during refreshes.
  - RGB tint availability now reflects the rendered helmet attachment.

- **Bug Fixes**
  - Fixed equipped helmet colors not consistently reappearing after appearance refreshes.
  - Improved tint handling for authored, native, and reset color selections.

- **Documentation**
  - Expanded tint rendering documentation to cover helmet palette transport and refresh behavior.
  - Added regression guidance for helmet appearance validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->