### PR TITLE
Preserve NPC cooldown precision and recover invalid timestamps

### DIFF
--- a/SWLOR.Game.Server.Tests/Service/RecastTimestampTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/RecastTimestampTests.cs
@@ -1,0 +1,94 @@
+using System.Globalization;
+using FluentAssertions;
+using NUnit.Framework;
+using SWLOR.Game.Server.Service;
+
+namespace SWLOR.Game.Server.Tests.Service;
+
+public class RecastTimestampTests
+{
+    [Test]
+    public void ShortCooldown_RemainsActiveUntilItsExactExpiry()
+    {
+        var now = new DateTime(2026, 9, 8, 12, 0, 0, DateTimeKind.Utc).AddMilliseconds(125);
+        var endsAt = now.AddSeconds(0.25);
+
+        RecastTimestamp.TryParse(RecastTimestamp.Format(endsAt), out var storedExpiry).Should().BeTrue();
+
+        storedExpiry.Should().Be(endsAt);
+        storedExpiry.Should().BeAfter(now);
+        storedExpiry.Should().BeAfter(endsAt.AddTicks(-1));
+        (endsAt < storedExpiry).Should().BeFalse();
+    }
+
+    [Test]
+    public void RepeatedReductions_PreserveTheRemainingFraction()
+    {
+        var now = new DateTime(2026, 9, 8, 12, 0, 0, DateTimeKind.Utc).AddTicks(1234567);
+        var stored = RecastTimestamp.Format(now.AddSeconds(2));
+
+        for (var index = 0; index < 3; index++)
+        {
+            RecastTimestamp.TryParse(stored, out var endsAt).Should().BeTrue();
+            stored = RecastTimestamp.Format(endsAt.AddSeconds(-0.5));
+        }
+
+        RecastTimestamp.TryParse(stored, out var reducedExpiry).Should().BeTrue();
+        reducedExpiry.Should().Be(now.AddSeconds(0.5));
+    }
+
+    [TestCase("en-US")]
+    [TestCase("th-TH")]
+    [TestCase("ar-SA")]
+    public void TimestampFormat_IsIndependentOfTheServerCulture(string culture)
+    {
+        var previousCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo(culture);
+            var endsAt = new DateTime(2026, 9, 8, 12, 0, 0, DateTimeKind.Utc).AddTicks(1234567);
+
+            var stored = RecastTimestamp.Format(endsAt);
+
+            stored.Should().Be("2026-09-08T12:00:00.1234567Z");
+            RecastTimestamp.TryParse(stored, out var parsed).Should().BeTrue();
+            parsed.Should().Be(endsAt);
+            parsed.Kind.Should().Be(DateTimeKind.Utc);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previousCulture;
+        }
+    }
+
+    [Test]
+    public void LegacyTimestamp_IsReadAsUtcAndCanBeReducedWithFractionalPrecision()
+    {
+        RecastTimestamp.TryParse("2026-09-08 12:00:02", out var endsAt).Should().BeTrue();
+        endsAt.Should().Be(new DateTime(2026, 9, 8, 12, 0, 2, DateTimeKind.Utc));
+        endsAt.Kind.Should().Be(DateTimeKind.Utc);
+
+        RecastTimestamp.Format(endsAt.AddSeconds(-0.25)).Should().Be("2026-09-08T12:00:01.7500000Z");
+    }
+
+    [Test]
+    public void TimestampWithOffset_IsNormalizedToUtc()
+    {
+        RecastTimestamp.TryParse("2026-09-08T17:30:00.1234567+05:30", out var endsAt).Should().BeTrue();
+
+        endsAt.Should().Be(new DateTime(2026, 9, 8, 12, 0, 0, DateTimeKind.Utc).AddTicks(1234567));
+        endsAt.Kind.Should().Be(DateTimeKind.Utc);
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase(" ")]
+    [TestCase("not a timestamp")]
+    [TestCase("2026-02-30 12:00:00")]
+    [TestCase("09/08/2026 12:00:00")]
+    public void MalformedTimestamp_IsRejectedWithoutThrowing(string value)
+    {
+        RecastTimestamp.TryParse(value, out var endsAt).Should().BeFalse();
+        endsAt.Should().Be(default(DateTime));
+    }
+}

--- a/SWLOR.Game.Server/Service/Recast.cs
+++ b/SWLOR.Game.Server/Service/Recast.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using SWLOR.Game.Server.Core;
 using SWLOR.Game.Server.Entity;
@@ -111,14 +110,12 @@ namespace SWLOR.Game.Server.Service
             // NPCs and DM-possessed NPCs
             else
             {
-                var unlockDate = GetLocalString(creature, $"ABILITY_RECAST_ID_{(int)recastGroup}");
-                if (string.IsNullOrWhiteSpace(unlockDate))
+                if (!TryGetNpcRecastTime(creature, recastGroup, out var dateTime))
                 {
                     return (false, string.Empty);
                 }
                 else
                 {
-                    var dateTime = DateTime.ParseExact(unlockDate, "yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
                     var timeToWait = Time.GetTimeToWaitLongIntervals(now, dateTime, false);
                     return (now < dateTime, timeToWait);
                 }
@@ -142,7 +139,7 @@ namespace SWLOR.Game.Server.Service
             if (!GetIsPC(activator) || GetIsDMPossessed(activator))
             {
                 var recastDate = now.AddSeconds(delaySeconds);
-                var recastDateString = recastDate.ToString("yyyy-MM-dd HH:mm:ss");
+                var recastDateString = RecastTimestamp.Format(recastDate);
                 SetLocalString(activator, $"ABILITY_RECAST_ID_{(int)group}", recastDateString);
             }
             // Players
@@ -174,11 +171,9 @@ namespace SWLOR.Game.Server.Service
             if (!GetIsPC(activator) || GetIsDMPossessed(activator))
             {
                 var localName = $"ABILITY_RECAST_ID_{(int)group}";
-                var unlockDate = GetLocalString(activator, localName);
-                if (string.IsNullOrWhiteSpace(unlockDate))
+                if (!TryGetNpcRecastTime(activator, group, out var dateTime))
                     return;
 
-                var dateTime = DateTime.ParseExact(unlockDate, "yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
                 if (dateTime <= now)
                 {
                     DeleteLocalString(activator, localName);
@@ -192,7 +187,7 @@ namespace SWLOR.Game.Server.Service
                 }
                 else
                 {
-                    SetLocalString(activator, localName, reducedDate.ToString("yyyy-MM-dd HH:mm:ss"));
+                    SetLocalString(activator, localName, RecastTimestamp.Format(reducedDate));
                 }
             }
             else if (GetIsPC(activator) && !GetIsDM(activator))
@@ -231,6 +226,20 @@ namespace SWLOR.Game.Server.Service
 
                 DB.Set(dbPlayer);
             }
+        }
+
+        private static bool TryGetNpcRecastTime(uint creature, RecastGroup group, out DateTime endsAt)
+        {
+            var localName = $"ABILITY_RECAST_ID_{(int)group}";
+            var value = GetLocalString(creature, localName);
+            if (RecastTimestamp.TryParse(value, out endsAt))
+                return true;
+
+            // A malformed local must not interrupt the creature's ability processing.
+            if (!string.IsNullOrEmpty(value))
+                DeleteLocalString(creature, localName);
+
+            return false;
         }
     }
 }

--- a/SWLOR.Game.Server/Service/RecastTimestamp.cs
+++ b/SWLOR.Game.Server/Service/RecastTimestamp.cs
@@ -1,0 +1,24 @@
+using System.Globalization;
+
+namespace SWLOR.Game.Server.Service
+{
+    /// <summary>
+    /// Stores NPC cooldown expiry times in local strings without losing fractional seconds.
+    /// </summary>
+    public static class RecastTimestamp
+    {
+        private static readonly string[] Formats = { "O", "yyyy-MM-dd HH:mm:ss" };
+
+        public static string Format(DateTime endsAt)
+        {
+            return endsAt.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture);
+        }
+
+        public static bool TryParse(string value, out DateTime endsAt)
+        {
+            // Legacy locals were written from UtcNow without a timezone suffix.
+            return DateTime.TryParseExact(value, Formats, CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out endsAt);
+        }
+    }
+}


### PR DESCRIPTION
NPC cooldowns currently lose fractional seconds when written to local strings. A 0.25-second cooldown applied at 12:00:00.125 is stored as 12:00:00, making it immediately ready; cooldown reductions also discard the remaining fraction.

Store NPC expiry times as invariant UTC round-trip timestamps and use the same formatter for application and reduction. Continue reading the existing second-resolution UTC format, and clear malformed local timestamps instead of throwing during ability checks or reductions. Player cooldown persistence, DM bypass behavior, and Capstone reduction immunity retain their existing behavior.

Validation: built SWLOR.Game.Server.Tests with `-p:RunPostBuildEvent=Never`, then ran 18 focused tests with `--no-build` covering RecastTimestampTests, AbilityCooldownVisualTests, and CooldownReduction_CannotResetCapstonesOrRunPastReady. All passed. The build reported eight existing warnings in untouched API/GUI files. Independent code review found no actionable issues. The change has not been tested on a running NWN server.