### PR TITLE
Preserve passive damage bonuses on control-only ability casts

### DIFF
--- a/SWLOR.Game.Server.EngineTests/Definitions/CombatPerkRegressionEngineTests.cs
+++ b/SWLOR.Game.Server.EngineTests/Definitions/CombatPerkRegressionEngineTests.cs
@@ -232,6 +232,8 @@ namespace SWLOR.Game.Server.EngineTests.Definitions
                 }
                 finally { Ability.EndAbilityImpact(caster); }
                 await ctx.DelaySecondsAsync(0.75f);
+                ctx.Assert(StatusEffect.HasStatusEffect(target, typeof(FlashStatusEffect)),
+                    "Flash delayed impact resolves");
                 ctx.AssertEqual(hp, GetCurrentHitPoints(target), "Flash causes no direct damage");
                 ctx.AssertEqual(31, Combat.ConsumeNextAbilityDamageBonus(caster, PerkType.Flash), "Perk damage remains armed");
                 var skill = Combat.ConsumeNextSkillAbilityBonuses(caster, SkillType.HeavyVibroblade);

--- a/SWLOR.Game.Server.EngineTests/Definitions/CombatPerkRegressionEngineTests.cs
+++ b/SWLOR.Game.Server.EngineTests/Definitions/CombatPerkRegressionEngineTests.cs
@@ -245,6 +245,34 @@ namespace SWLOR.Game.Server.EngineTests.Definitions
             finally { Combat.SetAbilityHitResolutionOverride(null); }
         }
 
+        [EngineTest("Repeated damage uses captured bonuses once and preserves newer bonuses", Category = "CombatPerkRegression", TimeoutSeconds = 15f)]
+        public static async Task RepeatedDamageUsesCapturedBonuses(EngineTestContext ctx)
+        {
+            var caster = ctx.SpawnCreature("nw_bandit001");
+            var target = ctx.SpawnCreature("nw_rat001", 2f);
+            await ctx.WaitFrameAsync();
+            Prepare(ctx, caster);
+            Prepare(ctx, target);
+            ctx.MakeHostile(target);
+            Stat.SetNPCMaxHitPoints(target, 1000, true);
+            var ability = new AbilityDetail { SkillType = SkillType.Force, IsHostileAbility = true,
+                ActivationType = AbilityActivationType.Casted };
+            Combat.GrantNextSkillAbilityBonuses(caster, (int)SkillType.Force, 75, 0, 120);
+            Ability.BeginAbilityImpact(caster, ability);
+            var pulse = Ability.CaptureRepeatedAbilityImpact(caster, () => Ability.ApplyCombatImpact(
+                caster, target, GetLocation(target), SkillType.Force, 10, 0, null, false,
+                resolvesHit: false, canCritical: false, useUnscaledDamage: true), baseDamage: 10);
+            Ability.EndAbilityImpact(caster);
+            Combat.GrantNextSkillAbilityBonuses(caster, (int)SkillType.Force, 101, 0, 120);
+            await ctx.ExecuteInCreatureContextAsync(caster, pulse);
+            var first = Ability.GetLastCompletedAbilityImpactSummary(caster).AttributedDamage;
+            await ctx.ExecuteInCreatureContextAsync(caster, pulse);
+            var second = Ability.GetLastCompletedAbilityImpactSummary(caster).AttributedDamage;
+            ctx.Assert(first > second && second > 0, "Only the first impacting pulse uses the captured damage");
+            ctx.AssertEqual(101, Combat.ConsumeNextSkillAbilityBonuses(caster, SkillType.Force).DamageBonus,
+                "Pulses preserve bonuses granted after the originating cast");
+        }
+
         [EngineTest("Force Choke applies its full scaled damage budget over thirty seconds", Category = "CombatPerkRegression", TimeoutSeconds = 55f)]
         public static async Task ForceChokeDamageBudget(EngineTestContext ctx)
         {
@@ -296,6 +324,16 @@ namespace SWLOR.Game.Server.EngineTests.Definitions
                     "Choke applies the hostile-hit damage bonus despite having no immediate base damage");
                 ctx.AssertEqual(0, Combat.GetAbilityImpactBaseDamageBonus(caster, targets[0], choke, SkillType.Force),
                     "Choke consumes the applied First Strike stack");
+                Combat.GrantNextSkillAbilityBonuses(caster, (int)SkillType.Force, 75, 0, 120);
+                Ability.BeginAbilityImpact(caster, choke);
+                try
+                {
+                    await ctx.ExecuteInCreatureContextAsync(caster,
+                        () => choke.ImpactAction(caster, targets[0], 1, GetLocation(targets[0])));
+                }
+                finally { Ability.EndAbilityImpact(caster); }
+                ctx.Assert(Ability.GetLastCompletedAbilityImpactSummary(caster).AttributedDamage > 0,
+                    "Choke applies captured flat damage even without a separate base-damage rider");
             }
             finally { Combat.SetAbilityHitResolutionOverride(null); }
         }

--- a/SWLOR.Game.Server.EngineTests/Definitions/CombatPerkRegressionEngineTests.cs
+++ b/SWLOR.Game.Server.EngineTests/Definitions/CombatPerkRegressionEngineTests.cs
@@ -202,6 +202,49 @@ namespace SWLOR.Game.Server.EngineTests.Definitions
             finally { Combat.SetAbilityHitResolutionOverride(null); }
         }
 
+        [EngineTest("Flash preserves armed activation bonuses through its delayed impact", Category = "CombatPerkRegression", TimeoutSeconds = 15f)]
+        public static async Task FlashPreservesActivationBonuses(EngineTestContext ctx)
+        {
+            var caster = ctx.SpawnCreature("nw_bandit001");
+            var target = ctx.SpawnCreature("nw_rat001", 2f);
+            await ctx.WaitFrameAsync();
+            Prepare(ctx, caster);
+            Prepare(ctx, target);
+            ctx.MakeHostile(target);
+            Combat.GrantNextAbilityDamageBonus(caster, (int)PerkType.Flash, 31, 120);
+            Combat.GrantNextSkillAbilityBonuses(caster, (int)SkillType.HeavyVibroblade, 37, 11, 120);
+            TemporaryStatModifier.Add(caster, StatType.NextAttackGuardedHitDMGBonus, 41, 120,
+                StatType.NextAttackGuardedHitDMGBonus);
+            TemporaryStatModifier.Add(caster, StatType.NextAttackGuardedHitCriticalRatePercentAdjustment, 13, 120,
+                StatType.NextAttackGuardedHitDMGBonus);
+            TemporaryStatModifier.Add(caster, StatType.NextAttackGuardedHitEnmityBonus, 43, 120,
+                StatType.NextAttackGuardedHitDMGBonus);
+            var ability = Ability.GetAbilityDetail(FeatType.Flash1);
+            var hp = GetCurrentHitPoints(target);
+            Combat.SetAbilityHitResolutionOverride(true);
+            try
+            {
+                Ability.BeginAbilityImpact(caster, ability);
+                try
+                {
+                    await ctx.ExecuteInCreatureContextAsync(caster,
+                        () => ability.ImpactAction(caster, target, 1, GetLocation(target)));
+                }
+                finally { Ability.EndAbilityImpact(caster); }
+                await ctx.DelaySecondsAsync(0.75f);
+                ctx.AssertEqual(hp, GetCurrentHitPoints(target), "Flash causes no direct damage");
+                ctx.AssertEqual(31, Combat.ConsumeNextAbilityDamageBonus(caster, PerkType.Flash), "Perk damage remains armed");
+                var skill = Combat.ConsumeNextSkillAbilityBonuses(caster, SkillType.HeavyVibroblade);
+                ctx.AssertEqual(37, skill.DamageBonus, "Skill damage remains armed");
+                ctx.AssertEqual(11, skill.CriticalRatePercentAdjustment, "Skill critical rate remains armed");
+                var guarded = Combat.ConsumeNextAttackGuardedHitBonuses(caster);
+                ctx.AssertEqual(41, guarded.DMGBonus, "Guarded damage remains armed");
+                ctx.AssertEqual(13, guarded.CriticalRatePercentAdjustment, "Guarded critical rate remains armed");
+                ctx.AssertEqual(43, guarded.EnmityBonus, "Guarded enmity remains armed");
+            }
+            finally { Combat.SetAbilityHitResolutionOverride(null); }
+        }
+
         [EngineTest("Force Choke applies its full scaled damage budget over thirty seconds", Category = "CombatPerkRegression", TimeoutSeconds = 55f)]
         public static async Task ForceChokeDamageBudget(EngineTestContext ctx)
         {

--- a/SWLOR.Game.Server.Tests/Feature/AbilityImpactDamageBonusTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/AbilityImpactDamageBonusTests.cs
@@ -1,30 +1,32 @@
 using System.Reflection;
 using FluentAssertions;
 using NUnit.Framework;
+using SWLOR.Game.Server.Feature.AbilityDefinition.HeavyVibroblade;
+using SWLOR.Game.Server.Feature.AbilityDefinition.Vibroblade;
 using SWLOR.Game.Server.Service;
 using SWLOR.Game.Server.Service.AbilityService;
-using SWLOR.Game.Server.Service.SkillService;
+using SWLOR.NWN.API.NWScript.Enum;
 
 namespace SWLOR.Game.Server.Tests.Feature;
 
 public class AbilityImpactDamageBonusTests
 {
-    private static readonly Func<int, SkillType, AbilityDetail, Func<int>, (int BaseDamage, bool DealsDamage)> Apply = typeof(Ability)
+    private static readonly Func<int, AbilityDetail, Func<int>, (int BaseDamage, bool DealsDamage)> Apply = typeof(Ability)
         .GetMethod("ResolveCombatImpactBaseDamage", BindingFlags.NonPublic | BindingFlags.Static)!
-        .CreateDelegate<Func<int, SkillType, AbilityDetail, Func<int>, (int, bool)>>();
+        .CreateDelegate<Func<int, AbilityDetail, Func<int>, (int, bool)>>();
 
     [TestCase(20)]
     [TestCase(75)]
     [TestCase(150)]
     public void ControlOnlyImpact_DoesNotGainPassiveDamage(int bonus)
     {
-        Apply(0, SkillType.Mimicry, new AbilityDetail(), () => bonus).Should().Be((0, false));
+        Apply(0, new AbilityDetail(), () => bonus).Should().Be((0, false));
     }
 
     [Test]
     public void ControlOnlyImpact_DoesNotConsumeDamageBonus()
     {
-        Apply(0, SkillType.Force, null, () => throw new AssertionException("Damage bonus must remain available"))
+        Apply(0, null, () => throw new AssertionException("Damage bonus must remain available"))
             .Should().Be((0, false));
     }
 
@@ -34,7 +36,11 @@ public class AbilityImpactDamageBonusTests
     public void DamagingImpact_AppliesBonusOnce(int baseDamage, bool usesWeaponDamage, int expected)
     {
         var calls = 0;
-        Apply(baseDamage, usesWeaponDamage ? SkillType.Vibroblade : SkillType.Mimicry, null, () =>
+        var ability = new AbilityDetail
+        {
+            ActivationType = usesWeaponDamage ? AbilityActivationType.Weapon : AbilityActivationType.Casted
+        };
+        Apply(baseDamage, ability, () =>
         {
             calls++;
             return 75;
@@ -46,13 +52,31 @@ public class AbilityImpactDamageBonusTests
     public void QueuedNaturalWeaponImpact_PreservesDamageBonus()
     {
         var ability = new AbilityDetail { ActivationType = AbilityActivationType.Weapon };
-        Apply(0, SkillType.BeastMastery, ability, () => 75).Should().Be((75, true));
+        Apply(0, ability, () => 75).Should().Be((75, true));
     }
 
     [Test]
     public void DeferredDamageImpact_PreservesDamageBonus()
     {
         var ability = new AbilityDetail { DealsDeferredDamage = true };
-        Apply(0, SkillType.Force, ability, () => 75).Should().Be((75, true));
+        Apply(0, ability, () => 75).Should().Be((75, true));
+    }
+
+    [Test]
+    public void Flash_DoesNotConsumeDamageBonusesOrFirstStrikeCounts()
+    {
+        var flash = new FlashAbilityDefinition().BuildAbilities()[FeatType.Flash1];
+        Apply(0, flash, () => throw new AssertionException("Flash must retain damage bonuses"))
+            .Should().Be((0, false));
+    }
+
+    [TestCase(FeatType.ShieldBash1)]
+    [TestCase(FeatType.ShieldBash2)]
+    [TestCase(FeatType.ShieldBash3)]
+    [TestCase(FeatType.ShieldBash4)]
+    public void ShieldBash_PreservesWeaponDamageAndBonusEligibility(FeatType feat)
+    {
+        var bash = new ShieldBashAbilityDefinition().BuildAbilities()[feat];
+        Apply(0, bash, () => 75).Should().Be((75, true));
     }
 }

--- a/SWLOR.Game.Server.Tests/Feature/AbilityImpactDamageBonusTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/AbilityImpactDamageBonusTests.cs
@@ -12,6 +12,44 @@ namespace SWLOR.Game.Server.Tests.Feature;
 
 public class AbilityImpactDamageBonusTests
 {
+    [TestCase(0, 0, false, false)]
+    [TestCase(0, 75, false, true)]
+    [TestCase(10, 0, false, true)]
+    [TestCase(0, 0, true, true)]
+    public void DamageCalculation_RecognizesCapturedDamageOnZeroBaseImpacts(
+        int baseDamage, int capturedBonus, bool weapon, bool expected)
+    {
+        var hasDamage = typeof(Ability).GetMethod("HasCombatImpactDamage", BindingFlags.NonPublic | BindingFlags.Static)!
+            .CreateDelegate<Func<int, int, bool, bool>>();
+        hasDamage(baseDamage, capturedBonus, weapon).Should().Be(expected);
+    }
+
+    [Test]
+    public void RepeatedPulseSnapshot_AppliesOnceAfterATargetIsImpacted()
+    {
+        var type = typeof(Ability).GetNestedType("TrackedAbilityImpact", BindingFlags.NonPublic)!;
+        object Create(int damage = 0, int statusDamage = 0) => type.GetConstructors().Single().Invoke(new object[]
+        {
+            new AbilityDetail(), damage, 11, 13, 17, statusDamage, false, 19,
+            Array.Empty<TelegraphGeometry>(), null
+        });
+        var source = Create(82, 7);
+        var copy = type.GetMethod("CopyRepeatedDamageBonusesFrom")!;
+        var complete = type.GetMethod("CompleteRepeatedDamageBonusImpact")!;
+        int Damage(object impact) => (int)type.GetProperty("NextAbilityDamageBonus")!.GetValue(impact)!;
+        var emptyPulse = Create();
+        copy.Invoke(emptyPulse, new[] { source });
+        Damage(emptyPulse).Should().Be(75, "a live next-attack status is not part of the scheduled snapshot");
+        complete.Invoke(source, new object[] { false });
+        var firstHitPulse = Create();
+        copy.Invoke(firstHitPulse, new[] { source });
+        Damage(firstHitPulse).Should().Be(75, "an empty pulse must retain the captured bonus");
+        complete.Invoke(source, new object[] { true });
+        var laterPulse = Create();
+        copy.Invoke(laterPulse, new[] { source });
+        Damage(laterPulse).Should().Be(0, "later pulses must not duplicate the consumed bonus");
+    }
+
     private static readonly Func<int, AbilityDetail, Func<int>, (int BaseDamage, bool DealsDamage)> Apply = typeof(Ability)
         .GetMethod("ResolveCombatImpactBaseDamage", BindingFlags.NonPublic | BindingFlags.Static)!
         .CreateDelegate<Func<int, AbilityDetail, Func<int>, (int, bool)>>();

--- a/SWLOR.Game.Server.Tests/Feature/AbilityImpactDamageBonusTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/AbilityImpactDamageBonusTests.cs
@@ -81,8 +81,9 @@ public class AbilityImpactDamageBonusTests
         Apply(0, bash, () => 75).Should().Be((75, true));
     }
 
-    [Test]
-    public void ImpactPreparation_LeavesControlBonusesArmedAndConsumesOnceForDamage()
+    [TestCase(false)]
+    [TestCase(true)]
+    public void ImpactPreparation_LeavesControlBonusesArmedAndConsumesOnceForDamage(bool scheduled)
     {
         var impactType = typeof(Ability).GetNestedType("TrackedAbilityImpact", BindingFlags.NonPublic)!;
         var flash = new FlashAbilityDefinition().BuildAbilities()[FeatType.Flash1];
@@ -100,10 +101,17 @@ public class AbilityImpactDamageBonusTests
         impacts.Add(caster, impact);
         try
         {
-            prepare(caster, 0);
+            void DeclareDamage(int damage)
+            {
+                if (scheduled)
+                    Ability.CaptureRepeatedAbilityImpact(caster, () => { }, baseDamage: damage);
+                else
+                    prepare(caster, damage);
+            }
+            DeclareDamage(0);
             calls.Should().Be(0, "control impacts must not invoke activation bonus consumers");
-            prepare(caster, 100);
-            prepare(caster, 100);
+            DeclareDamage(100);
+            DeclareDamage(100);
             calls.Should().Be(1, "multiple targets and phases share one consumption");
         }
         finally

--- a/SWLOR.Game.Server.Tests/Feature/AbilityImpactDamageBonusTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/AbilityImpactDamageBonusTests.cs
@@ -6,6 +6,7 @@ using SWLOR.Game.Server.Feature.AbilityDefinition.Vibroblade;
 using SWLOR.Game.Server.Service;
 using SWLOR.Game.Server.Service.AbilityService;
 using SWLOR.NWN.API.NWScript.Enum;
+using SWLOR.Game.Server.Service.TelegraphService;
 
 namespace SWLOR.Game.Server.Tests.Feature;
 
@@ -78,5 +79,36 @@ public class AbilityImpactDamageBonusTests
     {
         var bash = new ShieldBashAbilityDefinition().BuildAbilities()[feat];
         Apply(0, bash, () => 75).Should().Be((75, true));
+    }
+
+    [Test]
+    public void ImpactPreparation_LeavesControlBonusesArmedAndConsumesOnceForDamage()
+    {
+        var impactType = typeof(Ability).GetNestedType("TrackedAbilityImpact", BindingFlags.NonPublic)!;
+        var flash = new FlashAbilityDefinition().BuildAbilities()[FeatType.Flash1];
+        var impact = impactType.GetConstructors().Single().Invoke(new object[]
+        {
+            flash, 0, 0, 0, 0, 0, true, 0, Array.Empty<TelegraphGeometry>(), null
+        });
+        var calls = 0;
+        impactType.GetProperty("ResolveDamageBonuses")!.SetValue(impact, (Action)(() => calls++));
+        var impacts = (System.Collections.IDictionary)typeof(Ability)
+            .GetField("_trackedAbilityImpacts", BindingFlags.NonPublic | BindingFlags.Static)!.GetValue(null)!;
+        var prepare = typeof(Ability).GetMethod("PrepareCombatImpactDamageBonuses", BindingFlags.NonPublic | BindingFlags.Static)!
+            .CreateDelegate<Action<uint, int>>();
+        const uint caster = 0xFFFFFFFE;
+        impacts.Add(caster, impact);
+        try
+        {
+            prepare(caster, 0);
+            calls.Should().Be(0, "control impacts must not invoke activation bonus consumers");
+            prepare(caster, 100);
+            prepare(caster, 100);
+            calls.Should().Be(1, "multiple targets and phases share one consumption");
+        }
+        finally
+        {
+            impacts.Remove(caster);
+        }
     }
 }

--- a/SWLOR.Game.Server.Tests/Feature/AbilityImpactDamageBonusTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/AbilityImpactDamageBonusTests.cs
@@ -1,0 +1,42 @@
+using System.Reflection;
+using FluentAssertions;
+using NUnit.Framework;
+using SWLOR.Game.Server.Service;
+
+namespace SWLOR.Game.Server.Tests.Feature;
+
+public class AbilityImpactDamageBonusTests
+{
+    private static readonly Func<int, bool, Func<int>, int> Apply = typeof(Ability)
+        .GetMethod("ApplyCombatImpactBaseDamageBonuses", BindingFlags.NonPublic | BindingFlags.Static)!
+        .CreateDelegate<Func<int, bool, Func<int>, int>>();
+
+    [TestCase(20)]
+    [TestCase(75)]
+    [TestCase(150)]
+    public void ControlOnlyImpact_DoesNotGainPassiveDamage(int bonus)
+    {
+        Apply(0, false, () => bonus).Should().Be(0);
+    }
+
+    [Test]
+    public void ControlOnlyImpact_DoesNotConsumeDamageBonus()
+    {
+        Apply(0, false, () => throw new AssertionException("Damage bonus must remain available"))
+            .Should().Be(0);
+    }
+
+    [TestCase(100, false, 175)]
+    [TestCase(0, true, 75)]
+    [TestCase(100, true, 175)]
+    public void DamagingImpact_AppliesBonusOnce(int baseDamage, bool usesWeaponDamage, int expected)
+    {
+        var calls = 0;
+        Apply(baseDamage, usesWeaponDamage, () =>
+        {
+            calls++;
+            return 75;
+        }).Should().Be(expected);
+        calls.Should().Be(1);
+    }
+}

--- a/SWLOR.Game.Server.Tests/Perks/GeneratedWeaponPerkBehaviorTests.cs
+++ b/SWLOR.Game.Server.Tests/Perks/GeneratedWeaponPerkBehaviorTests.cs
@@ -1663,7 +1663,7 @@ public class GeneratedWeaponPerkBehaviorTests
             .Should().BeLessThan(
                 hostileCombatImpactSource.IndexOf("Combat.TryResolveAbilityHit(", StringComparison.Ordinal),
                 "the defender must enter combat even when the opening hostile cast misses");
-        hostileCombatImpactSource.Should().Contain("firstHostileAbilityHitDamageBonusApplied: dealsDamage",
+        hostileCombatImpactSource.Should().Contain("firstHostileAbilityHitDamageBonusApplied: impactDamage.DealsDamage",
             "control-only casts must preserve First Strike stacks because they did not receive the damage bonus");
         abilitySource.Should().Contain("bool firstHostileAbilityHitDamageBonusApplied = false");
         combatSource.Should().Contain("if (firstHostileAbilityHitDamageBonusApplied)");

--- a/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
@@ -611,7 +611,7 @@ public class CombatDamageTests
             damageCalculation.Should().Contain(
                 "trackedImpact?.Ability?.ActivationType == AbilityActivationType.Weapon");
             damageCalculation.Should().Contain("skillType == SkillType.BeastMastery");
-            damageCalculation.Should().Contain("!usesQueuedNaturalWeapon");
+            damageCalculation.Should().Contain("Combat.IsWeaponSkillType(skillType) || usesQueuedNaturalWeapon");
             damageCalculation.Should().Contain(
                 "Combat.GetCombatImpactWeaponDamage(activator, skillType, usesQueuedNaturalWeapon)");
         }

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/DeviceAbilityEffects.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/DeviceAbilityEffects.cs
@@ -69,7 +69,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition
                         ApplyAreaHostilePulse(this);
                     else
                         ApplySingleHostilePulse(this);
-                });
+                }, baseDamage: baseDamage);
             }
 
             public uint Activator { get; }

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Force/CreepingTerrorAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Force/CreepingTerrorAbilityDefinition.cs
@@ -208,7 +208,7 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
 
         private static void ApplyCreepingTerrorDamage(uint activator, uint target, int scaledPulseDamage)
         {
-            var damage = scaledPulseDamage;
+            var damage = Ability.ApplyCapturedAbilityDamageBonus(activator, scaledPulseDamage);
             damage = Resistance.ApplyResistanceToDamage(target, ResistanceType.Disruption, damage);
             damage = Combat.ApplyDamageOverTimeTakenModifiers(target, damage, CombatDamageType.Force);
             damage = Combat.ApplyDamageTakenModifiers(target, damage, activator, CombatDamageType.Force);

--- a/SWLOR.Game.Server/Feature/AbilityDefinition/Force/CreepingTerrorAbilityDefinition.cs
+++ b/SWLOR.Game.Server/Feature/AbilityDefinition/Force/CreepingTerrorAbilityDefinition.cs
@@ -186,7 +186,8 @@ namespace SWLOR.Game.Server.Feature.AbilityDefinition.Force
             ApplyEffectAtLocation(DurationType.Temporary, EffectAreaOfEffect(areaOfEffect), location, durationSeconds);
 
             var applyPulse = Ability.CaptureRepeatedAbilityImpact(activator,
-                () => ApplyCreepingTerrorPulse(activator, location, scaledPulseDamage, radius));
+                () => ApplyCreepingTerrorPulse(activator, location, scaledPulseDamage, radius),
+                baseDamage: scaledPulseDamage);
 
             CombatAreaPulses.SchedulePulses(
                 activator,

--- a/SWLOR.Game.Server/Service/Ability.cs
+++ b/SWLOR.Game.Server/Service/Ability.cs
@@ -247,11 +247,13 @@ namespace SWLOR.Game.Server.Service
 
                 var previousImpact = GetTrackedAbilityImpact(activator);
                 BeginAbilityImpact(activator, ability, 0, 0, countsAsAttackAttempt: false, sequence: sequence);
+                GetTrackedAbilityImpact(activator).CopyRepeatedDamageBonusesFrom(originatingImpact);
                 var completed = false;
                 try
                 {
                     impactAction();
                     var summary = EndAbilityImpact(activator);
+                    originatingImpact.CompleteRepeatedDamageBonusImpact(summary.ImpactedTargetCount > 0);
                     completed = true;
                     Combat.ApplyAbilityImpactEffects(activator, summary);
                 }
@@ -2452,6 +2454,20 @@ namespace SWLOR.Game.Server.Service
                    ability?.DealsDeferredDamage == true;
         }
 
+        private static bool HasCombatImpactDamage(int baseDamage, int capturedDamageBonus, bool usesWeaponDamage)
+        {
+            return baseDamage > 0 || capturedDamageBonus > 0 || usesWeaponDamage;
+        }
+
+        /// <summary>
+        /// Adds this impact's captured flat bonus to an already-scaled damage payload before
+        /// target mitigation. Control-only payloads remain zero.
+        /// </summary>
+        public static int ApplyCapturedAbilityDamageBonus(uint activator, int damage)
+        {
+            return damage > 0 ? damage + (GetTrackedAbilityImpact(activator)?.NextAbilityDamageBonus ?? 0) : 0;
+        }
+
         private static void PrepareCombatImpactDamageBonuses(uint activator, int baseDamage)
         {
             var impact = GetTrackedAbilityImpact(activator);
@@ -2657,10 +2673,10 @@ namespace SWLOR.Game.Server.Service
             int baseDamage,
             CombatDamageType damageType)
         {
-            if (baseDamage <= 0)
+            var trackedImpact = GetTrackedAbilityImpact(activator);
+            if (!HasCombatImpactDamage(baseDamage, trackedImpact?.NextAbilityDamageBonus ?? 0, false))
                 return 0;
 
-            var trackedImpact = GetTrackedAbilityImpact(activator);
             var damage = baseDamage + (trackedImpact?.NextAbilityDamageBonus ?? 0);
             damage = Combat.ApplyDamageDealtModifiers(
                 activator,
@@ -2698,9 +2714,8 @@ namespace SWLOR.Game.Server.Service
             var usesQueuedNaturalWeapon =
                 trackedImpact?.Ability?.ActivationType == AbilityActivationType.Weapon &&
                 skillType == SkillType.BeastMastery;
-            if (baseDamage <= 0 &&
-                !Combat.IsWeaponSkillType(skillType) &&
-                !usesQueuedNaturalWeapon)
+            if (!HasCombatImpactDamage(baseDamage, trackedImpact?.NextAbilityDamageBonus ?? 0,
+                    Combat.IsWeaponSkillType(skillType) || usesQueuedNaturalWeapon))
             {
                 return 0;
             }
@@ -2930,9 +2945,8 @@ namespace SWLOR.Game.Server.Service
             var usesQueuedNaturalWeapon =
                 trackedImpact?.Ability?.ActivationType == AbilityActivationType.Weapon &&
                 skillType == SkillType.BeastMastery;
-            if (baseDamage <= 0 &&
-                !Combat.IsWeaponSkillType(skillType) &&
-                !usesQueuedNaturalWeapon)
+            if (!HasCombatImpactDamage(baseDamage, trackedImpact?.NextAbilityDamageBonus ?? 0,
+                    Combat.IsWeaponSkillType(skillType) || usesQueuedNaturalWeapon))
             {
                 return 0;
             }
@@ -3393,6 +3407,26 @@ namespace SWLOR.Game.Server.Service
             public Action ResolveDamageBonuses { get; set; }
             public bool DarkForceConversionApplied { get; set; }
             private bool _statusAppliedNextAttackDamageBonusConsumed;
+            private bool _repeatedDamageBonusesConsumed;
+
+            public void CopyRepeatedDamageBonusesFrom(TrackedAbilityImpact source)
+            {
+                if (source._repeatedDamageBonusesConsumed)
+                    return;
+
+                AddDamageBonuses(
+                    source.NextAbilityDamageBonus - source.StatusAppliedNextAttackDamageBonus,
+                    source.NextAbilityCriticalRatePercentAdjustment,
+                    source.NextAbilityDefenseIgnorePercentAdjustment,
+                    source.NextAttackEnmityBonus,
+                    0,
+                    source.NextAbilityCriticalDamagePercentAdjustment);
+            }
+
+            public void CompleteRepeatedDamageBonusImpact(bool impactedTarget)
+            {
+                _repeatedDamageBonusesConsumed |= impactedTarget;
+            }
 
             public void EnsureDamageBonuses()
             {

--- a/SWLOR.Game.Server/Service/Ability.cs
+++ b/SWLOR.Game.Server/Service/Ability.cs
@@ -99,7 +99,7 @@ namespace SWLOR.Game.Server.Service
         }
 
         /// <summary>
-        /// Consumes the activator's pending combat bonuses and starts impact tracking,
+        /// Starts impact tracking and defers pending damage bonuses until a damaging payload,
         /// retaining any activation-marker snapshots for the impact flash decision.
         /// </summary>
         public static void BeginAbilityImpact(
@@ -112,40 +112,44 @@ namespace SWLOR.Game.Server.Service
             if (!GetIsObjectValid(activator) || ability == null)
                 return;
 
-            var abilitySkillType = Combat.GetAbilitySkillType(activator, ability);
-            var nextAbilityDamageBonus = Combat.ConsumeNextAbilityDamageBonus(activator, ability.EffectiveLevelPerkType);
-            var nextSkillAbilityBonuses = Combat.ConsumeNextSkillAbilityBonuses(activator, abilitySkillType);
-            var persistentCriticalRate = Combat.GetPersistentNextSkillAbilityCriticalRateBonus(
-                activator,
-                abilitySkillType);
-            var queuedWeaponBonuses = ability.ActivationType == AbilityActivationType.Weapon
-                ? Combat.ConsumeQueuedWeaponAbilityBonuses(activator, abilitySkillType)
-                : default;
-            var guardedHitBonuses = ability.IsHostileAbility
-                ? Combat.ConsumeNextAttackGuardedHitBonuses(activator)
-                : (DMGBonus: 0, CriticalRatePercentAdjustment: 0, EnmityBonus: 0);
-            var statusAppliedNextAttackDamageBonus = ability.IsHostileAbility
-                ? Combat.GetStatusAppliedNextAttackDamageBonus(activator)
-                : 0;
-            BeginAbilityImpact(
-                activator,
-                ability,
-                nextAbilityDamageBonus +
-                nextSkillAbilityBonuses.DamageBonus +
-                guardedHitBonuses.DMGBonus +
-                statusAppliedNextAttackDamageBonus +
-                queuedWeaponBonuses.DamageBonus,
-                nextSkillAbilityBonuses.CriticalRatePercentAdjustment +
-                persistentCriticalRate +
-                queuedWeaponBonuses.CriticalRatePercentAdjustment +
-                guardedHitBonuses.CriticalRatePercentAdjustment,
-                nextSkillAbilityBonuses.DefenseIgnorePercentAdjustment,
-                guardedHitBonuses.EnmityBonus,
-                statusAppliedNextAttackDamageBonus,
-                countsAsAttackAttempt,
-                queuedWeaponBonuses.CriticalDamagePercentAdjustment,
-                activationAreaTelegraphs,
-                sequence);
+            BeginAbilityImpact(activator, ability, 0, 0,
+                countsAsAttackAttempt: countsAsAttackAttempt,
+                activationAreaTelegraphs: activationAreaTelegraphs, sequence: sequence);
+            var trackedImpact = GetTrackedAbilityImpact(activator);
+            trackedImpact.ResolveDamageBonuses = () =>
+            {
+                var abilitySkillType = Combat.GetAbilitySkillType(activator, ability);
+                var nextAbilityDamageBonus = Combat.ConsumeNextAbilityDamageBonus(activator, ability.EffectiveLevelPerkType);
+                var nextSkillAbilityBonuses = Combat.ConsumeNextSkillAbilityBonuses(activator, abilitySkillType);
+                var persistentCriticalRate = Combat.GetPersistentNextSkillAbilityCriticalRateBonus(
+                    activator,
+                    abilitySkillType);
+                var queuedWeaponBonuses = ability.ActivationType == AbilityActivationType.Weapon
+                    ? Combat.ConsumeQueuedWeaponAbilityBonuses(activator, abilitySkillType)
+                    : default;
+                var guardedHitBonuses = ability.IsHostileAbility
+                    ? Combat.ConsumeNextAttackGuardedHitBonuses(activator)
+                    : (DMGBonus: 0, CriticalRatePercentAdjustment: 0, EnmityBonus: 0);
+                var statusAppliedNextAttackDamageBonus = ability.IsHostileAbility
+                    ? Combat.GetStatusAppliedNextAttackDamageBonus(activator)
+                    : 0;
+                trackedImpact.AddDamageBonuses(
+                    nextAbilityDamageBonus +
+                    nextSkillAbilityBonuses.DamageBonus +
+                    guardedHitBonuses.DMGBonus +
+                    statusAppliedNextAttackDamageBonus +
+                    queuedWeaponBonuses.DamageBonus,
+                    nextSkillAbilityBonuses.CriticalRatePercentAdjustment +
+                    persistentCriticalRate +
+                    queuedWeaponBonuses.CriticalRatePercentAdjustment +
+                    guardedHitBonuses.CriticalRatePercentAdjustment,
+                    nextSkillAbilityBonuses.DefenseIgnorePercentAdjustment,
+                    guardedHitBonuses.EnmityBonus,
+                    statusAppliedNextAttackDamageBonus,
+                    queuedWeaponBonuses.CriticalDamagePercentAdjustment);
+            };
+            if (CanDealCombatImpactDamage(0, ability))
+                trackedImpact.EnsureDamageBonuses();
         }
 
         /// <summary>
@@ -163,7 +167,8 @@ namespace SWLOR.Game.Server.Service
             int nextAbilityCriticalDamagePercentAdjustment = 0,
             IReadOnlyList<TelegraphGeometry> activationAreaTelegraphs = null,
             AbilityImpactSequence sequence = null,
-            TrackedAbilityImpact sequenceOwner = null)
+            TrackedAbilityImpact sequenceOwner = null,
+            bool resolveDamageBonusesFromOwner = false)
         {
             if (!GetIsObjectValid(activator) || ability == null)
                 return;
@@ -182,6 +187,21 @@ namespace SWLOR.Game.Server.Service
             {
                 SequenceOwner = sequenceOwner?.SequenceOwner ?? sequenceOwner
             };
+            if (resolveDamageBonusesFromOwner && sequenceOwner != null)
+            {
+                var impact = _trackedAbilityImpacts[activator];
+                impact.ResolveDamageBonuses = () =>
+                {
+                    sequenceOwner.EnsureDamageBonuses();
+                    impact.AddDamageBonuses(
+                        sequenceOwner.NextAbilityDamageBonus - sequenceOwner.StatusAppliedNextAttackDamageBonus,
+                        sequenceOwner.NextAbilityCriticalRatePercentAdjustment,
+                        sequenceOwner.NextAbilityDefenseIgnorePercentAdjustment,
+                        sequenceOwner.NextAttackEnmityBonus,
+                        0,
+                        sequenceOwner.NextAbilityCriticalDamagePercentAdjustment);
+                };
+            }
         }
 
         public static AbilityImpactSequence GetAbilityImpactSequence(uint activator)
@@ -1263,6 +1283,7 @@ namespace SWLOR.Game.Server.Service
             bool useUnscaledDamage = false,
             Action<uint> beforeImpact = null)
         {
+            PrepareCombatImpactDamageBonuses(activator, baseDamage);
             var totalDamage = 0;
             RecordAbilityImpactShape(activator, skillType, isArea);
 
@@ -1395,6 +1416,7 @@ namespace SWLOR.Game.Server.Service
             float impactFlashDuration = DefaultImpactFlashDuration,
             bool useUnscaledDamage = false)
         {
+            PrepareCombatImpactDamageBonuses(activator, baseDamage);
             RecordAbilityImpactShape(activator, skillType, true);
             var trackedImpact = GetTrackedAbilityImpact(activator);
             var backOffsetOrigin = trackedImpact?.Ability.Targeting?.Flags
@@ -1761,6 +1783,7 @@ namespace SWLOR.Game.Server.Service
             bool canCritical,
             bool useUnscaledDamage)
         {
+            var resolveDamageBonusesFromOwner = sequenceOwner?.ResolveDamageBonuses != null;
             return (creator, creatures) =>
             {
                 var impactStarted = false;
@@ -1811,7 +1834,8 @@ namespace SWLOR.Game.Server.Service
                             nextAttackEnmityBonus,
                             statusAppliedNextAttackDamageBonus,
                             countsAsAttackAttempt: false,
-                            sequenceOwner: sequenceOwner);
+                            sequenceOwner: sequenceOwner,
+                            resolveDamageBonusesFromOwner: resolveDamageBonusesFromOwner);
                         impactStarted = true;
                         RecordAbilityImpactShape(creator, skillType, true);
                     }
@@ -2372,10 +2396,14 @@ namespace SWLOR.Game.Server.Service
             var impactDamage = ResolveCombatImpactBaseDamage(
                 adjustedBaseDamage,
                 trackedImpact?.Ability,
-                () => Combat.GetAbilityImpactBaseDamageBonus(
+                () =>
+                {
+                    trackedImpact?.EnsureDamageBonuses();
+                    return Combat.GetAbilityImpactBaseDamageBonus(
                           activator, target, trackedImpact?.Ability, skillType) +
                       Combat.GetAbilityStatusCategoryDamageBonus(
-                          activator, skillType, appliedStatusCategories));
+                          activator, skillType, appliedStatusCategories);
+                });
             adjustedBaseDamage = impactDamage.BaseDamage;
             var damage = !impactDamage.DealsDamage ? 0 : useUnscaledDamage
                 ? CalculateUnscaledCombatImpactDamage(activator, target, skillType, adjustedBaseDamage, damageType)
@@ -2411,10 +2439,21 @@ namespace SWLOR.Game.Server.Service
         {
             // Queued weapon damage and explicitly declared deferred damage remain eligible even
             // with zero immediate base damage. Control-only impacts must not consume bonuses.
-            var dealsDamage = baseDamage > 0 ||
-                              ability?.ActivationType == AbilityActivationType.Weapon ||
-                              ability?.DealsDeferredDamage == true;
+            var dealsDamage = CanDealCombatImpactDamage(baseDamage, ability);
             return dealsDamage ? (baseDamage + getDamageBonus(), true) : (0, false);
+        }
+
+        private static bool CanDealCombatImpactDamage(int baseDamage, AbilityDetail ability)
+        {
+            return baseDamage > 0 || ability?.ActivationType == AbilityActivationType.Weapon ||
+                   ability?.DealsDeferredDamage == true;
+        }
+
+        private static void PrepareCombatImpactDamageBonuses(uint activator, int baseDamage)
+        {
+            var impact = GetTrackedAbilityImpact(activator);
+            if (impact != null && CanDealCombatImpactDamage(baseDamage, impact.Ability))
+                impact.EnsureDamageBonuses();
         }
 
         private static bool ShouldResolveCombatImpactHit(TrackedAbilityImpact trackedImpact)
@@ -3343,13 +3382,33 @@ namespace SWLOR.Game.Server.Service
             public bool CountsAsAttackAttempt { get; }
             public IReadOnlyList<TelegraphGeometry> ActivationAreaTelegraphs { get; }
             public int NextAbilityDamageBonus { get; private set; }
-            public int NextAbilityCriticalRatePercentAdjustment { get; }
-            public int NextAbilityCriticalDamagePercentAdjustment { get; }
+            public int NextAbilityCriticalRatePercentAdjustment { get; private set; }
+            public int NextAbilityCriticalDamagePercentAdjustment { get; private set; }
             public int NextAbilityDefenseIgnorePercentAdjustment { get; private set; }
-            public int NextAttackEnmityBonus { get; }
-            public int StatusAppliedNextAttackDamageBonus { get; }
+            public int NextAttackEnmityBonus { get; private set; }
+            public int StatusAppliedNextAttackDamageBonus { get; private set; }
+            public Action ResolveDamageBonuses { get; set; }
             public bool DarkForceConversionApplied { get; set; }
             private bool _statusAppliedNextAttackDamageBonusConsumed;
+
+            public void EnsureDamageBonuses()
+            {
+                var resolve = ResolveDamageBonuses;
+                ResolveDamageBonuses = null;
+                resolve?.Invoke();
+            }
+
+            public void AddDamageBonuses(
+                int damage, int criticalRate, int defenseIgnore, int enmity,
+                int statusAppliedDamage, int criticalDamage)
+            {
+                NextAbilityDamageBonus += damage;
+                NextAbilityCriticalRatePercentAdjustment += criticalRate;
+                NextAbilityDefenseIgnorePercentAdjustment += defenseIgnore;
+                NextAttackEnmityBonus += enmity;
+                StatusAppliedNextAttackDamageBonus += statusAppliedDamage;
+                NextAbilityCriticalDamagePercentAdjustment += criticalDamage;
+            }
 
             /// <summary>
             /// Initializes per-impact bonuses, summary classification, and the activation

--- a/SWLOR.Game.Server/Service/Ability.cs
+++ b/SWLOR.Game.Server/Service/Ability.cs
@@ -228,9 +228,12 @@ namespace SWLOR.Game.Server.Service
         /// Retains the originating ability and cast sequence for recurring impacts without
         /// consuming another activation's pending bonuses or replacing its impact tracker.
         /// </summary>
-        public static Action CaptureRepeatedAbilityImpact(uint activator, Action impactAction)
+        public static Action CaptureRepeatedAbilityImpact(uint activator, Action impactAction, int baseDamage = 0)
         {
             ArgumentNullException.ThrowIfNull(impactAction);
+            // Scheduled damage belongs to this cast. Resolve its armed bonuses now so
+            // later pulses cannot consume bonuses earned after the field was created.
+            PrepareCombatImpactDamageBonuses(activator, baseDamage);
             var originatingImpact = GetTrackedAbilityImpact(activator);
             if (originatingImpact == null)
                 return impactAction;

--- a/SWLOR.Game.Server/Service/Ability.cs
+++ b/SWLOR.Game.Server/Service/Ability.cs
@@ -2369,15 +2369,18 @@ namespace SWLOR.Game.Server.Service
                 SendCombatImpactResultMessage(activator, target, trackedImpact?.Ability, 1, hitRate);
 
             var adjustedBaseDamage = Math.Max(0, baseDamage + (baseDamageAdjustment?.Invoke(target) ?? 0));
-            adjustedBaseDamage += Combat.GetAbilityImpactBaseDamageBonus(
-                activator,
-                target,
-                trackedImpact?.Ability,
-                skillType);
-            adjustedBaseDamage += Combat.GetAbilityStatusCategoryDamageBonus(
-                activator,
-                skillType,
-                appliedStatusCategories);
+            var usesWeaponDamage = !useUnscaledDamage &&
+                (Combat.IsWeaponSkillType(skillType) ||
+                 (trackedImpact?.Ability?.ActivationType == AbilityActivationType.Weapon &&
+                  skillType == SkillType.BeastMastery));
+            var hasDirectDamage = adjustedBaseDamage > 0 || usesWeaponDamage;
+            adjustedBaseDamage = ApplyCombatImpactBaseDamageBonuses(
+                adjustedBaseDamage,
+                usesWeaponDamage,
+                () => Combat.GetAbilityImpactBaseDamageBonus(
+                          activator, target, trackedImpact?.Ability, skillType) +
+                      Combat.GetAbilityStatusCategoryDamageBonus(
+                          activator, skillType, appliedStatusCategories));
             var damage = useUnscaledDamage
                 ? CalculateUnscaledCombatImpactDamage(activator, target, skillType, adjustedBaseDamage, damageType)
                 : usesNPCStatScaling
@@ -2402,7 +2405,20 @@ namespace SWLOR.Game.Server.Service
                 beforeSuccessfulImpactRiders,
                 awardsCombatPoints,
                 effectDamageType,
-                firstHostileAbilityHitDamageBonusApplied: true);
+                firstHostileAbilityHitDamageBonusApplied: hasDirectDamage);
+        }
+
+        private static int ApplyCombatImpactBaseDamageBonuses(
+            int baseDamage,
+            bool usesWeaponDamage,
+            Func<int> getDamageBonus)
+        {
+            // Control-only impacts must not gain damage or consume damage bonuses. Weapon
+            // impacts can have zero added base damage because their weapon supplies the damage.
+            if (baseDamage <= 0 && !usesWeaponDamage)
+                return 0;
+
+            return baseDamage + getDamageBonus();
         }
 
         private static bool ShouldResolveCombatImpactHit(TrackedAbilityImpact trackedImpact)

--- a/SWLOR.Game.Server/Service/Ability.cs
+++ b/SWLOR.Game.Server/Service/Ability.cs
@@ -2371,7 +2371,6 @@ namespace SWLOR.Game.Server.Service
             var adjustedBaseDamage = Math.Max(0, baseDamage + (baseDamageAdjustment?.Invoke(target) ?? 0));
             var impactDamage = ResolveCombatImpactBaseDamage(
                 adjustedBaseDamage,
-                skillType,
                 trackedImpact?.Ability,
                 () => Combat.GetAbilityImpactBaseDamageBonus(
                           activator, target, trackedImpact?.Ability, skillType) +
@@ -2407,13 +2406,12 @@ namespace SWLOR.Game.Server.Service
 
         private static (int BaseDamage, bool DealsDamage) ResolveCombatImpactBaseDamage(
             int baseDamage,
-            SkillType skillType,
             AbilityDetail ability,
             Func<int> getDamageBonus)
         {
-            // Weapon damage and explicitly declared deferred damage remain eligible even
+            // Queued weapon damage and explicitly declared deferred damage remain eligible even
             // with zero immediate base damage. Control-only impacts must not consume bonuses.
-            var dealsDamage = baseDamage > 0 || Combat.IsWeaponSkillType(skillType) ||
+            var dealsDamage = baseDamage > 0 ||
                               ability?.ActivationType == AbilityActivationType.Weapon ||
                               ability?.DealsDeferredDamage == true;
             return dealsDamage ? (baseDamage + getDamageBonus(), true) : (0, false);


### PR DESCRIPTION
Control-only casts could gain unintended damage or consume armed damage bonuses before their zero-damage payload was checked. Flash also qualified solely because it belonged to a weapon skill.

Determine damage eligibility from a positive payload, queued weapon activation, or explicitly declared deferred damage. Resolve armed activation bonuses only for damaging payloads. Preserve pending damage, critical-rate, defense-ignore, enmity bonuses, and First Strike charges on control-only casts.

Scheduled fields capture bonuses during the originating cast and apply their snapshot to the first pulse that impacts a target, preserving it across empty pulses and preventing later reuse or consumption of newer bonuses. Force Choke and other eligible zero-base deferred impacts can apply stored flat damage instead of returning before reading it.

Add resolver, preparation, capture, and repeated-snapshot regression coverage, including actual Flash and Shield Bash definitions. Add/extend engine scenarios for Flash's activation lifecycle, repeated pulses, and Force Choke with stored damage bonuses.

Validation: build succeeded with deployment disabled; 170 focused tests passed. Six confirmed HAK-dependent tests were excluded. An earlier expanded field-test run also encountered five root-guard failures requiring missing HAK assets. Engine scenarios compile but were not run in NWN. The tester's exact 75-damage case remains unconfirmed pending ability names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved combat bonus handling for delayed, repeated, and telegraphed ability impacts.
  - Ensured damage, critical, guarded-damage, skill, and enmity bonuses apply to the correct impact and are consumed only once when appropriate.
  - Preserved newer bonuses across repeated pulses.
  - Corrected damage calculations for queued natural weapons and deferred damage.
  - Updated repeated damage behavior for Field Engineer Pulse Emitter and Creeping Terror.
  - Control-only abilities no longer incorrectly deal damage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->