### PR TITLE
Clear city tax debt when citizenship ends or begins

### DIFF
--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/ManageCitizenshipViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/ManageCitizenshipViewModel.cs
@@ -131,6 +131,11 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
             LoadData();
         }
 
+        /// <summary>
+        /// Creates the confirmation action for registering or revoking citizenship in this city.
+        /// Successful membership changes clear unpaid citizenship taxes before saving the player.
+        /// </summary>
+        /// <returns>The citizenship registration or revocation action.</returns>
         public Action RegisterRevoke() => () =>
         {
             var playerId = GetObjectUUID(Player);

--- a/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/ManageCitizenshipViewModel.cs
+++ b/SWLOR.Game.Server/Feature/GuiDefinition/ViewModel/ManageCitizenshipViewModel.cs
@@ -234,6 +234,8 @@ namespace SWLOR.Game.Server.Feature.GuiDefinition.ViewModel
 
                         var dbCity = DB.Get<WorldProperty>(_cityPropertyId);
                         dbPlayer.CitizenPropertyId = _cityPropertyId;
+                        // Clear any stale debt left by a previously deleted city.
+                        dbPlayer.PropertyOwedTaxes = 0;
 
                         DB.Set(dbPlayer);
 

--- a/SWLOR.Game.Server/Service/Property.cs
+++ b/SWLOR.Game.Server/Service/Property.cs
@@ -1911,6 +1911,11 @@ namespace SWLOR.Game.Server.Service
             Log.Write(LogGroup.Property, $"Finished processing citizenship fees for '{city.CustomName}' ({city.Id})");
         }
 
+        /// <summary>
+        /// Deletes a property and its owned children, clears associated data and permissions,
+        /// and revokes its citizens' membership and unpaid citizenship taxes.
+        /// </summary>
+        /// <param name="property">The property to delete.</param>
         public static void DeleteProperty(WorldProperty property)
         {
             // Recursively clear any children properties tied to this property.

--- a/SWLOR.Game.Server/Service/Property.cs
+++ b/SWLOR.Game.Server/Service/Property.cs
@@ -1987,6 +1987,7 @@ namespace SWLOR.Game.Server.Service
             {
                 Log.Write(LogGroup.Property, $"Citizenship revoked for player '{citizen.Name}' ({citizen.Id}) on property '{property.CustomName}' ({property.Id})");
                 citizen.CitizenPropertyId = string.Empty;
+                citizen.PropertyOwedTaxes = 0;
                 DB.Set(citizen);
             }
 
@@ -2449,6 +2450,8 @@ namespace SWLOR.Game.Server.Service
                 location);
 
             dbPlayer.CitizenPropertyId = city.Id;
+            // A new citizenship must not inherit taxes from a previously deleted city.
+            dbPlayer.PropertyOwedTaxes = 0;
             DB.Set(dbPlayer);
 
             Log.Write(LogGroup.Property, $"{GetName(player)} ({GetPCPlayerName(player)} / {GetPCPublicCDKey(player)}) founded a new city in {GetName(area)}.");


### PR DESCRIPTION
When a city is deleted, its citizens lose their city assignment but retain unpaid taxes. Joining or founding another city then carries that debt into the new city's treasury.

Clear unpaid citizenship taxes when deleting a city and when registering or founding a new city. The latter also clears stale balances left by past deletions before the player acquires a new citizenship. Existing debts within an unchanged citizenship remain untouched because the stored balance cannot distinguish historical carryover from legitimate current taxes.

Validation: `dotnet build SWLOR.Game.Server.Tests/SWLOR.Game.Server.Tests.csproj -p:RunPostBuildEvent=Never` succeeded (8 existing compiler warnings). All 36 focused PropertyOnDemandLoadingTests and LinkedBankStorageTests passed; the load-hint test was rerun successfully after initializing the pinned Haks submodule. `git diff --check` passed. No live NWN server test was performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Cleared outdated property tax balances when citizenship is revoked after a city is deleted.
  - Ensured players founding a new city start with no inherited property tax debt.
  - Prevented stale tax balances from carrying over when registering citizenship.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->