### PR TITLE
Remove weapon-family restrictions from perk abilities

### DIFF
--- a/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
@@ -187,21 +187,32 @@ public class CombatDamageTests
     }
 
     [Test]
-    public void WeaponAbilities_OnlyUseTheirDeclaredWeaponSkill()
+    public void WeaponAbilities_AcceptEveryWeaponSkillRegardlessOfTheirDeclaredSkill()
     {
-        Combat.CanWeaponSkillTriggerAbility(SkillType.Vibroknife, SkillType.Vibroknife).Should().BeTrue();
-        Combat.CanWeaponSkillTriggerAbility(SkillType.Spear, SkillType.Vibroknife).Should().BeFalse();
-        Combat.CanWeaponSkillTriggerAbility(SkillType.Vibroblade, SkillType.Lightsaber).Should().BeFalse();
-        Combat.CanWeaponSkillTriggerAbility(SkillType.Invalid, SkillType.Vibroknife).Should().BeFalse();
+        var weaponSkills = Enum.GetValues<SkillType>().Where(Combat.IsWeaponSkillType).ToArray();
+        weaponSkills.Should().NotBeEmpty();
+        foreach (var abilitySkill in weaponSkills)
+        {
+            foreach (var weaponSkill in weaponSkills)
+            {
+                Combat.CanWeaponSkillTriggerAbility(weaponSkill, abilitySkill).Should().BeTrue(
+                    $"{abilitySkill} abilities must work with {weaponSkill} weapons");
+            }
+
+            Combat.CanWeaponSkillTriggerAbility(SkillType.Invalid, abilitySkill).Should().BeFalse();
+            Combat.CanWeaponSkillTriggerAbility(SkillType.Armor, abilitySkill).Should().BeFalse();
+        }
+
         Combat.CanWeaponSkillTriggerAbility(SkillType.Spear, SkillType.Invalid).Should().BeTrue();
 
         var root = FindRepositoryRoot();
         var abilitySource = File.ReadAllText(Path.Combine(root.FullName, "SWLOR.Game.Server", "Service", "Ability.cs"));
         var usePerkFeatSource = File.ReadAllText(Path.Combine(root.FullName, "SWLOR.Game.Server", "Feature", "UsePerkFeat.cs"));
 
-        abilitySource.Should().Contain("Combat.HasEquippedWeaponForAbilitySkill(activator, ability.SkillType)");
-        abilitySource.Should().Contain("You must equip a {skillName} weapon to use this ability.");
+        abilitySource.Should().NotContain("HasEquippedWeaponForAbilitySkill");
+        abilitySource.Should().NotContain("You must equip a {skillName} weapon to use this ability.");
         usePerkFeatSource.Should().Contain("Combat.CanItemTriggerWeaponAbility(item, abilityDetail.SkillType)");
+        usePerkFeatSource.Should().Contain("Combat.CanWeaponSkillTriggerAbility(weaponSkillType, ability.SkillType)");
     }
 
     [Test]

--- a/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
@@ -252,6 +252,11 @@ public class CombatDamageTests
         attackSource.Should().Contain("Combat.GetAbilitySkillType(attacker.m_idSelf, queuedAbility)");
         attackSource.Should().Contain("Stat.GetAccuracyNative(attacker, weapon, abilitySkillType)");
         attackSource.Should().Contain("Stat.GetEvasionNative(defender, abilitySkillType)");
+        attackSource.Should().Contain("Combat.GetSideAttackHitChanceAdjustment(attacker.m_idSelf, defender.m_idSelf, abilitySkillType)");
+        System.Text.RegularExpressions.Regex.IsMatch(attackSource,
+            @"ApplySideAttackEvasionIgnore\(\s*attacker.m_idSelf,\s*defender.m_idSelf,\s*abilitySkillType,").Should().BeTrue();
+        System.Text.RegularExpressions.Regex.IsMatch(attackSource,
+            @"GetRangedAbilityLongRangeHitChanceAdjustment\(\s*attacker.m_idSelf,\s*defender.m_idSelf,\s*abilitySkillType\)").Should().BeTrue();
         System.Text.RegularExpressions.Regex.IsMatch(attackSource,
             @"GetQueuedWeaponAbilityActivationHitChanceAdjustment\(\s*attacker.m_idSelf,\s*abilitySkillType\)").Should().BeTrue();
         System.Text.RegularExpressions.Regex.IsMatch(attackSource,

--- a/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
@@ -244,6 +244,26 @@ public class CombatDamageTests
     }
 
     [Test]
+    public void QueuedWeaponHitRoll_UsesAbilitySkillForAccuracyAndStoredBonuses()
+    {
+        var root = FindRepositoryRoot();
+        var attackSource = File.ReadAllText(Path.Combine(root.FullName, "SWLOR.Game.Server", "Native", "ResolveAttackRoll.cs"));
+        var statSource = File.ReadAllText(Path.Combine(root.FullName, "SWLOR.Game.Server", "Service", "Stat.cs"));
+        attackSource.Should().Contain("Combat.GetAbilitySkillType(attacker.m_idSelf, queuedAbility)");
+        attackSource.Should().Contain("Stat.GetAccuracyNative(attacker, weapon, abilitySkillType)");
+        attackSource.Should().Contain("Stat.GetEvasionNative(defender, abilitySkillType)");
+        System.Text.RegularExpressions.Regex.IsMatch(attackSource,
+            @"GetQueuedWeaponAbilityActivationHitChanceAdjustment\(\s*attacker.m_idSelf,\s*abilitySkillType\)").Should().BeTrue();
+        System.Text.RegularExpressions.Regex.IsMatch(attackSource,
+            @"StoreQueuedWeaponAbilityCriticalRateBonus\(\s*attacker.m_idSelf,\s*abilitySkillType,").Should().BeTrue();
+        attackSource.Should().Contain("Combat.PrepareAutoAttackCycleCriticalRate(attacker.m_idSelf, weaponSkillType)");
+        attackSource.Should().Contain("Combat.ApplyRangedDeflectionReflection(defender.m_idSelf, attacker.m_idSelf, weaponSkillType)");
+        var accuracy = ExtractMethod(statSource, "public static int GetAccuracyNative");
+        accuracy.Should().Contain("skillOverride != SkillType.Invalid ? skillOverride : Skill.GetSkillTypeByBaseItem(baseItemType)");
+        accuracy.Should().Contain("skillLevel = dbPlayer.Skills[skillType].Rank");
+    }
+
+    [Test]
     public void NonCriticalRangedAbilities_ReserveStatDrivenStaminaCostAndRefundCriticalResults()
     {
         var root = FindRepositoryRoot();

--- a/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
@@ -255,7 +255,9 @@ public class CombatDamageTests
         Combat.GetQueuedAbilityAccuracyAbilityType(0, SkillType.Vibroblade).Should().Be(AbilityType.Perception);
         Combat.GetQueuedAbilityAccuracyAbilityType(0, SkillType.Rifle).Should().Be(AbilityType.Agility);
         Combat.GetQueuedAbilityAccuracyAbilityType(0, SkillType.Pistol).Should().Be(AbilityType.Agility);
-        Combat.GetQueuedAbilityAccuracyAbilityType(0, SkillType.Force).Should().Be(AbilityType.Willpower);
+        Combat.GetQueuedAbilityAccuracyAbilityType(0, SkillType.Force).Should().Be(AbilityType.Invalid);
+        Combat.GetQueuedAbilityAccuracyAbilityType(0, SkillType.BeastMastery).Should().Be(AbilityType.Invalid);
+        Combat.GetQueuedAbilityAccuracyAbilityType(0, SkillType.Invalid).Should().Be(AbilityType.Invalid);
         attackSource.Should().Contain("Stat.GetEvasionNative(defender, abilitySkillType)");
         attackSource.Should().Contain("Combat.GetSideAttackHitChanceAdjustment(attacker.m_idSelf, defender.m_idSelf, abilitySkillType)");
         System.Text.RegularExpressions.Regex.IsMatch(attackSource,

--- a/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
@@ -211,8 +211,36 @@ public class CombatDamageTests
 
         abilitySource.Should().NotContain("HasEquippedWeaponForAbilitySkill");
         abilitySource.Should().NotContain("You must equip a {skillName} weapon to use this ability.");
+        abilitySource.Should().Contain("!Combat.HasEquippedWeaponForAbility(activator)");
+        abilitySource.Should().Contain("You must equip a weapon to use this ability.");
         usePerkFeatSource.Should().Contain("Combat.CanItemTriggerWeaponAbility(item, abilityDetail.SkillType)");
         usePerkFeatSource.Should().Contain("Combat.CanWeaponSkillTriggerAbility(weaponSkillType, ability.SkillType)");
+    }
+
+    [Test]
+    public void QueuedWeaponDamage_UsesTheTriggeringItemAndPreservesReflectionWeaponSelection()
+    {
+        var root = FindRepositoryRoot();
+        var abilitySource = File.ReadAllText(Path.Combine(root.FullName, "SWLOR.Game.Server", "Service", "Ability.cs"));
+        var combatSource = File.ReadAllText(Path.Combine(root.FullName, "SWLOR.Game.Server", "Service", "Combat.cs"));
+        var usePerkFeatSource = File.ReadAllText(Path.Combine(root.FullName, "SWLOR.Game.Server", "Feature", "UsePerkFeat.cs"));
+
+        usePerkFeatSource.Should().Contain("Ability.BeginAbilityImpact(activator, abilityDetail, triggeringWeapon: item)");
+        abilitySource.Should().Contain("trackedImpact.TriggeringWeaponDamage = GetIsObjectValid(triggeringWeapon)");
+        abilitySource.Should().Contain("? Item.GetDMG(triggeringWeapon)");
+        abilitySource.Should().Contain("triggeringWeaponDamage: trackedImpact?.TriggeringWeaponDamage");
+        Combat.GetCombatImpactWeaponDamage(0, SkillType.Vibroblade, triggeringWeaponDamage: 23).Should().Be(23);
+        Combat.GetCombatImpactWeaponDamage(0, SkillType.Pistol, triggeringWeaponDamage: 0).Should().Be(0);
+        Combat.GetCombatImpactWeaponDamage(0, SkillType.Force, triggeringWeaponDamage: 23).Should().Be(0);
+        abilitySource.Should().Contain("TriggeringWeaponDamage = sequenceOwner?.TriggeringWeaponDamage");
+        abilitySource.Should().Contain("TriggeringWeaponDamage = originatingImpact.TriggeringWeaponDamage");
+        combatSource.Should().Contain("GetCombatImpactWeaponDamage(attacker, attackerWeaponSkill, requireMatchingSkill: true)");
+        var selection = ExtractMethod(combatSource, "private static uint GetCombatImpactWeapon");
+        selection.Should().Contain("Skill.GetSkillTypeByBaseItem(GetBaseItemType(rightHand)) == skillType");
+        selection.Should().Contain("Skill.GetSkillTypeByBaseItem(GetBaseItemType(leftHand)) == skillType");
+        var equipped = ExtractMethod(combatSource, "public static bool HasEquippedWeaponForAbility");
+        equipped.Should().Contain("IsAbilityWeapon(GetItemInSlot(InventorySlot.RightHand, creature))");
+        equipped.Should().Contain("IsAbilityWeapon(GetItemInSlot(InventorySlot.LeftHand, creature))");
     }
 
     [Test]
@@ -488,7 +516,7 @@ public class CombatDamageTests
 
         usePerkFeatSource.Should().Contain("Weapon abilities are queued for the next time the activator's attack lands on an enemy.");
         usePerkFeatSource.Should().Contain("ProcessQueuedWeaponAbility()");
-        usePerkFeatSource.Should().Contain("Ability.BeginAbilityImpact(activator, abilityDetail);");
+        usePerkFeatSource.Should().Contain("Ability.BeginAbilityImpact(activator, abilityDetail, triggeringWeapon: item);");
         usePerkFeatSource.Should().Contain("public static bool HasQueuedWeaponAbility(uint activator)");
         usePerkFeatSource.Should().Contain("public static bool HasQueuedWeaponAbility(uint activator, SkillType weaponSkillType)");
         usePerkFeatSource.Should().Contain("public static bool TryGetQueuedWeaponAbility(uint activator, out AbilityDetail ability)");
@@ -624,7 +652,7 @@ public class CombatDamageTests
             damageCalculation.Should().Contain("skillType == SkillType.BeastMastery");
             damageCalculation.Should().Contain("Combat.IsWeaponSkillType(skillType) || usesQueuedNaturalWeapon");
             damageCalculation.Should().Contain(
-                "Combat.GetCombatImpactWeaponDamage(activator, skillType, usesQueuedNaturalWeapon)");
+                "Combat.GetCombatImpactWeaponDamage(activator, skillType, usesQueuedNaturalWeapon, triggeringWeaponDamage: trackedImpact?.TriggeringWeaponDamage)");
         }
 
         impactWeaponDamage.Should().Contain(

--- a/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/CombatDamageTests.cs
@@ -250,7 +250,12 @@ public class CombatDamageTests
         var attackSource = File.ReadAllText(Path.Combine(root.FullName, "SWLOR.Game.Server", "Native", "ResolveAttackRoll.cs"));
         var statSource = File.ReadAllText(Path.Combine(root.FullName, "SWLOR.Game.Server", "Service", "Stat.cs"));
         attackSource.Should().Contain("Combat.GetAbilitySkillType(attacker.m_idSelf, queuedAbility)");
-        attackSource.Should().Contain("Stat.GetAccuracyNative(attacker, weapon, abilitySkillType)");
+        attackSource.Should().Contain("Stat.GetAccuracyNative(attacker, weapon, abilitySkillType, accuracyAbility)");
+        attackSource.Should().Contain("Combat.GetQueuedAbilityAccuracyAbilityType(attacker.m_idSelf, abilitySkillType)");
+        Combat.GetQueuedAbilityAccuracyAbilityType(0, SkillType.Vibroblade).Should().Be(AbilityType.Perception);
+        Combat.GetQueuedAbilityAccuracyAbilityType(0, SkillType.Rifle).Should().Be(AbilityType.Agility);
+        Combat.GetQueuedAbilityAccuracyAbilityType(0, SkillType.Pistol).Should().Be(AbilityType.Agility);
+        Combat.GetQueuedAbilityAccuracyAbilityType(0, SkillType.Force).Should().Be(AbilityType.Willpower);
         attackSource.Should().Contain("Stat.GetEvasionNative(defender, abilitySkillType)");
         attackSource.Should().Contain("Combat.GetSideAttackHitChanceAdjustment(attacker.m_idSelf, defender.m_idSelf, abilitySkillType)");
         System.Text.RegularExpressions.Regex.IsMatch(attackSource,
@@ -266,6 +271,8 @@ public class CombatDamageTests
         var accuracy = ExtractMethod(statSource, "public static int GetAccuracyNative");
         accuracy.Should().Contain("skillOverride != SkillType.Invalid ? skillOverride : Skill.GetSkillTypeByBaseItem(baseItemType)");
         accuracy.Should().Contain("skillLevel = dbPlayer.Skills[skillType].Rank");
+        accuracy.Should().Contain("var statType = accuracyAbilityOverride != AbilityType.Invalid");
+        accuracy.Should().Contain("accuracyBonus += ip.m_nCostTableValue");
     }
 
     [Test]

--- a/SWLOR.Game.Server/Feature/UsePerkFeat.cs
+++ b/SWLOR.Game.Server/Feature/UsePerkFeat.cs
@@ -1241,7 +1241,7 @@ namespace SWLOR.Game.Server.Feature
             var impactEnded = false;
             try
             {
-                Ability.BeginAbilityImpact(activator, abilityDetail);
+                Ability.BeginAbilityImpact(activator, abilityDetail, triggeringWeapon: item);
                 abilityDetail.ImpactAction?.Invoke(activator, target, activeAbilityEffectivePerkLevel, targetLocation);
                 var summary = Ability.EndAbilityImpact(activator);
                 impactEnded = true;

--- a/SWLOR.Game.Server/Native/ResolveAttackRoll.cs
+++ b/SWLOR.Game.Server/Native/ResolveAttackRoll.cs
@@ -10,6 +10,7 @@ using SWLOR.Game.Server.Service.SkillService;
 using SWLOR.Game.Server.Service.StatService;
 using SWLOR.NWN.API.NWNX;
 using System.Runtime.InteropServices;
+using AbilityType = SWLOR.NWN.API.NWScript.Enum.AbilityType;
 using AttackType = SWLOR.Game.Server.Enumeration.AttackType;
 using BaseItem = SWLOR.NWN.API.NWScript.Enum.Item.BaseItem;
 using ImmunityType = NWN.Native.API.ImmunityType;
@@ -165,7 +166,10 @@ namespace SWLOR.Game.Server.Native
 
                 Log.Write(LogGroup.Attack, "Selected attack type " + attackType + ", weapon " + (weapon == null ? "none" : weapon.GetFirstName().GetSimple(0)));
 
-                var attackerAccuracy = Stat.GetAccuracyNative(attacker, weapon, abilitySkillType);
+                var accuracyAbility = queuedAbility == null
+                    ? AbilityType.Invalid
+                    : Combat.GetQueuedAbilityAccuracyAbilityType(attacker.m_idSelf, abilitySkillType);
+                var attackerAccuracy = Stat.GetAccuracyNative(attacker, weapon, abilitySkillType, accuracyAbility);
                 attackerAccuracy = Combat.ApplyStatusSourceAccuracyModifiers(
                     attacker.m_idSelf,
                     defender.m_idSelf,

--- a/SWLOR.Game.Server/Native/ResolveAttackRoll.cs
+++ b/SWLOR.Game.Server/Native/ResolveAttackRoll.cs
@@ -174,7 +174,7 @@ namespace SWLOR.Game.Server.Native
                 defenderEvasion = Combat.ApplySideAttackEvasionIgnore(
                     attacker.m_idSelf,
                     defender.m_idSelf,
-                    weaponSkillType,
+                    abilitySkillType,
                     defenderEvasion);
 
                 //---------------------------------------------------------------------------------------------
@@ -235,10 +235,10 @@ namespace SWLOR.Game.Server.Native
                         ? Combat.GetRangedAbilityLongRangeHitChanceAdjustment(
                             attacker.m_idSelf,
                             defender.m_idSelf,
-                            weaponSkillType)
+                            abilitySkillType)
                         : 0;
                 var hitChanceModifier =
-                    Combat.GetSideAttackHitChanceAdjustment(attacker.m_idSelf, defender.m_idSelf, weaponSkillType) +
+                    Combat.GetSideAttackHitChanceAdjustment(attacker.m_idSelf, defender.m_idSelf, abilitySkillType) +
                     queuedWeaponAbilityLongRangeHitChanceAdjustment +
                     Combat.GetHitChanceAgainstSunderedTargetAdjustment(attacker.m_idSelf, defender.m_idSelf) +
                     Combat.GetQueuedWeaponAbilityActivationHitChanceAdjustment(

--- a/SWLOR.Game.Server/Native/ResolveAttackRoll.cs
+++ b/SWLOR.Game.Server/Native/ResolveAttackRoll.cs
@@ -125,6 +125,9 @@ namespace SWLOR.Game.Server.Native
                 var weaponSkillType = weapon == null
                     ? SkillType.Invalid
                     : SWLOR.Game.Server.Service.Skill.GetSkillTypeByBaseItem((BaseItem)weapon.m_nBaseItem);
+                var abilitySkillType = UsePerkFeat.TryGetQueuedWeaponAbility(attacker.m_idSelf, weaponSkillType, out var queuedAbility)
+                    ? Combat.GetAbilitySkillType(attacker.m_idSelf, queuedAbility)
+                    : weaponSkillType;
 
                 if (targetObject.m_nObjectType != (int)ObjectType.Creature)
                 {
@@ -162,12 +165,12 @@ namespace SWLOR.Game.Server.Native
 
                 Log.Write(LogGroup.Attack, "Selected attack type " + attackType + ", weapon " + (weapon == null ? "none" : weapon.GetFirstName().GetSimple(0)));
 
-                var attackerAccuracy = Stat.GetAccuracyNative(attacker, weapon);
+                var attackerAccuracy = Stat.GetAccuracyNative(attacker, weapon, abilitySkillType);
                 attackerAccuracy = Combat.ApplyStatusSourceAccuracyModifiers(
                     attacker.m_idSelf,
                     defender.m_idSelf,
                     attackerAccuracy);
-                var defenderEvasion = Stat.GetEvasionNative(defender, weaponSkillType);
+                var defenderEvasion = Stat.GetEvasionNative(defender, abilitySkillType);
                 defenderEvasion = Combat.ApplySideAttackEvasionIgnore(
                     attacker.m_idSelf,
                     defender.m_idSelf,
@@ -240,7 +243,7 @@ namespace SWLOR.Game.Server.Native
                     Combat.GetHitChanceAgainstSunderedTargetAdjustment(attacker.m_idSelf, defender.m_idSelf) +
                     Combat.GetQueuedWeaponAbilityActivationHitChanceAdjustment(
                         attacker.m_idSelf,
-                        weaponSkillType) +
+                        abilitySkillType) +
                     Combat.ConsumeSuppressionRangedAttackAccuracyAdjustment(
                         attacker.m_idSelf,
                         defender.m_idSelf,
@@ -396,7 +399,7 @@ namespace SWLOR.Game.Server.Native
                 {
                     Combat.StoreQueuedWeaponAbilityCriticalRateBonus(
                         attacker.m_idSelf,
-                        weaponSkillType,
+                        abilitySkillType,
                         autoAttackCycleCriticalRate);
                 }
                 else

--- a/SWLOR.Game.Server/Service/Ability.cs
+++ b/SWLOR.Game.Server/Service/Ability.cs
@@ -575,14 +575,6 @@ namespace SWLOR.Game.Server.Service
                 return Deny("You are busy.");
             }
 
-            if (ability.ActivationType == AbilityActivationType.Weapon &&
-                Combat.IsWeaponSkillType(ability.SkillType) &&
-                !Combat.HasEquippedWeaponForAbilitySkill(activator, ability.SkillType))
-            {
-                var skillName = Skill.GetSkillDetails(ability.SkillType).Name;
-                return Deny($"You must equip a {skillName} weapon to use this ability.");
-            }
-
             if (Combat.GetAbilitySkillType(activator, ability) == SkillType.Force &&
                 Stat.GetStatAdjustment(activator, StatType.ForceAbilityActivationDisabled) > 0)
             {

--- a/SWLOR.Game.Server/Service/Ability.cs
+++ b/SWLOR.Game.Server/Service/Ability.cs
@@ -108,7 +108,8 @@ namespace SWLOR.Game.Server.Service
             AbilityDetail ability,
             bool countsAsAttackAttempt = true,
             IReadOnlyList<TelegraphGeometry> activationAreaTelegraphs = null,
-            AbilityImpactSequence sequence = null)
+            AbilityImpactSequence sequence = null,
+            uint triggeringWeapon = OBJECT_INVALID)
         {
             if (!GetIsObjectValid(activator) || ability == null)
                 return;
@@ -117,6 +118,9 @@ namespace SWLOR.Game.Server.Service
                 countsAsAttackAttempt: countsAsAttackAttempt,
                 activationAreaTelegraphs: activationAreaTelegraphs, sequence: sequence);
             var trackedImpact = GetTrackedAbilityImpact(activator);
+            trackedImpact.TriggeringWeaponDamage = GetIsObjectValid(triggeringWeapon)
+                ? Item.GetDMG(triggeringWeapon)
+                : null;
             trackedImpact.ResolveDamageBonuses = () =>
             {
                 var abilitySkillType = Combat.GetAbilitySkillType(activator, ability);
@@ -186,7 +190,8 @@ namespace SWLOR.Game.Server.Service
                 activationAreaTelegraphs,
                 sequence)
             {
-                SequenceOwner = sequenceOwner?.SequenceOwner ?? sequenceOwner
+                SequenceOwner = sequenceOwner?.SequenceOwner ?? sequenceOwner,
+                TriggeringWeaponDamage = sequenceOwner?.TriggeringWeaponDamage
             };
             if (resolveDamageBonusesFromOwner && sequenceOwner != null)
             {
@@ -248,6 +253,7 @@ namespace SWLOR.Game.Server.Service
 
                 var previousImpact = GetTrackedAbilityImpact(activator);
                 BeginAbilityImpact(activator, ability, 0, 0, countsAsAttackAttempt: false, sequence: sequence);
+                GetTrackedAbilityImpact(activator).TriggeringWeaponDamage = originatingImpact.TriggeringWeaponDamage;
                 GetTrackedAbilityImpact(activator).CopyRepeatedDamageBonusesFrom(originatingImpact);
                 var completed = false;
                 try
@@ -573,6 +579,13 @@ namespace SWLOR.Game.Server.Service
             if (Activity.IsBusy(activator))
             {
                 return Deny("You are busy.");
+            }
+
+            if (ability.ActivationType == AbilityActivationType.Weapon &&
+                Combat.IsWeaponSkillType(ability.SkillType) &&
+                !Combat.HasEquippedWeaponForAbility(activator))
+            {
+                return Deny("You must equip a weapon to use this ability.");
             }
 
             if (Combat.GetAbilitySkillType(activator, ability) == SkillType.Force &&
@@ -2740,7 +2753,7 @@ namespace SWLOR.Game.Server.Service
             var perkType = trackedImpact?.Ability?.EffectiveLevelPerkType ?? PerkType.Invalid;
             var idleBonuses = Combat.GetIdleSkillAbilityBonuses(activator, skillType);
             var damage = baseDamage +
-                Combat.GetCombatImpactWeaponDamage(activator, skillType, usesQueuedNaturalWeapon) +
+                Combat.GetCombatImpactWeaponDamage(activator, skillType, usesQueuedNaturalWeapon, triggeringWeaponDamage: trackedImpact?.TriggeringWeaponDamage) +
                 Combat.GetAbilityDamageBonus(activator, skillType) +
                 Combat.GetAbilityDamageFlatAdjustment(activator, perkType, skillType) +
                 Combat.GetCostlyAbilityDamageBonus(activator, trackedImpact?.Ability, skillType) +
@@ -2972,7 +2985,7 @@ namespace SWLOR.Game.Server.Service
             var idleBonuses = Combat.GetIdleSkillAbilityBonuses(activator, skillType);
             var scalingRank = GetNPCAbilityScalingRank(activator, skillType, damageType, combatImpactDamageAbility);
             var damage = baseDamage +
-                Combat.GetCombatImpactWeaponDamage(activator, skillType, usesQueuedNaturalWeapon) +
+                Combat.GetCombatImpactWeaponDamage(activator, skillType, usesQueuedNaturalWeapon, triggeringWeaponDamage: trackedImpact?.TriggeringWeaponDamage) +
                 (int)Math.Ceiling(scalingRank * 0.15f) +
                 Combat.GetAbilityDamageFlatAdjustment(activator, perkType, skillType) +
                 Combat.GetCostlyAbilityDamageBonus(activator, trackedImpact?.Ability, skillType) +
@@ -3408,6 +3421,7 @@ namespace SWLOR.Game.Server.Service
             private Dictionary<StatType, IReadOnlyList<StatAdjustmentSource>> _statSources;
 
             public AbilityDetail Ability { get; }
+            public int? TriggeringWeaponDamage { get; set; }
             // Delayed shapes share the original tracker until a rider actually needs cast state.
             public TrackedAbilityImpact SequenceOwner { get; set; }
             public AbilityImpactSequence Sequence => _sequence ??= SequenceOwner?.Sequence ?? new AbilityImpactSequence();

--- a/SWLOR.Game.Server/Service/Combat.cs
+++ b/SWLOR.Game.Server/Service/Combat.cs
@@ -11126,15 +11126,6 @@ namespace SWLOR.Game.Server.Service
             return OBJECT_INVALID;
         }
 
-        public static bool HasEquippedWeaponForAbilitySkill(uint creature, SkillType abilitySkillType)
-        {
-            if (!GetIsObjectValid(creature) || !IsWeaponSkillType(abilitySkillType))
-                return false;
-
-            return CanItemTriggerWeaponAbility(GetItemInSlot(InventorySlot.RightHand, creature), abilitySkillType) ||
-                   CanItemTriggerWeaponAbility(GetItemInSlot(InventorySlot.LeftHand, creature), abilitySkillType);
-        }
-
         public static bool CanItemTriggerWeaponAbility(uint item, SkillType abilitySkillType)
         {
             if (!GetIsObjectValid(item))
@@ -11146,7 +11137,9 @@ namespace SWLOR.Game.Server.Service
 
         public static bool CanWeaponSkillTriggerAbility(SkillType weaponSkillType, SkillType abilitySkillType)
         {
-            return !IsWeaponSkillType(abilitySkillType) || weaponSkillType == abilitySkillType;
+            // An ability's skill controls scaling, not which weapon can deliver it.
+            // Keep non-weapon items from triggering weapon abilities through item-hit events.
+            return !IsWeaponSkillType(abilitySkillType) || IsWeaponSkillType(weaponSkillType);
         }
 
         public static bool IsWeaponSkillType(SkillType skillType)

--- a/SWLOR.Game.Server/Service/Combat.cs
+++ b/SWLOR.Game.Server/Service/Combat.cs
@@ -11696,8 +11696,8 @@ namespace SWLOR.Game.Server.Service
             if (skillType == SkillType.Staff)
                 return GetWeaponAccuracyAbilityType(creature, BaseItem.QuarterStaff);
 
-            if (skillType == SkillType.Force)
-                return AbilityType.Willpower;
+            if (!IsWeaponSkillType(skillType))
+                return AbilityType.Invalid;
 
             return IsRangedWeaponSkill(skillType) ? AbilityType.Agility : AbilityType.Perception;
         }

--- a/SWLOR.Game.Server/Service/Combat.cs
+++ b/SWLOR.Game.Server/Service/Combat.cs
@@ -11691,6 +11691,17 @@ namespace SWLOR.Game.Server.Service
             return Item.GetWeaponDamageAbilityType(weaponType);
         }
 
+        public static AbilityType GetQueuedAbilityAccuracyAbilityType(uint creature, SkillType skillType)
+        {
+            if (skillType == SkillType.Staff)
+                return GetWeaponAccuracyAbilityType(creature, BaseItem.QuarterStaff);
+
+            if (skillType == SkillType.Force)
+                return AbilityType.Willpower;
+
+            return IsRangedWeaponSkill(skillType) ? AbilityType.Agility : AbilityType.Perception;
+        }
+
         public static AbilityType GetWeaponAccuracyAbilityType(uint creature, BaseItem weaponType)
         {
             var overrideAbility = GetAbilityOverride(

--- a/SWLOR.Game.Server/Service/Combat.cs
+++ b/SWLOR.Game.Server/Service/Combat.cs
@@ -7582,7 +7582,7 @@ namespace SWLOR.Game.Server.Service
                 return 0;
 
             var reflected = GetRangedDeflectionReflectionAmount(
-                GetCombatImpactWeaponDamage(attacker, attackerWeaponSkill),
+                GetCombatImpactWeaponDamage(attacker, attackerWeaponSkill, requireMatchingSkill: true),
                 reflectPercent,
                 GetCombatImpactWeaponDamage(defender, GetEquippedWeaponSkillType(defender)),
                 capPercent);
@@ -11093,7 +11093,9 @@ namespace SWLOR.Game.Server.Service
         public static int GetCombatImpactWeaponDamage(
             uint activator,
             SkillType skillType,
-            bool usesQueuedNaturalWeapon = false)
+            bool usesQueuedNaturalWeapon = false,
+            bool requireMatchingSkill = false,
+            int? triggeringWeaponDamage = null)
         {
             if (!IsWeaponSkillType(skillType) &&
                 !(usesQueuedNaturalWeapon && skillType == SkillType.BeastMastery))
@@ -11101,7 +11103,10 @@ namespace SWLOR.Game.Server.Service
                 return 0;
             }
 
-            var weapon = GetCombatImpactWeapon(activator, skillType, usesQueuedNaturalWeapon);
+            if (triggeringWeaponDamage.HasValue)
+                return triggeringWeaponDamage.Value;
+
+            var weapon = GetCombatImpactWeapon(activator, skillType, usesQueuedNaturalWeapon, requireMatchingSkill);
             return GetIsObjectValid(weapon)
                 ? Item.GetDMG(weapon)
                 : 0;
@@ -11110,20 +11115,36 @@ namespace SWLOR.Game.Server.Service
         private static uint GetCombatImpactWeapon(
             uint activator,
             SkillType skillType,
-            bool usesQueuedNaturalWeapon = false)
+            bool usesQueuedNaturalWeapon = false,
+            bool requireMatchingSkill = false)
         {
             if (usesQueuedNaturalWeapon && skillType == SkillType.BeastMastery)
                 return GetCreatureNaturalWeapon(activator);
 
             var rightHand = GetItemInSlot(InventorySlot.RightHand, activator);
-            if (CanItemTriggerWeaponAbility(rightHand, skillType))
+            if (CanItemTriggerWeaponAbility(rightHand, skillType) &&
+                (!requireMatchingSkill || Skill.GetSkillTypeByBaseItem(GetBaseItemType(rightHand)) == skillType))
                 return rightHand;
 
             var leftHand = GetItemInSlot(InventorySlot.LeftHand, activator);
-            if (CanItemTriggerWeaponAbility(leftHand, skillType))
+            if (CanItemTriggerWeaponAbility(leftHand, skillType) &&
+                (!requireMatchingSkill || Skill.GetSkillTypeByBaseItem(GetBaseItemType(leftHand)) == skillType))
                 return leftHand;
 
             return OBJECT_INVALID;
+        }
+
+        public static bool HasEquippedWeaponForAbility(uint creature)
+        {
+            return GetIsObjectValid(creature) &&
+                   (IsAbilityWeapon(GetItemInSlot(InventorySlot.RightHand, creature)) ||
+                    IsAbilityWeapon(GetItemInSlot(InventorySlot.LeftHand, creature)));
+        }
+
+        private static bool IsAbilityWeapon(uint item)
+        {
+            return GetIsObjectValid(item) &&
+                   IsWeaponSkillType(Skill.GetSkillTypeByBaseItem(GetBaseItemType(item)));
         }
 
         public static bool CanItemTriggerWeaponAbility(uint item, SkillType abilitySkillType)

--- a/SWLOR.Game.Server/Service/Stat.cs
+++ b/SWLOR.Game.Server/Service/Stat.cs
@@ -1362,7 +1362,7 @@ namespace SWLOR.Game.Server.Service
         /// <param name="creature">The creature to retrieve from.</param>
         /// <param name="weapon">The weapon being used.</param>
         /// <returns>The accuracy rating for a creature using a specific weapon.</returns>
-        public static int GetAccuracyNative(CNWSCreature creature, CNWSItem weapon)
+        public static int GetAccuracyNative(CNWSCreature creature, CNWSItem weapon, SkillType skillOverride = SkillType.Invalid)
         {
             var accuracyBonus = 0;
             var statOverride = AbilityType.Invalid;
@@ -1389,7 +1389,7 @@ namespace SWLOR.Game.Server.Service
             var statType = statOverride == AbilityType.Invalid ?
                 Combat.GetWeaponAccuracyAbilityType(creature.m_idSelf, baseItemType) :
                 statOverride;
-            var skillType = Skill.GetSkillTypeByBaseItem(baseItemType);
+            var skillType = skillOverride != SkillType.Invalid ? skillOverride : Skill.GetSkillTypeByBaseItem(baseItemType);
             var stat = GetStatValueNative(creature, statType);
             var skillLevel = 0;
 

--- a/SWLOR.Game.Server/Service/Stat.cs
+++ b/SWLOR.Game.Server/Service/Stat.cs
@@ -1362,7 +1362,8 @@ namespace SWLOR.Game.Server.Service
         /// <param name="creature">The creature to retrieve from.</param>
         /// <param name="weapon">The weapon being used.</param>
         /// <returns>The accuracy rating for a creature using a specific weapon.</returns>
-        public static int GetAccuracyNative(CNWSCreature creature, CNWSItem weapon, SkillType skillOverride = SkillType.Invalid)
+        public static int GetAccuracyNative(CNWSCreature creature, CNWSItem weapon, SkillType skillOverride = SkillType.Invalid,
+            AbilityType accuracyAbilityOverride = AbilityType.Invalid)
         {
             var accuracyBonus = 0;
             var statOverride = AbilityType.Invalid;
@@ -1386,9 +1387,11 @@ namespace SWLOR.Game.Server.Service
             }
 
             var baseItemType = weapon == null ? BaseItem.Invalid : (BaseItem)weapon.m_nBaseItem;
-            var statType = statOverride == AbilityType.Invalid ?
-                Combat.GetWeaponAccuracyAbilityType(creature.m_idSelf, baseItemType) :
-                statOverride;
+            var statType = accuracyAbilityOverride != AbilityType.Invalid
+                ? accuracyAbilityOverride
+                : statOverride == AbilityType.Invalid
+                    ? Combat.GetWeaponAccuracyAbilityType(creature.m_idSelf, baseItemType)
+                    : statOverride;
             var skillType = skillOverride != SkillType.Invalid ? skillOverride : Skill.GetSkillTypeByBaseItem(baseItemType);
             var stat = GetStatValueNative(creature, statType);
             var skillLevel = 0;


### PR DESCRIPTION
Perk abilities such as Shield Bash incorrectly required a weapon matching their declared skill. Allow all weapon families for activation, queued-hit triggering, and weapon damage while preserving each ability's scaling skill. Queued weapon abilities still require a usable weapon in either hand so unarmed activation cannot waste stamina and cooldowns.

Queued hits retain the actual triggering weapon's damage through delayed/repeated impacts. Their hit accuracy, incoming-skill evasion and stored ability bonuses use the declared ability skill. Ordinary weapon delivery and ranged deflection reflection retain the actual weapon selection.

Validation: built with `-p:RunPostBuildEvent=Never`; all 175 selected combat damage, generated weapon perk behavior, weapon deflection, attack delay, active attack target, and lightsaber behavior tests passed. Six tests requiring the uninitialized SWLOR_Haks assets were excluded; an initial run confirmed those missing-asset failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Combat Updates**
  - Weapon abilities can now be activated with any equipped weapon, regardless of its specific weapon skill.
  - Queued weapon abilities use the weapon that triggered them for damage calculations, including reflected attacks.
  - Queued ability accuracy, evasion, side-attack, ranged, and critical-hit calculations now consistently use the ability’s skill.
  - Weapon requirement messaging is now generalized instead of naming a specific skill.
- **Bug Fixes**
  - Corrected queued weapon and natural-weapon damage handling during combat.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->