### PR TITLE
Stabilize hourly weather and fix hazards, protection, and area climates

### DIFF
--- a/Module/are/foszchimed.are.json
+++ b/Module/are/foszchimed.are.json
@@ -30,7 +30,7 @@
   },
   "Flags": {
     "type": "dword",
-    "value": 0
+    "value": 1
   },
   "FogClipDist": {
     "type": "float",

--- a/Module/are/foszestate.are.json
+++ b/Module/are/foszestate.are.json
@@ -30,7 +30,7 @@
   },
   "Flags": {
     "type": "dword",
-    "value": 0
+    "value": 1
   },
   "FogClipDist": {
     "type": "float",

--- a/Module/are/hutlar_smuggleba.are.json
+++ b/Module/are/hutlar_smuggleba.are.json
@@ -30,7 +30,7 @@
   },
   "Flags": {
     "type": "dword",
-    "value": 0
+    "value": 1
   },
   "FogClipDist": {
     "type": "float",

--- a/Module/are/korr_cavern.are.json
+++ b/Module/are/korr_cavern.are.json
@@ -30,7 +30,7 @@
   },
   "Flags": {
     "type": "dword",
-    "value": 0
+    "value": 3
   },
   "FogClipDist": {
     "type": "float",

--- a/Module/are/korr_crypt_zil.are.json
+++ b/Module/are/korr_crypt_zil.are.json
@@ -30,7 +30,7 @@
   },
   "Flags": {
     "type": "dword",
-    "value": 0
+    "value": 3
   },
   "FogClipDist": {
     "type": "float",

--- a/Module/are/narshadaar_pr001.are.json
+++ b/Module/are/narshadaar_pr001.are.json
@@ -30,7 +30,7 @@
   },
   "Flags": {
     "type": "dword",
-    "value": 0
+    "value": 1
   },
   "FogClipDist": {
     "type": "float",

--- a/Module/are/nashada_czlabf2.are.json
+++ b/Module/are/nashada_czlabf2.are.json
@@ -30,7 +30,7 @@
   },
   "Flags": {
     "type": "dword",
-    "value": 0
+    "value": 1
   },
   "FogClipDist": {
     "type": "float",

--- a/Module/are/nashadaa_czlabin.are.json
+++ b/Module/are/nashadaa_czlabin.are.json
@@ -30,7 +30,7 @@
   },
   "Flags": {
     "type": "dword",
-    "value": 0
+    "value": 1
   },
   "FogClipDist": {
     "type": "float",

--- a/Module/are/ns_prfb_nsinteri.are.json
+++ b/Module/are/ns_prfb_nsinteri.are.json
@@ -30,7 +30,7 @@
   },
   "Flags": {
     "type": "dword",
-    "value": 0
+    "value": 1
   },
   "FogClipDist": {
     "type": "float",

--- a/Module/are/ossus_cavefacili.are.json
+++ b/Module/are/ossus_cavefacili.are.json
@@ -30,7 +30,7 @@
   },
   "Flags": {
     "type": "dword",
-    "value": 0
+    "value": 3
   },
   "FogClipDist": {
     "type": "float",

--- a/Module/are/prefab_underwtun.are.json
+++ b/Module/are/prefab_underwtun.are.json
@@ -30,7 +30,7 @@
   },
   "Flags": {
     "type": "dword",
-    "value": 0
+    "value": 1
   },
   "FogClipDist": {
     "type": "float",

--- a/Module/are/prefabwarehouse.are.json
+++ b/Module/are/prefabwarehouse.are.json
@@ -30,7 +30,7 @@
   },
   "Flags": {
     "type": "dword",
-    "value": 0
+    "value": 1
   },
   "FogClipDist": {
     "type": "float",

--- a/Module/are/pw_ar_czarmrange.are.json
+++ b/Module/are/pw_ar_czarmrange.are.json
@@ -30,7 +30,7 @@
   },
   "Flags": {
     "type": "dword",
-    "value": 0
+    "value": 1
   },
   "FogClipDist": {
     "type": "float",

--- a/Module/are/pw_ar_sc_arki001.are.json
+++ b/Module/are/pw_ar_sc_arki001.are.json
@@ -30,7 +30,7 @@
   },
   "Flags": {
     "type": "dword",
-    "value": 0
+    "value": 1
   },
   "FogClipDist": {
     "type": "float",

--- a/Module/are/republicshipevnt.are.json
+++ b/Module/are/republicshipevnt.are.json
@@ -30,7 +30,7 @@
   },
   "Flags": {
     "type": "dword",
-    "value": 0
+    "value": 1
   },
   "FogClipDist": {
     "type": "float",

--- a/Module/are/smesks_palace.are.json
+++ b/Module/are/smesks_palace.are.json
@@ -30,7 +30,7 @@
   },
   "Flags": {
     "type": "dword",
-    "value": 0
+    "value": 1
   },
   "FogClipDist": {
     "type": "float",

--- a/Module/are/spacenarshaddung.are.json
+++ b/Module/are/spacenarshaddung.are.json
@@ -30,7 +30,7 @@
   },
   "Flags": {
     "type": "dword",
-    "value": 0
+    "value": 1
   },
   "FogClipDist": {
     "type": "float",

--- a/Module/are/spending_area.are.json
+++ b/Module/are/spending_area.are.json
@@ -30,7 +30,7 @@
   },
   "Flags": {
     "type": "dword",
-    "value": 0
+    "value": 1
   },
   "FogClipDist": {
     "type": "float",

--- a/Module/are/tat_anc_droidshp.are.json
+++ b/Module/are/tat_anc_droidshp.are.json
@@ -30,7 +30,7 @@
   },
   "Flags": {
     "type": "dword",
-    "value": 0
+    "value": 1
   },
   "FogClipDist": {
     "type": "float",

--- a/Module/are/tat_anc_gocorpst.are.json
+++ b/Module/are/tat_anc_gocorpst.are.json
@@ -30,7 +30,7 @@
   },
   "Flags": {
     "type": "dword",
-    "value": 0
+    "value": 1
   },
   "FogClipDist": {
     "type": "float",

--- a/Module/are/tat_anc_junix.are.json
+++ b/Module/are/tat_anc_junix.are.json
@@ -30,7 +30,7 @@
   },
   "Flags": {
     "type": "dword",
-    "value": 0
+    "value": 1
   },
   "FogClipDist": {
     "type": "float",

--- a/Module/are/valkorrdung1c.are.json
+++ b/Module/are/valkorrdung1c.are.json
@@ -30,7 +30,7 @@
   },
   "Flags": {
     "type": "dword",
-    "value": 0
+    "value": 1
   },
   "FogClipDist": {
     "type": "float",

--- a/Module/are/vprefsith1.are.json
+++ b/Module/are/vprefsith1.are.json
@@ -30,7 +30,7 @@
   },
   "Flags": {
     "type": "dword",
-    "value": 0
+    "value": 3
   },
   "FogClipDist": {
     "type": "float",

--- a/Module/are/vrotrhighoffice.are.json
+++ b/Module/are/vrotrhighoffice.are.json
@@ -30,7 +30,7 @@
   },
   "Flags": {
     "type": "dword",
-    "value": 0
+    "value": 1
   },
   "FogClipDist": {
     "type": "float",

--- a/Module/are/vrotrkorrdnkside.are.json
+++ b/Module/are/vrotrkorrdnkside.are.json
@@ -30,7 +30,7 @@
   },
   "Flags": {
     "type": "dword",
-    "value": 0
+    "value": 1
   },
   "FogClipDist": {
     "type": "float",

--- a/Module/are/vrotrnsinterior.are.json
+++ b/Module/are/vrotrnsinterior.are.json
@@ -30,7 +30,7 @@
   },
   "Flags": {
     "type": "dword",
-    "value": 0
+    "value": 1
   },
   "FogClipDist": {
     "type": "float",

--- a/Module/gic/pw_ar_kashyk.gic.json
+++ b/Module/gic/pw_ar_kashyk.gic.json
@@ -1672,6 +1672,14 @@
   },
   "WaypointList": {
     "type": "list",
-    "value": []
+    "value": [
+      {
+        "__struct_id": 5,
+        "Comment": {
+          "type": "cexostring",
+          "value": "Emergency /stuck recovery on the open canopy platform at tile (14, 8), thf02_a13_01 walkable floor Z=2.2. Keep clear of placeables."
+        }
+      }
+    ]
   }
 }

--- a/Module/git/hutlar_frozen_wa.git.json
+++ b/Module/git/hutlar_frozen_wa.git.json
@@ -19365,6 +19365,21 @@
           "type": "cexostring",
           "value": "RESOURCES_HUTLAR_WASTES"
         }
+      },
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "VAR_WEATHER_HUMIDITY"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 1
+        },
+        "Value": {
+          "type": "int",
+          "value": 9
+        }
       }
     ]
   },

--- a/Module/git/kash_village.git.json
+++ b/Module/git/kash_village.git.json
@@ -62007,5 +62007,25 @@
         }
       }
     ]
+  },
+  "VarTable": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "VAR_WEATHER_CLIMATE"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 3
+        },
+        "Value": {
+          "type": "cexostring",
+          "value": "Kashyyyk"
+        }
+      }
+    ]
   }
 }

--- a/Module/git/kashyyyk_camp.git.json
+++ b/Module/git/kashyyyk_camp.git.json
@@ -39206,5 +39206,25 @@
         }
       }
     ]
+  },
+  "VarTable": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "VAR_WEATHER_CLIMATE"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 3
+        },
+        "Value": {
+          "type": "cexostring",
+          "value": "Kashyyyk"
+        }
+      }
+    ]
   }
 }

--- a/Module/git/kashyyykpaths.git.json
+++ b/Module/git/kashyyykpaths.git.json
@@ -140,5 +140,25 @@
         }
       }
     ]
+  },
+  "VarTable": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "VAR_WEATHER_CLIMATE"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 3
+        },
+        "Value": {
+          "type": "cexostring",
+          "value": "Kashyyyk"
+        }
+      }
+    ]
   }
 }

--- a/Module/git/kashyyykshadow.git.json
+++ b/Module/git/kashyyykshadow.git.json
@@ -10088,5 +10088,25 @@
         }
       }
     ]
+  },
+  "VarTable": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "VAR_WEATHER_CLIMATE"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 3
+        },
+        "Value": {
+          "type": "cexostring",
+          "value": "Kashyyyk"
+        }
+      }
+    ]
   }
 }

--- a/Module/git/ossu_wastesruin.git.json
+++ b/Module/git/ossu_wastesruin.git.json
@@ -10125,5 +10125,25 @@
         }
       }
     ]
+  },
+  "VarTable": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "VAR_WEATHER_CLIMATE"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 3
+        },
+        "Value": {
+          "type": "cexostring",
+          "value": "Ossus"
+        }
+      }
+    ]
   }
 }

--- a/Module/git/ossus_landstart.git.json
+++ b/Module/git/ossus_landstart.git.json
@@ -4689,5 +4689,25 @@
         }
       }
     ]
+  },
+  "VarTable": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "VAR_WEATHER_CLIMATE"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 3
+        },
+        "Value": {
+          "type": "cexostring",
+          "value": "Ossus"
+        }
+      }
+    ]
   }
 }

--- a/Module/git/ossus_wastejungl.git.json
+++ b/Module/git/ossus_wastejungl.git.json
@@ -11491,5 +11491,25 @@
         }
       }
     ]
+  },
+  "VarTable": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "VAR_WEATHER_CLIMATE"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 3
+        },
+        "Value": {
+          "type": "cexostring",
+          "value": "Ossus"
+        }
+      }
+    ]
   }
 }

--- a/Module/git/ossustemp.git.json
+++ b/Module/git/ossustemp.git.json
@@ -17656,5 +17656,25 @@
         }
       }
     ]
+  },
+  "VarTable": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "VAR_WEATHER_CLIMATE"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 3
+        },
+        "Value": {
+          "type": "cexostring",
+          "value": "Ossus"
+        }
+      }
+    ]
   }
 }

--- a/Module/git/pw_ar_kashyk.git.json
+++ b/Module/git/pw_ar_kashyk.git.json
@@ -50758,5 +50758,25 @@
   "WaypointList": {
     "type": "list",
     "value": []
+  },
+  "VarTable": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "VAR_WEATHER_CLIMATE"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 3
+        },
+        "Value": {
+          "type": "cexostring",
+          "value": "Kashyyyk"
+        }
+      }
+    ]
   }
 }

--- a/Module/git/pw_ar_kashyk.git.json
+++ b/Module/git/pw_ar_kashyk.git.json
@@ -50757,7 +50757,69 @@
   },
   "WaypointList": {
     "type": "list",
-    "value": []
+    "value": [
+      {
+        "__struct_id": 5,
+        "Appearance": {
+          "type": "byte",
+          "value": 1
+        },
+        "Description": {
+          "type": "cexolocstring",
+          "value": {}
+        },
+        "HasMapNote": {
+          "type": "byte",
+          "value": 0
+        },
+        "LinkedTo": {
+          "type": "cexostring",
+          "value": ""
+        },
+        "LocalizedName": {
+          "type": "cexolocstring",
+          "value": {
+            "0": "Stuck Recovery"
+          }
+        },
+        "MapNote": {
+          "type": "cexolocstring",
+          "value": {}
+        },
+        "MapNoteEnabled": {
+          "type": "byte",
+          "value": 0
+        },
+        "Tag": {
+          "type": "cexostring",
+          "value": "STUCK_WAYPOINT"
+        },
+        "TemplateResRef": {
+          "type": "resref",
+          "value": "wp_stuck"
+        },
+        "XOrientation": {
+          "type": "float",
+          "value": 0.0
+        },
+        "XPosition": {
+          "type": "float",
+          "value": 145.0
+        },
+        "YOrientation": {
+          "type": "float",
+          "value": 1.0
+        },
+        "YPosition": {
+          "type": "float",
+          "value": 87.5
+        },
+        "ZPosition": {
+          "type": "float",
+          "value": 2.2
+        }
+      }
+    ]
   },
   "VarTable": {
     "type": "list",

--- a/SWLOR.Game.Server.Tests/Feature/KashyyykCanopyPlacementTests.cs
+++ b/SWLOR.Game.Server.Tests/Feature/KashyyykCanopyPlacementTests.cs
@@ -1,0 +1,42 @@
+using System.Text.Json;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace SWLOR.Game.Server.Tests.Feature;
+
+public class KashyyykCanopyPlacementTests
+{
+    [Test]
+    public void RecoveryWaypoint_UsesTheOpenPlatform_AndHasAnAlignedToolsetComment()
+    {
+        var root = new DirectoryInfo(AppContext.BaseDirectory);
+        while (root != null && !Directory.Exists(Path.Combine(root.FullName, "Module"))) root = root.Parent;
+        root.Should().NotBeNull();
+        using var git = Read("git");
+        using var gic = Read("gic");
+        using var are = Read("are");
+        var waypoints = git.RootElement.GetProperty("WaypointList").GetProperty("value");
+        var recovery = waypoints.EnumerateArray().Single(w =>
+            w.GetProperty("Tag").GetProperty("value").GetString() == "STUCK_WAYPOINT");
+        recovery.GetProperty("TemplateResRef").GetProperty("value").GetString().Should().Be("wp_stuck");
+
+        // thf02_a13_01 has a walkable wooden floor at Z=2.2. Keep the recovery
+        // point inside the clear central part of this platform, away from its edges.
+        var x = recovery.GetProperty("XPosition").GetProperty("value").GetSingle();
+        var y = recovery.GetProperty("YPosition").GetProperty("value").GetSingle();
+        x.Should().BeInRange(143f, 147f);
+        y.Should().BeInRange(85.5f, 89.5f);
+        recovery.GetProperty("ZPosition").GetProperty("value").GetSingle().Should().BeApproximately(2.2f, 0.01f);
+        var width = are.RootElement.GetProperty("Width").GetProperty("value").GetInt32();
+        var tile = are.RootElement.GetProperty("Tile_List").GetProperty("value")[(int)(y / 10) * width + (int)(x / 10)];
+        are.RootElement.GetProperty("Tileset").GetProperty("value").GetString().Should().Be("thf02");
+        tile.GetProperty("Tile_ID").GetProperty("value").GetInt32().Should().Be(14);
+        tile.GetProperty("Tile_Height").GetProperty("value").GetInt32().Should().Be(0);
+        tile.GetProperty("Tile_Orientation").GetProperty("value").GetInt32().Should().Be(1);
+        gic.RootElement.GetProperty("WaypointList").GetProperty("value").GetArrayLength()
+            .Should().Be(waypoints.GetArrayLength());
+
+        JsonDocument Read(string kind) => JsonDocument.Parse(File.ReadAllText(
+            Path.Combine(root!.FullName, "Module", kind, $"pw_ar_kashyk.{kind}.json")));
+    }
+}

--- a/SWLOR.Game.Server.Tests/Service/WeatherAreaConfigurationTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/WeatherAreaConfigurationTests.cs
@@ -1,0 +1,118 @@
+using System.Reflection;
+using System.Text.Json;
+using FluentAssertions;
+using NUnit.Framework;
+using SWLOR.Game.Server.Enumeration;
+using SWLOR.Game.Server.Service;
+using SWLOR.Game.Server.Service.WeatherService;
+using Precipitation = SWLOR.NWN.API.NWScript.Enum.Weather;
+
+namespace SWLOR.Game.Server.Tests.Service;
+
+[NonParallelizable]
+public class WeatherAreaConfigurationTests
+{
+    // GENERAL/Interior metadata from the shipped .set resources. These tilesets
+    // provide roofs; the three reviewed open-air layouts below are deliberate exceptions.
+    private static readonly HashSet<string> InteriorTilesets = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "fifi", "flow_pa", "net01", "shp02", "sjm01", "tbw01", "tbx78", "tcdh0", "tdc01", "tdm01",
+        "tdr01", "tds01", "tdt01", "tfb01", "tib01", "tii01", "tin01", "tjsb0", "tmi", "tni02",
+        "tqq01", "tsw01", "udp2", "vmr01", "zdc01", "zde01", "zdm01", "zib01", "zid01", "zin01", "zsf01"
+    };
+    private static readonly HashSet<string> OutdoorLayouts = new()
+    {
+        "pw_sc_canyonpit", // Tatooine capstone arena, open canyon.
+        "valkorrdung1b", // Korriban fortress courtyard, skybox 10.
+        "vrotrkorracadrft" // Academy rooftop, authored rain and visible sky.
+    };
+
+    private sealed record Area(string Resource, string Name, string Tileset, int Flags, PlanetType Planet,
+        string Override, bool Space, int HumidityModifier);
+
+    [Test]
+    public void ModuleCorpus_InteriorTilesetsProvideShelter_WhileReviewedOutdoorLayoutsRemainOpen()
+    {
+        var areas = ReadAreas();
+        var exposedInteriors = areas.Where(a => InteriorTilesets.Contains(a.Tileset) && (a.Flags & 3) == 0)
+            .Select(a => a.Resource);
+        exposedInteriors.Should().BeEquivalentTo(OutdoorLayouts);
+        (areas.Single(a => a.Resource == "korr_cavern").Flags & 2).Should().Be(2);
+    }
+
+    [Test]
+    public void ModuleCorpus_AllLiveOutdoorPlanetAreasHaveAnExplicitClimate()
+    {
+        var planets = WeatherPlanetDefinitions.GetPlanetClimates();
+        var named = WeatherPlanetDefinitions.GetNamedClimates(planets);
+        var areas = ReadAreas();
+        foreach (var area in areas)
+        {
+            if (!string.IsNullOrWhiteSpace(area.Override))
+                named.Should().ContainKey(area.Override, $"{area.Resource} must not silently lose its weather to a typo");
+            if ((area.Flags & 3) != 0 || area.Space) continue;
+            var climate = WeatherPlanetDefinitions.ResolveClimate(area.Planet, area.Override, planets, named);
+            if (area.Name.StartsWith("[") || area.Name.StartsWith("*") || area.Resource == "area_template") continue;
+            climate.Should().NotBeNull($"{area.Name} ({area.Resource}) needs an authored weather profile");
+            climate!.IsSheltered.Should().BeFalse($"{area.Name} is an outdoor planet area");
+        }
+    }
+
+    [Test]
+    public void StationsAreAlwaysSheltered_AndEveryRegisteredPlanetHasAWeatherPolicy()
+    {
+        var planets = WeatherPlanetDefinitions.GetPlanetClimates();
+        var areas = ReadAreas();
+        foreach (var planet in Planet.GetAllPlanets().Keys) planets.Should().ContainKey(planet);
+        foreach (var area in areas.Where(a => a.Planet is PlanetType.CZ220 or PlanetType.SmugglersMoonStation))
+        {
+            planets[area.Planet].IsSheltered.Should().BeTrue();
+            (area.Flags & 3).Should().NotBe(0, $"{area.Name} is inside a sealed station");
+        }
+    }
+
+    [Test]
+    public void FrozenWastes_PreserveAuthoredPermanentSnow_InEveryWeatherFront()
+    {
+        var area = ReadAreas().Single(a => a.Resource == "hutlar_frozen_wa");
+        var climate = WeatherPlanetDefinitions.GetPlanetClimates()[area.Planet];
+        for (var heat = -1; heat <= 12; heat++)
+        for (var humidity = 1; humidity <= 10; humidity++)
+            WeatherConditions.Create(heat, humidity, 5, climate, 0, area.HumidityModifier, 0, false,
+                WeatherStorm.None, max => max - 1).Precipitation.Should().Be(Precipitation.Snow);
+    }
+
+    private static List<Area> ReadAreas()
+    {
+        var root = new DirectoryInfo(AppContext.BaseDirectory);
+        while (root != null && !Directory.Exists(Path.Combine(root.FullName, "Module"))) root = root.Parent;
+        root.Should().NotBeNull();
+        const BindingFlags flags = BindingFlags.Static | BindingFlags.NonPublic;
+        typeof(Planet).GetMethod("CachePlanets", flags)!.Invoke(null, null);
+        var resolveName = typeof(Planet).GetMethod("ResolvePlanetTypeByAreaName", flags)!;
+        var areas = new List<Area>();
+        foreach (var file in Directory.EnumerateFiles(Path.Combine(root!.FullName, "Module", "are"), "*.are.json"))
+        {
+            var resource = Path.GetFileName(file).Replace(".are.json", "");
+            using var are = JsonDocument.Parse(File.ReadAllText(file));
+            using var git = JsonDocument.Parse(File.ReadAllText(Path.Combine(root.FullName, "Module", "git", resource + ".git.json")));
+            var data = are.RootElement;
+            var locals = new Dictionary<string, JsonElement>();
+            foreach (var source in new[] { data, git.RootElement.GetProperty("AreaProperties").GetProperty("value"), git.RootElement })
+                if (source.TryGetProperty("VarTable", out var table))
+                    foreach (var variable in table.GetProperty("value").EnumerateArray())
+                        locals[variable.GetProperty("Name").GetProperty("value").GetString()!] = variable.GetProperty("Value").GetProperty("value");
+            var name = data.GetProperty("Name").GetProperty("value").GetProperty("0").GetString()!;
+            var space = name.StartsWith("Space -") || locals.TryGetValue("SPACE", out var spaceFlag) && spaceFlag.GetInt32() != 0;
+            var planet = (PlanetType)resolveName.Invoke(null, new object[] { name })!;
+            if (planet == PlanetType.Invalid && !space) planet = Planet.GetPlanetTypeByAreaResref(resource);
+            if (planet == PlanetType.Invalid && locals.TryGetValue("PLANET_TYPE_ID", out var id)) planet = (PlanetType)id.GetInt32();
+            areas.Add(new Area(resource, name, data.GetProperty("Tileset").GetProperty("value").GetString()!,
+                data.GetProperty("Flags").GetProperty("value").GetInt32(), planet,
+                locals.TryGetValue("VAR_WEATHER_CLIMATE", out var custom) ? custom.GetString()! : "", space,
+                locals.TryGetValue("VAR_WEATHER_HUMIDITY", out var humidity) ? humidity.GetInt32() : 0));
+        }
+        areas.Should().HaveCountGreaterThan(450, "the audit must cover the complete module, including prefabs");
+        return areas;
+    }
+}

--- a/SWLOR.Game.Server.Tests/Service/WeatherTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/WeatherTests.cs
@@ -1,0 +1,350 @@
+using System.Reflection;
+using FluentAssertions;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using NUnit.Framework;
+using SWLOR.Game.Server.Core;
+using SWLOR.Game.Server.Enumeration;
+using SWLOR.Game.Server.Service;
+using SWLOR.Game.Server.Service.WeatherService;
+using Precipitation = SWLOR.NWN.API.NWScript.Enum.Weather;
+using WeatherRuntime = SWLOR.Game.Server.Service.Weather;
+
+namespace SWLOR.Game.Server.Tests.Service;
+
+[NonParallelizable]
+public class WeatherTests
+{
+    private static readonly DateTime Start = new(2026, 9, 12, 0, 0, 0, DateTimeKind.Utc);
+
+    [Test]
+    public void FirstUpdate_InitializesEvenAtMidnight_AndWaitsOneRealHour()
+    {
+        var pattern = new WeatherPattern();
+        pattern.TryAdvance(Start, 6, false, Rolls(4, 9, 9, 9)).Should().BeTrue();
+        pattern.Heat.Should().Be(12);
+        pattern.Humidity.Should().Be(10);
+        pattern.Wind.Should().Be(10);
+        pattern.Revision.Should().Be(1);
+        pattern.NextChangeUtc.Should().Be(Start.AddHours(1));
+
+        for (var second = 0; second < 3600; second += 6)
+        {
+            pattern.TryAdvance(Start.AddSeconds(second), 12, true, NoRoll).Should().BeFalse();
+            pattern.Heat.Should().Be(12, "dusk and calendar changes cannot bypass the real-time interval");
+            pattern.Humidity.Should().Be(10);
+        }
+
+        pattern.TryAdvance(Start.AddHours(1), 12, true, Rolls(0, 0, 0, 0)).Should().BeTrue();
+        pattern.Heat.Should().Be(11, "temperature moves by at most one point, including at dusk");
+        pattern.Humidity.Should().Be(9, "wind must not cause a humidity jump");
+    }
+
+    [Test]
+    public void MissedUpdate_AdvancesOnce_AndSchedulesFromTheActualUpdateTime()
+    {
+        var pattern = new WeatherPattern();
+        pattern.TryAdvance(Start, 6, false, Rolls(4, 9, 9, 9));
+        pattern.TryAdvance(Start.AddDays(3), 12, true, Rolls(0, 0, 0, 0)).Should().BeTrue();
+        pattern.Revision.Should().Be(2);
+        pattern.Heat.Should().Be(11);
+        pattern.NextChangeUtc.Should().Be(Start.AddDays(3).AddHours(1));
+        pattern.TryAdvance(Start.AddDays(3), 6, false, NoRoll).Should().BeFalse();
+    }
+
+    [Test]
+    public void ClockMovingBackwards_DoesNotCauseAnEarlyUpdate()
+    {
+        var pattern = new WeatherPattern();
+        pattern.TryAdvance(Start, 6, false, Rolls(0, 0, 0, 0));
+        pattern.TryAdvance(Start.AddHours(-1), 6, false, NoRoll).Should().BeFalse();
+    }
+
+    [Test]
+    public void EveryWindRoll_StaysInTheAuthoredRange()
+    {
+        for (var first = 0; first < 10; first++)
+        for (var second = 0; second < 10; second++)
+        {
+            var pattern = new WeatherPattern();
+            pattern.TryAdvance(Start, 6, false, Rolls(0, 0, first, second));
+            pattern.Wind.Should().BeInRange(1, 10);
+            pattern.NextChangeUtc.Should().Be(Start.AddHours(1));
+        }
+    }
+
+    [Test]
+    public void ExtendedSimulation_PreservesBoundsAndGradualTemperatureAndHumidity()
+    {
+        var random = new System.Random(1234);
+        var pattern = new WeatherPattern();
+        for (var hour = 0; hour < 10000; hour++)
+        {
+            var previousHeat = pattern.Heat;
+            var previousHumidity = pattern.Humidity;
+            pattern.TryAdvance(Start.AddHours(hour), hour % 12 + 1, hour % 2 == 0, random.Next).Should().BeTrue();
+            pattern.Heat.Should().BeInRange(-1, 12);
+            pattern.Humidity.Should().BeInRange(1, 10);
+            pattern.Wind.Should().BeInRange(1, 10);
+            if (hour == 0) continue;
+            Math.Abs(pattern.Heat - previousHeat).Should().BeLessThanOrEqualTo(1);
+            Math.Abs(pattern.Humidity - previousHumidity).Should().BeLessThanOrEqualTo(1);
+        }
+    }
+
+    [TestCase(3, 8, 2, Precipitation.Snow)]
+    [TestCase(4, 8, 2, Precipitation.Foggy)]
+    [TestCase(5, 8, 2, Precipitation.Foggy)]
+    [TestCase(5, 8, 3, Precipitation.Rain)]
+    [TestCase(6, 8, 2, Precipitation.Rain)]
+    [TestCase(1, 7, 10, Precipitation.Clear)]
+    [TestCase(10, 7, 10, Precipitation.Clear)]
+    public void Precipitation_UsesTheAuthoredThresholds(int heat, int humidity, int wind, Precipitation expected)
+    {
+        Conditions(heat, humidity, wind).Precipitation.Should().Be(expected);
+    }
+
+    [TestCase(PlanetType.Viscara, 4, 10, 5)]
+    [TestCase(PlanetType.Tatooine, 10, 1, 5)]
+    [TestCase(PlanetType.MonCala, 7, 8, 6)]
+    [TestCase(PlanetType.Hutlar, 1, 1, 5)]
+    [TestCase(PlanetType.Korriban, 9, 3, 5)]
+    public void PlanetClimates_AreAppliedOnce(PlanetType planet, int heat, int humidity, int wind)
+    {
+        var climate = WeatherPlanetDefinitions.GetPlanetClimates()[planet];
+        var result = WeatherConditions.Create(6, 8, 5, climate, 0, 0, 0, true, WeatherStorm.None, max => max - 1);
+        result.Heat.Should().Be(heat);
+        result.Humidity.Should().Be(humidity);
+        result.Wind.Should().Be(wind);
+    }
+
+    [Test]
+    public void LocalModifiers_AndCityShelter_CombineWithPlanetClimateBeforeClamping()
+    {
+        var climate = WeatherPlanetDefinitions.GetPlanetClimates()[PlanetType.MonCala];
+        var result = WeatherConditions.Create(6, 8, 5, climate, -2, -3, 2, false, WeatherStorm.None, NoRoll);
+        result.Heat.Should().Be(5);
+        result.Humidity.Should().Be(5);
+        result.Wind.Should().Be(7);
+        result.Precipitation.Should().Be(Precipitation.Clear);
+    }
+
+    [Test]
+    public void ClimateLookup_UsesTheSharedPlanetService_ForSpacedAndHyphenatedNames()
+    {
+        var flags = BindingFlags.NonPublic | BindingFlags.Static;
+        typeof(Planet).GetMethod("CachePlanets", flags)!.Invoke(null, null);
+        var resolve = typeof(Planet).GetMethod("ResolvePlanetTypeByAreaName", flags)!;
+        resolve.Invoke(null, new object[] { "Mon Cala - Coral Isles - Inner" }).Should().Be(PlanetType.MonCala);
+        resolve.Invoke(null, new object[] { "CZ-220 - Main Deck" }).Should().Be(PlanetType.CZ220);
+        resolve.Invoke(null, new object[] { "Smuggler's Moon Station - Corridors" }).Should().Be(PlanetType.SmugglersMoonStation);
+        Planet.GetPlanetTypeByAreaResref("canyon_001").Should().Be(PlanetType.Tatooine);
+        Method("GetAreaClimate").Should().Contain("Planet.GetPlanetType(area)").And.Contain("TryGetValue");
+    }
+
+    [Test]
+    public void Thunderstorm_StartProbabilityIsWindInTwenty_AndContinuationIsOneInThree()
+    {
+        for (var wind = 1; wind <= 10; wind++)
+        {
+            var starts = Enumerable.Range(0, 20).Count(roll =>
+                Conditions(6, 8, wind, random: _ => roll).Storm == WeatherStorm.Thunder);
+            starts.Should().Be(wind);
+            var continuations = Enumerable.Range(0, 3).Count(roll =>
+                Conditions(6, 8, wind, WeatherStorm.Thunder, _ => roll).Storm == WeatherStorm.Thunder);
+            continuations.Should().Be(1, "an existing storm has a two-in-three chance of clearing");
+        }
+    }
+
+    [TestCase(3, 10, 10)]
+    [TestCase(5, 10, 2)]
+    [TestCase(8, 7, 10)]
+    public void Thunderstorm_ClearsWhenRainConditionsEnd(int heat, int humidity, int wind)
+    {
+        Conditions(heat, humidity, wind, WeatherStorm.Thunder, NoRoll).Storm.Should().Be(WeatherStorm.None);
+    }
+
+    [TestCase(PlanetType.Tatooine, WeatherStorm.Sand, WeatherHazard.Sand)]
+    [TestCase(PlanetType.Hutlar, WeatherStorm.Snow, WeatherHazard.Snow)]
+    public void RegionalStorms_StartInStrongWind_AndClearWhenWindDrops(PlanetType planet, WeatherStorm storm, WeatherHazard hazard)
+    {
+        var climate = WeatherPlanetDefinitions.GetPlanetClimates()[planet];
+        var started = WeatherConditions.Create(6, 8, 9, climate, 0, 0, 0, true, WeatherStorm.None, _ => 0);
+        started.Storm.Should().Be(storm);
+        started.GetHazard(false).Should().Be(hazard);
+        var cleared = WeatherConditions.Create(6, 8, 8, climate, 0, 0, 0, true, storm, NoRoll);
+        cleared.Storm.Should().Be(WeatherStorm.None);
+        cleared.GetHazard(false).Should().Be(WeatherHazard.None);
+    }
+
+    [Test]
+    public void RepeatedAreaEntries_DoNotRerollStormsOrChangePrecipitation()
+    {
+        var pattern = new WeatherPattern();
+        pattern.TryAdvance(Start, 6, false, Rolls(0, 9, 9, 9));
+        var area = new WeatherAreaState();
+        area.TryUpdate(pattern, new WeatherClimate(), 0, 0, 0, true, _ => 0).Should().BeTrue();
+        var initial = area.Conditions;
+        initial.Storm.Should().Be(WeatherStorm.Thunder);
+        for (var entry = 0; entry < 1000; entry++)
+        {
+            area.TryUpdate(pattern, new WeatherClimate(), 0, 0, 0, true, NoRoll).Should().BeFalse();
+            area.Conditions.Should().BeSameAs(initial);
+        }
+        pattern.TryAdvance(Start.AddHours(1), 6, false, Rolls(0, 10, 9, 9));
+        area.TryUpdate(pattern, new WeatherClimate(), 0, 0, 0, true, _ => 2).Should().BeTrue();
+        area.Conditions.Storm.Should().Be(WeatherStorm.None);
+    }
+
+    [Test]
+    public void ExplicitAreaModifierEdit_InvalidatesOnlyThatArea()
+    {
+        var pattern = new WeatherPattern();
+        pattern.TryAdvance(Start, 6, false, Rolls(0, 0, 0, 0));
+        var changed = new WeatherAreaState();
+        var other = new WeatherAreaState();
+        changed.TryUpdate(pattern, new WeatherClimate(), 0, 0, 0, true, NoRoll);
+        other.TryUpdate(pattern, new WeatherClimate(), 0, 0, 0, true, NoRoll);
+        changed.Invalidate();
+        changed.TryUpdate(pattern, new WeatherClimate(), -20, 0, 0, true, NoRoll).Should().BeTrue();
+        other.TryUpdate(pattern, new WeatherClimate(), 0, 0, 0, true, NoRoll).Should().BeFalse();
+        changed.Conditions.Heat.Should().Be(1);
+        other.Conditions.Heat.Should().Be(8);
+    }
+
+    [Test]
+    public void HazardDamage_ContinuesEverySixSeconds_WithoutStackingOnEntryOrHeartbeat()
+    {
+        var exposure = new WeatherExposure();
+        exposure.GetDamageDice(Start, WeatherHazard.Acid).Should().Be(2);
+        for (var second = 0; second < 6; second++)
+            exposure.GetDamageDice(Start.AddSeconds(second), WeatherHazard.Acid).Should().Be(0);
+        exposure.GetDamageDice(Start.AddSeconds(6), WeatherHazard.Acid).Should().Be(1);
+        exposure.GetDamageDice(Start.AddSeconds(12), WeatherHazard.Acid).Should().Be(1);
+        exposure.GetDamageDice(Start.AddSeconds(18), WeatherHazard.Snow).Should().Be(2);
+        exposure.GetDamageDice(Start.AddSeconds(24), WeatherHazard.Sand).Should().Be(2);
+    }
+
+    [Test]
+    public void ShelterAndClearingWeather_StopDamage_AndReentryCannotBypassThePulseTimer()
+    {
+        var exposure = new WeatherExposure();
+        exposure.GetDamageDice(Start, WeatherHazard.Sand).Should().Be(2);
+        exposure.GetDamageDice(Start.AddSeconds(1), WeatherHazard.None).Should().Be(0);
+        exposure.GetDamageDice(Start.AddSeconds(2), WeatherHazard.Sand).Should().Be(0);
+        exposure.GetDamageDice(Start.AddSeconds(6), WeatherHazard.None).Should().Be(0);
+        exposure.GetDamageDice(Start.AddHours(1), WeatherHazard.None).Should().Be(0);
+    }
+
+    [Test]
+    public void AcidHazard_RequiresActualRain_AndWarningsMatchTheSelectedHazard()
+    {
+        var climate = new WeatherClimate();
+        Conditions(6, 8, 3).GetHazard(true).Should().Be(WeatherHazard.Acid);
+        Conditions(6, 8, 3).GetFeedback(climate, false, true).Should().Be(WeatherFeedbackText.AcidRain);
+        Conditions(5, 8, 2).GetHazard(true).Should().Be(WeatherHazard.None);
+        Conditions(3, 8, 3).GetHazard(true).Should().Be(WeatherHazard.None);
+        Conditions(6, 7, 3).GetHazard(true).Should().Be(WeatherHazard.None);
+        (Conditions(6, 7, 9) with { Storm = WeatherStorm.Sand }).GetFeedback(climate, false, false)
+            .Should().Be(WeatherFeedbackText.SandStorm);
+        (Conditions(1, 7, 9) with { Storm = WeatherStorm.Snow }).GetFeedback(climate, false, false)
+            .Should().Be(WeatherFeedbackText.SnowStorm);
+    }
+
+    [TestCase(11, 3f, 0)]
+    [TestCase(30, 3f, 0)]
+    [TestCase(40, 3f, 10)]
+    [TestCase(110, 0f, 110)]
+    public void LightningFalloff_NeverProducesNegativeDamage(int power, float distance, int expected)
+    {
+        WeatherConditions.GetLightningDamage(power, distance).Should().Be(expected);
+    }
+
+    [Test]
+    public void NativeWeatherOverride_StopsAcidWhenCleared_AndEnablesItWhenRainIsForced()
+    {
+        Conditions(6, 8, 3).GetHazard(true, Precipitation.Clear).Should().Be(WeatherHazard.None);
+        Conditions(6, 7, 3).GetHazard(true, Precipitation.Rain).Should().Be(WeatherHazard.Acid);
+        Conditions(6, 7, 3).GetFeedback(new WeatherClimate(), false, true, Precipitation.Rain)
+            .Should().Be(WeatherFeedbackText.AcidRain);
+        Method("ApplyWeatherDamage").Should().Contain("NWScript.GetWeather(area)");
+    }
+
+    [Test]
+    public void Runtime_InitializesAllAreas_AndUsesOneHeartbeatForExposureAndDistinctOccupiedAreas()
+    {
+        typeof(WeatherRuntime).GetMethod(nameof(WeatherRuntime.InitializeWeather))!
+            .GetCustomAttributes<NWNEventHandler>().Select(x => x.Script).Should().Contain(ScriptName.OnModuleLoad);
+        Method("AdjustWeather").Should().Contain("GetFirstArea()").And.Contain("GetNextArea()")
+            .And.NotContain("GetFirstPC()");
+        var heartbeat = Method("OnModuleHeartbeat");
+        heartbeat.Should().Contain("ApplyWeatherDamage(player, now)").And.Contain("new HashSet<uint>()")
+            .And.Contain("now.AddMinutes(1)").And.Contain("_exposures.Remove(player)");
+        Source().Should().NotContain("GetTimeHour()").And.NotContain("DelayCommand(")
+            .And.NotContain("GetMaster(");
+        Method("IsWeatherArea").Should().Contain("!GetIsAreaInterior(area)")
+            .And.Contain("GetIsAreaAboveGround(area)").And.Contain("\"SPACE\"");
+    }
+
+    [Test]
+    public void Runtime_UpdatesFogWhenPrecipitationChanges_AndRestoresAllAuthoredVisualSettings()
+    {
+        var update = Method("SetWeather", 1);
+        update.Should().Contain("state.Revision == _pattern.Revision")
+            .And.Contain("previous?.Precipitation != conditions.Precipitation")
+            .And.Contain("ClearMist(state)").And.NotContain("EnsureMist(");
+        foreach (var variable in new[] { "VAR_SKYBOX", "VAR_FOG_SUN", "VAR_FOG_MOON", "VAR_FOG_C_SUN", "VAR_FOG_C_MOON" })
+            update.Should().Contain($"GetLocalInt(area, {variable})");
+        Method("ClearMist").Should().Contain("DestroyObject(placeable)")
+            .And.Contain("state.MistPlaceables.Clear()");
+        Method("EnsureMist").Should().Contain("index = 0").And.Contain("state.MistInitialized = true");
+        Method("OnAreaEnter").Should().Contain("GetIsPC(creature)").And.Contain("EnsureMist(area, state)");
+        Method("OnModuleHeartbeat").Should().Contain("EnsureMist(area, state)");
+        Method("TryGetGroundLocation").Should().Contain("GetGroundHeight(location)");
+    }
+
+    [Test]
+    public void Runtime_HazardsExcludeDeadAndStaffPlayers_AndColdDamageUsesColdFeedback()
+    {
+        var damage = Method("ApplyWeatherDamage");
+        damage.Should().Contain("GetIsPC(creature)").And.Contain("!GetIsDM(creature)")
+            .And.Contain("!GetIsDMPossessed(creature)").And.Contain("!GetIsDead(creature)")
+            .And.Contain("conditions.GetHazard(").And.Contain("WeatherHazard.None")
+            .And.Contain("WeatherHazard.Snow => DamageType.Cold")
+            .And.Contain("VisualEffect.Vfx_Imp_Frost_S").And.Contain("AssignCommand(area,");
+        Method("Thunderstorm", 1).Should().Contain("state.Conditions.Storm != WeatherStorm.Thunder");
+    }
+
+    private static WeatherConditions Conditions(int heat, int humidity, int wind,
+        WeatherStorm previous = WeatherStorm.None, Func<int, int> random = null) =>
+        WeatherConditions.Create(heat, humidity, wind, new WeatherClimate(), 0, 0, 0, true,
+            previous, random ?? (max => max - 1));
+
+    private static Func<int, int> Rolls(params int[] values)
+    {
+        var rolls = new Queue<int>(values);
+        return max =>
+        {
+            rolls.Should().NotBeEmpty();
+            var value = rolls.Dequeue();
+            value.Should().BeInRange(0, max - 1);
+            return value;
+        };
+    }
+
+    private static int NoRoll(int max) => throw new AssertionException("Weather must not reroll here.");
+
+    private static string Source()
+    {
+        var root = new DirectoryInfo(AppContext.BaseDirectory);
+        while (root != null && !Directory.Exists(Path.Combine(root.FullName, "SWLOR.Game.Server"))) root = root.Parent;
+        return File.ReadAllText(Path.Combine(root!.FullName, "SWLOR.Game.Server", "Service", "Weather.cs"));
+    }
+
+    private static string Method(string name, int? parameterCount = null)
+    {
+        return CSharpSyntaxTree.ParseText(Source()).GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>()
+            .First(method => method.Identifier.ValueText == name &&
+                             (parameterCount == null || method.ParameterList.Parameters.Count == parameterCount)).ToString();
+    }
+}

--- a/SWLOR.Game.Server.Tests/Service/WeatherTests.cs
+++ b/SWLOR.Game.Server.Tests/Service/WeatherTests.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 using SWLOR.Game.Server.Core;
 using SWLOR.Game.Server.Enumeration;
 using SWLOR.Game.Server.Service;
+using SWLOR.Game.Server.Service.CombatService;
 using SWLOR.Game.Server.Service.WeatherService;
 using Precipitation = SWLOR.NWN.API.NWScript.Enum.Weather;
 using WeatherRuntime = SWLOR.Game.Server.Service.Weather;
@@ -107,7 +108,7 @@ public class WeatherTests
     [TestCase(PlanetType.Viscara, 4, 10, 5)]
     [TestCase(PlanetType.Tatooine, 10, 1, 5)]
     [TestCase(PlanetType.MonCala, 7, 8, 6)]
-    [TestCase(PlanetType.Hutlar, 1, 1, 5)]
+    [TestCase(PlanetType.Hutlar, 1, 10, 5)]
     [TestCase(PlanetType.Korriban, 9, 3, 5)]
     public void PlanetClimates_AreAppliedOnce(PlanetType planet, int heat, int humidity, int wind)
     {
@@ -139,7 +140,7 @@ public class WeatherTests
         resolve.Invoke(null, new object[] { "CZ-220 - Main Deck" }).Should().Be(PlanetType.CZ220);
         resolve.Invoke(null, new object[] { "Smuggler's Moon Station - Corridors" }).Should().Be(PlanetType.SmugglersMoonStation);
         Planet.GetPlanetTypeByAreaResref("canyon_001").Should().Be(PlanetType.Tatooine);
-        Method("GetAreaClimate").Should().Contain("Planet.GetPlanetType(area)").And.Contain("TryGetValue");
+        Method("GetAreaClimate").Should().Contain("Planet.GetPlanetType(area)").And.Contain("ResolveClimate");
     }
 
     [Test]
@@ -310,9 +311,72 @@ public class WeatherTests
         damage.Should().Contain("GetIsPC(creature)").And.Contain("!GetIsDM(creature)")
             .And.Contain("!GetIsDMPossessed(creature)").And.Contain("!GetIsDead(creature)")
             .And.Contain("conditions.GetHazard(").And.Contain("WeatherHazard.None")
-            .And.Contain("WeatherHazard.Snow => DamageType.Cold")
+            .And.Contain("WeatherHazard.Snow => CombatDamageType.Ice")
             .And.Contain("VisualEffect.Vfx_Imp_Frost_S").And.Contain("AssignCommand(area,");
         Method("Thunderstorm", 1).Should().Contain("state.Conditions.Storm != WeatherStorm.Thunder");
+    }
+
+    [Test]
+    public void Runtime_AllWeatherHitsUseResistanceAndDamageTakenProtection_BeforeApplyingEffects()
+    {
+        var pulse = Method("ApplyWeatherDamage");
+        pulse.Should().Contain("WeatherHazard.Acid => CombatDamageType.Poison")
+            .And.Contain("WeatherHazard.Snow => CombatDamageType.Ice")
+            .And.Contain("GetProtectedDamage(creature, d6(dice), damageType)")
+            .And.Contain("DamageType.Bludgeoning");
+        var bolt = Method("Thunderstorm", 2);
+        bolt.IndexOf("GetProtectedDamage(target, damage, CombatDamageType.Electrical)")
+            .Should().BeLessThan(bolt.IndexOf("EffectDamage(damage, DamageType.Electrical)"));
+        var protection = Method("GetProtectedDamage");
+        protection.Should().Contain("GetObjectType(target) != ObjectType.Creature")
+            .And.Contain("Resistance.ApplyResistanceToDamage(target, damageType, adjusted.Damage)")
+            .And.Contain("Combat.ApplyDamageTakenModifiers(target, damage, damageType: damageType")
+            .And.Contain("StatType.PhysicalDamageTakenPercentAdjustment")
+            .And.Contain("if (damage <= 0) return 0;");
+        CombatDamageType.Poison.GetNWScriptDamageType().Should().Be(SWLOR.NWN.API.NWScript.Enum.DamageType.Acid);
+        CombatDamageType.Ice.GetNWScriptDamageType().Should().Be(SWLOR.NWN.API.NWScript.Enum.DamageType.Cold);
+    }
+
+    [Test]
+    public void Hutlar_CanHaveClearSkiesAndSnowfall_ButNeverRainOrThunder()
+    {
+        var climate = WeatherPlanetDefinitions.GetPlanetClimates()[PlanetType.Hutlar];
+        var precipitation = new HashSet<Precipitation>();
+        for (var heat = -1; heat <= 12; heat++)
+        for (var humidity = 1; humidity <= 10; humidity++)
+        for (var wind = 1; wind <= 10; wind++)
+        {
+            var result = WeatherConditions.Create(heat, humidity, wind, climate, 0, 0, 0, true, WeatherStorm.None, _ => 0);
+            result.Heat.Should().BeLessThanOrEqualTo(3);
+            result.Storm.Should().NotBe(WeatherStorm.Thunder);
+            precipitation.Add(result.Precipitation);
+        }
+        precipitation.Should().BeEquivalentTo(new[] { Precipitation.Clear, Precipitation.Snow });
+    }
+
+    [TestCase("Kashyyyk")]
+    [TestCase("Ossus")]
+    public void AdditionalPlanetProfiles_AllowRainWithoutSnow(string name)
+    {
+        var climates = WeatherPlanetDefinitions.GetNamedClimates(WeatherPlanetDefinitions.GetPlanetClimates());
+        var precipitation = new HashSet<Precipitation>();
+        for (var heat = -1; heat <= 12; heat++)
+        for (var humidity = 1; humidity <= 10; humidity++)
+            precipitation.Add(WeatherConditions.Create(heat, humidity, 5, climates[name], 0, 0, 0, true,
+                WeatherStorm.None, max => max - 1).Precipitation);
+        precipitation.Should().Contain(Precipitation.Rain).And.NotContain(Precipitation.Snow);
+    }
+
+    [Test]
+    public void UnconfiguredAreasAndInvalidOverrides_DoNotAcquireRandomClimateOrHazards()
+    {
+        var planets = WeatherPlanetDefinitions.GetPlanetClimates();
+        var named = WeatherPlanetDefinitions.GetNamedClimates(planets);
+        WeatherPlanetDefinitions.ResolveClimate(PlanetType.Invalid, "", planets, named).Should().BeNull();
+        WeatherPlanetDefinitions.ResolveClimate(PlanetType.Tatooine, "typo", planets, named).Should().BeNull();
+        WeatherPlanetDefinitions.ResolveClimate(PlanetType.Invalid, "kashyyyk", planets, named).Should().BeSameAs(named["Kashyyyk"]);
+        WeatherPlanetDefinitions.ResolveClimate(PlanetType.Tatooine, "None", planets, named)!.IsSheltered.Should().BeTrue();
+        Method("IsWeatherArea").Should().Contain("GetAreaClimate(area) is { IsSheltered: false }");
     }
 
     private static WeatherConditions Conditions(int heat, int humidity, int wind,

--- a/SWLOR.Game.Server/Readmes/PlayerMessageAudit.json
+++ b/SWLOR.Game.Server/Readmes/PlayerMessageAudit.json
@@ -5272,14 +5272,14 @@
   },
   {
     "File": "SWLOR.Game.Server/Service/Weather.cs",
-    "Line": 236,
+    "Line": 238,
     "Member": "DoWeatherEffects",
     "Delivery": "Retained",
     "Call": "SendMessageToPC(creature, message)"
   },
   {
     "File": "SWLOR.Game.Server/Service/Weather.cs",
-    "Line": 299,
+    "Line": 319,
     "Member": "Thunderstorm",
     "Delivery": "Retained",
     "Call": "SendMessageToPC(target, WeatherFeedbackText.Lightning)"

--- a/SWLOR.Game.Server/Readmes/PlayerMessageAudit.json
+++ b/SWLOR.Game.Server/Readmes/PlayerMessageAudit.json
@@ -5272,14 +5272,14 @@
   },
   {
     "File": "SWLOR.Game.Server/Service/Weather.cs",
-    "Line": 238,
+    "Line": 243,
     "Member": "DoWeatherEffects",
     "Delivery": "Retained",
     "Call": "SendMessageToPC(creature, message)"
   },
   {
     "File": "SWLOR.Game.Server/Service/Weather.cs",
-    "Line": 319,
+    "Line": 324,
     "Member": "Thunderstorm",
     "Delivery": "Retained",
     "Call": "SendMessageToPC(target, WeatherFeedbackText.Lightning)"

--- a/SWLOR.Game.Server/Readmes/PlayerMessageAudit.json
+++ b/SWLOR.Game.Server/Readmes/PlayerMessageAudit.json
@@ -5272,16 +5272,16 @@
   },
   {
     "File": "SWLOR.Game.Server/Service/Weather.cs",
-    "Line": 462,
+    "Line": 236,
     "Member": "DoWeatherEffects",
     "Delivery": "Retained",
-    "Call": "SendMessageToPC(oCreature, sMessage)"
+    "Call": "SendMessageToPC(creature, message)"
   },
   {
     "File": "SWLOR.Game.Server/Service/Weather.cs",
-    "Line": 603,
+    "Line": 299,
     "Member": "Thunderstorm",
     "Delivery": "Retained",
-    "Call": "SendMessageToPC(oObject, WeatherFeedbackText.Lightning)"
+    "Call": "SendMessageToPC(target, WeatherFeedbackText.Lightning)"
   }
 ]

--- a/SWLOR.Game.Server/Readmes/Weather.md
+++ b/SWLOR.Game.Server/Readmes/Weather.md
@@ -1,0 +1,112 @@
+# Weather system
+
+Weather is managed by `Service/Weather.cs`. `WeatherPattern`, `WeatherAreaState`,
+`WeatherConditions`, and `WeatherExposure` contain the independently testable timing,
+climate, storm, feedback, and damage rules.
+
+## Timing and conditions
+
+- A shared weather front advances no more than once per **60 real minutes**.
+  The six-second SWLOR heartbeat checks its UTC deadline. Game hours, midnight,
+  dawn/dusk, calendar changes, and area traffic cannot shorten that interval.
+  Restarting the module initializes a new front. A late heartbeat advances once
+  and schedules the next update one hour later; it does not replay missed updates.
+- Initial temperature retains the seasonal formula and day/night adjustment.
+  Subsequent updates move temperature at most one point toward that target,
+  including at dawn/dusk. Humidity also moves at most one point per update.
+  Wind retains the existing two-d10 distribution, bounded from 1 to 10.
+- Each area retains one condition snapshot per front. Entering creatures and
+  multiple players do not reroll storms. All outdoor, above-ground areas receive
+  scripted precipitation at initialization and on each update. Interior,
+  underground, and explicitly marked/named space areas are excluded.
+- The shared `Planet.GetPlanetType` lookup supplies the climate, including
+  authored planet IDs and resref fallbacks. An unconfigured planet uses the
+  default climate. Existing planet modifiers and text remain unchanged.
+- Local `VAR_WEATHER_HEAT`, `VAR_WEATHER_HUMIDITY`, and `VAR_WEATHER_WIND`
+  modifiers are combined with the planet climate. Artificial areas retain their
+  one-point wind shelter bonus. Final area indices are clamped to 1–10.
+  `SetAreaHeatModifier`, `SetAreaHumidityModifier`, and `SetAreaWindModifier`
+  immediately refresh the edited area; these explicit builder changes bypass
+  the ordinary hourly cadence.
+
+Humidity above 7 produces snow at heat 1–3, mist at heat 4–5 with wind below 3,
+and rain otherwise. Lower humidity produces clear weather. Mist uses native clear
+precipitation plus grounded mist placeables. Placeables are created only in occupied
+areas, at up to one per eight tiles, and removed as soon as mist ends. Empty instance
+templates are not populated with generated mist. Sand/snow storms restore the
+area's original sun/moon fog colors, fog amounts, and skybox when they end.
+
+During warm rain (heat above 4), a new thunderstorm has a wind-in-20 chance to
+start. An existing thunderstorm has a one-in-three chance to continue. Strong wind
+(9–10) can instead trigger the planet's sand or snow storm with a one-in-three
+chance. These are mutually exclusive storm states. Lightning attempts occur once
+per minute per occupied area during a thunderstorm, with a one-in-three strike
+chance; there are no delayed strikes that can fire after the storm ends. Damage
+falloff is nonnegative, and zero-damage targets are not knocked down.
+
+## Exposure and feedback
+
+Acid rain requires actual native rain (including a DM's manual override) plus the
+area's `VAR_WEATHER_ACID_RAIN = 1` flag. Sand and snow storms use their current
+condition snapshot. Living ordinary players take the existing damage amounts:
+acid rain starts with 2d6 and continues at 1d6; sand/snow storms deal 2d6
+bludgeoning/cold damage. Each player has one six-second damage clock shared by
+entry and heartbeat. Shelter, death, staff possession, or the hazard ending stops
+damage. Re-entry cannot stack pulses, and disconnected-player clocks are removed.
+There is no passive damage from a low temperature alone.
+
+Entry and hourly updates deliver the authored climate description or an explicit
+acid/sand/snow hazard warning. Routine damage pulses do not repeat the weather
+paragraph. Snow impacts use cold feedback; sand damage no longer displays flames.
+
+## Review findings repaired
+
+The previous implementation could update every six real minutes (the module has
+six minutes per game hour), rerolled temperature by four points, and applied another
+four-point dawn/dusk jump. It read the module's humidity and wind as both the base
+and the area modifier, doubling them. Every area entry rerolled storm state and
+every occupant caused another area update. The thunderstorm start branch required
+an already active thunderstorm, making ordinary starts impossible; its continuation
+probability also differed from the documented one-in-three rule.
+
+Weather separately parsed area names using enum descriptions, so `Mon Cala` missed
+its `MonCala` climate and names containing hyphens were split incorrectly. The
+hour-only scheduler could miss a scheduled update or skip initialization at hour
+zero. Fog creation/cleanup depended on another area entry, used an entering
+creature's elevation for unrelated tiles, and started its placement counter at a
+random d6 instead of zero.
+
+Repeating hazard callbacks rejected normal players because their master was not
+a player. Their remaining guards never checked whether the hazard still existed,
+and repeated starts could stack callbacks. An unused cold callback dealt acid
+damage. Hazard branches also bypassed the existing sand/snow warning text.
+Lightning could compute negative damage near the edge of a weak strike's radius.
+
+## Verification and in-engine checks
+
+`WeatherTests` covers hourly timing, missed deadlines, game-clock independence,
+10,000 simulated updates, climate/local modifiers, precipitation boundaries,
+exact storm probabilities, repeated area entries, hazard cessation and duplicate
+pulses, lightning falloff, and runtime event/visual-cleanup wiring. The player
+message audit is refreshed for the retained weather messages.
+
+After deploying the server assembly, verify in NWN:
+
+1. Stay in one outdoor area across dawn/dusk and repeated transitions; precipitation
+   must remain stable until the next real-hour update. Crossing different planet
+   climates can still show different weather.
+2. Observe Mon Cala, Tatooine, Hutlar, and Viscara climate text and precipitation.
+   Check an interior, an underground area, and space for unwanted effects.
+3. Force mist using the area modifier helpers; verify ground placement, no duplicate
+   mist on re-entry, and cleanup when humidity is reduced. Create an outdoor
+   instance from an empty template and check for copied mist.
+4. During acid rain or a regional storm, verify damage continues every six seconds,
+   then stops on shelter, death, or clearing conditions. Re-enter rapidly and verify
+   the pulse count does not increase. Staff avatars/possessed creatures are exempt.
+5. Verify storm skies and regional fog restore their original values, lightning
+   stops when the storm ends, and cold damage uses the frost impact effect.
+
+Native client rendering and live NWNX event behavior require these in-engine
+checks; the unit tests do not emulate an NWN server. Native DMFI weather buttons
+can override precipitation visually until the next scripted front; they do not
+edit the scripted climate or storm state.

--- a/SWLOR.Game.Server/Readmes/Weather.md
+++ b/SWLOR.Game.Server/Readmes/Weather.md
@@ -17,14 +17,25 @@ climate, storm, feedback, and damage rules.
   Wind retains the existing two-d10 distribution, bounded from 1 to 10.
 - Each area retains one condition snapshot per front. Entering creatures and
   multiple players do not reroll storms. All outdoor, above-ground areas receive
-  scripted precipitation at initialization and on each update. Interior,
-  underground, and explicitly marked/named space areas are excluded.
+  scripted precipitation at initialization and on each update when a climate is
+  configured. Interior, underground, sealed station, and space areas are excluded.
 - The shared `Planet.GetPlanetType` lookup supplies the climate, including
-  authored planet IDs and resref fallbacks. An unconfigured planet uses the
-  default climate. Existing planet modifiers and text remain unchanged.
+  authored planet IDs and resref fallbacks. `VAR_WEATHER_CLIMATE` (area string)
+  overrides that lookup with a name from `WeatherPlanetDefinitions.GetNamedClimates`.
+  Unknown areas/invalid overrides retain native authored ambience and receive no
+  scripted hazards. `None` explicitly disables scripted weather. Generic prefabs
+  need an explicit climate when builders want scripted weather in their instances.
+- Hutlar has humidity +2 and maximum heat 3, allowing ordinary snowfall without
+  rain or thunderstorms. Frozen Wastes has local humidity +9 to preserve its
+  authored permanent snowfall. Its blizzards still require strong wind.
+- Kashyyyk uses heat +3, humidity +3, and minimum heat 4; Ossus uses heat +2,
+  humidity -1, and minimum heat 4. Their nine outdoor areas explicitly select
+  those profiles. These weather profiles do not register new galaxy-map planets.
+  CZ-220 and Smuggler's Moon Station always use sheltered profiles.
 - Local `VAR_WEATHER_HEAT`, `VAR_WEATHER_HUMIDITY`, and `VAR_WEATHER_WIND`
   modifiers are combined with the planet climate. Artificial areas retain their
-  one-point wind shelter bonus. Final area indices are clamped to 1–10.
+  one-point wind shelter bonus. Final indices are clamped to 1–10; heat also
+  respects the profile's minimum/maximum.
   `SetAreaHeatModifier`, `SetAreaHumidityModifier`, and `SetAreaWindModifier`
   immediately refresh the edited area; these explicit builder changes bypass
   the ordinary hourly cadence.
@@ -55,9 +66,52 @@ entry and heartbeat. Shelter, death, staff possession, or the hazard ending stop
 damage. Re-entry cannot stack pulses, and disconnected-player clocks are removed.
 There is no passive damage from a low temperature alone.
 
+Before native damage is applied, creature targets now use the shared resistance
+and damage-taken services. Blizzard damage uses **Ice resistance**, acid rain uses
+**Poison resistance** (SWLOR maps that element to native acid), and lightning uses
+**Electrical resistance**. Sandstorms respect physical-damage percent reductions
+and physical immunity. Generic damage reductions, Leadership reductions,
+damage-sharing/protection effects, and fatal-damage prevention also apply through
+the shared service. Doors/placeables struck by lightning bypass character stats.
+
+Protection comes from items, food, or active effects that actually grant these
+stats. Clothing appearance, armor's ordinary Physical Defense rating, provisions,
+and decorative roofs/trees do not provide weather protection on their own. Entering
+an area marked interior/underground stops exposure. This is an area-wide shelter
+rule; there is no geometric cover test inside an outdoor area.
+
+Unprotected sandstorms/blizzards average 7 HP per pulse (about 70 HP/minute); ongoing
+acid rain averages 3.5 HP per pulse (about 35 HP/minute after the initial hit).
+These are the existing dice, not newly increased damage. Resistance follows the
+shared rounding/minimum-damage rules: positive damage normally stays at least 1,
+while temporary immunity can reduce it to zero. Lightning starts at 11–110 damage,
+loses 10 per metre, and has a 3–6m radius; Mobility resistance shortens its knockdown,
+and knockdown immunity prevents it. Fully prevented lightning hits do not knock down.
+Ordinary rain, snow, fog, heat and cold do not deal damage or slow travel. No authored
+area currently enables acid rain; it remains an explicit builder opt-in.
+
 Entry and hourly updates deliver the authored climate description or an explicit
 acid/sand/snow hazard warning. Routine damage pulses do not repeat the weather
 paragraph. Snow impacts use cold feedback; sand damage no longer displays flames.
+Descriptions no longer promise protection from winter clothes, boots, or provisions,
+or imply movement penalties that the weather system does not implement.
+
+## Area configuration audit
+
+[WeatherAreaAudit.md](WeatherAreaAudit.md) records all 453 authored areas, including
+prefabs, their shelter flags, and their selected climate or native-only policy.
+The review corrected 26 exposed interiors: shops, labs, ship/station corridors,
+crypts, caves, offices, warehouses, and the forgeworks. It deliberately preserves
+the open Canyon Dueling Pit, Sith Fortress Courtyard, and Academy Rooftop despite
+their interior tilesets. The fixes change ARE flags and ten GIT local-variable
+tables; repack and deploy the module together with the server assembly.
+
+`WeatherAreaConfigurationTests` checks the complete ARE/GIT corpus for exposed
+interior tilesets, missing live-planet climates, invalid profile names, station
+shelter, and permanent Frozen Wastes snowfall. The tileset shelter metadata was
+checked against the existing HAK `.set` files; no HAK resources changed. Area flags
+and authored content support these classifications; in-client roof rendering and
+walkable layouts still require the checks below.
 
 ## Review findings repaired
 
@@ -90,7 +144,7 @@ exact storm probabilities, repeated area entries, hazard cessation and duplicate
 pulses, lightning falloff, and runtime event/visual-cleanup wiring. The player
 message audit is refreshed for the retained weather messages.
 
-After deploying the server assembly, verify in NWN:
+After repacking/deploying the module and server assembly, verify in NWN:
 
 1. Stay in one outdoor area across dawn/dusk and repeated transitions; precipitation
    must remain stable until the next real-hour update. Crossing different planet
@@ -105,6 +159,13 @@ After deploying the server assembly, verify in NWN:
    the pulse count does not increase. Staff avatars/possessed creatures are exempt.
 5. Verify storm skies and regional fog restore their original values, lightning
    stops when the storm ends, and cold damage uses the frost impact effect.
+6. Compare Ice/Poison/Electrical resistance 0 and 50 during the matching hazard,
+   then test temporary immunity and physical-damage reduction during a sandstorm.
+   Confirm protected hits use the shared rounding rules and fully prevented
+   lightning does not knock down.
+7. Check the corrected shops, outpost, station and caves for shelter, and the
+   three deliberately open layouts for outdoor weather. Verify Hutlar snowfall,
+   persistent Frozen Wastes snow, and rain without snow on Kashyyyk/Ossus.
 
 Native client rendering and live NWNX event behavior require these in-engine
 checks; the unit tests do not emulate an NWN server. Native DMFI weather buttons

--- a/SWLOR.Game.Server/Readmes/Weather.md
+++ b/SWLOR.Game.Server/Readmes/Weather.md
@@ -19,6 +19,9 @@ climate, storm, feedback, and damage rules.
   multiple players do not reroll storms. All outdoor, above-ground areas receive
   scripted precipitation at initialization and on each update when a climate is
   configured. Interior, underground, sealed station, and space areas are excluded.
+  Accepted updates write a structured Server log event with the area resref,
+  revision, heat, humidity, wind, precipitation, and storm. Repeated entries do not
+  emit duplicate update events.
 - The shared `Planet.GetPlanetType` lookup supplies the climate, including
   authored planet IDs and resref fallbacks. `VAR_WEATHER_CLIMATE` (area string)
   overrides that lookup with a name from `WeatherPlanetDefinitions.GetNamedClimates`.

--- a/SWLOR.Game.Server/Readmes/WeatherAreaAudit.md
+++ b/SWLOR.Game.Server/Readmes/WeatherAreaAudit.md
@@ -50,8 +50,7 @@ not an in-client inspection of every tile. See [Weather.md](Weather.md) for depl
 | `coolship` | [Prefab] Ship - The Gwenivere | 3 | Sheltered |  |
 | `coxxian_hq` | Viscara - Coxxion Headquarters | 1 | Sheltered |  |
 | `cz220shipbreaker` | CZ-220 - Breaker Yard | 1 | Sheltered |  |
-| `cz220shipbreakin` | CZ-220 - Breaker Bay
- | 1 | Sheltered |  |
+| `cz220shipbreakin` | CZ-220 - Breaker Bay | 1 | Sheltered |  |
 | `czs220_hangar` | CZ-220 - Hangar | 1 | Sheltered |  |
 | `czs220_maintlvl` | CZ-220 - Maintenance Level | 3 | Sheltered |  |
 | `dan_battlemon` | Dantooine - Battle Monster Gym | 1 | Sheltered |  |
@@ -281,8 +280,7 @@ not an in-client inspection of every tile. See [Weather.md](Weather.md) for depl
 | `pw_sc_dantprowar` | Dantooine - Protected Ward | 3 | Sheltered |  |
 | `pw_sc_dath_apexd` | Dathomir - Grotto Apex Den | 7 | Sheltered |  |
 | `pw_sc_dath_sden` | Dathomir - Sealed Apex Den | 7 | Sheltered |  |
-| `pw_sc_emfbackr` | Smuggler's Moon - Fight Club Backrooms
- | 3 | Sheltered |  |
+| `pw_sc_emfbackr` | Smuggler's Moon - Fight Club Backrooms | 3 | Sheltered |  |
 | `pw_sc_jeditrial` | Dantooine - Saber Trial Chamber | 1 | Sheltered |  |
 | `pw_sc_korrforge` | Korriban - Champion Forge | 7 | Sheltered |  |
 | `pw_sc_qioncore` | Hutlar - Overload Chamber | 1 | Sheltered |  |

--- a/SWLOR.Game.Server/Readmes/WeatherAreaAudit.md
+++ b/SWLOR.Game.Server/Readmes/WeatherAreaAudit.md
@@ -1,0 +1,484 @@
+# Weather area audit
+
+Audit of all 453 ARE resources and their matching GIT area locals, updated 2026-09-12.
+Resource filenames, rather than stale embedded ResRef fields, identify matching files.
+Flags: 1 = interior, 2 = underground, 4 = natural. Either shelter bit stops exposure.
+
+Native-only areas retain their authored visual settings and have no scripted hazard damage.
+They are generic prefabs or technical areas without an assigned planet climate.
+Interior tileset classifications were cross-checked against HAK `.set` GENERAL/Interior metadata;
+three authored open-air layouts deliberately retain outdoor flags. This is a source audit,
+not an in-client inspection of every tile. See [Weather.md](Weather.md) for deployment and playtests.
+
+| Policy | Areas |
+|---|---:|
+| Authored native only | 67 |
+| Scripted: Dantooine | 18 |
+| Scripted: Dathomir | 11 |
+| Scripted: Hutlar | 8 |
+| Scripted: Kashyyyk | 5 |
+| Scripted: Korriban | 10 |
+| Scripted: MonCala | 6 |
+| Scripted: Ossus | 4 |
+| Scripted: SmugglersMoon | 8 |
+| Scripted: Tatooine | 44 |
+| Scripted: Viscara | 22 |
+| Sheltered | 250 |
+
+| Resource | Area | Flags | Weather policy | Audit note |
+|---|---|---:|---|---|
+| `anc_dsrt_speeder` | Tatooine - Anchorhead - To Mos Eisley | 4 | Scripted: Tatooine |  |
+| `anchor_entreenor` | Tatooine - Anchorhead - North Entrance | 4 | Scripted: Tatooine |  |
+| `anchor_entreesud` | Tatooine - Anchorhead - South Entry | 4 | Scripted: Tatooine |  |
+| `anchor_road_est` | Tatooine - Anchorhead - Sandy Dune Desert - North East | 4 | Scripted: Tatooine |  |
+| `anchor_roche01` | Tatooine - Rocky Pass | 4 | Scripted: Tatooine |  |
+| `apartment_002` | Small Player Apartment - Style 1 | 1 | Sheltered |  |
+| `apartment_2` | Medium Player Apartment - Style 1 | 1 | Sheltered |  |
+| `apartment_3` | Large Player Apartment - Style 1 | 1 | Sheltered |  |
+| `ar_pw_indusvel` | [Prefab] City, Industrial Slum | 0 | Authored native only |  |
+| `ar_scor_kacademy` | Korriban - Sith Academy | 3 | Sheltered |  |
+| `ar_scor_korrcan` | Korriban - Starport - Cantina | 1 | Sheltered |  |
+| `ar_scor_kortemp` | Korriban - Valley Temples | 0 | Scripted: Korriban |  |
+| `ar_scor_kvalinte` | Korriban - Valley Temple Interiors | 3 | Sheltered |  |
+| `area` | Viscara - Cavern | 3 | Sheltered |  |
+| `area_template` | area_template | 4 | Authored native only |  |
+| `bank` | Building Template - Bank Style 1 | 1 | Sheltered |  |
+| `cantina` | Building Template - Cantina Style 1 | 3 | Sheltered |  |
+| `canyon_001` | Tatooine - Deep Canyon | 4 | Scripted: Tatooine |  |
+| `char_migration` | *Character Rebuild | 4 | Authored native only |  |
+| `city_hall` | Building Template - City Hall Style 1 | 1 | Sheltered |  |
+| `coolship` | [Prefab] Ship - The Gwenivere | 3 | Sheltered |  |
+| `coxxian_hq` | Viscara - Coxxion Headquarters | 1 | Sheltered |  |
+| `cz220shipbreaker` | CZ-220 - Breaker Yard | 1 | Sheltered |  |
+| `cz220shipbreakin` | CZ-220 - Breaker Bay
+ | 1 | Sheltered |  |
+| `czs220_hangar` | CZ-220 - Hangar | 1 | Sheltered |  |
+| `czs220_maintlvl` | CZ-220 - Maintenance Level | 3 | Sheltered |  |
+| `dan_battlemon` | Dantooine - Battle Monster Gym | 1 | Sheltered |  |
+| `dan_centcolony` | Dantooine - Colony Central | 0 | Scripted: Dantooine |  |
+| `dan_colony` | Dantooine - Colony | 0 | Scripted: Dantooine |  |
+| `dan_colonyfarms` | Dantooine - Colony South Farms | 0 | Scripted: Dantooine |  |
+| `dan_colonyspa` | Dantooine - Colony Spa | 1 | Sheltered |  |
+| `dan_crafterbase` | Dantooine - Central Craft Base | 1 | Sheltered |  |
+| `dan_crystalcavez` | Dantooine - Canyon Crystal Caves | 7 | Sheltered |  |
+| `dan_crystalflied` | Dantooine - Canyon Crystal Fields | 0 | Scripted: Dantooine |  |
+| `dan_destroyfarm` | Dantooine - Ruined Farmlands | 0 | Scripted: Dantooine |  |
+| `dan_enclosemount` | Dantooine - Enclosed Mountain | 0 | Scripted: Dantooine |  |
+| `dan_fieldtrail` | Dantooine - Field Trail | 0 | Scripted: Dantooine |  |
+| `dan_hiddenmount` | Dantooine - Hidden Trail | 0 | Scripted: Dantooine |  |
+| `dan_interiors` | Dantooine - Interior | 1 | Sheltered |  |
+| `dan_iriazfarm` | Dantooine - Iriaz Fields | 0 | Scripted: Dantooine |  |
+| `dan_jantacaves` | Dantooine - Janta Caves | 3 | Sheltered |  |
+| `dan_jedienclave` | Dantooine - Jedi Enclave | 1 | Sheltered |  |
+| `dan_jedienlibry` | Dantooine - Jedi Enclave Library | 3 | Sheltered |  |
+| `dan_jedlibrary` | Dantooine - Jedi Library | 1 | Sheltered |  |
+| `dan_jungle1` | Dantooine - Forsaken Jungles | 4 | Scripted: Dantooine |  |
+| `dan_junglemount` | Dantooine - Jungle Mountain | 0 | Scripted: Dantooine |  |
+| `dan_kathden` | Dantooine - Janta Caves Lower | 3 | Sheltered |  |
+| `dan_kinrathcave` | Dantooine - Kinrath Caves | 7 | Sheltered |  |
+| `dan_lakencave` | Dantooine - Lake | 2 | Sheltered |  |
+| `dan_medical` | Dantooine - Medical Safehouse | 0 | Scripted: Dantooine |  |
+| `dan_medinterior` | Dantooine - Medical Interior | 1 | Sheltered |  |
+| `dan_mountcrycave` | Dantooine - Mountain Crystal Caves | 1 | Sheltered |  |
+| `dan_playerland2` | Dantooine - Clear Jungles | 0 | Scripted: Dantooine |  |
+| `dan_playerlands` | Dantooine - Tranquil Plains | 0 | Scripted: Dantooine |  |
+| `dan_repgarrison` | Dantooine - Republic Garrison | 0 | Scripted: Dantooine |  |
+| `dan_repinside` | Dantooine - Republic Base | 1 | Sheltered |  |
+| `dan_repubmed` | Dantooine - Republic Med Center | 1 | Sheltered |  |
+| `dan_rivercanyon` | Dantooine - Canyon  River | 0 | Scripted: Dantooine |  |
+| `dan_smugcaverns` | Dantooine - Smuggler Caverns | 7 | Sheltered |  |
+| `dan_tribefields` | Dantooine - South Fields | 0 | Scripted: Dantooine |  |
+| `dan_warehouse` | Dantooine - Abandoned Warehouse | 3 | Sheltered |  |
+| `dan_wildplain` | Dantooine - Wild Plains | 0 | Scripted: Dantooine |  |
+| `dantooineorbit` | Space - Dantooine Orbit | 1 | Sheltered |  |
+| `dath_caveruins1` | Dathomir - Cave Ruins | 3 | Sheltered |  |
+| `dath_cz_baseok` | Dathomir - Czerka Base | 0 | Scripted: Dathomir |  |
+| `dath_desert` | Dathomir - Desert | 0 | Scripted: Dathomir |  |
+| `dath_grottos` | Dathomir - Grottos | 0 | Scripted: Dathomir |  |
+| `dath_hidtunnels` | Dathomir - Hidden Cave | 7 | Sheltered |  |
+| `dath_landingpad` | Dathomir - Jungle Landing | 0 | Scripted: Dathomir |  |
+| `dath_mountains` | Dathomir - Mountains | 0 | Scripted: Dathomir |  |
+| `dath_mountcaves` | Dathomir - Mountain Caves | 3 | Sheltered |  |
+| `dath_ruin_base` | Dathomir - Ruin Base | 3 | Sheltered |  |
+| `dath_tarnjungles` | Dathomir - Tarnished Jungles | 0 | Scripted: Dathomir |  |
+| `dath_tranjungl2` | Dathomir - Tarnished Jungles North | 0 | Scripted: Dathomir |  |
+| `dath_tribevill` | Dathomir - Tribe Village | 0 | Scripted: Dathomir |  |
+| `dath_waterfallru` | Dathomir - Waterfall Ruins | 0 | Scripted: Dathomir |  |
+| `dath_west_desert` | Dathomir - Desert West Side | 0 | Scripted: Dathomir |  |
+| `dathgrottocavern` | Dathomir - Grotto Caverns | 7 | Sheltered |  |
+| `dmfi_custom_enc` | *DMFI Custom Encounter Region | 4 | Authored native only |  |
+| `druz_shalim` | Viscara - Druzer | 4 | Scripted: Viscara |  |
+| `druz_wpnarm` | Viscara - Druzer Store | 1 | Sheltered |  |
+| `ebonhawk` | [Prefab] Ebon Hawk | 3 | Sheltered |  |
+| `esriauncharted` | [Prefab] Esria - Uncharted Island | 4 | Authored native only |  |
+| `foszchimed` | Viscara - Chi-Med | 1 | Sheltered | Shelter flags corrected |
+| `foszestate` | [Prefab] Former Fosz Estate | 1 | Sheltered | Shelter flags corrected |
+| `foszestateext` | [Prefab] Former Fosz Estate - Exterior | 0 | Scripted: Viscara |  |
+| `gl_ksthacdmyextr` | [Prefab] Korriban - Sith Academy Exterior | 4 | Authored native only |  |
+| `hiddenquestzone` | *Hidden Access Area | 3 | Sheltered |  |
+| `house_int_1` | Small Player Home - Style 1 | 1 | Sheltered |  |
+| `house_int_10` | Small Player Home - Style 4 | 5 | Sheltered |  |
+| `house_int_11` | Medium Player Home - Style 4 | 5 | Sheltered |  |
+| `house_int_12` | Large Player Home - Style 4 | 5 | Sheltered |  |
+| `house_int_2` | Medium Player Home - Style 1 | 1 | Sheltered |  |
+| `house_int_3` | Large Player Home - Style 1 | 1 | Sheltered |  |
+| `house_int_4` | Small Player Home - Style 2 | 5 | Sheltered |  |
+| `house_int_5` | Medium Player Home - Style 2 | 5 | Sheltered |  |
+| `house_int_6` | Large Player Home - Style 2 | 5 | Sheltered |  |
+| `house_int_7` | Small Player Home - Style 3 | 1 | Sheltered |  |
+| `house_int_8` | Medium Player Home - Style 3 | 1 | Sheltered |  |
+| `house_int_9` | Large Player Home - Style 3 | 5 | Sheltered |  |
+| `hutlar_frozen_wa` | Hutlar - Frozen Wastes | 0 | Scripted: Hutlar | Humidity +9: permanent snow |
+| `hutlar_orbit` | Space - Hutlar Orbit | 1 | Sheltered |  |
+| `hutlar_outpost` | Hutlar - Outpost | 0 | Scripted: Hutlar |  |
+| `hutlar_qion` | Hutlar - Qion Tundra | 0 | Scripted: Hutlar |  |
+| `hutlar_smuggleba` | Hutlar - Abandoned Outpost | 1 | Sheltered | Shelter flags corrected |
+| `hutlar_testsite` | Hutlar - Cloning Test Site | 0 | Scripted: Hutlar |  |
+| `hutlar_valley` | Hutlar - Qion Valley | 0 | Scripted: Hutlar |  |
+| `hutlar_wastes_ca` | Hutlar - Frozen Caves | 7 | Sheltered |  |
+| `jedishuttle` | [Prefab] Ship - Nova Shuttle | 1 | Sheltered |  |
+| `jeditemp_int` | Viscara - Jedi Temple Interior | 1 | Sheltered |  |
+| `ka_ar_czweaparen` | Smuggler's Moon - Czerka Blast-Safe Cell | 0 | Scripted: SmugglersMoon |  |
+| `ka_crnt_corellia` | [Prefab] Corellia, Bridge | 0 | Authored native only |  |
+| `ka_dropsh_cr_sno` | [Prefab] Winter Crash Site | 0 | Authored native only |  |
+| `ka_dropship_spac` | [Prefab] Dropship | 1 | Sheltered |  |
+| `ka_drps_crsh_kor` | [Prefab] Korriban Crash Site | 0 | Authored native only |  |
+| `ka_drps_crsh_vis` | [Prefab] Viscaran Crash Site | 4 | Authored native only |  |
+| `ka_trenchpr1` | [Prefab] Trench Warfare | 0 | Authored native only |  |
+| `ka_vis_mntscrapy` | [Prefab] Scrapyard | 0 | Authored native only |  |
+| `karthviscdun1` | [Prefab] Old Mine | 3 | Sheltered |  |
+| `kash_village` | Kashyyyk - Village | 0 | Scripted: Kashyyyk | Explicit climate override |
+| `kashyyyk_camp` | Kashyyyk - War Camp | 4 | Scripted: Kashyyyk | Explicit climate override |
+| `kashyyykpaths` | Kashyyyk - Forest Paths | 4 | Scripted: Kashyyyk | Explicit climate override |
+| `kashyyykshadow` | Kashyyyk - Shadowlands | 4 | Scripted: Kashyyyk | Explicit climate override |
+| `korr_cavern` | Korriban - Caverns | 3 | Sheltered | Shelter flags corrected |
+| `korr_crypt_zil` | Korriban - Sith Crypt | 3 | Sheltered | Shelter flags corrected |
+| `korr_plains` | Korriban - Dunes | 4 | Scripted: Korriban |  |
+| `korr_ravine` | Korriban - Ravine | 4 | Scripted: Korriban |  |
+| `korr_valley` | Korriban - Valley | 0 | Scripted: Korriban |  |
+| `korr_waste2_zil` | Korriban - Wastelands - South | 4 | Scripted: Korriban |  |
+| `korr_waste_zil` | Korriban - Wastelands - North | 4 | Scripted: Korriban |  |
+| `korribanlandingp` | Korriban - Starport | 4 | Scripted: Korriban |  |
+| `manda_facility` | Viscara - Mandalorian Facility | 3 | Sheltered |  |
+| `medical_center` | Building Template - Medical Center Style 1 | 1 | Sheltered |  |
+| `moncala_swamp` | Mon Cala - Sunkenhedge Swamps | 0 | Scripted: MonCala |  |
+| `moncalacifacilit` | Mon Cala - Coral Isles - Facility | 3 | Sheltered |  |
+| `moncalacorali001` | Mon Cala - Coral Isles - Outer | 4 | Scripted: MonCala |  |
+| `moncalacoralisle` | Mon Cala - Coral Isles - Inner | 4 | Scripted: MonCala |  |
+| `moncaladaccityex` | Mon Cala - Dac City - The "Elite" Hotel | 3 | Sheltered |  |
+| `moncaladaccitysu` | Mon Cala - Dac City - Surface | 4 | Scripted: MonCala |  |
+| `moncaladungeon1` | Mon Cala - Sharptooth Jungle - Caves | 3 | Sheltered |  |
+| `moncalajungelsu` | Mon Cala - Sharptooth Jungle - South | 0 | Scripted: MonCala |  |
+| `moncalaorbit` | Space - Mon Cala Orbit | 1 | Sheltered |  |
+| `moncalawildjungl` | Mon Cala - Sharptooth Jungle - North | 0 | Scripted: MonCala |  |
+| `moseis_dow_ca001` | Tatooine - Mos Eisley - Docking Bay 94 | 4 | Scripted: Tatooine |  |
+| `moseis_dow_can` | Tatooine - Mos Esper - Dowager Queen | 4 | Scripted: Tatooine |  |
+| `moseis_exit_sud` | Tatooine - Mos Esper - South Entrance | 4 | Scripted: Tatooine |  |
+| `moseis_lucky` | Tatooine - Mos Esper - Cantina Quarter | 4 | Scripted: Tatooine |  |
+| `moseis_sand_001` | Tatooine - Dune Desert | 4 | Scripted: Tatooine |  |
+| `moseis_sand_003` | Tatooine - Deep Canyon | 4 | Scripted: Tatooine |  |
+| `moseis_sand_004` | Tatooine - Dune Desert | 4 | Scripted: Tatooine |  |
+| `moseis_sand_005` | Tatooine - Dune Desert | 4 | Scripted: Tatooine |  |
+| `mus_ironwoods_ka` | [Prefab] Lava Planet - Iron Woods | 0 | Authored native only |  |
+| `mustafar_lava_ka` | [Prefab] Lava Planet - Mine | 0 | Authored native only |  |
+| `na_ka_pref_scene` | [Prefab] City, Battle | 0 | Authored native only |  |
+| `nanostation015` | CZ-220 - Offices & Labs | 3 | Sheltered |  |
+| `narshad_czklab` | [Prefab] Czerka Tower, Exterior | 0 | Authored native only |  |
+| `narshadaar_midoc` | [Prefab] Nar Shaddaa - Midcity Docks | 0 | Authored native only |  |
+| `narshadaar_pr001` | [Prefab] Promenade Casino | 1 | Sheltered | Shelter flags corrected |
+| `narshadaar_promi` | [Prefab] Promenade | 0 | Authored native only |  |
+| `narshadorbit` | Space - Smuggler's Moon Orbit | 1 | Sheltered |  |
+| `nashada_czlabf2` | [Prefab] Czerka Lab Floor 2 | 1 | Sheltered | Shelter flags corrected |
+| `nashadaa_czlabin` | [Prefab] Czerka Lab Floor 1 | 1 | Sheltered | Shelter flags corrected |
+| `no_access` | *No Access | 0 | Authored native only |  |
+| `ns_comrcial_ka` | [Prefab] City, Commerce | 0 | Authored native only |  |
+| `ns_industrialsec` | [Prefab] Industrial Sector | 0 | Authored native only |  |
+| `ns_prfb_nsinteri` | [Prefab] Nar Shaddaa - Interior | 1 | Sheltered | Shelter flags corrected |
+| `ooc_area` | *Welcome to Star Wars: Legends of the Old Republic! | 1 | Sheltered |  |
+| `ossu_wastesruin` | Ossus - Wastes Ruins | 0 | Scripted: Ossus | Explicit climate override |
+| `ossus_cavefacili` | Ossus - Wastes Cave Facility | 3 | Sheltered | Shelter flags corrected |
+| `ossus_landstart` | Ossus - Landing Pads | 0 | Scripted: Ossus | Explicit climate override |
+| `ossus_tempinisde` | Ossus - Jedi Temple | 3 | Sheltered |  |
+| `ossus_wastejungl` | Ossus - Waste Jungle | 4 | Scripted: Ossus | Explicit climate override |
+| `ossustemp` | Ossus - Ruin Temple | 0 | Scripted: Ossus | Explicit climate override |
+| `player_rnd` | Building Template - Lab Style 1 | 5 | Sheltered |  |
+| `playerap_l_fur` | Large Player Apartment - Style 2 (Furnished) | 1 | Sheltered |  |
+| `playerap_l_unf` | Large Player Apartment - Style 2 (Unfurnished) | 1 | Sheltered |  |
+| `playerap_m_fur` | Medium Player Apartment - Style 2 (Furnished) | 1 | Sheltered |  |
+| `playerap_m_unf` | Medium Player Apartment - Style 2 (Unfurnished) | 1 | Sheltered |  |
+| `playerap_s_fur` | Small Player Apartment - Style 2 (Furnished) | 1 | Sheltered |  |
+| `playerap_s_unf` | Small Player Apartment - Style 2 (Unfurnished) | 1 | Sheltered |  |
+| `pref_caves` | [Prefab] Caves | 7 | Sheltered |  |
+| `pref_facilidark` | [Prefab] Facility, Dark | 1 | Sheltered |  |
+| `pref_facility` | [Prefab] Facility | 1 | Sheltered |  |
+| `pref_forest` | [Prefab] Forest | 0 | Authored native only |  |
+| `pref_frozen` | [Prefab] Frozen Waste | 4 | Authored native only |  |
+| `pref_hammerhead` | [Prefab] Hammerhead Cruiser | 1 | Sheltered |  |
+| `pref_interior` | [Prefab] Interior, Generic | 1 | Sheltered |  |
+| `pref_leviathan` | [Prefab] Leviathan, Revan's Flagship, Bridge | 1 | Sheltered |  |
+| `pref_ship1` | [Prefab] Ship Bridge | 1 | Sheltered |  |
+| `pref_shipbattle` | [Prefab] Ships | 1 | Sheltered |  |
+| `pref_snow` | [Prefab] Forest, Winter | 0 | Authored native only |  |
+| `pref_wasteland` | [Prefab] Wasteland | 0 | Authored native only |  |
+| `pref_wildlands` | [Prefab] Wildlands | 0 | Authored native only |  |
+| `prefab_beachside` | [Prefab] Beachside | 4 | Authored native only |  |
+| `prefab_desoutp` | [Prefab] Desert Outpost | 0 | Authored native only |  |
+| `prefab_hauntcave` | [Prefab] Haunted Cave | 3 | Sheltered |  |
+| `prefab_space` | [Prefab] Space | 1 | Sheltered |  |
+| `prefab_space003` | [Prefab] Space 3 | 1 | Sheltered |  |
+| `prefab_space004` | [Prefab] The Void | 1 | Sheltered |  |
+| `prefab_space2` | [Prefab] Space 2 | 1 | Sheltered |  |
+| `prefab_sunkenlab` | [Prefab] Sunken Lab | 1 | Sheltered |  |
+| `prefab_underwtun` | [Prefab] Underwater Tunnel | 1 | Sheltered | Shelter flags corrected |
+| `prefabcorvette` | [Prefab] Corvette | 1 | Sheltered |  |
+| `prefabdarkbase` | [Prefab] Dark Side Area | 3 | Sheltered |  |
+| `prefabfighter` | [Prefab] Fighter | 1 | Sheltered |  |
+| `prefabgriddesert` | [Prefab Grid] Desert | 0 | Authored native only |  |
+| `prefabgridgrass` | [Prefab Grid] Grasslands | 4 | Authored native only |  |
+| `prefabgridsnowy` | [Prefab Grid] Snowy City | 0 | Authored native only |  |
+| `prefabgridwaste` | [Prefab Grid] Wastelands | 1 | Sheltered |  |
+| `prefabgridwater` | [Prefab Grid] Water/Ocean | 4 | Authored native only |  |
+| `prefabwarehouse` | [Prefab] Warehouse | 1 | Sheltered | Shelter flags corrected |
+| `pw_ar_abovcity` | [Prefab] Above the City | 0 | Authored native only |  |
+| `pw_ar_bhbar` | Smuggler's Moon - The Tilted Visor | 1 | Sheltered |  |
+| `pw_ar_citbat003` | [Prefab] City, Warfare | 0 | Authored native only |  |
+| `pw_ar_czarmrange` | Smuggler's Moon - Czerka Weapons Testing Facility | 1 | Sheltered | Shelter flags corrected |
+| `pw_ar_czoffice` | Smuggler's Moon - Czerka Shipyard Office | 1 | Sheltered |  |
+| `pw_ar_gentemp` | [Prefab] Temple, Generic | 1 | Sheltered |  |
+| `pw_ar_indzon_vka` | [Prefab] City, Industrial Sector | 0 | Authored native only |  |
+| `pw_ar_ka_arkania` | [Prefab] Arkania  | 0 | Authored native only |  |
+| `pw_ar_kashyk` | Kashyyyk - Wookie Village, Canopy | 0 | Scripted: Kashyyyk | Explicit climate override |
+| `pw_ar_narcatwalk` | Smuggler's Moon - Catwalks | 0 | Scripted: SmugglersMoon |  |
+| `pw_ar_nardocks` | Smuggler's Moon - Shipping District | 0 | Scripted: SmugglersMoon |  |
+| `pw_ar_narpromena` | Smuggler's Moon - Promenade | 0 | Scripted: SmugglersMoon |  |
+| `pw_ar_nars_canhd` | Smuggler's Moon - Hyper Dive Cantina | 1 | Sheltered |  |
+| `pw_ar_narscorpd` | Smuggler's Moon - Corporate District | 0 | Scripted: SmugglersMoon |  |
+| `pw_ar_narshahub` | Smuggler's Moon - The Hub | 0 | Scripted: SmugglersMoon |  |
+| `pw_ar_narslum` | Smuggler's Moon - The Slums | 0 | Scripted: SmugglersMoon |  |
+| `pw_ar_ns_doffice` | Smuggler's Moon - Shipping District, Foreman's Office | 1 | Sheltered |  |
+| `pw_ar_ns_medical` | Smuggler's Moon - Medshed | 1 | Sheltered |  |
+| `pw_ar_nscasino` | Smuggler's Moon - Casino | 1 | Sheltered |  |
+| `pw_ar_nscrafting` | Smuggler's Moon - Fabrication Facility | 1 | Sheltered |  |
+| `pw_ar_nsczgnstr` | Smuggler's Moon - Czerka Arms, Store | 1 | Sheltered |  |
+| `pw_ar_nsficlub` | Smuggler's Moon - Fight Club | 1 | Sheltered |  |
+| `pw_ar_nsgsidunge` | Smuggler's Moon - GSI Base | 1 | Sheltered |  |
+| `pw_ar_nsshipyard` | Smuggler's Moon - Landing Pads | 0 | Scripted: SmugglersMoon |  |
+| `pw_ar_oceancity` | [Prefab] Ocean Planet City | 0 | Authored native only |  |
+| `pw_ar_prfbcitysc` | [Prefab] Cityscape,  Vertical | 0 | Authored native only |  |
+| `pw_ar_sc_arkcave` | [Prefab] Arkania - Caves | 6 | Sheltered |  |
+| `pw_ar_sc_arki001` | [Prefab] Arkania - Interior | 1 | Sheltered | Shelter flags corrected |
+| `pw_ar_sc_arkmine` | [Prefab] Arkania - Crystal Mines | 0 | Authored native only |  |
+| `pw_ar_trench3bl` | [Prefab] Trenches, Front Line | 0 | Authored native only |  |
+| `pw_ar_trenchv2` | [Prefab] Trenches, Back Line | 0 | Authored native only |  |
+| `pw_ar_undrnasha` | Smuggler's Moon - Sewers | 1 | Sheltered |  |
+| `pw_ar_undrwat` | [Prefab] Underwater | 7 | Sheltered |  |
+| `pw_ar_velrevam` | [Prefab] City Planet | 0 | Authored native only |  |
+| `pw_ar_velundr` | [Prefab] Undercity  | 3 | Sheltered |  |
+| `pw_sc_aboveland` | [Prefab] Above the Land | 0 | Authored native only |  |
+| `pw_sc_abovewater` | [Prefab] Above the Water | 0 | Authored native only |  |
+| `pw_sc_canyonpit` | Tatooine - Canyon Dueling Pit | 4 | Scripted: Tatooine | Reviewed open-air layout |
+| `pw_sc_dantmedsub` | Dantooine - Medical Sublevel | 7 | Sheltered |  |
+| `pw_sc_dantprowar` | Dantooine - Protected Ward | 3 | Sheltered |  |
+| `pw_sc_dath_apexd` | Dathomir - Grotto Apex Den | 7 | Sheltered |  |
+| `pw_sc_dath_sden` | Dathomir - Sealed Apex Den | 7 | Sheltered |  |
+| `pw_sc_emfbackr` | Smuggler's Moon - Fight Club Backrooms
+ | 3 | Sheltered |  |
+| `pw_sc_jeditrial` | Dantooine - Saber Trial Chamber | 1 | Sheltered |  |
+| `pw_sc_korrforge` | Korriban - Champion Forge | 7 | Sheltered |  |
+| `pw_sc_qioncore` | Hutlar - Overload Chamber | 1 | Sheltered |  |
+| `pw_sc_repubcmd` | Viscara - Engineering Command Room | 3 | Sheltered |  |
+| `pw_sc_sithritual` | Korriban - Final Ritual Chamber | 3 | Sheltered |  |
+| `pw_sc_smarena` | Smuggler's Moon - Private Pit | 3 | Sheltered |  |
+| `pw_sc_tarnalpha` | Dathomir - Alpha Beast Hollow | 4 | Scripted: Dathomir |  |
+| `pw_sc_velescmd` | Viscara - Militia Command Room | 1 | Sheltered |  |
+| `pw_sc_velsewboss` | Viscara - Veles - Sewers - The Cistern Ring | 3 | Sheltered |  |
+| `r_prax_centralsp` | Twilight Praxeum - Central Spire | 3 | Sheltered |  |
+| `r_prax_combatdec` | Twilight Praxeum - Combat Deck | 1 | Sheltered |  |
+| `r_prax_hangar` | Twilight Praxeum - Hangar and Cantina | 1 | Sheltered |  |
+| `r_prax_interiors` | Twilight Praxeum - Interiors | 1 | Sheltered |  |
+| `r_prax_sith` | Twilight Praxeum - Sith Chambers | 1 | Sheltered |  |
+| `randoncity_01` | [Prefab] Randon - City | 4 | Authored native only |  |
+| `randoncity_02` | [Prefab] Randon - City Ruins | 0 | Authored native only |  |
+| `republicshipevnt` | [Prefab] Republic Cruiser - The Sovereign - Lower Decks | 1 | Sheltered | Shelter flags corrected |
+| `roch_govbuild` | [Prefab] Roche System - Nickel One - Verpine Starships Enterprise | 1 | Sheltered |  |
+| `rochenickelone` | [Prefab] Roche System - Nickel One | 1 | Sheltered |  |
+| `rochenickeltwo` | [Prefab] Roche System - Nickel One Under Assault! | 1 | Sheltered |  |
+| `scor_knwinterior` | Korriban - Wasteland Interiors | 1 | Sheltered |  |
+| `scor_kscaves` | Korriban - Wastelands Tunnels | 7 | Sheltered |  |
+| `ship_basi_v` | Starship - Basilisk | 1 | Sheltered |  |
+| `ship_condor_z` | Starship - Condor | 1 | Sheltered |  |
+| `ship_consul_z` | Starship - Consular | 1 | Sheltered |  |
+| `ship_corv_v` | Starship - Corvette | 1 | Sheltered |  |
+| `ship_falchion_z` | Starship - Falchion | 1 | Sheltered |  |
+| `ship_fight_v` | Starship - Fighter | 1 | Sheltered |  |
+| `ship_firstlight` | [Prefab] Ship - The First Light | 3 | Sheltered |  |
+| `ship_hound_z` | Starship - Hound | 1 | Sheltered |  |
+| `ship_merchant_z` | Starship - Merchant | 1 | Sheltered |  |
+| `ship_mule_z` | Starship - Mule | 1 | Sheltered |  |
+| `ship_panth_z` | Starship - Panther | 1 | Sheltered |  |
+| `ship_saber_z` | Starship - Saber | 1 | Sheltered |  |
+| `ship_secchan_int` | Starship - Second Chance | 1 | Sheltered |  |
+| `ship_strike_z` | Starship - Striker | 1 | Sheltered |  |
+| `ship_throne_z` | Starship - Throne | 1 | Sheltered |  |
+| `shuttle` | Starship Shuttle - Interior | 1 | Sheltered |  |
+| `smesks_entry` | Tatooine - Smesk's Entryway | 7 | Sheltered |  |
+| `smesks_palace` | Tatooine - Mos Esper - Smesk's Palace | 1 | Sheltered | Shelter flags corrected |
+| `sol_hutlarqcanyo` | Hutlar - Qion Box Canyon | 4 | Scripted: Hutlar |  |
+| `sol_hutlarqfooth` | Hutlar - Qion Foothills | 4 | Scripted: Hutlar |  |
+| `sol_mandaloriani` | Hutlar - Qion Box Canyon - Fort Ka'ra | 3 | Sheltered |  |
+| `sol_swampsbase` | Viscara - Swamp Base - Interior | 3 | Sheltered |  |
+| `sol_swampstemple` | Viscara - Swamp Base - Temple | 3 | Sheltered |  |
+| `space_dathomir` | Space - Dathomir Orbit | 1 | Sheltered |  |
+| `space_derelict_k` | [Prefab] Derelict Facility | 1 | Sheltered |  |
+| `space_korriban` | Space - Korriban Orbit | 1 | Sheltered |  |
+| `space_midrim1` | Space - A Nebula within the Mid Rim | 1 | Sheltered |  |
+| `space_midrim2` | Space - Approaching the Outer Rim | 1 | Sheltered |  |
+| `spacenarshaddung` | Smuggler's Moon Station - Abandoned | 1 | Sheltered | Shelter flags corrected |
+| `spacenarshalower` | Smuggler's Moon Station - Lower Level | 3 | Sheltered |  |
+| `spending_area` | *Character Rebuild - Spending Area | 1 | Sheltered | Shelter flags corrected |
+| `starport` | Building Template - Starport Style 1 | 1 | Sheltered |  |
+| `starship1_int` | Starship - Light Freighter 1 | 1 | Sheltered |  |
+| `starship2_int` | Starship - Light Escort 1 | 1 | Sheltered |  |
+| `starship3_int` | Starship - Light Freighter 1 | 1 | Sheltered |  |
+| `starship4_int` | Starship - Heavy Freighter - Interior | 1 | Sheltered |  |
+| `tat_anc_aridhill` | Tatooine - Arid Hilly Desert | 4 | Scripted: Tatooine |  |
+| `tat_anc_astropor` | Tatooine - Anchorhead - Spaceport | 4 | Scripted: Tatooine |  |
+| `tat_anc_cantina` | Tatooine - Anchorhead - Cantina | 3 | Sheltered |  |
+| `tat_anc_desroad1` | Tatooine - Desert Road | 4 | Scripted: Tatooine |  |
+| `tat_anc_desroad2` | Tatooine - Desert Road | 4 | Scripted: Tatooine |  |
+| `tat_anc_droidshp` | Tatooine - Anchorhead - Droid Shop | 1 | Sheltered | Shelter flags corrected |
+| `tat_anc_flatlnd1` | Tatooine - Flatlands | 0 | Scripted: Tatooine |  |
+| `tat_anc_flatlnd2` | Tatooine - Flatlands | 0 | Scripted: Tatooine |  |
+| `tat_anc_gocorpst` | Tatooine - Anchorhead - Go-Corp Station | 1 | Sheltered | Shelter flags corrected |
+| `tat_anc_hillydes` | Tatooine - Hilly Desert | 4 | Scripted: Tatooine |  |
+| `tat_anc_junix` | Tatooine - Anchorhead - Junix's Joint | 1 | Sheltered | Shelter flags corrected |
+| `tat_anc_medical` | Tatooine - Anchorhead - Medical Center | 1 | Sheltered |  |
+| `tat_anc_nedunes` | Tatooine - North East Dunes | 4 | Scripted: Tatooine |  |
+| `tat_anc_nminecli` | Tatooine - North Mine Cliffs | 4 | Scripted: Tatooine |  |
+| `tat_anc_northdis` | Tatooine - Anchorhead - North District | 4 | Scripted: Tatooine |  |
+| `tat_anc_northhil` | Tatooine - North Hills | 4 | Scripted: Tatooine |  |
+| `tat_anc_nthdunes` | Tatooine - Northern Dunes | 0 | Scripted: Tatooine |  |
+| `tat_anc_rckpass1` | Tatooine - Rocky Pass | 4 | Scripted: Tatooine |  |
+| `tat_anc_rckpass2` | Tatooine - Rocky Pass | 4 | Scripted: Tatooine |  |
+| `tat_anc_rockdess` | Tatooine - Rocky Desert | 4 | Scripted: Tatooine |  |
+| `tat_anc_southdis` | Tatooine - Anchorhead - South District | 4 | Scripted: Tatooine |  |
+| `tat_anc_southent` | Tatooine - Anchorhead - Southern Entrance | 4 | Scripted: Tatooine |  |
+| `tat_anc_southpas` | Tatooine - Southern Pass | 0 | Scripted: Tatooine |  |
+| `tat_anc_totoche1` | Tatooine - To Tochee | 4 | Scripted: Tatooine |  |
+| `tat_anc_totoche2` | Tatooine - To Tochee | 4 | Scripted: Tatooine |  |
+| `tat_anc_totoche3` | Tatooine - To Tochee | 4 | Scripted: Tatooine |  |
+| `tat_anc_tuskncmp` | Tatooine - Tusken Camp | 4 | Scripted: Tatooine |  |
+| `tat_anc_tuskntnt` | Tatooine - Tusken Raider Tent | 1 | Sheltered |  |
+| `tat_anc_verpexba` | Tatooine - Anchorhead - Verpex Bazaar | 3 | Sheltered |  |
+| `tat_babysarlacc` | Tatooine - Baby Sarlacc Cave | 7 | Sheltered |  |
+| `tat_brokenjawa` | Tatooine - Broken Down Jawa Machine | 4 | Scripted: Tatooine |  |
+| `tat_chasmpass` | Tatooine - Chasm Pass | 0 | Scripted: Tatooine |  |
+| `tat_elevagiifarm` | Tatooine - Elevagii Farm | 4 | Scripted: Tatooine |  |
+| `tat_rancorcave` | Tatooine - Rancor Cave | 7 | Sheltered |  |
+| `tat_rockypasslge` | Tatooine - Rocky Pass | 4 | Scripted: Tatooine |  |
+| `tat_smeskspalace` | Tatooine - Smesk's Palace | 4 | Scripted: Tatooine |  |
+| `tat_tocheemain` | Tatooine - Tochee | 4 | Scripted: Tatooine |  |
+| `tat_tomoseisley1` | Tatooine - To Mos Eisley | 4 | Scripted: Tatooine |  |
+| `tat_tuskcavebot` | Tatooine - Tusken Raider Cave - Bottom Floor | 7 | Sheltered |  |
+| `tat_tuskcavemain` | Tatooine - Tusken Raider Cave - Main Floor | 3 | Sheltered |  |
+| `tat_tuskcavetunn` | Tatooine - Tusken Raider Cave - Tunnels | 7 | Sheltered |  |
+| `tat_wormden` | Tatooine - The Worm Den | 7 | Sheltered |  |
+| `tatooineorbit` | Space - Tatooine Orbit | 1 | Sheltered |  |
+| `tochee_cantina` | Tatooine - Anchorhead - Club d'Ash | 3 | Sheltered |  |
+| `tosche_cantina_s` | Tatooine - Anchorhead - Smuggler's Den | 3 | Sheltered |  |
+| `v_cox_base` | Viscara - Coxxion Base | 1 | Sheltered |  |
+| `v_jediforest_cav` | Viscara - Jedi Temple Forest Cave | 7 | Sheltered |  |
+| `v_jeditemple_v2` | Viscara - Jedi Temple Exterior | 4 | Scripted: Viscara |  |
+| `v_repubbase_1` | Viscara - Republic Base - Entrance | 3 | Sheltered |  |
+| `v_repubbase_2` | Viscara - Republic Base - Medical and Brig | 3 | Sheltered |  |
+| `v_repubbase_cd` | Viscara - Republic Base - Combat Deck | 1 | Sheltered |  |
+| `v_repubbase_ext` | Viscara - Republic Base - Exterior | 0 | Scripted: Viscara |  |
+| `v_repubbase_hang` | Viscara - Republic Base - Hangar | 3 | Sheltered |  |
+| `v_repubbase_jnrm` | Viscara - Republic Base - Junior Mess | 1 | Sheltered |  |
+| `v_repubbase_off` | Viscara - Republic Base - Offices | 1 | Sheltered |  |
+| `v_sithlake_int` | Viscara - Sith Lake Outpost | 3 | Sheltered |  |
+| `v_swamp_base` | Viscara - Swamplands - Sith Base | 4 | Scripted: Viscara |  |
+| `v_swamp_ruins001` | Viscara - Swamplands Ruins | 4 | Scripted: Viscara |  |
+| `v_swamp_undergro` | Viscara - Swamplands Underground | 3 | Sheltered |  |
+| `valkorrdung1a` | Korriban - Sith Fortress, Approach | 4 | Scripted: Korriban |  |
+| `valkorrdung1b` | Korriban - Sith Fortress, Courtyard | 0 | Scripted: Korriban | Reviewed open-air layout |
+| `valkorrdung1c` | Korriban - Sith Fortress, Forgeworks | 1 | Sheltered | Shelter flags corrected |
+| `valkorrdung1d` | Korriban - Sith Fortress, Lord's Quarters | 3 | Sheltered |  |
+| `veles_cantina` | Viscara - Veles - Racin' Jims | 3 | Sheltered |  |
+| `veles_cz_tower` | Viscara - Veles - Czerka Tower | 1 | Sheltered |  |
+| `veles_exterior` | Viscara - Veles | 0 | Scripted: Viscara |  |
+| `veles_genstore` | Viscara - Veles - General Store | 1 | Sheltered |  |
+| `veles_holonews` | Viscara - Veles - HNN Office | 1 | Sheltered |  |
+| `veles_sewers` | Viscara - Veles - Sewers | 3 | Sheltered |  |
+| `veles_sheriff` | Viscara - Veles - Sheriff/Clinic | 1 | Sheltered |  |
+| `veles_shops` | Viscara - Veles - Shops | 1 | Sheltered |  |
+| `velesinterior` | Viscara - Veles - Starport | 1 | Sheltered |  |
+| `velesrestgarden` | Viscara - Rest's Public Gardens | 1 | Sheltered |  |
+| `visc_forcevision` | Force Vision - First Rites | 1 | Sheltered |  |
+| `visc_sewer_depth` | Viscara - Veles - Sewers Depths | 3 | Sheltered |  |
+| `viscara_archive` | [Prefab] Czerka Archives | 3 | Sheltered |  |
+| `viscara_cave_2ka` | [Prefab] Overgrown Caves | 7 | Sheltered |  |
+| `viscara_forkeast` | Viscara - Crossroads East | 0 | Scripted: Viscara |  |
+| `viscara_forkwest` | Viscara - Crossroads West | 0 | Scripted: Viscara |  |
+| `viscara_jedigrou` | Viscara - Jedi Forest Grounds | 0 | Scripted: Viscara |  |
+| `viscara_lakegrou` | Viscara - Lake Grounds | 0 | Scripted: Viscara |  |
+| `viscara_mountasc` | Viscara - Mountain Ascent | 0 | Scripted: Viscara |  |
+| `viscara_npcship1` | [Prefab] Ship - The Ivory Harrier | 1 | Sheltered |  |
+| `viscara_wwnorth` | Viscara - Wildwoods - North | 0 | Scripted: Viscara |  |
+| `viscara_wwruined` | Viscara - Wildwoods - Ruined | 0 | Scripted: Viscara |  |
+| `viscaradeepmount` | Viscara - Deep Mountains | 4 | Scripted: Viscara |  |
+| `viscaradeepwo001` | Viscara - Deepwoods | 4 | Scripted: Viscara |  |
+| `viscaralake` | Viscara - Lake | 4 | Scripted: Viscara |  |
+| `viscaranswamp` | Viscara - Eastern Swamplands | 4 | Scripted: Viscara |  |
+| `viscaranwswamp` | Viscara - Western Swamplands | 4 | Scripted: Viscara |  |
+| `viscaraorbit` | Space - Viscara Orbit | 1 | Sheltered |  |
+| `viscarawildlands` | Viscara - Wildlands | 4 | Scripted: Viscara |  |
+| `viscarawildwest` | Viscara - Mountain Valley | 4 | Scripted: Viscara |  |
+| `viscarawildwoods` | Viscara - Wildwoods | 4 | Scripted: Viscara |  |
+| `vlegionbasemain` | Viscara - Legion Base | 1 | Sheltered |  |
+| `vlegsecond` | Viscara - Legion Base - Second Floor | 1 | Sheltered |  |
+| `vprefsith1` | [Prefab] Sith Crypt | 3 | Sheltered | Shelter flags corrected |
+| `vrotranccsitharc` | [Prefab] Ancient Sith Archive | 3 | Sheltered |  |
+| `vrotrbescloudext` | [Prefab] Bespin - Cloud City | 0 | Authored native only |  |
+| `vrotrbescloudint` | [Prefab] Bespin - Cloud City Interior | 1 | Sheltered |  |
+| `vrotrbescomshop` | [Prefab] Bespin - Commerce Guild Shop | 1 | Sheltered |  |
+| `vrotrbesgasmine` | [Prefab] Bespin - Tibanna Gas Mine | 3 | Sheltered |  |
+| `vrotrbeslanding` | [Prefab] Bespin - Landing Pads | 0 | Authored native only |  |
+| `vrotrbesporttown` | [Prefab] Bespin - Port Town | 3 | Sheltered |  |
+| `vrotrcapship1` | [Prefab] Capital Ship | 3 | Sheltered |  |
+| `vrotrcorelclouds` | [Prefab] Corellia - City in the Clouds | 0 | Authored native only |  |
+| `vrotrdantcourt` | [Prefab] Dantooine - Courtyard | 4 | Authored native only |  |
+| `vrotrdantcrystal` | [Prefab] Dantooine - Crystal Cave | 7 | Sheltered |  |
+| `vrotrdantfarms` | [Prefab] Dantooine - Farmlands | 4 | Authored native only |  |
+| `vrotrdantkhoonda` | [Prefab] Dantooine - Khoonda | 4 | Authored native only |  |
+| `vrotrdantplains` | [Prefab] Dantooine - Plains | 4 | Authored native only |  |
+| `vrotrghostship` | [Prefab] Ghost Ship | 1 | Sheltered |  |
+| `vrotrhighoffice` | [Prefab] Senator's Office | 1 | Sheltered | Shelter flags corrected |
+| `vrotrkorracadarc` | [Prefab] Korriban - Academy Archives | 3 | Sheltered |  |
+| `vrotrkorracadrft` | [Prefab] Korriban - Academy Rooftop | 0 | Authored native only | Reviewed open-air layout |
+| `vrotrkorracsacad` | [Prefab] Korriban - Sith Academy | 3 | Sheltered |  |
+| `vrotrkorrdnkside` | [Prefab] Korriban - The Drunk Side | 1 | Sheltered | Shelter flags corrected |
+| `vrotrkorrdresh` | [Prefab] Korriban - Dreshdae | 4 | Authored native only |  |
+| `vrotrkorretpyre` | [Prefab] Korriban - Eternal Pyre Pathway | 4 | Authored native only |  |
+| `vrotrkorrforgcav` | [Prefab] Korriban - Forgotten Cave | 7 | Sheltered |  |
+| `vrotrkorrmission` | [Prefab] Korriban - Wasteland Ruins | 4 | Scripted: Korriban |  |
+| `vrotrkorrvalley` | [Prefab] Korriban - Valley of the Dark Lords | 4 | Authored native only |  |
+| `vrotrnabmission` | [Prefab] Dantooine - Fortress | 4 | Authored native only |  |
+| `vrotrnsdockbay` | [Prefab] Nar Shaddaa - Docking Bay | 0 | Authored native only |  |
+| `vrotrnsinterior` | [Prefab] Nar Shaddaa - Interior | 1 | Sheltered | Shelter flags corrected |
+| `vrotrnsroofconf` | [Prefab] Nar Shaddaa - Rooftop Confrontation | 0 | Authored native only |  |
+| `vrotrnsrooftops` | [Prefab] Nar Shaddaa - Rooftops | 0 | Authored native only |  |
+| `vrotrnsrooftops2` | [Prefab] Nar Shaddaa - Rooftops 2 | 0 | Authored native only |  |
+| `vrotrnsslums` | [Prefab] Nar Shaddaa - Slums | 0 | Authored native only |  |
+| `vrotrsithlordext` | [Prefab] Sith Lord's Fortress | 0 | Authored native only |  |
+| `vrotrsithlordint` | [Prefab] Sith Lord's Quarters | 3 | Sheltered |  |
+| `vrotrtatdescamp` | [Prefab] Tatooine - Desert Camp | 4 | Authored native only |  |
+| `vrotrviscvokouts` | [Prefab] Viscara - Vokus Outskirts | 4 | Authored native only |  |
+| `yavin` | [Prefab] Yavin | 0 | Authored native only |  |
+| `ziyhutdung1a` | Hutlar - Qion Hive, Approach | 0 | Scripted: Hutlar |  |
+| `ziyhutdung1b` | Hutlar - Qion Hive, Ziggurat | 3 | Sheltered |  |
+| `ziyhutdung1c` | Hutlar - Qion Hive, Outer Hive | 3 | Sheltered |  |
+| `ziyhutdung1d` | Hutlar - Qion Hive, Broodmother | 3 | Sheltered |  |
+| `zomb_abanstatio2` | Abandoned Station - Restricted Level | 1 | Sheltered |  |
+| `zomb_abanstatio3` | Abandoned Station - Director's Chambers | 1 | Sheltered |  |
+| `zomb_abanstation` | Abandoned Station - Main Level | 1 | Sheltered |  |

--- a/SWLOR.Game.Server/Service/Weather.cs
+++ b/SWLOR.Game.Server/Service/Weather.cs
@@ -25,8 +25,8 @@ namespace SWLOR.Game.Server.Service
 
         private static readonly Dictionary<uint, AreaWeather> _areas = new();
         private static readonly Dictionary<uint, WeatherExposure> _exposures = new();
-        private static readonly WeatherClimate _defaultClimate = new();
         private static Dictionary<PlanetType, WeatherClimate> _planetClimates = WeatherPlanetDefinitions.GetPlanetClimates();
+        private static Dictionary<string, WeatherClimate> _namedClimates = WeatherPlanetDefinitions.GetNamedClimates(_planetClimates);
         private static WeatherPattern _pattern = new();
 
         private const string VAR_WEATHER_HEAT = "VAR_WEATHER_HEAT";
@@ -44,6 +44,7 @@ namespace SWLOR.Game.Server.Service
         public static void LoadData()
         {
             _planetClimates = WeatherPlanetDefinitions.GetPlanetClimates();
+            _namedClimates = WeatherPlanetDefinitions.GetNamedClimates(_planetClimates);
             _pattern = new WeatherPattern();
             _areas.Clear();
             _exposures.Clear();
@@ -51,15 +52,16 @@ namespace SWLOR.Game.Server.Service
 
         private static WeatherClimate GetAreaClimate(uint area)
         {
-            return _planetClimates.TryGetValue(Planet.GetPlanetType(area), out var climate)
-                ? climate : _defaultClimate;
+            return WeatherPlanetDefinitions.ResolveClimate(Planet.GetPlanetType(area),
+                GetLocalString(area, "VAR_WEATHER_CLIMATE"), _planetClimates, _namedClimates);
         }
 
         private static bool IsWeatherArea(uint area)
         {
             return GetIsObjectValid(area) && area != GetModule() &&
                    !GetIsAreaInterior(area) && GetIsAreaAboveGround(area) &&
-                   !GetLocalBool(area, "SPACE") && !GetName(area).StartsWith("Space -", StringComparison.OrdinalIgnoreCase);
+                   !GetLocalBool(area, "SPACE") && !GetName(area).StartsWith("Space -", StringComparison.OrdinalIgnoreCase) &&
+                   GetAreaClimate(area) is { IsSheltered: false };
         }
 
         [NWNEventHandler(ScriptName.OnModuleLoad)]
@@ -256,19 +258,35 @@ namespace SWLOR.Game.Server.Service
 
             var damageType = hazard switch
             {
-                WeatherHazard.Acid => DamageType.Acid,
-                WeatherHazard.Snow => DamageType.Cold,
-                _ => DamageType.Bludgeoning
+                WeatherHazard.Acid => CombatDamageType.Poison,
+                WeatherHazard.Snow => CombatDamageType.Ice,
+                _ => CombatDamageType.Physical
             };
             AssignCommand(area, () =>
             {
-                ApplyEffectToObject(DurationType.Instant, EffectDamage(d6(dice), damageType), creature);
+                var damage = GetProtectedDamage(creature, d6(dice), damageType);
+                if (damage <= 0) return;
+                var nativeType = hazard == WeatherHazard.Sand ? DamageType.Bludgeoning : damageType.GetNWScriptDamageType();
+                ApplyEffectToObject(DurationType.Instant, EffectDamage(damage, nativeType), creature);
                 if (hazard == WeatherHazard.Acid || hazard == WeatherHazard.Snow)
                 {
                     var visual = hazard == WeatherHazard.Acid ? VisualEffect.Vfx_Imp_Acid_S : VisualEffect.Vfx_Imp_Frost_S;
                     ApplyEffectToObject(DurationType.Instant, EffectVisualEffect(visual), creature);
                 }
             });
+        }
+
+        private static int GetProtectedDamage(uint target, int damage, CombatDamageType damageType)
+        {
+            // Doors/placeables hit by lightning do not have character stats.
+            if (damage <= 0 || GetObjectType(target) != ObjectType.Creature) return Math.Max(0, damage);
+            var typedAdjustment = damageType.IsPhysicalDamageType()
+                ? Stat.GetStatAdjustment(target, StatType.PhysicalDamageTakenPercentAdjustment) : 0;
+            var adjusted = Combat.ApplyTriggeredDamageTargetAdjustment(damage, typedAdjustment, null);
+            damage = Resistance.ApplyResistanceToDamage(target, damageType, adjusted.Damage);
+            if (damage <= 0) return 0;
+            return Combat.ApplyDamageTakenModifiers(target, damage, damageType: damageType,
+                targetStatusDamagePercentAdjustment: adjusted.Adjustment);
         }
 
         public static void Thunderstorm(uint area)
@@ -293,6 +311,8 @@ namespace SWLOR.Game.Server.Service
             {
                 var damage = WeatherConditions.GetLightningDamage(power, GetDistanceBetweenLocations(location, GetLocation(target)));
                 if (damage <= 0 || GetIsDM(target) || GetIsDMPossessed(target)) continue;
+                damage = GetProtectedDamage(target, damage, CombatDamageType.Electrical);
+                if (damage <= 0) continue;
                 ApplyEffectToObject(DurationType.Instant, EffectDamage(damage, DamageType.Electrical), target);
                 if (GetObjectType(target) != ObjectType.Creature || GetIsDead(target)) continue;
 

--- a/SWLOR.Game.Server/Service/Weather.cs
+++ b/SWLOR.Game.Server/Service/Weather.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using SWLOR.Game.Server.Core;
 using SWLOR.Game.Server.Enumeration;
 using SWLOR.Game.Server.Service.WeatherService;
-using SWLOR.Game.Server.Extension;
 using SWLOR.Game.Server.Service.CombatService;
 using SWLOR.Game.Server.Service.StatService;
 using SWLOR.NWN.API.NWScript;
@@ -11,57 +10,25 @@ using SWLOR.NWN.API.NWScript.Enum;
 using SWLOR.NWN.API.NWScript.Enum.Area;
 using SWLOR.NWN.API.NWScript.Enum.VisualEffect;
 using SWLOR.NWN.API.Engine;
+using Precipitation = SWLOR.NWN.API.NWScript.Enum.Weather;
 
 namespace SWLOR.Game.Server.Service
 {
     public static class Weather
     {
-        private static readonly Dictionary<uint, List<uint>> _areaWeatherPlaceables = new Dictionary<uint, List<uint>>();
-        private static Dictionary<PlanetType, WeatherClimate> _planetClimates;
-        private static readonly Dictionary<string, PlanetType> _planetsByName = new Dictionary<string, PlanetType>();
-
-        /// <summary>
-        /// When the module loads, cache planet climates and other pertinent data.
-        /// </summary>
-        [NWNEventHandler(ScriptName.OnModuleCacheBefore)]
-        public static void LoadData()
+        private sealed class AreaWeather : WeatherAreaState
         {
-            _planetClimates = WeatherPlanetDefinitions.GetPlanetClimates();
-
-            foreach (var @enum in Enum.GetValues(typeof(PlanetType)))
-            {
-                var type = (PlanetType)@enum;
-                _planetsByName[type.GetDescriptionAttribute()] = type;
-            }
+            public DateTime NextLightningUtc { get; set; }
+            public List<uint> MistPlaceables { get; } = new();
+            public bool MistInitialized { get; set; }
         }
 
-        /// <summary>
-        /// Retrieves a planet's climate by its name. If the planet is not registered a default climate will be returned.
-        /// </summary>
-        /// <param name="planetName">The name of the planet to look for.</param>
-        /// <returns>A weather climate for the specified planet.</returns>
-        private static WeatherClimate GetClimateByPlanetName(string planetName)
-        {
-            if (!_planetsByName.ContainsKey(planetName))
-            {
-                return new WeatherClimate();
-            }
+        private static readonly Dictionary<uint, AreaWeather> _areas = new();
+        private static readonly Dictionary<uint, WeatherExposure> _exposures = new();
+        private static readonly WeatherClimate _defaultClimate = new();
+        private static Dictionary<PlanetType, WeatherClimate> _planetClimates = WeatherPlanetDefinitions.GetPlanetClimates();
+        private static WeatherPattern _pattern = new();
 
-            var planetType = _planetsByName[planetName];
-            return _planetClimates[planetType];
-        }
-
-        private static WeatherClimate GetAreaClimate(uint area)
-        {
-            var index = GetName(area).IndexOf("-", StringComparison.Ordinal);
-            if (index <= 0) return new WeatherClimate();
-            var planetName = GetName(area).Substring(0, index - 1);
-
-            return GetClimateByPlanetName(planetName);
-        }
-
-        // Module and area variables.
-        private const string VAR_WEATHER_CHANGE = "VAR_WEATHER_CHANGE";
         private const string VAR_WEATHER_HEAT = "VAR_WEATHER_HEAT";
         private const string VAR_WEATHER_HUMIDITY = "VAR_WEATHER_HUMIDITY";
         private const string VAR_WEATHER_WIND = "VAR_WEATHER_WIND";
@@ -73,648 +40,318 @@ namespace SWLOR.Game.Server.Service
         private const string VAR_FOG_C_SUN = "VAR_WH_FOG_C_SUN";
         private const string VAR_FOG_C_MOON = "VAR_WH_FOG_C_MOON";
 
+        [NWNEventHandler(ScriptName.OnModuleCacheBefore)]
+        public static void LoadData()
+        {
+            _planetClimates = WeatherPlanetDefinitions.GetPlanetClimates();
+            _pattern = new WeatherPattern();
+            _areas.Clear();
+            _exposures.Clear();
+        }
+
+        private static WeatherClimate GetAreaClimate(uint area)
+        {
+            return _planetClimates.TryGetValue(Planet.GetPlanetType(area), out var climate)
+                ? climate : _defaultClimate;
+        }
+
+        private static bool IsWeatherArea(uint area)
+        {
+            return GetIsObjectValid(area) && area != GetModule() &&
+                   !GetIsAreaInterior(area) && GetIsAreaAboveGround(area) &&
+                   !GetLocalBool(area, "SPACE") && !GetName(area).StartsWith("Space -", StringComparison.OrdinalIgnoreCase);
+        }
+
+        [NWNEventHandler(ScriptName.OnModuleLoad)]
+        public static void InitializeWeather()
+        {
+            AdjustWeather();
+        }
 
         public static bool AdjustWeather()
         {
-            var oMod = GetModule();
-
-            //--------------------------------------------------------------------------
-            // Always change the weather the very first time
-            //--------------------------------------------------------------------------
-            if (GetLocalInt(oMod, VAR_INITIALIZED) == 0)
-            {
-                SetLocalInt(oMod, VAR_INITIALIZED, 1);
-                _SetHumidity(Random(10) + 1);
-            }
-            else if (GetTimeHour() != GetLocalInt(oMod, VAR_WEATHER_CHANGE))
-            {
+            if (!_pattern.TryAdvance(DateTime.UtcNow, GetCalendarMonth(), GetIsNight(), NWScript.Random))
                 return false;
-            }
 
-            //--------------------------------------------------------------------------
-            // Adjust the indices.  Only humidity is affected by the current values.
-            //--------------------------------------------------------------------------
-            var nHumidity = GetHumidity(OBJECT_SELF);
-            var nWind = GetWindStrength(OBJECT_SELF);
+            // Apply once per area, including unoccupied areas, so native precipitation
+            // and old fog do not survive until another creature enters.
+            foreach (var area in _areas.Keys.Where(area => !GetIsObjectValid(area)).ToArray())
+                _areas.Remove(area);
 
-            //--------------------------------------------------------------------------
-            // Heat is affected by time of year.
-            //--------------------------------------------------------------------------
-            var nHeat = Random(5) + (6 - abs(GetCalendarMonth() - 6));
-            if (nHeat < 1) nHeat = 1;
-
-            //--------------------------------------------------------------------------
-            // Humidity is random but moves slowly.
-            //--------------------------------------------------------------------------
-            nHumidity = nHumidity + (Random(2 * nWind + 1) - nWind);
-            if (nHumidity > 10) nHumidity = 20 - nHumidity;
-            if (nHumidity < 1) nHumidity = 1 - nHumidity;
-
-            //--------------------------------------------------------------------------
-            // Wind is more likely to be calm, but can change quickly.
-            //--------------------------------------------------------------------------
-            nWind = d10(2) - 10;
-            if (nWind < 1) nWind = 1 - nWind;
-
-            _SetHeatIndex(nHeat);
-            _SetHumidity(nHumidity);
-            _SetWindStrength(nWind);
-
-            //--------------------------------------------------------------------------
-            // Work out when to next change the weather.
-            //--------------------------------------------------------------------------
-            var nNextChange = GetTimeHour() + (11 - nWind);
-            if (nNextChange > 23) nNextChange -= 24;
-            SetLocalInt(oMod, VAR_WEATHER_CHANGE, nNextChange);
-
-            // Update all occupied areas with the new settings.
-            var oPC = GetFirstPC();
-            while (GetIsObjectValid(oPC))
-            {
-                SetWeather(GetArea(oPC));
-                oPC = GetNextPC();
-            }
+            for (var area = GetFirstArea(); GetIsObjectValid(area); area = GetNextArea())
+                SetWeather(area);
 
             return true;
         }
 
-        public static void SetWeather()
-        {
-            SetWeather(OBJECT_SELF);
-        }
+        public static void SetWeather() => SetWeather(OBJECT_SELF);
 
-        public static void SetWeather(uint oArea)
+        public static void SetWeather(uint area)
         {
+            if (!IsWeatherArea(area)) return;
+            if (_pattern.Revision == 0)
+                _pattern.TryAdvance(DateTime.UtcNow, GetCalendarMonth(), GetIsNight(), NWScript.Random);
 
-            if (GetLocalInt(oArea, VAR_INITIALIZED) == 0)
+            if (!_areas.TryGetValue(area, out var state))
             {
-                if (GetIsAreaInterior(oArea) ||
-                    GetIsAreaAboveGround(oArea) == false)
-                    return;
-                SetLocalInt(oArea, VAR_SKYBOX, (int)GetSkyBox(oArea));
-                SetLocalInt(oArea, VAR_FOG_SUN, GetFogAmount(FogType.Sun, oArea));
-                SetLocalInt(oArea, VAR_FOG_MOON, GetFogAmount(FogType.Moon, oArea));
-                SetLocalInt(oArea, VAR_FOG_C_SUN, (int)GetFogColor(FogType.Sun, oArea));
-                SetLocalInt(oArea, VAR_FOG_C_MOON, (int)GetFogColor(FogType.Moon, oArea));
-                SetLocalInt(oArea, VAR_INITIALIZED, 1);
+                state = new AreaWeather();
+                _areas.Add(area, state);
             }
 
-            var nHeat = GetHeatIndex(oArea);
-            var nHumidity = GetHumidity(oArea);
-            var nWind = GetWindStrength(oArea);
-            var bStormy = GetSkyBox(oArea) == Skybox.GrassStorm;
-            var bDustStorm = (GetLocalInt(oArea, "DUST_STORM") == 1);
-            var bSandStorm = (GetLocalInt(oArea, "SAND_STORM") == 1);
-            var bSnowStorm = (GetLocalInt(oArea, "SNOW_STORM") == 1);
+            // Entry and multiple occupants request the same snapshot. Only a new
+            // weather front (or an explicit builder edit) rolls storms.
+            if (state.Revision == _pattern.Revision) return;
 
-            //--------------------------------------------------------------------------
-            // Process weather rules for this area.
-            //--------------------------------------------------------------------------
-            if (nHumidity > 7 && nHeat > 3)
+            if (GetLocalInt(area, VAR_INITIALIZED) == 0)
             {
-                if (nHeat < 6 && nWind < 3)
+                SetLocalInt(area, VAR_SKYBOX, (int)GetSkyBox(area));
+                SetLocalInt(area, VAR_FOG_SUN, GetFogAmount(FogType.Sun, area));
+                SetLocalInt(area, VAR_FOG_MOON, GetFogAmount(FogType.Moon, area));
+                SetLocalInt(area, VAR_FOG_C_SUN, (int)GetFogColor(FogType.Sun, area));
+                SetLocalInt(area, VAR_FOG_C_MOON, (int)GetFogColor(FogType.Moon, area));
+                SetLocalInt(area, VAR_INITIALIZED, 1);
+            }
+
+            var previous = state.Conditions;
+            state.TryUpdate(_pattern, GetAreaClimate(area),
+                GetLocalInt(area, VAR_WEATHER_HEAT), GetLocalInt(area, VAR_WEATHER_HUMIDITY),
+                GetLocalInt(area, VAR_WEATHER_WIND), GetIsAreaNatural(area) != 0,
+                NWScript.Random);
+            var conditions = state.Conditions;
+            NWScript.SetWeather(area, conditions.Precipitation switch
+            {
+                Precipitation.Rain => WeatherType.Rain,
+                Precipitation.Snow => WeatherType.Snow,
+                _ => WeatherType.Clear
+            });
+
+            DeleteLocalInt(area, "GS_AM_SKY_OVERRIDE");
+            DeleteLocalInt(area, "DUST_STORM");
+            DeleteLocalInt(area, "SAND_STORM");
+            DeleteLocalInt(area, "SNOW_STORM");
+            SetSkyBox((Skybox)GetLocalInt(area, VAR_SKYBOX), area);
+            SetFogColor(FogType.Sun, (FogColor)GetLocalInt(area, VAR_FOG_C_SUN), area);
+            SetFogColor(FogType.Moon, (FogColor)GetLocalInt(area, VAR_FOG_C_MOON), area);
+            SetFogAmount(FogType.Sun, GetLocalInt(area, VAR_FOG_SUN), area);
+            SetFogAmount(FogType.Moon, GetLocalInt(area, VAR_FOG_MOON), area);
+
+            if (conditions.Storm == WeatherStorm.Thunder)
+            {
+                SetSkyBox(Skybox.GrassStorm, area);
+                SetLocalInt(area, "GS_AM_SKY_OVERRIDE", 1);
+            }
+            else if (conditions.Storm == WeatherStorm.Sand || conditions.Storm == WeatherStorm.Snow)
+            {
+                var isSand = conditions.Storm == WeatherStorm.Sand;
+                var color = isSand ? FogColor.OrangeDark : FogColor.White;
+                SetLocalInt(area, isSand ? "SAND_STORM" : "SNOW_STORM", 1);
+                SetFogColor(FogType.Sun, color, area);
+                SetFogColor(FogType.Moon, color, area);
+                SetFogAmount(FogType.Sun, 80, area);
+                SetFogAmount(FogType.Moon, 80, area);
+            }
+
+            if (previous?.Precipitation != conditions.Precipitation)
+                ClearMist(state);
+        }
+
+        private static void ClearMist(AreaWeather state)
+        {
+            foreach (var placeable in state.MistPlaceables)
+            {
+                if (GetIsObjectValid(placeable)) DestroyObject(placeable);
+            }
+            state.MistPlaceables.Clear();
+            state.MistInitialized = false;
+        }
+
+        private static void EnsureMist(uint area, AreaWeather state)
+        {
+            if (state.MistInitialized || state.Conditions.Precipitation != Precipitation.Foggy) return;
+            // Populate occupied areas only. Unoccupied instance templates must not
+            // copy generated mist into new instances as untracked placeables.
+            state.MistInitialized = true;
+
+            var count = GetAreaSize(Dimension.Width, area) * GetAreaSize(Dimension.Height, area) / 8;
+            for (var index = 0; index < count; index++)
+            {
+                // Use the ground at the chosen tile, not the entering creature's height.
+                if (!TryGetGroundLocation(area, out var location)) continue;
+                var placeable = CreateObject(ObjectType.Placeable, "x3_plc_mist", location);
+                if (!GetIsObjectValid(placeable)) continue;
+                SetObjectVisualTransform(placeable, ObjectVisualTransform.Scale, (200 + Random(200)) / 100f);
+                state.MistPlaceables.Add(placeable);
+            }
+        }
+
+        private static bool TryGetGroundLocation(uint area, out Location location)
+        {
+            var width = GetAreaSize(Dimension.Width, area) * 10;
+            var height = GetAreaSize(Dimension.Height, area) * 10;
+            location = default;
+            if (width <= 0 || height <= 0) return false;
+
+            for (var attempt = 0; attempt < 5; attempt++)
+            {
+                var position = Vector3(Random(width) + Random(10) * 0.1f, Random(height) + Random(10) * 0.1f);
+                location = Location(area, position, Random(360));
+                if (GetSurfaceMaterial(location) == 0) continue;
+                position.Z = GetGroundHeight(location);
+                if (position.Z == -6f) continue;
+                location = Location(area, position, GetFacingFromLocation(location));
+                return true;
+            }
+            return false;
+        }
+
+        public static Precipitation GetWeather() => GetWeather(OBJECT_SELF);
+
+        public static Precipitation GetWeather(uint area)
+        {
+            var conditions = GetConditions(area);
+            if (conditions == null) return Precipitation.Invalid;
+            var precipitation = NWScript.GetWeather(area);
+            return precipitation == Precipitation.Clear && conditions.Precipitation == Precipitation.Foggy
+                ? Precipitation.Foggy : precipitation;
+        }
+        public static int GetHeatIndex(uint area) => GetConditions(area)?.Heat ?? Math.Clamp(_pattern.Heat, 1, 10);
+        public static int GetHumidity(uint area) => GetConditions(area)?.Humidity ?? Math.Clamp(_pattern.Humidity, 1, 10);
+        public static int GetWindStrength(uint area) => GetConditions(area)?.Wind ?? Math.Clamp(_pattern.Wind, 1, 10);
+
+        private static WeatherConditions GetConditions(uint area)
+        {
+            SetWeather(area);
+            return IsWeatherArea(area) && _areas.TryGetValue(area, out var state) ? state.Conditions : null;
+        }
+
+        public static void DoWeatherEffects(uint creature)
+        {
+            if (!GetIsObjectValid(creature) || !GetIsPC(creature)) return;
+            var area = GetArea(creature);
+            var conditions = GetConditions(area);
+            if (conditions == null) return;
+
+            var message = conditions.GetFeedback(GetAreaClimate(area), GetIsNight(),
+                GetLocalInt(area, VAR_WEATHER_ACID_RAIN) == 1, NWScript.GetWeather(area));
+            SendMessageToPC(creature, message);
+            ApplyWeatherDamage(creature, DateTime.UtcNow);
+        }
+
+        private static void ApplyWeatherDamage(uint creature, DateTime now)
+        {
+            if (!_exposures.TryGetValue(creature, out var exposure))
+            {
+                exposure = new WeatherExposure();
+                _exposures.Add(creature, exposure);
+            }
+
+            var area = GetArea(creature);
+            var conditions = GetConditions(area);
+            var hazard = GetIsPC(creature) && !GetIsDM(creature) && !GetIsDMPossessed(creature) &&
+                         !GetIsDead(creature) && conditions != null
+                ? conditions.GetHazard(GetLocalInt(area, VAR_WEATHER_ACID_RAIN) == 1, NWScript.GetWeather(area))
+                : WeatherHazard.None;
+            var dice = exposure.GetDamageDice(now, hazard);
+            if (dice == 0) return;
+
+            var damageType = hazard switch
+            {
+                WeatherHazard.Acid => DamageType.Acid,
+                WeatherHazard.Snow => DamageType.Cold,
+                _ => DamageType.Bludgeoning
+            };
+            AssignCommand(area, () =>
+            {
+                ApplyEffectToObject(DurationType.Instant, EffectDamage(d6(dice), damageType), creature);
+                if (hazard == WeatherHazard.Acid || hazard == WeatherHazard.Snow)
                 {
-                    NWScript.SetWeather(oArea, WeatherType.Clear);
+                    var visual = hazard == WeatherHazard.Acid ? VisualEffect.Vfx_Imp_Acid_S : VisualEffect.Vfx_Imp_Frost_S;
+                    ApplyEffectToObject(DurationType.Instant, EffectVisualEffect(visual), creature);
                 }
-                else NWScript.SetWeather(oArea, WeatherType.Rain);
-            }
-            else if (nHumidity > 7) NWScript.SetWeather(oArea, WeatherType.Snow);
-            else NWScript.SetWeather(oArea, WeatherType.Clear);
-
-            //--------------------------------------------------------------------------
-            // Stormy if heat is greater than 4 only; if already stormy then 2 in 3
-            // chance of storm clearing, otherwise x in 20 chance of storm starting,
-            // where x is the wind level.
-            //--------------------------------------------------------------------------
-            if (nHeat > 4 && nHumidity > 7 &&
-                ((bStormy && d20() - nWind < 1) || (bStormy && d3() == 1)))
-            {
-                SetSkyBox(Skybox.GrassStorm, oArea);
-                Thunderstorm(oArea);
-                SetLocalInt(oArea, "GS_AM_SKY_OVERRIDE", 1);
-            }
-            else
-            {
-                SetSkyBox((Skybox)GetLocalInt(oArea, VAR_SKYBOX), oArea);
-                DeleteLocalInt(oArea, "GS_AM_SKY_OVERRIDE");
-                bStormy = false;
-            }
-
-            // Does this area suffer from dust or sand storms?
-            if (!bStormy && nWind >= 9 && d3() == 1)
-            {
-                // Dust storm - low visibility but no damage.
-                if (GetAreaClimate(oArea).HasSandStorms)
-                {
-                    SetFogColor(FogType.Sun, FogColor.OrangeDark, oArea);
-                    SetFogColor(FogType.Moon, FogColor.OrangeDark, oArea);
-                    SetFogAmount(FogType.Sun, 80, oArea);
-                    SetFogAmount(FogType.Moon, 80, oArea);
-
-                    SetLocalInt(oArea, "SAND_STORM", 1);
-                }
-                else if (GetAreaClimate(oArea).HasSnowStorms)
-                {
-                    SetFogColor(FogType.Sun, FogColor.White, oArea);
-                    SetFogColor(FogType.Moon, FogColor.White, oArea);
-                    SetFogAmount(FogType.Sun, 80, oArea);
-                    SetFogAmount(FogType.Moon, 80, oArea);
-
-                    SetLocalInt(oArea, "SNOW_STORM", 1);
-                }
-            }
-            else if (bDustStorm || bSandStorm || bSnowStorm)
-            {
-                // End the storm.
-                DeleteLocalInt(oArea, "DUST_STORM");
-                DeleteLocalInt(oArea, "SAND_STORM");
-                DeleteLocalInt(oArea, "SNOW_STORM");
-
-                SetFogColor(FogType.Sun, (FogColor)GetLocalInt(oArea, VAR_FOG_C_SUN), oArea);
-                SetFogColor(FogType.Moon, (FogColor)GetLocalInt(oArea, VAR_FOG_C_MOON), oArea);
-                SetFogAmount(FogType.Sun, GetLocalInt(oArea, VAR_FOG_SUN), oArea);
-                SetFogAmount(FogType.Moon, GetLocalInt(oArea, VAR_FOG_MOON), oArea);
-            }
+            });
         }
 
-        public static NWN.API.NWScript.Enum.Weather GetWeather()
+        public static void Thunderstorm(uint area)
         {
-            return GetWeather(OBJECT_SELF);
+            if (!IsWeatherArea(area) || !_areas.TryGetValue(area, out var state) ||
+                state.Conditions.Storm != WeatherStorm.Thunder || d3() != 1 ||
+                !TryGetGroundLocation(area, out var location)) return;
+
+            // The heartbeat owns strike timing. No delayed bolt can outlive a storm.
+            AssignCommand(area, () => Thunderstorm(location, d100() + 10));
         }
 
-        public static NWN.API.NWScript.Enum.Weather GetWeather(uint oArea)
+        private static void Thunderstorm(Location location, int power)
         {
-            if (GetIsAreaInterior(oArea) || GetIsAreaAboveGround(oArea) == false)
+            var range = Math.Clamp(power * 0.1f, 3f, 6f);
+            ApplyEffectAtLocation(DurationType.Instant, EffectVisualEffect(VisualEffect.Vfx_Imp_Lightning_M), location);
+
+            const ObjectType targets = ObjectType.Creature | ObjectType.Door | ObjectType.Placeable;
+            for (var target = GetFirstObjectInShape(Shape.Sphere, range, location, false, targets);
+                 GetIsObjectValid(target);
+                 target = GetNextObjectInShape(Shape.Sphere, range, location, false, targets))
             {
-                return NWN.API.NWScript.Enum.Weather.Invalid;
-            }
+                var damage = WeatherConditions.GetLightningDamage(power, GetDistanceBetweenLocations(location, GetLocation(target)));
+                if (damage <= 0 || GetIsDM(target) || GetIsDMPossessed(target)) continue;
+                ApplyEffectToObject(DurationType.Instant, EffectDamage(damage, DamageType.Electrical), target);
+                if (GetObjectType(target) != ObjectType.Creature || GetIsDead(target)) continue;
 
-            var nHeat = GetHeatIndex(oArea);
-            var nHumidity = GetHumidity(oArea);
-            var nWind = GetWindStrength(oArea);
-
-            if (nHumidity > 7 && nHeat > 3 && nHeat < 6 && nWind < 3)
-            {
-                return NWN.API.NWScript.Enum.Weather.Foggy;
-            }
-
-            // Rather unfortunately, the default method is also called GetWeather.
-            return NWScript.GetWeather(oArea);
-        }
-
-        public static void ApplyAcid(uint oTarget, uint oArea)
-        {
-            if (GetArea(oTarget) != oArea) return;
-            if (GetIsDead(oTarget)) return;
-            if (GetIsPC(oTarget) && GetIsPC(GetMaster(oTarget)) == false) return;
-
-            //apply
-            var eEffect =
-                EffectLinkEffects(
-                    EffectVisualEffect(VisualEffect.Vfx_Imp_Acid_S),
-                    EffectDamage(
-                        d6(),
-                        DamageType.Acid));
-
-            ApplyEffectToObject(DurationType.Instant, eEffect, oTarget);
-
-            DelayCommand(6.0f, () => { ApplyAcid(oTarget, oArea); });
-        }
-
-        public static void ApplyCold(uint oTarget, uint oArea)
-        {
-            if (GetArea(oTarget) != oArea) return;
-            if (GetIsDead(oTarget)) return;
-            if (GetIsPC(oTarget) && GetIsPC(GetMaster(oTarget)) == false) return;
-
-            //apply
-            var eEffect =
-                EffectLinkEffects(
-                    EffectVisualEffect(VisualEffect.Vfx_Imp_Acid_S),
-                    EffectDamage(
-                        d6(),
-                        DamageType.Acid));
-
-            ApplyEffectToObject(DurationType.Instant, eEffect, oTarget);
-
-            DelayCommand(6.0f, () => { ApplyCold(oTarget, oArea); });
-        }
-
-        public static void ApplySandstorm(uint oTarget, uint oArea)
-        {
-            if (GetArea(oTarget) != oArea) return;
-            if (GetIsDead(oTarget)) return;
-            if (GetIsPC(oTarget) && GetIsPC(GetMaster(oTarget)) == false) return;
-
-            //apply
-            var eEffect =
-                EffectLinkEffects(
-                    EffectVisualEffect(VisualEffect.Vfx_Imp_Flame_S),
-                    EffectDamage(
-                        d6(2),
-                        DamageType.Bludgeoning));
-
-            ApplyEffectToObject(DurationType.Instant, eEffect, oTarget);
-
-            DelayCommand(6.0f, () => { ApplySandstorm(oTarget, oArea); });
-        }
-
-        public static void ApplySnowstorm(uint oTarget, uint oArea)
-        {
-            if (GetArea(oTarget) != oArea) return;
-            if (GetIsDead(oTarget)) return;
-            if (GetIsPC(oTarget) && GetIsPC(GetMaster(oTarget)) == false) return;
-
-            //apply
-            var eEffect =
-                EffectLinkEffects(
-                    EffectVisualEffect(VisualEffect.Vfx_Dur_Iceskin),
-                    EffectDamage(
-                        d6(2),
-                        DamageType.Cold));
-
-            ApplyEffectToObject(DurationType.Instant, eEffect, oTarget);
-
-            DelayCommand(6.0f, () => { ApplySnowstorm(oTarget, oArea); });
-        }
-
-        public static void DoWeatherEffects(uint oCreature)
-        {
-            var oArea = GetArea(oCreature);
-            if (GetIsAreaInterior(oArea) || GetIsAreaAboveGround(oArea) == false) return;
-
-            var nHeat = GetHeatIndex(oArea);
-            var nHumidity = GetHumidity(oArea);
-            var nWind = GetWindStrength(oArea);
-            var bStormy = GetSkyBox(oArea) == Skybox.GrassStorm;
-            var bIsPC = GetIsPC(oCreature);
-            string sMessage;
-            var climate = GetAreaClimate(oArea);
-
-            //--------------------------------------------------------------------------
-            // Apply acid rain, if applicable.  Stolen shamelessly from the Melf's Acid
-            // Arrow spell.
-            //--------------------------------------------------------------------------
-            if (bIsPC && NWScript.GetWeather(oArea) == NWN.API.NWScript.Enum.Weather.Rain && GetLocalInt(oArea, VAR_WEATHER_ACID_RAIN) == 1)
-            {
-                var eEffect =
-                  EffectLinkEffects(
-                      EffectVisualEffect(VisualEffect.Vfx_Imp_Acid_S),
-                      EffectDamage(
-                          d6(2),
-                          DamageType.Acid));
-
-                ApplyEffectToObject(DurationType.Instant, eEffect, oCreature);
-
-                DelayCommand(6.0f, () => { ApplyAcid(oCreature, oArea); });
-            }
-            else if (bIsPC && GetLocalInt(oArea, "DUST_STORM") == 1)
-            {
-            }
-            else if (bIsPC && GetLocalInt(oArea, "SAND_STORM") == 1)
-            {
-                var eEffect =
-                    EffectLinkEffects(
-                        EffectVisualEffect(VisualEffect.Vfx_Imp_Flame_S),
-                        EffectDamage(
-                            d6(2),
-                            DamageType.Bludgeoning));
-
-                ApplyEffectToObject(DurationType.Instant, eEffect, oCreature);
-
-                DelayCommand(6.0f, () => { ApplySandstorm(oCreature, oArea); });
-            }
-            else if (bIsPC && GetLocalInt(oArea, "SNOW_STORM") == 1)
-            {
-                var eEffect =
-                    EffectLinkEffects(
-                        EffectVisualEffect(VisualEffect.Vfx_Dur_Iceskin),
-                        EffectDamage(
-                            d6(2),
-                            DamageType.Cold));
-
-                ApplyEffectToObject(DurationType.Instant, eEffect, oCreature);
-
-                DelayCommand(6.0f, () => { ApplySnowstorm(oCreature, oArea); });
-            }
-            else if (bIsPC)
-            {
-                // Stormy weather
-                if (bStormy)
-                {
-                    sMessage = climate.StormText;
-                }
-                // Rain or mist
-                else if (nHumidity > 7 && nHeat > 3)
-                {
-                    // Mist
-                    if (nHeat < 6 && nWind < 3)
-                    {
-                        sMessage = climate.MistText;
-                    }
-                    // Humid
-                    else if (nHeat > 7)
-                    {
-                        sMessage = climate.RainWarmText;
-                    }
-                    else
-                    {
-                        sMessage = climate.RainNormalText;
-                    }
-                }
-                // Snow
-                else if (nHumidity > 7)
-                {
-                    sMessage = climate.SnowText;
-                }
-                // Freezing
-                else if (nHeat < 3)
-                {
-                    sMessage = climate.FreezingText;
-                }
-                // Boiling
-                else if (nHeat > 8)
-                {
-                    sMessage = climate.ScorchingText;
-                }
-                // Cold
-                else if (nHeat < 5)
-                {
-                    if (nWind < 5) sMessage = climate.ColdMildText;
-                    else if (nWind < 8) sMessage = climate.ColdCloudyText;
-                    else sMessage = climate.ColdWindyText;
-                }
-                // Hot
-                else if (nHeat > 6)
-                {
-                    if (nWind < 5) sMessage = climate.WarmMildText;
-                    else if (nWind < 8) sMessage = climate.WarmCloudyText;
-                    else sMessage = climate.WarmWindyText;
-                }
-                else if (nWind < 5)
-                {
-                    if (GetIsNight() == false) sMessage = climate.MildText;
-                    else sMessage = climate.MildNightText;
-                }
-                else if (nWind < 8) sMessage = climate.CloudyText;
-                else sMessage = climate.WindyText;
-
-                SendMessageToPC(oCreature, sMessage);
-            }
-        }
-
-        public static int GetHeatIndex(uint oArea)
-        {
-            //--------------------------------------------------------------------------
-            // Areas may have one of the CLIMATE_* values stored in each weather var.
-            //--------------------------------------------------------------------------
-            var oMod = GetModule();
-            var nHeat = GetLocalInt(oMod, VAR_WEATHER_HEAT);
-            if (GetIsObjectValid(oArea))
-            {
-                nHeat += GetLocalInt(oArea, VAR_WEATHER_HEAT);
-                nHeat += GetAreaClimate(oArea).HeatModifier;
-            }
-
-            nHeat = (GetIsNight()) ? nHeat - 2 : nHeat + 2;
-
-            if (nHeat > 10) nHeat = 10;
-            if (nHeat < 1) nHeat = 1;
-
-            return nHeat;
-        }
-
-        public static int GetHumidity(uint oArea)
-        {
-            //--------------------------------------------------------------------------
-            // Areas may have one of the CLIMATE_* values stored in each weather var.
-            //--------------------------------------------------------------------------
-            var oMod = GetModule();
-            var nHumidity = GetLocalInt(oMod, VAR_WEATHER_HUMIDITY);
-            if (GetIsObjectValid(oArea))
-            {
-                nHumidity += GetLocalInt(oArea, VAR_WEATHER_HUMIDITY);
-                nHumidity += GetAreaClimate(oArea).HumidityModifier;
-            }
-
-            if (nHumidity > 10) nHumidity = 10;
-            if (nHumidity < 1) nHumidity = 1;
-
-            return nHumidity;
-        }
-
-        public static int GetWindStrength(uint oArea)
-        {
-            //--------------------------------------------------------------------------
-            // Areas will have one of the CLIMATE_* values stored in each weather var.
-            //--------------------------------------------------------------------------
-            var oMod = GetModule();
-            var nWind = GetLocalInt(oMod, VAR_WEATHER_WIND);
-            if (GetIsObjectValid(oArea))
-            {
-                nWind += GetLocalInt(oArea, VAR_WEATHER_WIND);
-                nWind += GetAreaClimate(oArea).WindModifier;
-
-                //----------------------------------------------------------------------
-                // Automatic cover bonus for artificial areas such as cities (lots of
-                // buildings).
-                //----------------------------------------------------------------------
-                if (GetIsAreaNatural(oArea) == 0) nWind -= 1;
-            }
-
-            if (nWind > 10) nWind = 10;
-            if (nWind < 1) nWind = 1;
-
-            return nWind;
-        }
-
-        private static void _SetHeatIndex(int nHeat)
-        {
-            var oMod = GetModule();
-            SetLocalInt(oMod, VAR_WEATHER_HEAT, nHeat);
-        }
-
-        private static void _SetHumidity(int nHumidity)
-        {
-            var oMod = GetModule();
-            SetLocalInt(oMod, VAR_WEATHER_HUMIDITY, nHumidity);
-        }
-
-        private static void _SetWindStrength(int nWind)
-        {
-            var oMod = GetModule();
-            SetLocalInt(oMod, VAR_WEATHER_WIND, nWind);
-        }
-
-        public static void Thunderstorm(uint oArea)
-        {
-            // 1 in 3 chance of a bolt.
-            if (d3() != 1) return;
-
-            // Pick a spot. Any spot.
-            var nWidth = GetAreaSize(Dimension.Width, oArea);
-            var nHeight = GetAreaSize(Dimension.Height, oArea);
-            var nPointWide = Random(nWidth * 10);
-            var nPointHigh = Random(nHeight * 10);
-            var fStrikeX = IntToFloat(nPointWide) + (IntToFloat(Random(10)) * 0.1f);
-            var fStrikeY = IntToFloat(nPointHigh) + (IntToFloat(Random(10)) * 0.1f);
-
-            // Now find out the power
-            var nPower = d100() + 10;
-
-            // Fire ze thunderboltz!
-            DelayCommand(IntToFloat(Random(60)),
-                () =>
-                {
-                    Thunderstorm(Location(oArea,
-                                               Vector3(fStrikeX, fStrikeY),
-                                               0.0f),
-                                           nPower);
-                }
-                         );
-        }
-
-        private static void Thunderstorm(Location lLocation, int nPower)
-        {
-            var fRange = IntToFloat(nPower) * 0.1f;
-            // Caps on sphere of influence
-            if (fRange < 3.0) fRange = 3.0f;
-            if (fRange > 6.0) fRange = 6.0f;
-
-            //Effects
-            var eEffBolt = EffectVisualEffect(VisualEffect.Vfx_Imp_Lightning_M);
-            ApplyEffectAtLocation(DurationType.Instant, eEffBolt, lLocation);
-
-            var oObject = GetFirstObjectInShape(Shape.Sphere, fRange, lLocation, false, ObjectType.Creature | ObjectType.Door | ObjectType.Placeable);
-            while (GetIsObjectValid(oObject))
-            {
-                var nType = GetObjectType(oObject);
-                if (nType == ObjectType.Creature ||
-                    nType == ObjectType.Door ||
-                    nType == ObjectType.Placeable)
-                {
-                    var eEffDam = EffectDamage(
-                        FloatToInt(IntToFloat(nPower) - (GetDistanceBetweenLocations(lLocation, GetLocation(oObject)) * 10.0f)),
-                        DamageType.Electrical);
-                    ApplyEffectToObject(DurationType.Instant, eEffDam, oObject);
-
-                    if (nType == ObjectType.Creature)
-                    {
-                        if (GetIsPC(oObject)) SendMessageToPC(oObject, WeatherFeedbackText.Lightning);
-
-                        PlayVoiceChat(VoiceChat.Pain1, oObject);
-                        var duration = Resistance.CalculateResistedTicks(oObject, ResistanceType.Mobility, d6());
-                        if (GetIsObjectValid(oObject) && duration > 0f &&
-                            Stat.GetStatAdjustment(oObject, StatType.KnockdownImmunity) <= 0)
-                        {
-                            ApplyEffectToObject(DurationType.Temporary, EffectKnockdown(), oObject, duration);
-                        }
-                    }
-                }
-                oObject = GetNextObjectInShape(Shape.Sphere, fRange, lLocation, false, ObjectType.Creature | ObjectType.Door | ObjectType.Placeable);
+                if (GetIsPC(target)) SendMessageToPC(target, WeatherFeedbackText.Lightning);
+                PlayVoiceChat(VoiceChat.Pain1, target);
+                var duration = Resistance.CalculateResistedTicks(target, ResistanceType.Mobility, d6());
+                if (GetIsObjectValid(target) && duration > 0 && Stat.GetStatAdjustment(target, StatType.KnockdownImmunity) <= 0)
+                    ApplyEffectToObject(DurationType.Temporary, EffectKnockdown(), target, duration);
             }
         }
 
         [NWNEventHandler(ScriptName.OnAreaEnter)]
         public static void OnAreaEnter()
         {
-            SetWeather();
-            DoWeatherEffects(GetEnteringObject());
-
-            var oArea = (OBJECT_SELF);
-            var nHour = GetTimeHour();
-            var nLastHour = GetLocalInt(oArea, "WEATHER_LAST_HOUR");
-
-            if (nHour != nLastHour)
-            {
-                if (!_areaWeatherPlaceables.ContainsKey(oArea))
-                    _areaWeatherPlaceables[oArea] = new List<uint>();
-
-                var weatherObjects = _areaWeatherPlaceables[oArea];
-
-                // Clean up any old weather placeables.
-                for (var x = weatherObjects.Count - 1; x >= 0; x--)
-                {
-                    var placeable = weatherObjects.ElementAt(x);
-                    DestroyObject(placeable);
-                    weatherObjects.RemoveAt(x);
-                }
-
-                // Create new ones depending on the current weather.
-                var nWeather = GetWeather();
-
-                if (nWeather == NWN.API.NWScript.Enum.Weather.Foggy)
-                {
-                    // Get the size in tiles.
-                    var nSizeX = GetAreaSize(Dimension.Width, oArea);
-                    var nSizeY = GetAreaSize(Dimension.Height, oArea);
-
-                    // We want one placeable per 8 tiles.
-                    var nMax = (nSizeX * nSizeY) / 8;
-
-                    for (var nCount = d6(); nCount < nMax; nCount++)
-                    {
-                        var vPosition = GetPosition(GetEnteringObject());
-
-                        // Vectors are in meters - 10 meters to a tile.
-                        vPosition.X = IntToFloat(Random(nSizeX * 10));
-                        vPosition.Y = IntToFloat(Random(nSizeY * 10));
-
-                        var fFacing = IntToFloat(Random(360));
-
-                        var sResRef = "x3_plc_mist";
-
-                        var oPlaceable = CreateObject(ObjectType.Placeable, sResRef, Location(oArea, vPosition, fFacing));
-                        SetObjectVisualTransform(oPlaceable, ObjectVisualTransform.Scale, IntToFloat(200 + Random(200)) / 100.0f);
-
-                        weatherObjects.Add(oPlaceable);
-                    }
-                }
-
-                _areaWeatherPlaceables[oArea] = weatherObjects;
-                SetLocalInt(oArea, "WEATHER_LAST_HOUR", nHour);
-            }
+            var area = OBJECT_SELF;
+            var creature = GetEnteringObject();
+            SetWeather(area);
+            if (GetIsPC(creature) && _areas.TryGetValue(area, out var state)) EnsureMist(area, state);
+            DoWeatherEffects(creature);
         }
 
         [NWNEventHandler(ScriptName.OnSwlorHeartbeat)]
         public static void OnModuleHeartbeat()
         {
-            var oMod = GetModule();
-            var nHour = GetTimeHour();
-            var nLastHour = GetLocalInt(oMod, "WEATHER_LAST_HOUR");
-
-            if (nHour != nLastHour)
+            var changed = AdjustWeather();
+            var now = DateTime.UtcNow;
+            var players = new HashSet<uint>();
+            var occupiedAreas = new HashSet<uint>();
+            for (var player = GetFirstPC(); GetIsObjectValid(player); player = GetNextPC())
             {
-                if (AdjustWeather())
-                {
-                    for (var player = GetFirstPC(); GetIsObjectValid(player); player = GetNextPC())
-                    {
-                        DoWeatherEffects(player);
-                    }
-                }
+                players.Add(player);
+                occupiedAreas.Add(GetArea(player));
+                if (changed) DoWeatherEffects(player);
+                else ApplyWeatherDamage(player, now);
+            }
 
-                SetLocalInt(oMod, "WEATHER_LAST_HOUR", nHour);
+            foreach (var player in _exposures.Keys.Where(player => !players.Contains(player)).ToArray())
+                _exposures.Remove(player);
+
+            foreach (var area in occupiedAreas)
+            {
+                if (!_areas.TryGetValue(area, out var state) || !IsWeatherArea(area)) continue;
+                EnsureMist(area, state);
+                if (state.NextLightningUtc > now) continue;
+                state.NextLightningUtc = now.AddMinutes(1);
+                Thunderstorm(area);
             }
         }
 
-        public static void SetAreaHeatModifier(uint oArea, int nModifier)
+        private static void SetAreaModifier(uint area, string variable, int modifier)
         {
-            SetLocalInt(oArea, VAR_WEATHER_HEAT, nModifier);
+            SetLocalInt(area, variable, modifier);
+            if (_areas.TryGetValue(area, out var state)) state.Invalidate();
+            SetWeather(area);
         }
 
-        public static void SetAreaWindModifier(uint oArea, int nModifier)
-        {
-            SetLocalInt(oArea, VAR_WEATHER_WIND, nModifier);
-        }
-
-        public static void SetAreaHumidityModifier(uint oArea, int nModifier)
-        {
-            SetLocalInt(oArea, VAR_WEATHER_HUMIDITY, nModifier);
-        }
-
-        public static void SetAreaAcidRain(uint oArea, int nModifier)
-        {
-            SetLocalInt(oArea, VAR_WEATHER_ACID_RAIN, nModifier);
-        }
+        public static void SetAreaHeatModifier(uint area, int modifier) => SetAreaModifier(area, VAR_WEATHER_HEAT, modifier);
+        public static void SetAreaWindModifier(uint area, int modifier) => SetAreaModifier(area, VAR_WEATHER_WIND, modifier);
+        public static void SetAreaHumidityModifier(uint area, int modifier) => SetAreaModifier(area, VAR_WEATHER_HUMIDITY, modifier);
+        public static void SetAreaAcidRain(uint area, int modifier) => SetLocalInt(area, VAR_WEATHER_ACID_RAIN, modifier);
     }
 }

--- a/SWLOR.Game.Server/Service/Weather.cs
+++ b/SWLOR.Game.Server/Service/Weather.cs
@@ -5,6 +5,7 @@ using SWLOR.Game.Server.Enumeration;
 using SWLOR.Game.Server.Service.WeatherService;
 using SWLOR.Game.Server.Service.CombatService;
 using SWLOR.Game.Server.Service.StatService;
+using SWLOR.Game.Server.Service.LogService;
 using SWLOR.NWN.API.NWScript;
 using SWLOR.NWN.API.NWScript.Enum;
 using SWLOR.NWN.API.NWScript.Enum.Area;
@@ -115,11 +116,15 @@ namespace SWLOR.Game.Server.Service
             }
 
             var previous = state.Conditions;
-            state.TryUpdate(_pattern, GetAreaClimate(area),
+            if (!state.TryUpdate(_pattern, GetAreaClimate(area),
                 GetLocalInt(area, VAR_WEATHER_HEAT), GetLocalInt(area, VAR_WEATHER_HUMIDITY),
                 GetLocalInt(area, VAR_WEATHER_WIND), GetIsAreaNatural(area) != 0,
-                NWScript.Random);
+                NWScript.Random)) return;
             var conditions = state.Conditions;
+            Log.WriteStructured(LogGroup.Server,
+                "Weather updated for {AreaResref}: revision {Revision}, heat {Heat}, humidity {Humidity}, wind {Wind}, precipitation {Precipitation}, storm {Storm}",
+                GetResRef(area), state.Revision, conditions.Heat, conditions.Humidity, conditions.Wind,
+                conditions.Precipitation, conditions.Storm);
             NWScript.SetWeather(area, conditions.Precipitation switch
             {
                 Precipitation.Rain => WeatherType.Rain,

--- a/SWLOR.Game.Server/Service/WeatherService/WeatherAreaState.cs
+++ b/SWLOR.Game.Server/Service/WeatherService/WeatherAreaState.cs
@@ -1,0 +1,23 @@
+namespace SWLOR.Game.Server.Service.WeatherService
+{
+    /// <summary>Retains the same area's conditions throughout a weather front.</summary>
+    public class WeatherAreaState
+    {
+        public int Revision { get; private set; }
+        public WeatherConditions Conditions { get; private set; }
+
+        public bool TryUpdate(WeatherPattern pattern, WeatherClimate climate,
+            int heatModifier, int humidityModifier, int windModifier, bool isNatural, Func<int, int> random)
+        {
+            if (Revision == pattern.Revision) return false;
+
+            Conditions = WeatherConditions.Create(pattern.Heat, pattern.Humidity, pattern.Wind,
+                climate, heatModifier, humidityModifier, windModifier, isNatural,
+                Conditions?.Storm ?? WeatherStorm.None, random);
+            Revision = pattern.Revision;
+            return true;
+        }
+
+        public void Invalidate() => Revision = 0;
+    }
+}

--- a/SWLOR.Game.Server/Service/WeatherService/WeatherClimate.cs
+++ b/SWLOR.Game.Server/Service/WeatherService/WeatherClimate.cs
@@ -5,6 +5,9 @@ namespace SWLOR.Game.Server.Service.WeatherService
         public int HeatModifier { get; set; } = 0;
         public int HumidityModifier { get; set; } = 0;
         public int WindModifier { get; set; } = 0;
+        public int MinimumHeat { get; set; } = 1;
+        public int MaximumHeat { get; set; } = 10;
+        public bool IsSheltered { get; set; }
 
         public bool HasSandStorms { get; set; } = false;
         public bool HasSnowStorms { get; set; } = false;

--- a/SWLOR.Game.Server/Service/WeatherService/WeatherConditions.cs
+++ b/SWLOR.Game.Server/Service/WeatherService/WeatherConditions.cs
@@ -1,0 +1,87 @@
+using Precipitation = SWLOR.NWN.API.NWScript.Enum.Weather;
+
+namespace SWLOR.Game.Server.Service.WeatherService
+{
+    public enum WeatherStorm
+    {
+        None,
+        Thunder,
+        Sand,
+        Snow
+    }
+
+    public enum WeatherHazard
+    {
+        None,
+        Acid,
+        Sand,
+        Snow
+    }
+
+    public sealed record WeatherConditions(int Heat, int Humidity, int Wind, Precipitation Precipitation, WeatherStorm Storm)
+    {
+        public static WeatherConditions Create(
+            int heat, int humidity, int wind, WeatherClimate climate,
+            int heatModifier, int humidityModifier, int windModifier, bool isNatural,
+            WeatherStorm previousStorm, Func<int, int> random)
+        {
+            heat = Math.Clamp(heat + climate.HeatModifier + heatModifier, 1, 10);
+            humidity = Math.Clamp(humidity + climate.HumidityModifier + humidityModifier, 1, 10);
+            wind = Math.Clamp(wind + climate.WindModifier + windModifier - (isNatural ? 0 : 1), 1, 10);
+
+            var precipitation = Precipitation.Clear;
+            if (humidity > 7)
+            {
+                precipitation = heat <= 3 ? Precipitation.Snow :
+                    heat < 6 && wind < 3 ? Precipitation.Foggy : Precipitation.Rain;
+            }
+
+            var storm = WeatherStorm.None;
+            if (precipitation == Precipitation.Rain && heat > 4 &&
+                (previousStorm == WeatherStorm.Thunder ? random(3) == 0 : random(20) < wind))
+            {
+                storm = WeatherStorm.Thunder;
+            }
+            else if (wind >= 9 && (climate.HasSandStorms || climate.HasSnowStorms) && random(3) == 0)
+            {
+                storm = climate.HasSandStorms ? WeatherStorm.Sand : WeatherStorm.Snow;
+            }
+
+            return new WeatherConditions(heat, humidity, wind, precipitation, storm);
+        }
+
+        public WeatherHazard GetHazard(bool acidRain, Precipitation? actualPrecipitation = null)
+        {
+            if (acidRain && (actualPrecipitation ?? Precipitation) == Precipitation.Rain) return WeatherHazard.Acid;
+            if (Storm == WeatherStorm.Sand) return WeatherHazard.Sand;
+            if (Storm == WeatherStorm.Snow) return WeatherHazard.Snow;
+            return WeatherHazard.None;
+        }
+
+        public string GetFeedback(WeatherClimate climate, bool isNight, bool acidRain, Precipitation? actualPrecipitation = null)
+        {
+            switch (GetHazard(acidRain, actualPrecipitation))
+            {
+                case WeatherHazard.Acid: return WeatherFeedbackText.AcidRain;
+                case WeatherHazard.Sand: return WeatherFeedbackText.SandStorm;
+                case WeatherHazard.Snow: return WeatherFeedbackText.SnowStorm;
+            }
+
+            if (Storm == WeatherStorm.Thunder) return climate.StormText;
+            if (Precipitation == Precipitation.Foggy) return climate.MistText;
+            if (Precipitation == Precipitation.Rain) return Heat > 7 ? climate.RainWarmText : climate.RainNormalText;
+            if (Precipitation == Precipitation.Snow) return climate.SnowText;
+            if (Heat < 3) return climate.FreezingText;
+            if (Heat > 8) return climate.ScorchingText;
+            if (Heat < 5) return Wind < 5 ? climate.ColdMildText : Wind < 8 ? climate.ColdCloudyText : climate.ColdWindyText;
+            if (Heat > 6) return Wind < 5 ? climate.WarmMildText : Wind < 8 ? climate.WarmCloudyText : climate.WarmWindyText;
+            if (Wind < 5) return isNight ? climate.MildNightText : climate.MildText;
+            return Wind < 8 ? climate.CloudyText : climate.WindyText;
+        }
+
+        public static int GetLightningDamage(int power, float distance)
+        {
+            return Math.Max(0, (int)(power - distance * 10f));
+        }
+    }
+}

--- a/SWLOR.Game.Server/Service/WeatherService/WeatherConditions.cs
+++ b/SWLOR.Game.Server/Service/WeatherService/WeatherConditions.cs
@@ -25,7 +25,7 @@ namespace SWLOR.Game.Server.Service.WeatherService
             int heatModifier, int humidityModifier, int windModifier, bool isNatural,
             WeatherStorm previousStorm, Func<int, int> random)
         {
-            heat = Math.Clamp(heat + climate.HeatModifier + heatModifier, 1, 10);
+            heat = Math.Clamp(heat + climate.HeatModifier + heatModifier, climate.MinimumHeat, climate.MaximumHeat);
             humidity = Math.Clamp(humidity + climate.HumidityModifier + humidityModifier, 1, 10);
             wind = Math.Clamp(wind + climate.WindModifier + windModifier - (isNatural ? 0 : 1), 1, 10);
 

--- a/SWLOR.Game.Server/Service/WeatherService/WeatherExposure.cs
+++ b/SWLOR.Game.Server/Service/WeatherService/WeatherExposure.cs
@@ -1,0 +1,29 @@
+namespace SWLOR.Game.Server.Service.WeatherService
+{
+    /// <summary>
+    /// One damage clock per player, shared by area entry and the module heartbeat.
+    /// Taking shelter stops damage without allowing rapid re-entry to stack pulses.
+    /// </summary>
+    public sealed class WeatherExposure
+    {
+        private DateTime _nextDamageUtc;
+        private WeatherHazard _previousHazard;
+
+        public int GetDamageDice(DateTime now, WeatherHazard hazard)
+        {
+            if (hazard == WeatherHazard.None)
+            {
+                _previousHazard = hazard;
+                return 0;
+            }
+
+            if (now < _nextDamageUtc)
+                return 0;
+
+            var dice = hazard == WeatherHazard.Acid && _previousHazard == hazard ? 1 : 2;
+            _previousHazard = hazard;
+            _nextDamageUtc = now.AddSeconds(6);
+            return dice;
+        }
+    }
+}

--- a/SWLOR.Game.Server/Service/WeatherService/WeatherFeedbackText.cs
+++ b/SWLOR.Game.Server/Service/WeatherService/WeatherFeedbackText.cs
@@ -4,28 +4,28 @@ namespace SWLOR.Game.Server.Service.WeatherService
     {
 
         public const string Lightning = "You were hit by the bolt of lightning!";
-        public const string AcidRain = "Acid rain burns exposed skin. Take shelter immediately!";
+        public const string AcidRain = "Acid rain is causing damage. Enter an interior or underground area for shelter; Poison resistance reduces the damage.";
         public const string Cloudy = "Clouds move across the sky at a brisk pace, driven by strong wind.";
         public const string ColdCloudy = "Cold air is punctuated by an overcast sky, the clouds thick and dark.";
         public const string ColdWindy = "A chill wind is in the air, cutting like a knife.";
-        public const string ColdMild = "It is quite cold out. Wrap up warm by wearing winter clothing.";
-        public const string Freezing = "The air is bitingly cold right now. Make sure you are wrapped up warm and have plenty of rations.";
+        public const string ColdMild = "It is quite cold out, though the air is still.";
+        public const string Freezing = "The air is bitingly cold right now.";
         public const string Mild = "It is lovely and sunny here.";
         public const string MildNight = "The weather is fine tonight.";
         public const string Mist = "It is still and very humid, the mist hangs in the air about you.";
-        public const string WarmCloudy = "It is hot, and clouds are dotted around. Travels will be tiring - you should wear light clothing.";
-        public const string WarmMild = "It is warm and calm here. Make sure you have enough to drink in the extra heat, and wear light clothing.";
+        public const string WarmCloudy = "It is hot, and scattered clouds offer patches of shade.";
+        public const string WarmMild = "It is warm and calm here.";
         public const string WarmWindy = "Warm gusts of wind ripple the air here, and there are a worrying number of clouds casting shadows over the earth. We might experience thunderstorms, so be careful.";
-        public const string RainNormal = "It is raining. Your travels will be a little difficult because of it.";
-        public const string RainWarm = "It is raining, and the air is humid. Thunderstorms are likely, and it will be more difficult to make progress on your journey.";
-        public const string Scorching = "The heat is blazing here! You should wear something to protect your face and hands, if you can.";
-        public const string Snow = "It is snowing right now! Remember to wrap up warm and pack extra provisions.";
-        public const string Storm = "There is a thunderstorm at the moment. It will be quite dangerous out.";
-        public const string Windy = "The wind is very strong, and there are many clouds in the sky. The weather could shift at any time.";
+        public const string RainNormal = "It is raining steadily.";
+        public const string RainWarm = "It is raining, and the air is warm and humid.";
+        public const string Scorching = "The heat is blazing here, and a haze shimmers in the distance.";
+        public const string Snow = "Snowflakes drift through the air.";
+        public const string Storm = "Lightning threatens this area. Enter an interior or underground area for shelter; Electrical resistance reduces lightning damage.";
+        public const string Windy = "The wind is very strong, and there are many clouds in the sky.";
 
         public const string DustStorm = "There is a dust storm!  Visibility is drastically reduced.";
-        public const string SandStorm = "There is a sand storm! Take cover immediately, these storms are very dangerous!";
-        public const string SnowStorm = "There is a snow storm! Visibility is reduced.";
+        public const string SandStorm = "A sand storm is causing physical damage! Enter an interior or underground area for shelter.";
+        public const string SnowStorm = "A blizzard is causing cold damage! Enter an interior or underground area for shelter; Ice resistance reduces the damage.";
 
     }
 }

--- a/SWLOR.Game.Server/Service/WeatherService/WeatherFeedbackText.cs
+++ b/SWLOR.Game.Server/Service/WeatherService/WeatherFeedbackText.cs
@@ -4,6 +4,7 @@ namespace SWLOR.Game.Server.Service.WeatherService
     {
 
         public const string Lightning = "You were hit by the bolt of lightning!";
+        public const string AcidRain = "Acid rain burns exposed skin. Take shelter immediately!";
         public const string Cloudy = "Clouds move across the sky at a brisk pace, driven by strong wind.";
         public const string ColdCloudy = "Cold air is punctuated by an overcast sky, the clouds thick and dark.";
         public const string ColdWindy = "A chill wind is in the air, cutting like a knife.";

--- a/SWLOR.Game.Server/Service/WeatherService/WeatherPattern.cs
+++ b/SWLOR.Game.Server/Service/WeatherService/WeatherPattern.cs
@@ -1,0 +1,46 @@
+namespace SWLOR.Game.Server.Service.WeatherService
+{
+    /// <summary>
+    /// The shared weather front. Game-clock changes and area traffic must not advance it.
+    /// </summary>
+    public sealed class WeatherPattern
+    {
+        public static readonly TimeSpan UpdateInterval = TimeSpan.FromHours(1);
+
+        public int Heat { get; private set; }
+        public int Humidity { get; private set; }
+        public int Wind { get; private set; }
+        public int Revision { get; private set; }
+        public DateTime NextChangeUtc { get; private set; }
+
+        public bool TryAdvance(DateTime now, int month, bool isNight, Func<int, int> random)
+        {
+            if (Revision > 0 && now < NextChangeUtc)
+                return false;
+
+            var seasonalHeat = Math.Max(1, random(5) + 6 - Math.Abs(month - 6));
+            var targetHeat = seasonalHeat + (isNight ? -2 : 2);
+            if (Revision == 0)
+            {
+                Heat = targetHeat;
+                Humidity = random(10) + 1;
+            }
+            else
+            {
+                // Include dawn/dusk in the gradual change, rather than applying an
+                // instantaneous four-point temperature jump to each area.
+                Heat += Math.Sign(targetHeat - Heat);
+                var humidityChange = random(2 * Wind + 1) - Wind;
+                Humidity = Math.Clamp(Humidity + Math.Sign(humidityChange), 1, 10);
+            }
+
+            Wind = random(10) + random(10) - 8;
+            if (Wind < 1) Wind = 1 - Wind;
+
+            Revision++;
+            // Do not catch up missed updates in a burst after a long pause.
+            NextChangeUtc = now + UpdateInterval;
+            return true;
+        }
+    }
+}

--- a/SWLOR.Game.Server/Service/WeatherService/WeatherPlanetDefinitions.cs
+++ b/SWLOR.Game.Server/Service/WeatherService/WeatherPlanetDefinitions.cs
@@ -11,15 +11,15 @@ namespace SWLOR.Game.Server.Service.WeatherService
         {
             var climates = new Dictionary<string, WeatherClimate>(StringComparer.OrdinalIgnoreCase);
             foreach (var (planet, climate) in planets) climates.Add(planet.ToString(), climate);
-            climates.Add("Kashyyyk", new WeatherClimate
+            climates["Kashyyyk"] = new WeatherClimate
             {
                 HeatModifier = 3, HumidityModifier = 3, MinimumHeat = 4
-            });
-            climates.Add("Ossus", new WeatherClimate
+            };
+            climates["Ossus"] = new WeatherClimate
             {
                 HeatModifier = 2, HumidityModifier = -1, MinimumHeat = 4
-            });
-            climates.Add("None", new WeatherClimate { IsSheltered = true });
+            };
+            climates["None"] = new WeatherClimate { IsSheltered = true };
             return climates;
         }
 

--- a/SWLOR.Game.Server/Service/WeatherService/WeatherPlanetDefinitions.cs
+++ b/SWLOR.Game.Server/Service/WeatherService/WeatherPlanetDefinitions.cs
@@ -5,6 +5,32 @@ namespace SWLOR.Game.Server.Service.WeatherService
 {
     public static class WeatherPlanetDefinitions
     {
+        // These profiles also support authored areas outside the active galaxy map.
+        // Unknown overrides deliberately do not fall back to a different planet.
+        public static Dictionary<string, WeatherClimate> GetNamedClimates(Dictionary<PlanetType, WeatherClimate> planets)
+        {
+            var climates = new Dictionary<string, WeatherClimate>(StringComparer.OrdinalIgnoreCase);
+            foreach (var (planet, climate) in planets) climates.Add(planet.ToString(), climate);
+            climates.Add("Kashyyyk", new WeatherClimate
+            {
+                HeatModifier = 3, HumidityModifier = 3, MinimumHeat = 4
+            });
+            climates.Add("Ossus", new WeatherClimate
+            {
+                HeatModifier = 2, HumidityModifier = -1, MinimumHeat = 4
+            });
+            climates.Add("None", new WeatherClimate { IsSheltered = true });
+            return climates;
+        }
+
+        public static WeatherClimate ResolveClimate(PlanetType planet, string climateOverride,
+            IReadOnlyDictionary<PlanetType, WeatherClimate> planets, IReadOnlyDictionary<string, WeatherClimate> named)
+        {
+            if (!string.IsNullOrWhiteSpace(climateOverride))
+                return named.TryGetValue(climateOverride.Trim(), out var custom) ? custom : null;
+            return planets.TryGetValue(planet, out var climate) ? climate : null;
+        }
+
         public static Dictionary<PlanetType, WeatherClimate> GetPlanetClimates()
         {
             return new Dictionary<PlanetType, WeatherClimate>
@@ -44,8 +70,8 @@ namespace SWLOR.Game.Server.Service.WeatherService
                     RainNormalText = "The ocean, affronted by the existence of patches of non-ocean on the surface of the planet, is attempting to reclaim the land by air drop.  In other words, it's raining.",
                     RainWarmText = "A heavy rain shower is passing over, but is doing little to dispel the humidity in the air.",
                     SnowText = "It's snowing!  The local flora seems most surprised at this turn of events.",
-                    StormText = "A storm rips in off the sea, filling the sky with dramatic flashes.",
-                    ScorchingText = "The sun bakes the sand, making it extremely uncomfortable to those without insulated boots.",
+                    StormText = "A storm rips in off the sea. " + WeatherFeedbackText.Storm,
+                    ScorchingText = "The sun bakes the sand, and heat shimmers above the beach.",
                     ColdWindyText = "A chill wind sweeps over the isles, the moisture in the air cutting to the bone.",
                     WarmWindyText = "The wind is picking up, a warm front rolling over.  There could be a storm soon.",
                     WindyText = "A strong wind sweeps in.  The sea is choppy, waves crashing onto the beach.",
@@ -53,7 +79,8 @@ namespace SWLOR.Game.Server.Service.WeatherService
                 [PlanetType.Hutlar] = new WeatherClimate
                 {
                     HeatModifier = -8,
-                    HumidityModifier = -8,
+                    HumidityModifier = +2,
+                    MaximumHeat = 3,
                     HasSnowStorms = true,
                     FreezingText = "A wave of cold air rolls in, stinging exposed flesh.",
                     SnowText = "It's snowing... again...",
@@ -64,6 +91,7 @@ namespace SWLOR.Game.Server.Service.WeatherService
                     MildText = "It is cold, the sky is clear, and there is a gentle breeze.",
                     WarmCloudyText = "It is cold."
                 },
+                [PlanetType.CZ220] = new WeatherClimate { IsSheltered = true },
                 [PlanetType.Korriban] = new WeatherClimate
                 {
                     HeatModifier = +3,
@@ -86,6 +114,7 @@ namespace SWLOR.Game.Server.Service.WeatherService
 				},
 				[PlanetType.SmugglersMoonStation] = new WeatherClimate
 				{
+					IsSheltered = true,
 					HeatModifier = -2,
 					HumidityModifier = -2,
 					WindModifier = -5,


### PR DESCRIPTION
Weather could switch from sunshine to rain to snow within minutes because updates followed accelerated game time, temperature rerolled abruptly, and area entry rerolled storms. Conditions now persist between updates at least **60 real minutes apart**, with temperature and humidity changing by at most one point per update. Explicit builder edits and module restarts remain exceptions.

The weather audit repairs the following behavior:

- Climate calculation applies module, planet, and area modifiers once and uses the shared planet resolver, including Mon Cala. Hutlar can now receive ordinary snowfall without rain or thunderstorms, and Frozen Wastes preserves its authored permanent snow. Nine outdoor Kashyyyk/Ossus areas select explicit warm climate profiles. Unconfigured areas retain authored native ambience without acquiring scripted hazards. Named overrides replace generated entries deterministically. Accepted weather updates emit structured Server logs with area identity and all condition fields.
- Storms roll once per area per weather front. Thunderstorms can start, use the intended continuation probability, and have a separate lightning timer per occupied area. Lightning stops with the storm, has nonnegative damage falloff, and cannot knock down targets whose damage is fully prevented.
- Fog initializes and clears consistently, restores authored sky/fog settings, and uses grounded placement. Generated mist is limited to occupied areas so empty templates cannot copy untracked effects into instances.
- One six-second exposure clock per player replaces repeating hazard callbacks that rejected ordinary players, stacked on entry, or survived shelter and clearing weather. Acid exposure respects native rain/clear overrides. Damage stops for sheltered, dead, or staff-controlled players.
- Weather now uses shared resistance and damage-taken protection: Ice for blizzards, Poison for acid rain, Electrical for lightning, and physical-damage reductions/immunity for sandstorms. Shared general reductions and protection effects also apply. Existing damage dice are retained: sand/blizzard 2d6 per pulse; acid 2d6 initially and 1d6 thereafter. No authored area enables acid rain. Ordinary precipitation and temperature alone cause no damage or movement penalty.
- The complete 453-area audit corrects 26 exposed interiors, including shops, laboratories, crypts, caves, and station corridors. The Canyon Dueling Pit, Sith Fortress Courtyard, and Academy Rooftop deliberately remain outdoors. Sealed stations receive sheltered profiles. The Kashyyyk canopy has a recovery waypoint on a verified walkable platform for `/stuck`. Warnings explain actual shelter/resistance options and no longer imply protection from clothing appearance or provisions.

`SWLOR.Game.Server/Readmes/Weather.md` documents gameplay, protection rules, deployment, and live checks. `WeatherAreaAudit.md` records the configuration of every authored area. Shelter is determined by area flags; decorative roofs or trees within an outdoor area do not provide geometric cover.

Validation:
- Server/test build succeeds with `-p:RunPostBuildEvent=Never`; eight existing nullable warnings remain outside weather code.
- **116 focused regressions pass on the latest commit**, covering weather timing/climates, the full area corpus, canopy recovery placement, and player feedback/message audit. The earlier broader audit run passed 225 available regressions including shared damage/protection behavior. Three unrelated weapon-2DA tests require the uninitialized HAK submodule and were excluded from that successful broader run.
- Full module repack succeeds: **16,175 resources and 126 scripts**. Packing temporary directories were cleaned up; no server or live deployment was started.
- `git diff --check` passes. Native client visuals, area geometry, and live NWNX behavior still require the documented in-game checks.

Deploy the repacked module together with the updated server assembly and restart normally. ARE shelter flags and ten GIT local-variable tables change. No HAK resources or submodule pointers change, so no companion HAK PR is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Weather now updates hourly with shared regional conditions and climate-specific patterns.
  - Added support for rain, snow, mist, thunderstorms, sandstorms, acid rain, lightning, and environmental exposure effects.
  - Weather responds to area shelter, underground, station, planet, and climate settings.
  - Added climate overrides for selected Kashyyyk and Ossus areas, plus Frozen Wastes snow preservation.
  - Improved weather feedback messages, resistance handling, and hazard damage behavior.

- **Bug Fixes**
  - Corrected weather exposure and shelter settings across numerous areas.
  - Improved storm scheduling, fog and mist cleanup, lightning damage, and weather state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->