### PR TITLE
Import 35 rifle appearances with rifle-specific authoring and grip review

### DIFF
--- a/SWLOR.Game.Server/Readmes/RifleModelImport.md
+++ b/SWLOR.Game.Server/Readmes/RifleModelImport.md
@@ -1,0 +1,68 @@
+# Importing rifle models
+
+Use `tools/ImportRifleModel.py` in Blender 4.0 with the pinned GR2 4.2.1
+add-on installed by `tools/SetupBlasterImporter.ps1`. It shares static geometry,
+normal-map decoding and material export with the [blaster converter](BlasterModelImport.md),
+but uses rifle attachment coordinates, material validation and inventory dimensions.
+Keep original archives, extracted files, manifests, scenes and review images in
+ignored `.tmp/rifle/` staging. Only finished MDL, MTR and DDS resources belong in HAKs.
+
+Rifles are base item **7**, item class **WBwXl**. The appearance editor ID is
+`color * 100 + model`; the native middle part is `model * 10 + color`.
+For example, editor 115 replaces `wbwxl_m_151.mdl` and `iwbwxl_m_151.dds`.
+Do not interpret editor IDs as native part numbers. Register new editor IDs in
+`RifleAppearanceDefinition.MiddleParts`; existing replacements need no catalog change.
+
+Extract nested archives separately so similarly named texture sets do not overwrite
+one another. Import rifle meshes, including rifle bowcasters and scoped rifles.
+Exclude cannons regardless of naming: supplied cannon archives may start with `as_`,
+and meshes may start with `as_a0x` or `assaultcannon_`. The rifle entry point accepts
+only `rifle_*.gr2`. Shared `blaster_*` texture names do not change mesh classification.
+
+Use the blaster manifest schema with `base_item: 7`, the native `middle_slot`,
+an inspected `source_material` matching the imported GR2 assignment, and
+`preserve_emission: true`. Supply all source file hashes. Resolve diffuse, normal
+and specular files independently: their variant names need not match. This rigid
+single-material preset rejects multiple material assignments instead of flattening them.
+
+Rifle attachment space is **barrel +X, grip -Z**, as seen in existing rifle parts.
+The supplied SWTOR rifles use source barrel +Y and grip +Z: Euler rotation
+`[180, 0, 90]` maps those axes correctly. Uniform scale `9.6` and translation
+`[0.03, 0, -0.02]` are the initial reviewed human-size fit, not a universal fit guarantee. Inspect grip/trigger
+contact, stock clearance and support-hand placement against rifle animation poses;
+never reuse the pistol bowshot fixture unchanged. Retain proportions and fit around
+the grip rather than normalizing rifles and long sniper barrels to equal lengths.
+
+```powershell
+& '<Blender 4.0>/blender.exe' -b --factory-startup --python-exit-code 1 `
+  --python tools/ImportRifleModel.py -- `
+  --manifest .tmp/rifle/inputs/rifle.json `
+  --addon-root .tmp/blaster-tools/Granny2-Plug-In-Blender-2.8x-4.2.1 `
+  --output .tmp/rifle/review
+```
+
+Review the textured preview and the **64 x 128** transparent middle inventory layer.
+The converter preserves smaller source maps, caps maps at the manifest size,
+unpacks normal alpha/green once, preserves colored specular, and derives emission
+from normal blue multiplied by diffuse in linear light. Zero-mask pixels stay black.
+The normal blue channel is not part of the decoded normal vector.
+
+Compress maps with the documented NWN Crunch channel presets; icons use lossless
+RGBA DDS without mipmaps. Replace the matching old icon TGA so it cannot override
+the DDS. Compile staged ASCII models with `tools/CompileBlasterModels.py` and the
+installed NWN:EE executable. It accepts `wbwxl` resrefs as well as pistol resrefs.
+Keep `CompileModels: false` when packing HAKs. Validate native-reader geometry,
+normals, material bindings, texture dependencies and compiled triangle corners.
+Do not make validation depend on local source manifests.
+
+Run both converter test files under Blender when modifying shared conversion code.
+For client acceptance, restart NWN and check inventory/ground appearance, rifle idle
+and attack poses, muzzle direction, and different body sizes. Offline previews alone
+do not establish live fit. Resource-only replacements require a weapon HAK rebuild;
+they do not require a module repack.
+
+`tools/RenderRifleGrip.py` reads the actual `xbowshot` right-hand hook rotation from
+an ASCII `a_ba_med_weap.mdl` reference. Supply `--source <review.blend>`,
+`--hand <ASCII pmh0_handr001.mdl>`, `--animation <ASCII a_ba_med_weap.mdl>` and
+`--output <local review folder>`. It renders both sides of the grip. The fixture
+checks the right hand only; support-hand and body clearance still need client review.

--- a/SWLOR.Game.Server/Readmes/RifleModelImport.md
+++ b/SWLOR.Game.Server/Readmes/RifleModelImport.md
@@ -67,8 +67,21 @@ and attack poses, muzzle direction, and different body sizes. Offline previews a
 do not establish live fit. Resource-only replacements require a weapon HAK rebuild;
 they do not require a module repack.
 
-`tools/RenderRifleGrip.py` reads the actual `xbowshot` right-hand hook rotation from
-an ASCII `a_ba_med_weap.mdl` reference. Supply `--source <review.blend>`,
+`tools/RenderRifleGrip.py` reads the rifle pose from an ASCII `a_ba_med_weap.mdl`
+reference. Supply `--source <review.blend>`,
 `--hand <ASCII pmh0_handr001.mdl>`, `--animation <ASCII a_ba_med_weap.mdl>` and
-`--output <local review folder>`. It renders both sides of the grip. The fixture
-checks the right hand only; support-hand and body clearance still need client review.
+`--output <local review folder>`. For fitting rifles, also supply
+`--skeleton <ASCII pmh0.mdl>` and `--left-hand <ASCII pmh0_handl001.mdl>`.
+This composes the complete arm hierarchy and shows both hands from both sides.
+Skeleton/animation node names must be matched case-insensitively: the skeleton's
+`Lbicep_g` and animation's `lbicep_g` are the same bone. Skipping this ancestor
+places the support hand incorrectly even when the right hand appears plausible.
+Use `--pose xbowrdy` for the holding pose or `--pose xbowshot` for the initial
+attack frame. Moving attack frames and body clearance still need client review.
+
+Review every replacement separately. A shared attachment-axis correction does not
+establish a good fit for different fore-end thicknesses, stocks and grips. Small
+vertical seating adjustments and pitch around the grip can close support-hand gaps;
+preserve uniform scale and inspect trigger contact after each adjustment. Record
+per-model fits locally and apply changes to the existing compiled node transforms
+where possible, preserving the verified geometry, UVs, normals and tangents.

--- a/SWLOR.Game.Server/Readmes/RifleModelImport.md
+++ b/SWLOR.Game.Server/Readmes/RifleModelImport.md
@@ -53,8 +53,8 @@ unpacks normal alpha/green once, preserves colored specular, and derives emissio
 from normal blue multiplied by diffuse in linear light. Zero-mask pixels stay black.
 The normal blue channel is not part of the decoded normal vector.
 
-Compress maps with the documented NWN Crunch channel presets; icons use lossless
-RGBA DDS without mipmaps. Replace the matching old icon TGA so it cannot override
+Compress maps with the documented NWN Crunch channel presets; icons use DXT5
+DDS with alpha and no mipmaps (`-fileformat dds -unflip -yflip -DXT5 -dxtQuality uber -gamma 2.2 -mipMode None`). Native CResDDS cannot decode uncompressed RGBA DDS. Replace the matching old icon TGA so it cannot override
 the DDS. Compile staged ASCII models with `tools/CompileBlasterModels.py` and the
 installed NWN:EE executable. It accepts `wbwxl` resrefs as well as pistol resrefs.
 Keep `CompileModels: false` when packing HAKs. Validate native-reader geometry,

--- a/SWLOR.Game.Server/Readmes/RifleModelImport.md
+++ b/SWLOR.Game.Server/Readmes/RifleModelImport.md
@@ -25,10 +25,16 @@ an inspected `source_material` matching the imported GR2 assignment, and
 and specular files independently: their variant names need not match. This rigid
 single-material preset rejects multiple material assignments instead of flattening them.
 
-Rifle attachment space is **barrel +X, grip -Z**, as seen in existing rifle parts.
+Rifle attachment space is **barrel -Z, grip -Y** after composing mesh-node transforms.
+The legacy `wbwxl_m_151` vertex arrays alone point +X with grip -Z; each mesh
+also has axis-angle rotation `[0.5773503, -0.5773503, -0.5773503, -2.0944]`
+and position `[-0.00521167, 0.0562191, -0.0280922]`. Ignoring those node fields
+leaves the weapon hanging below the hands. Always inspect complete node transforms,
+including ancestors, when deriving attachment conventions from an existing model.
 The supplied SWTOR rifles use source barrel +Y and grip +Z: Euler rotation
-`[180, 0, 90]` maps those axes correctly. Uniform scale `9.6` and translation
-`[0.03, 0, -0.02]` are the initial reviewed human-size fit, not a universal fit guarantee. Inspect grip/trigger
+`[90, 180, 0]` maps those axes correctly. Uniform scale `9.6` and translation
+`[-0.00521167, 0.0362191, -0.0580922]` compose the batch fit with that reference
+transform. These values are a starting fit, not a universal fit guarantee. Inspect grip/trigger
 contact, stock clearance and support-hand placement against rifle animation poses;
 never reuse the pistol bowshot fixture unchanged. Retain proportions and fit around
 the grip rather than normalizing rifles and long sniper barrels to equal lengths.

--- a/tools/ImportBlasterModel.py
+++ b/tools/ImportBlasterModel.py
@@ -15,9 +15,10 @@ import sys
 from pathlib import Path
 
 
-def validate_manifest(config):
-    if config.get("schema_version") != 1 or config.get("base_item") != 11:
-        raise ValueError("Expected schema_version 1 and pistol base_item 11")
+def validate_manifest(config, weapon="pistol"):
+    base_item = {"pistol": 11, "rifle": 7}[weapon]
+    if config.get("schema_version") != 1 or config.get("base_item") != base_item:
+        raise ValueError(f"Expected schema_version 1 and {weapon} base_item {base_item}")
     slot = config.get("middle_slot")
     if type(slot) is not int or not 1 <= slot <= 255:
         raise ValueError("middle_slot must be a native pistol part ID from 1 to 255")
@@ -45,15 +46,16 @@ def validate_manifest(config):
             raise ValueError(f"Missing SHA-256 for {key}")
 
 
-def validate_attachment(rotation, config):
+def validate_attachment(rotation, config, weapon="pistol"):
     # NWN pistols point down -Z in attachment space; their handles extend -Y.
     # Verify authored landmarks rather than judging an upright inventory preview.
     from mathutils import Vector
     attachment = config["attachment"]
-    for key, expected in (("source_muzzle_axis", (0, 0, -1)), ("source_grip_axis", (0, -1, 0))):
+    axes = ((0, 0, -1), (0, -1, 0)) if weapon == "pistol" else ((1, 0, 0), (0, 0, -1))
+    for key, expected in zip(("source_muzzle_axis", "source_grip_axis"), axes):
         actual = (rotation.to_3x3() @ Vector(attachment[key])).normalized()
         if actual.dot(Vector(expected)) < .99:
-            raise ValueError(f"Pistol attachment {key} does not match NWN axes: {tuple(actual)}")
+            raise ValueError(f"{weapon} attachment {key} does not match NWN axes: {tuple(actual)}")
 
 
 def unpack_normal(pixels, np):
@@ -134,11 +136,11 @@ def export_mesh(mesh, transform):
     return verts, uvs, faces, normals
 
 
-def main():
+def main(weapon="pistol"):
     import bpy
     import addon_utils
     import numpy as np
-    from mathutils import Euler, Matrix, Vector
+    from mathutils import Euler, Matrix, Quaternion, Vector
 
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--manifest", type=Path, required=True)
@@ -147,7 +149,7 @@ def main():
     args = parser.parse_args(sys.argv[sys.argv.index("--") + 1:])
     manifest = args.manifest.resolve()
     config = json.loads(manifest.read_text(encoding="utf-8-sig"))
-    validate_manifest(config)
+    validate_manifest(config, weapon)
     paths = {key: (manifest.parent / value).resolve() for key, value in config["sources"].items()}
     for key, path in paths.items():
         if hashlib.sha256(path.read_bytes()).hexdigest() != config["sha256"][key]:
@@ -172,12 +174,14 @@ def main():
     if not objects or any(ob.type == "ARMATURE" for ob in bpy.context.scene.objects):
         raise ValueError("Expected rigid mesh geometry without a skeleton")
     rotation = Euler(tuple(math.radians(n) for n in config["rotation_degrees"])).to_matrix().to_4x4()
-    validate_attachment(rotation, config)
+    validate_attachment(rotation, config, weapon)
     transform = Matrix.Translation(Vector(config["translation"])) @ rotation @ Matrix.Scale(config["scale"], 4)
     meshes = []
     for ob in objects:
         if len(ob.data.materials) != 1 or ob.modifiers or not ob.data.uv_layers:
             raise ValueError("Only static single-material meshes with UVs are supported")
+        if weapon == "rifle" and ob.data.materials[0].name != config.get("source_material"):
+            raise ValueError("Rifle source material differs from the inspected manifest assignment")
         # The importer assigns a Blender-only +90 X object rotation. Manifest axes refer
         # to raw SWTOR vertex coordinates, not the importer's viewport conversion.
         ob.matrix_world = transform
@@ -185,7 +189,8 @@ def main():
     output.mkdir(parents=True, exist_ok=True)
     resources = output / "resources"
     resources.mkdir()
-    model = f"wbwsh_m_{config['middle_slot']:03d}"
+    item_class = "wbwsh" if weapon == "pistol" else "wbwxl"
+    model = f"{item_class}_m_{config['middle_slot']:03d}"
     texture = config["texture"]
     write_mdl(resources / f"{model}.mdl", model, texture, meshes)
 
@@ -213,12 +218,23 @@ def main():
         return image
 
     diffuse = save_texture(texture, read_pixels(paths["diffuse"], config["texture_size"])[..., :3])
-    normal = save_texture(texture + "_n", unpack_normal(read_pixels(paths["normal"], config["texture_size"]), np))
+    packed_normal = read_pixels(paths["normal"], config["texture_size"])
+    normal = save_texture(texture + "_n", unpack_normal(packed_normal, np))
     # Preserve colored specular RGB; SWTOR gloss alpha is not NWN roughness.
     specular = save_texture(texture + "_s", read_pixels(paths["specular"], config["texture_size"])[..., :3])
     (resources / (texture + ".mtr")).write_text(
         f"renderhint NormalAndSpecMapped\ntexture0 {texture}\ntexture1 {texture}_n\ntexture2 {texture}_s\n",
         encoding="ascii")
+    emission = None
+    if config.get("preserve_emission") and np.max(packed_normal[..., 2]) > 0:
+        # Source blue is emission intensity, independent of the packed normal XY.
+        rgb = read_pixels(paths["diffuse"], packed_normal.shape[0])[..., :3]
+        linear = np.where(rgb <= .04045, rgb / 12.92, ((rgb + .055) / 1.055) ** 2.4)
+        linear *= packed_normal[..., 2:3]
+        encoded = np.where(linear <= .0031308, linear * 12.92, 1.055 * linear ** (1 / 2.4) - .055)
+        emission = save_texture(texture + "_e", encoded)
+        with (resources / (texture + ".mtr")).open("a", encoding="ascii") as stream:
+            stream.write(f"texture5 {texture}_e\n")
 
     material = bpy.data.materials.new("NWN blaster preview")
     material.use_nodes = True
@@ -236,6 +252,12 @@ def main():
     links.new(normal_node.outputs["Normal"], shader.inputs["Normal"])
     spec = nodes.new("ShaderNodeTexImage"); spec.image = specular
     links.new(spec.outputs["Color"], shader.inputs["Specular IOR Level"])
+    if emission:
+        glow = nodes.new("ShaderNodeTexImage")
+        glow.image = bpy.data.images.load(emission.filepath_raw, check_existing=False)
+        glow.image.colorspace_settings.name = "sRGB"
+        links.new(glow.outputs["Color"], shader.inputs["Emission Color"])
+        shader.inputs["Emission Strength"].default_value = 1
     for ob in objects:
         ob.data.materials.clear()
         ob.data.materials.append(material)
@@ -257,7 +279,8 @@ def main():
         light.data.energy = energy
         light.data.size = 2
         light.rotation_euler = (center - light.location).to_track_quat("-Z", "Y").to_euler()
-    bpy.ops.object.camera_add(location=center + Vector((1, -.25, .15)))
+    direction = (1, -.25, .15) if weapon == "pistol" else (.15, -1, .15)
+    bpy.ops.object.camera_add(location=center + Vector(direction))
     camera = bpy.context.object
     camera.rotation_euler = (center - camera.location).to_track_quat("-Z", "Y").to_euler()
     camera.data.type = "ORTHO"
@@ -269,6 +292,12 @@ def main():
     bpy.ops.render.render(write_still=True)
     # Inventory composite middle layer: native 64 x 64 transparent TGA.
     scene.render.resolution_x = scene.render.resolution_y = 64
+    if weapon == "rifle":
+        # Rifle composite layers fill a 2 x 4 inventory footprint (64 x 128).
+        # Align the barrel with image vertical, preserving the entire silhouette.
+        camera.rotation_euler = ((center - camera.location).to_track_quat("-Z", "Y") @ Quaternion((0, 0, 1), -math.pi / 2)).to_euler()
+        scene.render.resolution_y = 128
+        camera.data.ortho_scale = max((hi.x - lo.x) * 1.2, (hi.z - lo.z) * 2.4)
     scene.render.image_settings.file_format = "TARGA_RAW"
     scene.render.image_settings.color_mode = "RGBA"
     scene.render.filepath = str(resources / f"i{model}.tga")

--- a/tools/ImportBlasterModel.py
+++ b/tools/ImportBlasterModel.py
@@ -138,6 +138,11 @@ def export_mesh(mesh, transform):
     return verts, uvs, faces, normals
 
 
+def validate_emission_dimensions(diffuse, packed_normal):
+    if diffuse.shape[:2] != packed_normal.shape[:2]:
+        raise ValueError("Emission needs diffuse and normal maps at the same resolution")
+
+
 def main(weapon="pistol"):
     import bpy
     import addon_utils
@@ -194,7 +199,6 @@ def main(weapon="pistol"):
     item_class = "wbwsh" if weapon == "pistol" else "wbwxl"
     model = f"{item_class}_m_{config['middle_slot']:03d}"
     texture = config["texture"]
-    write_mdl(resources / f"{model}.mdl", model, texture, meshes)
 
     def read_pixels(path, size=None):
         image = bpy.data.images.load(str(path), check_existing=False)
@@ -219,8 +223,12 @@ def main(weapon="pistol"):
         image.save()
         return image
 
-    diffuse = save_texture(texture, read_pixels(paths["diffuse"], config["texture_size"])[..., :3])
+    diffuse_rgb = read_pixels(paths["diffuse"], config["texture_size"])[..., :3]
     packed_normal = read_pixels(paths["normal"], config["texture_size"])
+    if config.get("preserve_emission"):
+        validate_emission_dimensions(diffuse_rgb, packed_normal)
+    write_mdl(resources / f"{model}.mdl", model, texture, meshes)
+    diffuse = save_texture(texture, diffuse_rgb)
     normal = save_texture(texture + "_n", unpack_normal(packed_normal, np))
     # Preserve colored specular RGB; SWTOR gloss alpha is not NWN roughness.
     specular = save_texture(texture + "_s", read_pixels(paths["specular"], config["texture_size"])[..., :3])
@@ -230,7 +238,7 @@ def main(weapon="pistol"):
     emission = None
     if config.get("preserve_emission") and np.max(packed_normal[..., 2]) > 0:
         # Source blue is emission intensity, independent of the packed normal XY.
-        rgb = read_pixels(paths["diffuse"], packed_normal.shape[0])[..., :3]
+        rgb = diffuse_rgb
         linear = np.where(rgb <= .04045, rgb / 12.92, ((rgb + .055) / 1.055) ** 2.4)
         linear *= packed_normal[..., 2:3]
         encoded = np.where(linear <= .0031308, linear * 12.92, 1.055 * linear ** (1 / 2.4) - .055)

--- a/tools/ImportBlasterModel.py
+++ b/tools/ImportBlasterModel.py
@@ -51,7 +51,9 @@ def validate_attachment(rotation, config, weapon="pistol"):
     # Verify authored landmarks rather than judging an upright inventory preview.
     from mathutils import Vector
     attachment = config["attachment"]
-    axes = ((0, 0, -1), (0, -1, 0)) if weapon == "pistol" else ((1, 0, 0), (0, 0, -1))
+    # Rifle reference vertices use +X/-Z before their mesh-node transform.
+    # The complete node transform maps them to the same -Z/-Y attachment axes.
+    axes = ((0, 0, -1), (0, -1, 0))
     for key, expected in zip(("source_muzzle_axis", "source_grip_axis"), axes):
         actual = (rotation.to_3x3() @ Vector(attachment[key])).normalized()
         if actual.dot(Vector(expected)) < .99:
@@ -279,10 +281,12 @@ def main(weapon="pistol"):
         light.data.energy = energy
         light.data.size = 2
         light.rotation_euler = (center - light.location).to_track_quat("-Z", "Y").to_euler()
-    direction = (1, -.25, .15) if weapon == "pistol" else (.15, -1, .15)
+    direction = (1, -.25, .15)
     bpy.ops.object.camera_add(location=center + Vector(direction))
     camera = bpy.context.object
     camera.rotation_euler = (center - camera.location).to_track_quat("-Z", "Y").to_euler()
+    if weapon == "rifle":
+        camera.rotation_euler = ((center - camera.location).to_track_quat("-Z", "Y") @ Quaternion((0, 0, 1), -math.pi / 2)).to_euler()
     camera.data.type = "ORTHO"
     camera.data.ortho_scale = span * 1.2
     scene.camera = camera
@@ -295,9 +299,9 @@ def main(weapon="pistol"):
     if weapon == "rifle":
         # Rifle composite layers fill a 2 x 4 inventory footprint (64 x 128).
         # Align the barrel with image vertical, preserving the entire silhouette.
-        camera.rotation_euler = ((center - camera.location).to_track_quat("-Z", "Y") @ Quaternion((0, 0, 1), -math.pi / 2)).to_euler()
+        camera.rotation_euler = ((center - camera.location).to_track_quat("-Z", "Y") @ Quaternion((0, 0, 1), math.pi)).to_euler()
         scene.render.resolution_y = 128
-        camera.data.ortho_scale = max((hi.x - lo.x) * 1.2, (hi.z - lo.z) * 2.4)
+        camera.data.ortho_scale = max((hi.z - lo.z) * 1.2, (hi.y - lo.y) * 2.4)
     scene.render.image_settings.file_format = "TARGA_RAW"
     scene.render.image_settings.color_mode = "RGBA"
     scene.render.filepath = str(resources / f"i{model}.tga")

--- a/tools/ImportRifleModel.py
+++ b/tools/ImportRifleModel.py
@@ -1,0 +1,29 @@
+"""Import a reviewed rigid GR2 rifle using base item 7 / WBwXl attachment space.
+
+Run in Blender 4.0 with the same CLI arguments as ImportBlasterModel.py.
+Rifle manifests require source_material, +X muzzle / -Z grip after transformation,
+and preserve_emission=true to retain the SWTOR packed emission channel.
+Cannons are deliberately rejected, including both as_a0x and assaultcannon names.
+"""
+import json
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from ImportBlasterModel import main, validate_manifest
+
+
+def validate_rifle(config):
+    validate_manifest(config, "rifle")
+    source = Path(config["sources"]["model"]).name.lower()
+    if not source.startswith("rifle_") or not source.endswith(".gr2"):
+        raise ValueError("Only rifle_ GR2 meshes belong in the rifle workflow; exclude cannons")
+    if not config.get("source_material") or config.get("preserve_emission") is not True:
+        raise ValueError("Inspect source_material and explicitly preserve source emission")
+
+
+if __name__ == "__main__":
+    arguments = sys.argv[sys.argv.index("--") + 1:]
+    manifest = Path(arguments[arguments.index("--manifest") + 1])
+    validate_rifle(json.loads(manifest.read_text(encoding="utf-8-sig")))
+    main("rifle")

--- a/tools/ImportRifleModel.py
+++ b/tools/ImportRifleModel.py
@@ -5,6 +5,7 @@ Rifle manifests require source_material, -Z muzzle / -Y grip after transformatio
 and preserve_emission=true to retain the SWTOR packed emission channel.
 Cannons are deliberately rejected, including both as_a0x and assaultcannon names.
 """
+import argparse
 import json
 from pathlib import Path
 import sys
@@ -22,8 +23,15 @@ def validate_rifle(config):
         raise ValueError("Inspect source_material and explicitly preserve source emission")
 
 
+def parse_manifest(arguments):
+    parser = argparse.ArgumentParser(description=__doc__, add_help=False)
+    parser.add_argument("--manifest", type=Path, required=True)
+    known, _ = parser.parse_known_args(arguments)
+    return known.manifest
+
+
 if __name__ == "__main__":
-    arguments = sys.argv[sys.argv.index("--") + 1:]
-    manifest = Path(arguments[arguments.index("--manifest") + 1])
+    arguments = sys.argv[sys.argv.index("--") + 1:] if "--" in sys.argv else []
+    manifest = parse_manifest(arguments)
     validate_rifle(json.loads(manifest.read_text(encoding="utf-8-sig")))
     main("rifle")

--- a/tools/ImportRifleModel.py
+++ b/tools/ImportRifleModel.py
@@ -1,7 +1,7 @@
 """Import a reviewed rigid GR2 rifle using base item 7 / WBwXl attachment space.
 
 Run in Blender 4.0 with the same CLI arguments as ImportBlasterModel.py.
-Rifle manifests require source_material, +X muzzle / -Z grip after transformation,
+Rifle manifests require source_material, -Z muzzle / -Y grip after transformation,
 and preserve_emission=true to retain the SWTOR packed emission channel.
 Cannons are deliberately rejected, including both as_a0x and assaultcannon names.
 """

--- a/tools/RenderRifleGrip.py
+++ b/tools/RenderRifleGrip.py
@@ -10,6 +10,52 @@ import sys
 from pathlib import Path
 
 
+def hand_pose_transforms(skeleton_text, animation_text, pose='xbowrdy'):
+    """Resolve both hand geometry hooks relative to the weapon hook at pose start.
+
+    NWN node matching is case-insensitive (e.g. Lbicep_g versus lbicep_g).
+    Compose the full skeleton hierarchy before converting to weapon space.
+    """
+    from mathutils import Matrix, Quaternion, Vector
+    def nodes(text):
+        return {name.lower(): body for _, name, body in
+                re.findall(r'node (\w+) (\S+)\n(.*?)endnode', text, re.S)}
+    def rotation(values):
+        return Quaternion(Vector(values[:3]), values[3]) if any(values[:3]) else Quaternion()
+    skeleton = nodes(skeleton_text.split('endmodelgeom')[0])
+    local = {}
+    for name, body in skeleton.items():
+        position = re.search(r'^\s*position (.+)$', body, re.M)
+        orientation = re.search(r'^\s*orientation (.+)$', body, re.M)
+        local[name] = (Vector(tuple(map(float, position[1].split()))) if position else Vector(),
+                       rotation(list(map(float, orientation[1].split()))) if orientation else Quaternion())
+    match = re.search(r'newanim ' + re.escape(pose) + r' .*?\n(.*?)doneanim', animation_text, re.S)
+    if not match:
+        raise ValueError(f'Missing rifle pose: {pose}')
+    for name, body in nodes(match[1]).items():
+        if name not in local:
+            continue
+        position, orientation = local[name]
+        for channel in ('position', 'orientation'):
+            key = re.search(channel + r'key \d+\s*\n([^\n]+)', body)
+            if key:
+                values = list(map(float, key[1].split()))[1:]
+                if channel == 'position':
+                    position = Vector(values)
+                else:
+                    orientation = rotation(values)
+        local[name] = position, orientation
+    cache = {'null': Matrix.Identity(4)}
+    def world(name):
+        if name not in cache:
+            position, orientation = local[name]
+            parent = re.search(r'parent (\S+)', skeleton[name])[1].lower()
+            cache[name] = world(parent) @ Matrix.Translation(position) @ orientation.to_matrix().to_4x4()
+        return cache[name]
+    weapon = world('rhand').inverted()
+    return {side: weapon @ world(side + 'hand_g') for side in ('r', 'l')}
+
+
 def main():
     import bpy
     from mathutils import Matrix, Quaternion, Vector
@@ -17,9 +63,14 @@ def main():
     parser.add_argument('--source',type=Path,required=True)
     parser.add_argument('--animation',type=Path,required=True,help='ASCII a_ba_med_weap rifle animation reference')
     parser.add_argument('--hand',type=Path,required=True)
+    parser.add_argument('--skeleton',type=Path,help='ASCII pmh0 skeleton for both-hand review')
+    parser.add_argument('--left-hand',type=Path,help='ASCII pmh0_handl001; requires --skeleton')
+    parser.add_argument('--pose',default='xbowrdy',choices=('xbowrdy','xbowshot'))
     parser.add_argument('--fit',type=Path)
     parser.add_argument('--output',type=Path,required=True)
     args=parser.parse_args(sys.argv[sys.argv.index('--')+1:])
+    if bool(args.skeleton) != bool(args.left_hand):
+        raise ValueError('Supply both --skeleton and --left-hand for two-hand review')
     output=args.output.resolve();output.mkdir(parents=True,exist_ok=True)
     bpy.ops.wm.open_mainfile(filepath=str(args.source.resolve()))
     scene=bpy.context.scene
@@ -49,11 +100,32 @@ def main():
     material=bpy.data.materials.new('Reference hand');material.use_nodes=True
     shader=material.node_tree.nodes.get('Principled BSDF');shader.inputs['Base Color'].default_value=(.32,.17,.085,1);shader.inputs['Roughness'].default_value=.75
     mesh.materials.append(material)
+    if args.skeleton:
+        poses=hand_pose_transforms(args.skeleton.read_text(),animation,args.pose)
+        hand.matrix_world=poses['r'] @ Matrix.Translation(position) @ orientation.to_matrix().to_4x4()
+        left_text=args.left_hand.read_text()
+        if 'newmodel pmh0_handl001' not in left_text:
+            raise ValueError('Expected ASCII human left-hand reference pmh0_handl001')
+        block=re.search(r'node trimesh \S+\s*\n(.*?)endnode',left_text,re.S)[1]
+        left_position=Vector();left_orientation=Quaternion();lines=block.splitlines()
+        for i,line in enumerate(lines):
+            parts=line.split()
+            if not parts:continue
+            if parts[0]=='verts':verts=[tuple(map(float,l.split())) for l in lines[i+1:i+1+int(parts[1])]]
+            if parts[0]=='faces':faces=[tuple(map(int,l.split()[:3])) for l in lines[i+1:i+1+int(parts[1])]]
+            if parts[0]=='position':left_position=Vector(tuple(map(float,parts[1:])))
+            if parts[0]=='orientation':left_orientation=Quaternion(Vector(tuple(map(float,parts[1:4]))),float(parts[4]))
+        left_mesh=bpy.data.meshes.new('Human left-hand reference');left_mesh.from_pydata(verts,[],faces);left_mesh.update()
+        left=bpy.data.objects.new('Human left-hand reference',left_mesh);bpy.context.collection.objects.link(left)
+        left.matrix_world=poses['l'] @ Matrix.Translation(left_position) @ left_orientation.to_matrix().to_4x4()
+        left_mesh.materials.append(material)
     scene.render.engine='BLENDER_EEVEE';scene.eevee.taa_render_samples=64
     scene.render.resolution_x=1400;scene.render.resolution_y=900;scene.render.resolution_percentage=100
     scene.render.image_settings.file_format='PNG';scene.render.film_transparent=True
     camera=scene.camera;camera.data.type='ORTHO';camera.data.ortho_scale=.40
     center=Vector((0,.025,-.05))
+    if args.skeleton:
+        center=Vector((0,.025,-.15));camera.data.ortho_scale=.7
     for side,name in ((1,'grip-preview.png'),(-1,'grip-preview-reverse.png')):
         camera.location=center+Vector((side,-.03,.06))
         camera.rotation_euler=((center-camera.location).to_track_quat('-Z','Y') @ Quaternion((0,0,1),-side*math.pi/2)).to_euler()

--- a/tools/RenderRifleGrip.py
+++ b/tools/RenderRifleGrip.py
@@ -1,0 +1,62 @@
+"""Render a rifle against the human right hand in the rifle xbowshot pose.
+Run inside Blender 4.0. --hand must be an ASCII pmh0_handr001 model;
+--fit is optional for a scene already using NWN attachment coordinates.
+"""
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+def main():
+    import bpy
+    from mathutils import Matrix, Quaternion, Vector
+    parser=argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--source',type=Path,required=True)
+    parser.add_argument('--animation',type=Path,required=True,help='ASCII a_ba_med_weap rifle animation reference')
+    parser.add_argument('--hand',type=Path,required=True)
+    parser.add_argument('--fit',type=Path)
+    parser.add_argument('--output',type=Path,required=True)
+    args=parser.parse_args(sys.argv[sys.argv.index('--')+1:])
+    output=args.output.resolve();output.mkdir(parents=True,exist_ok=True)
+    bpy.ops.wm.open_mainfile(filepath=str(args.source.resolve()))
+    scene=bpy.context.scene
+    if args.fit:
+        fit=Matrix(json.loads(args.fit.read_text())['matrix'])
+        for ob in scene.objects:ob.matrix_world=fit @ ob.matrix_world
+    text=args.hand.read_text()
+    if 'newmodel pmh0_handr001' not in text:raise ValueError('Expected ASCII human right-hand reference pmh0_handr001')
+    block=re.search(r'node trimesh Hand\s*\n(.*?)endnode',text,re.S)[1]
+    lines=block.splitlines();position=Vector((0,0,0));orientation=Quaternion()
+    for i,line in enumerate(lines):
+        p=line.split()
+        if not p:continue
+        if p[0]=='verts':verts=[tuple(map(float,l.split())) for l in lines[i+1:i+1+int(p[1])]]
+        if p[0]=='faces':faces=[tuple(map(int,l.split()))[:3] for l in lines[i+1:i+1+int(p[1])]]
+        if p[0]=='position':position=Vector(tuple(map(float,p[1:])))
+        if p[0]=='orientation':orientation=Quaternion(Vector(tuple(map(float,p[1:4]))),float(p[4]))
+    mesh=bpy.data.meshes.new('Human right-hand reference');mesh.from_pydata(verts,[],faces);mesh.update()
+    hand=bpy.data.objects.new('Human right-hand reference',mesh);bpy.context.collection.objects.link(hand)
+    # Apply the rifle animation hook rotation; the pistol bowshot hook is different.
+    animation=args.animation.read_text()
+    shot=re.search(r'newanim xbowshot .*?\n(.*?)doneanim',animation,re.S)[1]
+    hook_node=re.search(r'node dummy rhand\s*\n(.*?)endnode',shot,re.S)[1]
+    axis_angle=list(map(float,re.search(r'orientationkey \d+\s*\n([^\n]+)',hook_node)[1].split()))[1:]
+    hook=Matrix.Translation(Vector((.0110681,0,-.0961281))) @ Quaternion(Vector(axis_angle[:3]),axis_angle[3]).to_matrix().to_4x4()
+    hand.matrix_world=hook.inverted() @ Matrix.Translation(position) @ orientation.to_matrix().to_4x4()
+    material=bpy.data.materials.new('Reference hand');material.use_nodes=True
+    shader=material.node_tree.nodes.get('Principled BSDF');shader.inputs['Base Color'].default_value=(.32,.17,.085,1);shader.inputs['Roughness'].default_value=.75
+    mesh.materials.append(material)
+    scene.render.engine='BLENDER_EEVEE';scene.eevee.taa_render_samples=64
+    scene.render.resolution_x=1400;scene.render.resolution_y=900;scene.render.resolution_percentage=100
+    scene.render.image_settings.file_format='PNG';scene.render.film_transparent=True
+    camera=scene.camera;camera.data.type='ORTHO';camera.data.ortho_scale=.40
+    center=Vector((.02,0,0))
+    for side,name in ((1,'grip-preview.png'),(-1,'grip-preview-reverse.png')):
+        camera.location=center+Vector((.03,side,.03))
+        camera.rotation_euler=(center-camera.location).to_track_quat('-Z','Y').to_euler()
+        scene.render.filepath=str(output/name);bpy.ops.render.render(write_still=True)
+    bpy.ops.wm.save_as_mainfile(filepath=str(output/'grip-review.blend'))
+
+if __name__=='__main__':main()

--- a/tools/RenderRifleGrip.py
+++ b/tools/RenderRifleGrip.py
@@ -56,6 +56,45 @@ def hand_pose_transforms(skeleton_text, animation_text, pose='xbowrdy'):
     return {side: weapon @ world(side + 'hand_g') for side in ('r', 'l')}
 
 
+def required_block(pattern, text, description):
+    match = re.search(pattern, text, re.S | re.I)
+    if not match:
+        raise ValueError(f"Missing {description}")
+    return match[1]
+
+
+def hand_geometry(text, side):
+    from mathutils import Quaternion, Vector
+    model = 'pmh0_handr001' if side == 'right' else 'pmh0_handl001'
+    if not re.search(r'newmodel\s+' + model + r'\b', text, re.I):
+        raise ValueError(f'Expected ASCII human {side}-hand reference {model}')
+    block = required_block(r'node trimesh \S+\s*\n(.*?)endnode', text, f'{side}-hand trimesh')
+    lines = block.splitlines()
+    verts = faces = None
+    position, orientation = Vector(), Quaternion()
+    for i, line in enumerate(lines):
+        parts = line.split()
+        if not parts:
+            continue
+        key = parts[0].lower()
+        if key in ('verts', 'faces'):
+            count = int(parts[1])
+            rows = lines[i + 1:i + 1 + count]
+            if len(rows) != count:
+                raise ValueError(f'Incomplete {side}-hand {key} rows')
+            if key == 'verts':
+                verts = [tuple(map(float, row.split())) for row in rows]
+            else:
+                faces = [tuple(map(int, row.split()[:3])) for row in rows]
+        elif key == 'position':
+            position = Vector(tuple(map(float, parts[1:])))
+        elif key == 'orientation':
+            orientation = Quaternion(Vector(tuple(map(float, parts[1:4]))), float(parts[4]))
+    if not verts or not faces:
+        raise ValueError(f'{side}-hand reference trimesh has no verts/faces rows')
+    return verts, faces, position, orientation
+
+
 def main():
     import bpy
     from mathutils import Matrix, Quaternion, Vector
@@ -77,24 +116,17 @@ def main():
     if args.fit:
         fit=Matrix(json.loads(args.fit.read_text())['matrix'])
         for ob in scene.objects:ob.matrix_world=fit @ ob.matrix_world
-    text=args.hand.read_text()
-    if 'newmodel pmh0_handr001' not in text:raise ValueError('Expected ASCII human right-hand reference pmh0_handr001')
-    block=re.search(r'node trimesh Hand\s*\n(.*?)endnode',text,re.S)[1]
-    lines=block.splitlines();position=Vector((0,0,0));orientation=Quaternion()
-    for i,line in enumerate(lines):
-        p=line.split()
-        if not p:continue
-        if p[0]=='verts':verts=[tuple(map(float,l.split())) for l in lines[i+1:i+1+int(p[1])]]
-        if p[0]=='faces':faces=[tuple(map(int,l.split()))[:3] for l in lines[i+1:i+1+int(p[1])]]
-        if p[0]=='position':position=Vector(tuple(map(float,p[1:])))
-        if p[0]=='orientation':orientation=Quaternion(Vector(tuple(map(float,p[1:4]))),float(p[4]))
+    verts,faces,position,orientation=hand_geometry(args.hand.read_text(), 'right')
     mesh=bpy.data.meshes.new('Human right-hand reference');mesh.from_pydata(verts,[],faces);mesh.update()
     hand=bpy.data.objects.new('Human right-hand reference',mesh);bpy.context.collection.objects.link(hand)
     # Apply the rifle animation hook rotation; the pistol bowshot hook is different.
     animation=args.animation.read_text()
-    shot=re.search(r'newanim xbowshot .*?\n(.*?)doneanim',animation,re.S)[1]
-    hook_node=re.search(r'node dummy rhand\s*\n(.*?)endnode',shot,re.S)[1]
-    axis_angle=list(map(float,re.search(r'orientationkey \d+\s*\n([^\n]+)',hook_node)[1].split()))[1:]
+    shot=required_block(r'newanim xbowshot .*?\n(.*?)doneanim',animation,'xbowshot animation')
+    hook_node=required_block(r'node dummy rhand\s*\n(.*?)endnode',shot,'rhand animation node')
+    key=required_block(r'orientationkey \d+\s*\n([^\n]+)',hook_node,'rhand orientation key')
+    axis_angle=list(map(float,key.split()))[1:]
+    if len(axis_angle) != 4:
+        raise ValueError('Expected four axis-angle values in rhand orientation key')
     hook=Matrix.Translation(Vector((.0110681,0,-.0961281))) @ Quaternion(Vector(axis_angle[:3]),axis_angle[3]).to_matrix().to_4x4()
     hand.matrix_world=hook.inverted() @ Matrix.Translation(position) @ orientation.to_matrix().to_4x4()
     material=bpy.data.materials.new('Reference hand');material.use_nodes=True
@@ -103,19 +135,8 @@ def main():
     if args.skeleton:
         poses=hand_pose_transforms(args.skeleton.read_text(),animation,args.pose)
         hand.matrix_world=poses['r'] @ Matrix.Translation(position) @ orientation.to_matrix().to_4x4()
-        left_text=args.left_hand.read_text()
-        if 'newmodel pmh0_handl001' not in left_text:
-            raise ValueError('Expected ASCII human left-hand reference pmh0_handl001')
-        block=re.search(r'node trimesh \S+\s*\n(.*?)endnode',left_text,re.S)[1]
-        left_position=Vector();left_orientation=Quaternion();lines=block.splitlines()
-        for i,line in enumerate(lines):
-            parts=line.split()
-            if not parts:continue
-            if parts[0]=='verts':verts=[tuple(map(float,l.split())) for l in lines[i+1:i+1+int(parts[1])]]
-            if parts[0]=='faces':faces=[tuple(map(int,l.split()[:3])) for l in lines[i+1:i+1+int(parts[1])]]
-            if parts[0]=='position':left_position=Vector(tuple(map(float,parts[1:])))
-            if parts[0]=='orientation':left_orientation=Quaternion(Vector(tuple(map(float,parts[1:4]))),float(parts[4]))
-        left_mesh=bpy.data.meshes.new('Human left-hand reference');left_mesh.from_pydata(verts,[],faces);left_mesh.update()
+        left_verts,left_faces,left_position,left_orientation=hand_geometry(args.left_hand.read_text(), 'left')
+        left_mesh=bpy.data.meshes.new('Human left-hand reference');left_mesh.from_pydata(left_verts,[],left_faces);left_mesh.update()
         left=bpy.data.objects.new('Human left-hand reference',left_mesh);bpy.context.collection.objects.link(left)
         left.matrix_world=poses['l'] @ Matrix.Translation(left_position) @ left_orientation.to_matrix().to_4x4()
         left_mesh.materials.append(material)

--- a/tools/RenderRifleGrip.py
+++ b/tools/RenderRifleGrip.py
@@ -4,6 +4,7 @@ Run inside Blender 4.0. --hand must be an ASCII pmh0_handr001 model;
 """
 import argparse
 import json
+import math
 import re
 import sys
 from pathlib import Path
@@ -52,10 +53,10 @@ def main():
     scene.render.resolution_x=1400;scene.render.resolution_y=900;scene.render.resolution_percentage=100
     scene.render.image_settings.file_format='PNG';scene.render.film_transparent=True
     camera=scene.camera;camera.data.type='ORTHO';camera.data.ortho_scale=.40
-    center=Vector((.02,0,0))
+    center=Vector((0,.025,-.05))
     for side,name in ((1,'grip-preview.png'),(-1,'grip-preview-reverse.png')):
-        camera.location=center+Vector((.03,side,.03))
-        camera.rotation_euler=(center-camera.location).to_track_quat('-Z','Y').to_euler()
+        camera.location=center+Vector((side,-.03,.06))
+        camera.rotation_euler=((center-camera.location).to_track_quat('-Z','Y') @ Quaternion((0,0,1),-side*math.pi/2)).to_euler()
         scene.render.filepath=str(output/name);bpy.ops.render.render(write_still=True)
     bpy.ops.wm.save_as_mainfile(filepath=str(output/'grip-review.blend'))
 

--- a/tools/RenderRifleGrip.py
+++ b/tools/RenderRifleGrip.py
@@ -95,6 +95,18 @@ def hand_geometry(text, side):
     return verts, faces, position, orientation
 
 
+def single_hand_hook(animation, pose):
+    from mathutils import Matrix, Quaternion, Vector
+    shot=required_block(r'newanim ' + re.escape(pose) + r' .*?\n(.*?)doneanim',animation,f'{pose} animation')
+    hook_node=required_block(r'node dummy rhand\s*\n(.*?)endnode',shot,'rhand animation node')
+    key=required_block(r'orientationkey \d+\s*\n([^\n]+)',hook_node,'rhand orientation key')
+    axis_angle=list(map(float,key.split()))[1:]
+    if len(axis_angle) != 4:
+        raise ValueError('Expected four axis-angle values in rhand orientation key')
+    hook=Matrix.Translation(Vector((.0110681,0,-.0961281))) @ Quaternion(Vector(axis_angle[:3]),axis_angle[3]).to_matrix().to_4x4()
+    return hook
+
+
 def main():
     import bpy
     from mathutils import Matrix, Quaternion, Vector
@@ -121,14 +133,9 @@ def main():
     hand=bpy.data.objects.new('Human right-hand reference',mesh);bpy.context.collection.objects.link(hand)
     # Apply the rifle animation hook rotation; the pistol bowshot hook is different.
     animation=args.animation.read_text()
-    shot=required_block(r'newanim xbowshot .*?\n(.*?)doneanim',animation,'xbowshot animation')
-    hook_node=required_block(r'node dummy rhand\s*\n(.*?)endnode',shot,'rhand animation node')
-    key=required_block(r'orientationkey \d+\s*\n([^\n]+)',hook_node,'rhand orientation key')
-    axis_angle=list(map(float,key.split()))[1:]
-    if len(axis_angle) != 4:
-        raise ValueError('Expected four axis-angle values in rhand orientation key')
-    hook=Matrix.Translation(Vector((.0110681,0,-.0961281))) @ Quaternion(Vector(axis_angle[:3]),axis_angle[3]).to_matrix().to_4x4()
-    hand.matrix_world=hook.inverted() @ Matrix.Translation(position) @ orientation.to_matrix().to_4x4()
+    if not args.skeleton:
+        hook=single_hand_hook(animation,args.pose)
+        hand.matrix_world=hook.inverted() @ Matrix.Translation(position) @ orientation.to_matrix().to_4x4()
     material=bpy.data.materials.new('Reference hand');material.use_nodes=True
     shader=material.node_tree.nodes.get('Principled BSDF');shader.inputs['Base Color'].default_value=(.32,.17,.085,1);shader.inputs['Roughness'].default_value=.75
     mesh.materials.append(material)

--- a/tools/tests/test_import_rifle_model.py
+++ b/tools/tests/test_import_rifle_model.py
@@ -8,6 +8,7 @@ import unittest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from ImportRifleModel import validate_rifle
 from ImportBlasterModel import validate_attachment
+from RenderRifleGrip import hand_pose_transforms
 
 
 class RifleImportTests(unittest.TestCase):
@@ -47,6 +48,46 @@ class RifleImportTests(unittest.TestCase):
             rotation = Euler(tuple(math.radians(v) for v in angles)).to_matrix().to_4x4()
             with self.subTest(angles=angles), self.assertRaises(ValueError):
                 validate_attachment(rotation, self.config, "rifle")
+
+    def test_two_hand_fixture_applies_case_insensitive_ancestor_pose(self):
+        try:
+            from mathutils import Vector
+        except ImportError:
+            self.skipTest("Run in Blender for skeletal transforms")
+        skeleton = """node dummy Rig
+  parent NULL
+endnode
+node dummy Rbicep_g
+  parent Rig
+endnode
+node dummy rhand_g
+  parent Rbicep_g
+endnode
+node dummy rhand
+  parent rhand_g
+endnode
+node dummy Lbicep_g
+  parent Rig
+  position 1 0 0
+endnode
+node dummy lhand_g
+  parent Lbicep_g
+endnode
+endmodelgeom Rig
+"""
+        for name in ('lbicep_g', 'LBICEP_G', 'Lbicep_g'):
+            animation = f"""newanim xbowrdy Rig
+node dummy {name}
+  parent Rig
+  positionkey 1
+    0 2 3 4
+endnode
+doneanim xbowrdy Rig
+"""
+            with self.subTest(name=name):
+                transforms = hand_pose_transforms(skeleton, animation)
+                self.assertLess((transforms['l'] @ Vector() - Vector((2, 3, 4))).length, 1e-6)
+                self.assertLess((transforms['r'] @ Vector()).length, 1e-6)
 
 
 if __name__ == "__main__":

--- a/tools/tests/test_import_rifle_model.py
+++ b/tools/tests/test_import_rifle_model.py
@@ -14,7 +14,7 @@ class RifleImportTests(unittest.TestCase):
     def setUp(self):
         self.config = dict(schema_version=1, base_item=7, middle_slot=151,
                            texture="rf_gs02", material_mode="opaque", scale=9.6,
-                           rotation_degrees=[180, 0, 90], translation=[0, 0, 0],
+                           rotation_degrees=[90, 180, 0], translation=[-.00521167, .0362191, -.0580922],
                            texture_size=1024, source_material="ranged_gs02_a01_v01",
                            preserve_emission=True,
                            attachment=dict(source_muzzle_axis=[0, 1, 0], source_grip_axis=[0, 0, 1]),
@@ -36,14 +36,14 @@ class RifleImportTests(unittest.TestCase):
             with self.subTest(name=name), self.assertRaises(ValueError):
                 validate_rifle(config)
 
-    def test_rifle_axes_reject_pistol_and_upside_down_fit(self):
+    def test_rifle_axes_reject_untransformed_reference_vertices(self):
         try:
             from mathutils import Euler
         except ImportError:
             self.skipTest("Run in Blender for attachment transforms")
         rotation = Euler(tuple(math.radians(v) for v in self.config["rotation_degrees"])).to_matrix().to_4x4()
         validate_attachment(rotation, self.config, "rifle")
-        for angles in ((90, 180, 0), (0, 0, -90)):
+        for angles in ((180, 0, 90), (0, 0, -90)):
             rotation = Euler(tuple(math.radians(v) for v in angles)).to_matrix().to_4x4()
             with self.subTest(angles=angles), self.assertRaises(ValueError):
                 validate_attachment(rotation, self.config, "rifle")

--- a/tools/tests/test_import_rifle_model.py
+++ b/tools/tests/test_import_rifle_model.py
@@ -1,0 +1,53 @@
+"""Run in Blender 4.0 to include rifle attachment-space checks."""
+import copy
+import math
+from pathlib import Path
+import sys
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from ImportRifleModel import validate_rifle
+from ImportBlasterModel import validate_attachment
+
+
+class RifleImportTests(unittest.TestCase):
+    def setUp(self):
+        self.config = dict(schema_version=1, base_item=7, middle_slot=151,
+                           texture="rf_gs02", material_mode="opaque", scale=9.6,
+                           rotation_degrees=[180, 0, 90], translation=[0, 0, 0],
+                           texture_size=1024, source_material="ranged_gs02_a01_v01",
+                           preserve_emission=True,
+                           attachment=dict(source_muzzle_axis=[0, 1, 0], source_grip_axis=[0, 0, 1]),
+                           sources=dict(model="rifle_gs02_a01_v01.gr2", diffuse="d.dds", normal="n.dds", specular="s.dds"),
+                           sha256={key: "a" * 64 for key in ("model", "diffuse", "normal", "specular")})
+
+    def test_rifle_base_item_and_reviewed_material_required(self):
+        validate_rifle(self.config)
+        for key, value in (("base_item", 11), ("base_item", 6), ("source_material", ""), ("preserve_emission", False)):
+            config = copy.deepcopy(self.config)
+            config[key] = value
+            with self.subTest(key=key, value=value), self.assertRaises(ValueError):
+                validate_rifle(config)
+
+    def test_cannons_and_pistols_cannot_enter_rifle_pipeline(self):
+        for name in ("as_a01.gr2", "as_a0x.gr2", "assaultcannon_high35_a01_v02.gr2", "blaster_high41.gr2"):
+            config = copy.deepcopy(self.config)
+            config["sources"]["model"] = name
+            with self.subTest(name=name), self.assertRaises(ValueError):
+                validate_rifle(config)
+
+    def test_rifle_axes_reject_pistol_and_upside_down_fit(self):
+        try:
+            from mathutils import Euler
+        except ImportError:
+            self.skipTest("Run in Blender for attachment transforms")
+        rotation = Euler(tuple(math.radians(v) for v in self.config["rotation_degrees"])).to_matrix().to_4x4()
+        validate_attachment(rotation, self.config, "rifle")
+        for angles in ((90, 180, 0), (0, 0, -90)):
+            rotation = Euler(tuple(math.radians(v) for v in angles)).to_matrix().to_4x4()
+            with self.subTest(angles=angles), self.assertRaises(ValueError):
+                validate_attachment(rotation, self.config, "rifle")
+
+
+if __name__ == "__main__":
+    unittest.main(argv=[sys.argv[0]])

--- a/tools/tests/test_import_rifle_model.py
+++ b/tools/tests/test_import_rifle_model.py
@@ -12,6 +12,42 @@ from RenderRifleGrip import hand_pose_transforms
 
 
 class RifleImportTests(unittest.TestCase):
+    def test_manifest_argument_forms_and_missing_values(self):
+        from ImportRifleModel import parse_manifest
+        from contextlib import redirect_stderr
+        from io import StringIO
+        for args in (['--manifest', 'rifle.json'], ['--manifest=rifle.json', '--output', 'out']):
+            self.assertEqual(parse_manifest(args), Path('rifle.json'))
+        for args in ([], ['--manifest']):
+            with redirect_stderr(StringIO()), self.assertRaises(SystemExit) as error:
+                parse_manifest(args)
+            self.assertEqual(error.exception.code, 2)
+
+    def test_emission_requires_matching_dimensions(self):
+        import numpy as np
+        from ImportBlasterModel import validate_emission_dimensions
+        validate_emission_dimensions(np.zeros((4, 4, 3)), np.zeros((4, 4, 4)))
+        with self.assertRaisesRegex(ValueError, 'same resolution'):
+            validate_emission_dimensions(np.zeros((2, 2, 3)), np.zeros((4, 4, 4)))
+
+    def test_hand_geometry_is_case_insensitive_and_requires_own_rows(self):
+        from RenderRifleGrip import hand_geometry, required_block
+        rows = 'verts 3\n0 0 0\n1 0 0\n0 1 0\nfaces 1\n0 1 2\n'
+        for side, model in (('right', 'PMH0_HANDR001'), ('left', 'PMH0_HANDL001')):
+            prefix = f'NEWMODEL {model}\nNODE TRIMESH HAND\n'
+            verts, faces, _, _ = hand_geometry(prefix + rows + 'ENDNODE', side)
+            self.assertEqual(len(verts), 3)
+            self.assertEqual(faces, [(0, 1, 2)])
+            for incomplete in ('verts 1\n0 0 0\n', 'faces 1\n0 0 0\n', ''):
+                with self.assertRaisesRegex(ValueError, 'verts/faces'):
+                    hand_geometry(prefix + incomplete + 'ENDNODE', side)
+            with self.assertRaisesRegex(ValueError, 'trimesh'):
+                hand_geometry(f'newmodel {model}', side)
+        self.assertEqual(required_block(r'node dummy rhand\n(.*?)endnode',
+                                       'NODE DUMMY RHAND\nkey\nENDNODE', 'hook'), 'key\n')
+        with self.assertRaisesRegex(ValueError, 'Missing hook'):
+            required_block(r'node dummy rhand\n(.*?)endnode', '', 'hook')
+
     def setUp(self):
         self.config = dict(schema_version=1, base_item=7, middle_slot=151,
                            texture="rf_gs02", material_mode="opaque", scale=9.6,

--- a/tools/tests/test_import_rifle_model.py
+++ b/tools/tests/test_import_rifle_model.py
@@ -48,6 +48,20 @@ class RifleImportTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, 'Missing hook'):
             required_block(r'node dummy rhand\n(.*?)endnode', '', 'hook')
 
+    def test_single_hand_uses_selected_pose(self):
+        from RenderRifleGrip import single_hand_hook
+        from mathutils import Vector
+        animation = ''
+        for pose, angle in (('xbowrdy', 0), ('xbowshot', math.pi / 2)):
+            animation += (f'newanim {pose} Rig\nnode dummy rhand\n'
+                          f'orientationkey 1\n0 0 0 1 {angle}\nendnode\ndoneanim\n')
+        ready = single_hand_hook(animation, 'xbowrdy').to_3x3() @ Vector((1, 0, 0))
+        shot = single_hand_hook(animation, 'xbowshot').to_3x3() @ Vector((1, 0, 0))
+        self.assertLess((ready - Vector((1, 0, 0))).length, 1e-6)
+        self.assertLess((shot - Vector((0, 1, 0))).length, 1e-6)
+        with self.assertRaisesRegex(ValueError, 'missing animation'):
+            single_hand_hook(animation, 'missing')
+
     def setUp(self):
         self.config = dict(schema_version=1, base_item=7, middle_slot=151,
                            texture="rf_gs02", material_mode="opaque", scale=9.6,

--- a/tools/tests/test_rifle_inventory_icons.py
+++ b/tools/tests/test_rifle_inventory_icons.py
@@ -1,0 +1,34 @@
+"""Verify native-compatible DDS inventory artwork for the imported rifles."""
+from pathlib import Path
+import struct
+import unittest
+
+from PIL import Image
+
+WEAPONS = Path(__file__).resolve().parents[2] / "SWLOR_Haks/sw_weapon"
+PARTS = (115, 116, 117, 118, 119, 121, 122, 124, 125, 201, 202, 205,
+         207, 208, 210, 211, 213, 218, 219, 220, 221, 222, 301, 302,
+         303, 305, 307, 308, 309, 311, 313, 318, 319, 419, 420)
+
+
+class RifleInventoryIconTests(unittest.TestCase):
+    def test_imported_icons_use_native_dxt5_with_alpha_without_mipmaps(self):
+        for part in PARTS:
+            with self.subTest(part=part):
+                stem = f"iwbwxl_m_{part % 100 * 10 + part // 100:03}"
+                path = WEAPONS / (stem + ".dds")
+                data = path.read_bytes()
+                self.assertEqual(data[:4], b"DDS ")
+                self.assertEqual(data[84:88], b"DXT5")
+                self.assertIn(struct.unpack_from("<I", data, 28)[0], (0, 1))
+                self.assertEqual(len(data), 128 + 64 * 128)
+                self.assertFalse((WEAPONS / (stem + ".tga")).exists())
+                with Image.open(path) as image:
+                    self.assertEqual(image.size, (64, 128))
+                    alpha = image.convert("RGBA").getchannel("A")
+                    self.assertIsNotNone(alpha.getbbox())
+                    self.assertEqual(alpha.getextrema()[0], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add a rifle-specific import workflow and replace 35 existing rifle appearances through the HAK update. The importer validates rifle base types and source materials, preserves emission, and produces rifle-sized inventory icons. The grip review tool composes the full animation hierarchy to inspect both hands, including case-insensitive bone names.

All imported rifles received attachment and fit adjustments, with the final local in-game result approved by the user. Cannons are excluded.

Validation: 8 focused rifle tests, a corpus audit of all 35 DXT5 rifle icons, and 13 blaster tests pass in Blender 4.0.2; all 35 compiled model geometry/material preservation and packed resource hashes verified; deployed server/client HAK hashes match; git diff --check passes.

Companion HAK PR: https://github.com/zunath/SWLOR_Haks/pull/417. Merge the HAK PR first, retaining the referenced submodule commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for importing rifle models through the existing weapon-model conversion workflow.
  - Added rifle-specific validation, material handling, texture processing, emission-map support, and inventory previews.
  - Added a tool for previewing rifle grip and hand alignment in supported poses.
- **Documentation**
  - Added guidance covering rifle model preparation, conversion, fitting, packaging, and client acceptance testing.
- **Tests**
  - Added validation for rifle configuration, model eligibility, attachment alignment, materials, and two-handed poses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->